### PR TITLE
Fix code formatting issues with Prettier

### DIFF
--- a/src/durable-objects/KeyManager.ts
+++ b/src/durable-objects/KeyManager.ts
@@ -294,13 +294,13 @@ export class KeyManager {
     return new Response(
       JSON.stringify({
         error: 'Unauthorized',
-        message: 'Valid authentication token required'
+        message: 'Valid authentication token required',
       }),
       {
         status: 401,
         headers: {
           'Content-Type': 'application/json',
-          'WWW-Authenticate': 'Bearer realm="KeyManager"'
+          'WWW-Authenticate': 'Bearer realm="KeyManager"',
         },
       }
     );


### PR DESCRIPTION
Fixed code style issues in KeyManager.ts that were causing the format:check CI step to fail. All formatting now complies with the project's Prettier configuration.