### PR TITLE
Rename product from Hibana to Enrai

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,5 +7,5 @@ contact_links:
     url: https://openid.net/certification/testing/
     about: OpenID Foundation Conformance Testing documentation
   - name: Project Documentation
-    url: https://github.com/sgrastar/hibana/blob/main/README.md
-    about: Read the Hibana project documentation
+    url: https://github.com/sgrastar/enrai/blob/main/README.md
+    about: Read the Enrai project documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# Contributing to Hibana
+# Contributing to Enrai
 
-Thank you for your interest in Hibana!
+Thank you for your interest in Enrai!
 
 ## Development Model
 
-Hibana is primarily a **solo development project** by [sgrastar](https://github.com/sgrastar).
+Enrai is primarily a **solo development project** by [sgrastar](https://github.com/sgrastar).
 
 ### What We Accept
 
@@ -50,8 +50,8 @@ If you have questions:
 
 ## License
 
-Hibana is licensed under the Apache License 2.0. By reporting issues, you agree that any code examples or suggestions you provide may be used under this license.
+Enrai is licensed under the Apache License 2.0. By reporting issues, you agree that any code examples or suggestions you provide may be used under this license.
 
 ---
 
-Thank you for your interest in Hibana! 🔥
+Thank you for your interest in Enrai! 🔥

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development Guide
 
-This guide will help you set up your development environment for Hibana.
+This guide will help you set up your development environment for Enrai.
 
 ## Table of Contents
 
@@ -26,8 +26,8 @@ Before you begin, ensure you have the following installed:
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/YOUR-USERNAME/hibana.git
-cd hibana
+git clone https://github.com/YOUR-USERNAME/enrai.git
+cd enrai
 ```
 
 ### 2. Install Dependencies
@@ -153,7 +153,7 @@ npm run generate-keys    # Generate RSA key pair
 ### Project Structure
 
 ```
-hibana/
+enrai/
 ├── .github/
 │   └── workflows/       # GitHub Actions CI/CD
 ├── docs/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hibana 💥
+# Enrai 💥
 
 > **One-command identity infrastructure for the modern web**
 
@@ -12,11 +12,11 @@ A lightweight, serverless **OpenID Connect Provider** that deploys to **Cloudfla
 
 ## 🎯 Vision
 
-**Hibana** makes identity infrastructure as simple as deploying a website:
+**Enrai** makes identity infrastructure as simple as deploying a website:
 
 ```bash
 # Future goal (Phase 6)
-npx create-hibana my-identity-provider
+npx create-enrai my-identity-provider
 ```
 
 **Result:** A production-ready OpenID Connect Provider with login screens, admin dashboard, and global edge deployment—all in under 5 minutes.
@@ -25,18 +25,18 @@ npx create-hibana my-identity-provider
 
 ---
 
-## ✨ What is Hibana?
+## ✨ What is Enrai?
 
-Hibana is an **enterprise-grade OpenID Connect Provider** built for:
+Enrai is an **enterprise-grade OpenID Connect Provider** built for:
 
 - 🚀 **Developers** - Simple integration, great DX
 - 🏢 **Enterprises** - Self-hosted, no vendor lock-in
 - 🌍 **Global apps** - <50ms latency worldwide
 - 💰 **Startups** - Generous free tier, no hidden costs
 
-### Why Hibana?
+### Why Enrai?
 
-| Feature | Hibana | Auth0 | Keycloak | Cognito |
+| Feature | Enrai | Auth0 | Keycloak | Cognito |
 |---------|--------|-------|----------|---------|
 | **Setup Time** | 5 min (goal) | 30 min | 2+ hours | 1+ hour |
 | **Cold Starts** | 0ms | N/A | N/A | 100-500ms |
@@ -135,7 +135,7 @@ Hibana is an **enterprise-grade OpenID Connect Provider** built for:
 - 💾 Data storage abstraction (KV/D1/DO)
 
 **Phase 6: CLI & Automation** (Jun-Aug 2026)
-- 📦 `create-hibana` NPM package
+- 📦 `create-enrai` NPM package
 - 🚀 One-command deployment
 - 🤖 Cloudflare integration
 - 🛠️ Management CLI (users, clients, keys)
@@ -179,8 +179,8 @@ Hibana is an **enterprise-grade OpenID Connect Provider** built for:
 
 ```bash
 # 1. Clone repository
-git clone https://github.com/sgrastar/hibana.git
-cd hibana
+git clone https://github.com/sgrastar/enrai.git
+cd enrai
 
 # 2. Install dependencies
 npm install
@@ -258,7 +258,7 @@ Coverage:
 
 ## 🔐 Security
 
-Hibana implements security best practices:
+Enrai implements security best practices:
 
 - ✅ **PKCE** (Proof Key for Code Exchange) - RFC 7636
 - ✅ **Single-use authorization codes** - Replay attack prevention
@@ -268,13 +268,13 @@ Hibana implements security best practices:
 - ✅ **CSRF protection** - State parameter validation
 - ✅ **Rate limiting** - Implemented (Phase 4)
 
-**Responsible Disclosure:** security@hibana.dev
+**Responsible Disclosure:** security@enrai.org
 
 ---
 
 ## 🤝 Contributing
 
-Hibana is primarily a solo development project. See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
+Enrai is primarily a solo development project. See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
 
 **What we accept:**
 - 🐛 Bug reports via GitHub Issues
@@ -313,7 +313,7 @@ Hibana is primarily a solo development project. See [CONTRIBUTING.md](./CONTRIBU
 
 ### Quick Deploy to Cloudflare Workers
 
-Deploy Hibana to Cloudflare's global edge network and get a production-ready OpenID Provider with a public URL.
+Deploy Enrai to Cloudflare's global edge network and get a production-ready OpenID Provider with a public URL.
 
 ```bash
 # 1. Install dependencies
@@ -330,7 +330,7 @@ npm run deploy
 ```
 
 **After deployment, you'll get:**
-- 🌍 **Public URL**: `https://hibana.{your-subdomain}.workers.dev`
+- 🌍 **Public URL**: `https://enrai.{your-subdomain}.workers.dev`
 - ✅ **Live Endpoints**:
   - Discovery: `/.well-known/openid-configuration`
   - JWKS: `/.well-known/jwks.json`
@@ -349,7 +349,7 @@ Automatic deployment is configured for the `main` branch:
 
 **Future (Phase 6):**
 ```bash
-npx create-hibana my-idp
+npx create-enrai my-idp
 # One command, fully automated setup
 ```
 
@@ -382,14 +382,14 @@ See [LICENSE](./LICENSE) for details.
 
 ## 💬 Community
 
-- 💼 **GitHub**: [sgrastar/hibana](https://github.com/sgrastar/hibana)
-- 🐛 **Issues**: [Report bugs](https://github.com/sgrastar/hibana/issues)
-- 💡 **Discussions**: [Feature requests](https://github.com/sgrastar/hibana/discussions)
-- 📧 **Email**: hello@hibana.dev
+- 💼 **GitHub**: [sgrastar/enrai](https://github.com/sgrastar/enrai)
+- 🐛 **Issues**: [Report bugs](https://github.com/sgrastar/enrai/issues)
+- 💡 **Discussions**: [Feature requests](https://github.com/sgrastar/enrai/discussions)
+- 📧 **Email**: hello@enrai.org
 
 ---
 
-> **Hibana** 💥 — *A spark of identity on the edge.*
+> **Enrai** 💥 — *A spark of identity on the edge.*
 >
 > **Status:** Phase 2 Complete (Core API) | **Next:** Phase 3 (Conformance Testing)
 >

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Deployment Guide
 
-This guide walks you through deploying Hibana to Cloudflare Workers, resulting in a production-ready OpenID Connect Provider accessible via a public URL.
+This guide walks you through deploying Enrai to Cloudflare Workers, resulting in a production-ready OpenID Connect Provider accessible via a public URL.
 
 ## 📋 Table of Contents
 
@@ -18,7 +18,7 @@ This guide walks you through deploying Hibana to Cloudflare Workers, resulting i
 
 ## Prerequisites
 
-Before deploying Hibana, ensure you have:
+Before deploying Enrai, ensure you have:
 
 1. **Cloudflare Account** (free tier works)
    - Sign up at [cloudflare.com](https://dash.cloudflare.com/sign-up)
@@ -39,12 +39,12 @@ Before deploying Hibana, ensure you have:
 
 ## Deployment Overview
 
-When you deploy Hibana, you'll get:
+When you deploy Enrai, you'll get:
 
 ### 🌍 Public URL
 Your OpenID Provider will be accessible at:
 ```
-https://hibana.{your-subdomain}.workers.dev
+https://enrai.{your-subdomain}.workers.dev
 ```
 
 Or with a custom domain:
@@ -76,8 +76,8 @@ https://id.yourdomain.com
 
 ```bash
 # Clone the repository
-git clone https://github.com/sgrastar/hibana.git
-cd hibana
+git clone https://github.com/sgrastar/enrai.git
+cd enrai
 
 # Install dependencies
 npm install
@@ -143,8 +143,8 @@ Also update the production issuer URL:
 
 ```toml
 [env.production]
-name = "hibana-prod"
-vars = { ISSUER_URL = "https://hibana.YOUR_SUBDOMAIN.workers.dev" }
+name = "enrai-prod"
+vars = { ISSUER_URL = "https://enrai.YOUR_SUBDOMAIN.workers.dev" }
 ```
 
 Replace `YOUR_SUBDOMAIN` with your Cloudflare Workers subdomain.
@@ -199,7 +199,7 @@ After deployment, Wrangler will output your Worker's URL. Test the deployment:
 
 ```bash
 # Replace with your actual Worker URL
-WORKER_URL="https://hibana.YOUR_SUBDOMAIN.workers.dev"
+WORKER_URL="https://enrai.YOUR_SUBDOMAIN.workers.dev"
 
 # Test discovery endpoint
 curl "$WORKER_URL/.well-known/openid-configuration" | jq
@@ -247,7 +247,7 @@ wrangler secret put PUBLIC_JWK_JSON --env production
 
 ## GitHub Actions CI/CD
 
-Hibana includes pre-configured GitHub Actions workflows for automated testing and deployment.
+Enrai includes pre-configured GitHub Actions workflows for automated testing and deployment.
 
 ### Setup GitHub Secrets
 
@@ -300,7 +300,7 @@ Ensure your `ISSUER_URL` in production matches your actual deployment URL:
 
 ```toml
 [env.production]
-vars = { ISSUER_URL = "https://hibana.YOUR_SUBDOMAIN.workers.dev" }
+vars = { ISSUER_URL = "https://enrai.YOUR_SUBDOMAIN.workers.dev" }
 ```
 
 Then redeploy:
@@ -314,7 +314,7 @@ Use the deployed OP with a test client application:
 
 ```bash
 # Example authorization URL
-https://hibana.YOUR_SUBDOMAIN.workers.dev/authorize?
+https://enrai.YOUR_SUBDOMAIN.workers.dev/authorize?
   response_type=code&
   client_id=test-client&
   redirect_uri=https://your-app.com/callback&
@@ -332,7 +332,7 @@ View logs in Cloudflare Dashboard or via Wrangler:
 wrangler tail --env production
 
 # View logs in dashboard
-# https://dash.cloudflare.com → Workers → hibana-prod → Logs
+# https://dash.cloudflare.com → Workers → enrai-prod → Logs
 ```
 
 ---
@@ -343,7 +343,7 @@ wrangler tail --env production
 
 If your domain is managed by Cloudflare:
 
-1. Go to **Workers & Pages** → **hibana-prod** → **Settings** → **Domains & Routes**
+1. Go to **Workers & Pages** → **enrai-prod** → **Settings** → **Domains & Routes**
 2. Click **Add Custom Domain**
 3. Enter your domain (e.g., `id.yourdomain.com`)
 4. Cloudflare will automatically provision SSL certificate
@@ -352,7 +352,7 @@ If your domain is managed by Cloudflare:
 
 1. Add a CNAME record pointing to your Worker:
    ```
-   id.yourdomain.com CNAME hibana.YOUR_SUBDOMAIN.workers.dev
+   id.yourdomain.com CNAME enrai.YOUR_SUBDOMAIN.workers.dev
    ```
 
 2. Add the custom domain in Cloudflare Dashboard (same as above)
@@ -512,7 +512,7 @@ After successful deployment:
 - [Cloudflare Workers Documentation](https://developers.cloudflare.com/workers/)
 - [Wrangler CLI Documentation](https://developers.cloudflare.com/workers/wrangler/)
 - [OpenID Connect Specification](https://openid.net/specs/openid-connect-core-1_0.html)
-- [Hibana Development Setup](./conformance/SETUP.md)
+- [Enrai Development Setup](./conformance/SETUP.md)
 
 ---
 
@@ -521,7 +521,7 @@ After successful deployment:
 If you encounter issues:
 
 1. Check the [Troubleshooting](#troubleshooting) section
-2. Review [GitHub Issues](https://github.com/sgrastar/hibana/issues)
+2. Review [GitHub Issues](https://github.com/sgrastar/enrai/issues)
 3. Create a new issue with:
    - Deployment logs
    - Error messages
@@ -533,7 +533,7 @@ If you encounter issues:
 
 Your OpenID Connect Provider is now live at:
 ```
-https://hibana.YOUR_SUBDOMAIN.workers.dev
+https://enrai.YOUR_SUBDOMAIN.workers.dev
 ```
 
 Start integrating with your applications and enjoy global edge authentication!

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# Hibana Documentation
+# Enrai Documentation
 
-Complete documentation for the Hibana OpenID Connect Provider project.
+Complete documentation for the Enrai OpenID Connect Provider project.
 
 > **Quick Navigation**: Use the search function (Ctrl+F / Cmd+F) or jump to:
 > [Project Management](#-project-management) | [Architecture](#️-architecture--specifications) | [Conformance Testing](#-conformance-testing) | [Finding Information](#-finding-information)
@@ -31,7 +31,7 @@ Technical specifications and protocol flow documentation.
 | [Protocol Flow](./architecture/protocol-flow.md) | End-to-end OIDC Authorization Code Flow specification |
 | [Technical Specs](./architecture/technical-specs.md) | System architecture, components, and endpoint specifications |
 
-**For AI/LLM Analysis**: These documents are structured for machine-readable analysis of Hibana's behavior and compliance.
+**For AI/LLM Analysis**: These documents are structured for machine-readable analysis of Enrai's behavior and compliance.
 
 ---
 
@@ -122,7 +122,7 @@ Phase 5: Certification Prep  [May 1 - May 31, 2026]   ⏳ Planned
 ### "How do I track issues?"
 → [GitHub Workflow](./project-management/GITHUB_WORKFLOW.md)
 
-### "How does OIDC work in Hibana?"
+### "How does OIDC work in Enrai?"
 → [Protocol Flow](./architecture/protocol-flow.md)
 
 ### "What are the technical requirements?"
@@ -146,7 +146,7 @@ When adding or updating documentation:
 4. **Keep it current**: Update status and dates as project progresses
 5. **Be consistent**: Follow existing formatting and style
 6. **Add cross-references**: Link to related documents at the beginning of each file
-7. **Use examples**: Include `id.example.dev` for examples, `id.hibana.dev` for production references
+7. **Use examples**: Include `id.example.dev` for examples, `id.enrai.org` for production references
 
 ### Documentation Quality Standards
 
@@ -183,4 +183,4 @@ When adding or updating documentation:
 
 ---
 
-> **Hibana** 🔥 — Comprehensive documentation for edge-native OpenID Connect.
+> **Enrai** 🔥 — Comprehensive documentation for edge-native OpenID Connect.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,4 +1,4 @@
-# Hibana Product Roadmap 🗺️
+# Enrai Product Roadmap 🗺️
 
 **Vision:** One-command identity infrastructure for the modern web
 
@@ -497,7 +497,7 @@ Legend:
 ### Week 32-33: CLI Tool Development (Jun 12-25)
 
 **Key Features:**
-- [ ] `create-hibana` NPM package
+- [ ] `create-enrai` NPM package
 - [ ] Interactive setup wizard
 - [ ] Project scaffolding
 - [ ] Deployment commands
@@ -522,7 +522,7 @@ Legend:
 - [ ] NPM package publishing
 
 **Deliverables:**
-- [ ] `create-hibana` package published
+- [ ] `create-enrai` package published
 - [ ] One-command deployment functional
 - [ ] CLI with 20+ management commands
 - [ ] Production-ready error handling
@@ -744,7 +744,7 @@ Legend:
 ### Production Deployment
 
 - [ ] Production Cloudflare account setup
-- [ ] Custom domain configuration (`id.hibana.dev`)
+- [ ] Custom domain configuration (`id.enrai.org`)
 - [ ] DNS records & SSL/TLS configuration
 - [ ] Production secrets generation
 - [ ] Production deployment & verification
@@ -768,7 +768,7 @@ Legend:
 
 **Deliverables:**
 - [ ] OpenID Certification obtained ✨
-- [ ] Production deployment live (`https://id.hibana.dev`)
+- [ ] Production deployment live (`https://id.enrai.org`)
 - [ ] Public announcement ready
 - [ ] Migration guides published
 - [ ] Celebrate! 🎉
@@ -861,7 +861,7 @@ Legend:
 - [ ] 50%+ users using Passkey (goal)
 
 ### Phase 7: CLI 🆕
-- [ ] <5 min from `npx create-hibana` to running IdP
+- [ ] <5 min from `npx create-enrai` to running IdP
 - [ ] <1 min deployment time
 - [ ] 100% automated setup
 - [ ] Zero manual configuration required
@@ -897,7 +897,7 @@ Legend:
 ## 🎯 Key Results (Overall)
 
 ### By August 2026 (Phase 7 Complete)
-Hibana will be:
+Enrai will be:
 
 1. **🏆 OpenID Certified** - Official certification obtained
 2. **🔐 Passwordless-first** - WebAuthn + Magic Link (Auth0/Clerkを超える)
@@ -968,7 +968,7 @@ Add:
 > **Last Update:** 2025-11-12 (Phase 4 COMPLETE ✅)
 > **Next Update:** 2026-05-31 (Post Phase 5)
 >
-> 💥 **Hibana** - Building the future of identity infrastructure, one phase at a time.
+> 💥 **Enrai** - Building the future of identity infrastructure, one phase at a time.
 >
 > **Current Status:**
 > - **Phase 4 COMPLETE:** All extended security features implemented ✅

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,6 +1,6 @@
-# Hibana Vision 🔥
+# Enrai Vision 🔥
 
-**Hibana** is an enterprise-grade OpenID Connect Provider that deploys in minutes, not days.
+**Enrai** is an enterprise-grade OpenID Connect Provider that deploys in minutes, not days.
 
 ---
 
@@ -18,7 +18,7 @@ Setting up identity infrastructure is complex:
 
 ## 💡 Our Solution
 
-Hibana provides a **lightweight, serverless OpenID Connect Provider** that:
+Enrai provides a **lightweight, serverless OpenID Connect Provider** that:
 
 1. **Deploys in one command** - No complex setup
 2. **Runs on Cloudflare Workers** - Global edge network, zero cold starts
@@ -31,13 +31,13 @@ Hibana provides a **lightweight, serverless OpenID Connect Provider** that:
 ## 🚀 The Vision: One-Command Identity Infrastructure
 
 ```bash
-npx create-hibana my-identity-provider
+npx create-enrai my-identity-provider
 ```
 
 ### The Experience
 
 ```
-🔥 Hibana - OpenID Connect Provider Setup
+🔥 Enrai - OpenID Connect Provider Setup
 
 We'll set up your identity provider in a few steps.
 
@@ -97,8 +97,8 @@ Next steps:
   3. Register your first OAuth client
   4. Test the login flow
 
-Documentation: https://hibana.dev/docs
-Support: https://github.com/hibana/hibana/issues
+Documentation: https://enrai.org/docs
+Support: https://github.com/enrai/enrai/issues
 ```
 
 ---
@@ -151,7 +151,7 @@ Support: https://github.com/hibana/hibana/issues
 **Dashboard:**
 ```
 ┌─────────────────────────────────────────────────────┐
-│  🔥 Hibana Admin                    admin@acme.com ▼│
+│  🔥 Enrai Admin                    admin@acme.com ▼│
 ├─────────────────────────────────────────────────────┤
 │                                                     │
 │  Overview                                           │
@@ -220,12 +220,12 @@ Support: https://github.com/hibana/hibana/issues
 
 ```javascript
 // 1. Install client library
-npm install @hibana/client
+npm install @enrai/client
 
 // 2. Configure
-import { HibanaClient } from '@hibana/client';
+import { EnraiClient } from '@enrai/client';
 
-const auth = new HibanaClient({
+const auth = new EnraiClient({
   issuer: 'https://id.example.com',
   clientId: 'your-client-id',
   clientSecret: 'your-client-secret',
@@ -266,7 +266,7 @@ app.get('/callback', async (req, res) => {
 ┌─────────┐         │  (290+ cities)          │         ┌─────────┐
 │ User    │────────▶│                         │────────▶│ Your    │
 │ Browser │         │  ┌──────────────────┐  │         │ App     │
-└─────────┘         │  │ Hibana Workers   │  │         └─────────┘
+└─────────┘         │  │ Enrai Workers   │  │         └─────────┘
                     │  │ - Auth endpoints │  │
                     │  │ - Token issuance │  │
                     │  │ - User validation│  │
@@ -327,7 +327,7 @@ app.get('/callback', async (req, res) => {
 - Email template editor
 
 ### 🆕 Phase 7: CLI & Automation (Aug 2026)
-- `create-hibana` CLI tool
+- `create-enrai` CLI tool
 - One-command deployment
 - Interactive setup wizard
 - Cloudflare integration
@@ -348,7 +348,7 @@ app.get('/callback', async (req, res) => {
 ## 🎯 Success Metrics
 
 ### Developer Experience
-- ⏱️ **<5 minutes** from `npx create-hibana` to working IdP
+- ⏱️ **<5 minutes** from `npx create-enrai` to working IdP
 - 📚 **<30 minutes** to integrate first application
 - 🎨 **<1 hour** to fully customize branding
 
@@ -371,7 +371,7 @@ app.get('/callback', async (req, res) => {
 
 ## 🌟 Competitive Advantages
 
-| Feature | Hibana | Auth0 | Keycloak | Cognito |
+| Feature | Enrai | Auth0 | Keycloak | Cognito |
 |---------|--------|-------|----------|---------|
 | **Setup Time** | 5 min | 30 min | 2+ hours | 1+ hour |
 | **Cold Starts** | 0ms | N/A | N/A | 100-500ms |
@@ -410,7 +410,7 @@ app.get('/callback', async (req, res) => {
 
 ## 🤝 Open Source Philosophy
 
-Hibana is **open source** (MIT License):
+Enrai is **open source** (MIT License):
 - ✅ Full source code available
 - ✅ Community-driven development
 - ✅ No vendor lock-in
@@ -467,12 +467,12 @@ Hibana is **open source** (MIT License):
 ## 🚀 Get Started
 
 ```bash
-# Install Hibana
-npx create-hibana my-identity-provider
+# Install Enrai
+npx create-enrai my-identity-provider
 
 # Or clone and deploy manually
-git clone https://github.com/sgrastar/hibana.git
-cd hibana
+git clone https://github.com/sgrastar/enrai.git
+cd enrai
 npm install
 npm run deploy
 ```
@@ -481,10 +481,10 @@ npm run deploy
 
 ## 💬 Community
 
-- 💼 **GitHub**: https://github.com/sgrastar/hibana
-- 💬 **Discord**: https://discord.gg/hibana
-- 🐦 **Twitter**: @hibana_dev
-- 📧 **Email**: hello@hibana.dev
+- 💼 **GitHub**: https://github.com/sgrastar/enrai
+- 💬 **Discord**: https://discord.gg/enrai
+- 🐦 **Twitter**: @enrai_dev
+- 📧 **Email**: hello@enrai.org
 
 ---
 
@@ -494,6 +494,6 @@ MIT License - Use it however you want!
 
 ---
 
-> **Hibana** 🔥 — Identity infrastructure that sparks joy.
+> **Enrai** 🔥 — Identity infrastructure that sparks joy.
 >
 > *From zero to production-ready OpenID Provider in under 5 minutes.*

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,4 +1,4 @@
-# Hibana API Documentation 🚀
+# Enrai API Documentation 🚀
 
 **最終更新**: 2025-11-13
 **API Version**: v1.0 (Phase 5)
@@ -20,7 +20,7 @@
 
 ## 概要
 
-Hibana OIDC OPは、39以上のAPIエンドポイントを提供します：
+Enrai OIDC OPは、39以上のAPIエンドポイントを提供します：
 
 | カテゴリ | エンドポイント数 | ステータス |
 |---------|----------------|-----------|
@@ -195,7 +195,7 @@ X-RateLimit-Reset: 1678901234
 {
   "error": "invalid_request",
   "error_description": "The request is missing a required parameter",
-  "error_uri": "https://docs.hibana.dev/errors/invalid_request"
+  "error_uri": "https://docs.enrai.org/errors/invalid_request"
 }
 ```
 
@@ -225,7 +225,7 @@ X-RateLimit-Reset: 1678901234
 | `invalid_request_uri` | 400 | request_uriが不正 |
 | `invalid_request_object` | 400 | request JWTが不正 |
 
-#### Hibana独自エラー
+#### Enrai独自エラー
 
 | エラーコード | HTTP Status | 説明 |
 |-------------|-------------|------|
@@ -345,15 +345,15 @@ curl https://your-domain.com/admin/users?q=john&limit=50 \
 
 ### 公式SDK（Phase 6で提供予定）
 
-- **TypeScript/JavaScript SDK** - npm: `@hibana/sdk`
-- **Python SDK** - PyPI: `hibana-sdk`
-- **Go SDK** - `github.com/hibana/go-sdk`
-- **Rust SDK** - Crates.io: `hibana-sdk`
+- **TypeScript/JavaScript SDK** - npm: `@enrai/sdk`
+- **Python SDK** - PyPI: `enrai-sdk`
+- **Go SDK** - `github.com/enrai/go-sdk`
+- **Rust SDK** - Crates.io: `enrai-sdk`
 
 ### コミュニティSDK
 
-- **Ruby** - `hibana-ruby` (community-maintained)
-- **PHP** - `hibana-php` (community-maintained)
+- **Ruby** - `enrai-ruby` (community-maintained)
+- **PHP** - `enrai-php` (community-maintained)
 
 ---
 
@@ -381,7 +381,7 @@ curl https://your-domain.com/admin/users?q=john&limit=50 \
 ```http
 Deprecation: true
 Sunset: Sat, 1 Jan 2026 00:00:00 GMT
-Link: <https://docs.hibana.dev/migration/v2>; rel="sunset"
+Link: <https://docs.enrai.org/migration/v2>; rel="sunset"
 ```
 
 ---
@@ -397,11 +397,11 @@ Link: <https://docs.hibana.dev/migration/v2>; rel="sunset"
 
 ### Issue報告
 
-GitHub Issues: https://github.com/sgrastar/hibana/issues
+GitHub Issues: https://github.com/sgrastar/enrai/issues
 
 ### コントリビューション
 
-Pull Requests歓迎: https://github.com/sgrastar/hibana/pulls
+Pull Requests歓迎: https://github.com/sgrastar/enrai/pulls
 
 ---
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,9 +1,9 @@
 openapi: 3.1.0
 info:
-  title: Hibana OIDC OP API
+  title: Enrai OIDC OP API
   version: 1.0.0
   description: |
-    Hibana is a modern OpenID Connect Provider (OP) built for the edge.
+    Enrai is a modern OpenID Connect Provider (OP) built for the edge.
 
     **Features**:
     - ✅ OIDC Core 1.0 compliant
@@ -17,10 +17,10 @@ info:
     - Phase 4 Complete: OIDC Core + Extensions
     - Phase 5 Planning: UI/UX + Admin APIs
 
-    **Documentation**: https://github.com/sgrastar/hibana
+    **Documentation**: https://github.com/sgrastar/enrai
   contact:
-    name: Hibana Development Team
-    url: https://github.com/sgrastar/hibana
+    name: Enrai Development Team
+    url: https://github.com/sgrastar/enrai
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT
@@ -1668,4 +1668,4 @@ components:
           example: The request is missing a required parameter
         error_uri:
           type: string
-          example: https://docs.hibana.dev/errors/invalid_request
+          example: https://docs.enrai.org/errors/invalid_request

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -1,4 +1,4 @@
-# Hibana Database Schema - ER Diagram 🗄️
+# Enrai Database Schema - ER Diagram 🗄️
 
 **最終更新**: 2025-11-13
 **ステータス**: Phase 5 設計
@@ -19,7 +19,7 @@
 
 ## 概要
 
-このドキュメントは、Hibana OIDC OPのデータベーススキーマを定義します。
+このドキュメントは、Enrai OIDC OPのデータベーススキーマを定義します。
 
 ### 統計サマリー
 

--- a/docs/architecture/durable-objects.md
+++ b/docs/architecture/durable-objects.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Hibana uses Cloudflare Durable Objects for managing cryptographic keys and enabling zero-downtime key rotation. Durable Objects provide strongly consistent, distributed storage that is ideal for managing critical infrastructure like signing keys.
+Enrai uses Cloudflare Durable Objects for managing cryptographic keys and enabling zero-downtime key rotation. Durable Objects provide strongly consistent, distributed storage that is ideal for managing critical infrastructure like signing keys.
 
 ## KeyManager Durable Object
 
@@ -198,7 +198,7 @@ Configuration can be updated via the `/config` endpoint or by modifying the init
    - No public HTTP access to KeyManager endpoints
    - Use Cloudflare Access or Workers authentication
 
-### Usage in Hibana
+### Usage in Enrai
 
 #### Initialization
 
@@ -207,7 +207,7 @@ Configuration can be updated via the `/config` endpoint or by modifying the init
 [[durable_objects.bindings]]
 name = "KEY_MANAGER"
 class_name = "KeyManager"
-script_name = "hibana"
+script_name = "enrai"
 
 // In worker code
 const keyManagerId = env.KEY_MANAGER.idFromName('default');

--- a/docs/architecture/protocol-flow.md
+++ b/docs/architecture/protocol-flow.md
@@ -1,8 +1,8 @@
-# hibana – Protocol Flow Specification (for AI reasoning)
+# enrai – Protocol Flow Specification (for AI reasoning)
 
 ## 1. Overview
-This document describes the **end-to-end protocol flow** of the `hibana` OpenID Connect Provider (OP).
-The purpose is to enable automated systems (AI / LLM) to reason about hibana's behavior, data flow, and compliance with OIDC Core 1.0 and OAuth 2.0 specifications.
+This document describes the **end-to-end protocol flow** of the `enrai` OpenID Connect Provider (OP).
+The purpose is to enable automated systems (AI / LLM) to reason about enrai's behavior, data flow, and compliance with OIDC Core 1.0 and OAuth 2.0 specifications.
 
 **Related Documents:**
 - [Technical Specifications](./technical-specs.md) - System architecture and endpoint specifications
@@ -16,7 +16,7 @@ The purpose is to enable automated systems (AI / LLM) to reason about hibana's b
 |:--|:--|
 | **User Agent (UA)** | Web browser or client initiating authorization. |
 | **Relying Party (RP)** | The client application using OIDC to authenticate users. |
-| **hibana (OP)** | The OpenID Provider (implemented via Cloudflare Workers + Hono). |
+| **enrai (OP)** | The OpenID Provider (implemented via Cloudflare Workers + Hono). |
 | **Cloudflare KV** | Persistent store for transient states, codes, and nonces. |
 | **Durable Object** | Persistent key manager for JWK rotation and private key storage. |
 
@@ -195,7 +195,7 @@ IDLE
 ## 7. Sequence Diagram (Logical Representation)
 
 ```text
- RP                    hibana (OP)                 KV Store
+ RP                    enrai (OP)                 KV Store
  │                          │                          │
  │  GET /.well-known        │                          │
  │──────────────────────────>│                          │
@@ -228,7 +228,7 @@ IDLE
 
 ## 9. AI Interpretation Notes
 
-For AI systems analyzing hibana:
+For AI systems analyzing enrai:
 
 1. **Identify endpoints** — There are exactly five currently active endpoints: discovery, jwks, authorize, token, userinfo.
 2. **Stateful elements** — Only `KV` stores ephemeral data (`code`, `state`, `nonce`). No persistent DB.
@@ -250,5 +250,5 @@ For AI systems analyzing hibana:
 
 ---
 
-> *hibana* — igniting identity, one request at a time.
+> *enrai* — igniting identity, one request at a time.
 

--- a/docs/architecture/technical-specs.md
+++ b/docs/architecture/technical-specs.md
@@ -1,7 +1,7 @@
-# hibana – Technical Specification (for AI analysis)
+# enrai – Technical Specification (for AI analysis)
 
 ## 1. Project Overview
-**hibana** is a lightweight, standards-compliant **OpenID Connect Provider (OP)** implemented entirely on **Cloudflare Workers** using **Hono** as the routing framework.
+**enrai** is a lightweight, standards-compliant **OpenID Connect Provider (OP)** implemented entirely on **Cloudflare Workers** using **Hono** as the routing framework.
 It demonstrates that an individual developer can deploy a fully functional, globally distributed OpenID Provider (OIDC OP) at the edge.
 
 **Related Documents:**
@@ -33,7 +33,7 @@ It demonstrates that an individual developer can deploy a fully functional, glob
 
 ### 3.2 Logical Flow Diagram
 ```
-User → /authorize → [hibana OP] → redirect_uri (with code)
+User → /authorize → [enrai OP] → redirect_uri (with code)
 ↳ /token → returns { access_token, id_token }
 ↳ /userinfo → user claims (static or dynamic)
 ```
@@ -257,10 +257,10 @@ MIT License © 2025 [sgrastar](https://github.com/sgrastar)
 
 In short:
 
-* **hibana** is a Cloudflare Workers-based implementation of an **OpenID Provider (OP)**.
+* **enrai** is a Cloudflare Workers-based implementation of an **OpenID Provider (OP)**.
 * It adheres to **OIDC Core**, **Discovery**, and **OAuth 2.0** specifications.
 * It’s **stateless**, **edge-native**, and suitable for **OpenID Conformance certification**.
 * Its key innovation: *individual developers can deploy their own issuer on the edge.*
 
-> Conceptually: “hibana ignites identity — a spark of trust at the edge.”
+> Conceptually: “enrai ignites identity — a spark of trust at the edge.”
 

--- a/docs/archive/phase1-review-report.md
+++ b/docs/archive/phase1-review-report.md
@@ -1,6 +1,6 @@
 # Phase 1 コードレビュー & 完了報告書
 
-**プロジェクト:** Hibana OpenID Connect Provider
+**プロジェクト:** Enrai OpenID Connect Provider
 **レビュー日:** 2025-11-11（更新）
 **レビュー対象:** Phase 1 (Week 1-5) 実装
 **ステータス:** ✅ **完了（すべての修正完了、Phase 2開始可能）**
@@ -809,4 +809,4 @@ Phase 2（Week 6-12: Core OIDC Endpoints）を開始するための準備状況�
 **更新日:** 2025-11-11
 **次回レビュー:** Phase 2完了時（Week 12終了時）
 
-🔥 **Hibana - Phase 1 完全完了！Phase 2開始準備完了！**
+🔥 **Enrai - Phase 1 完全完了！Phase 2開始準備完了！**

--- a/docs/archive/phase2-prerequisites-checklist.md
+++ b/docs/archive/phase2-prerequisites-checklist.md
@@ -1,6 +1,6 @@
 # Phase 2 前提条件チェックリスト
 
-**プロジェクト:** Hibana OpenID Connect Provider
+**プロジェクト:** Enrai OpenID Connect Provider
 **作成日:** 2025-11-11
 **Phase 2期間:** Week 6-12
 **ステータス:** ✅ すべての前提条件を完全達成

--- a/docs/archive/phase5-certification-original.md
+++ b/docs/archive/phase5-certification-original.md
@@ -58,7 +58,7 @@
 
 #### Production Deployment
 - [ ] Production Cloudflare account setup
-- [ ] Custom domain configuration (`id.hibana.dev`)
+- [ ] Custom domain configuration (`id.enrai.org`)
 - [ ] DNS records setup
 - [ ] SSL/TLS configuration (with MTLS support)
 - [ ] Production secrets generation

--- a/docs/conformance/SETUP.md
+++ b/docs/conformance/SETUP.md
@@ -1,6 +1,6 @@
-# Hibana Development Setup Guide
+# Enrai Development Setup Guide
 
-This guide explains how to set up Hibana for local development and testing.
+This guide explains how to set up Enrai for local development and testing.
 
 ## Prerequisites
 

--- a/docs/conformance/manual-checklist.md
+++ b/docs/conformance/manual-checklist.md
@@ -1,4 +1,4 @@
-# Hibana Manual Conformance Checklist 💥
+# Enrai Manual Conformance Checklist 💥
 
 **Purpose:** Manual verification checklist for OpenID Connect Basic OP Profile conformance
 **Target:** Phase 3 - Testing & Validation
@@ -577,7 +577,7 @@ curl -i http://localhost:8787/authorize?response_type=invalid
 
 ---
 
-> 💥 **Hibana** - Manual conformance testing for Phase 3
+> 💥 **Enrai** - Manual conformance testing for Phase 3
 >
 > **初回テスト実施日:** 2025-11-11 (適合率: 38.9%)
 > **再テスト実施日:** 2025-11-11 (適合率: 88.9%)

--- a/docs/conformance/overview.md
+++ b/docs/conformance/overview.md
@@ -1,7 +1,7 @@
-# hibana – Conformance Overview
+# enrai – Conformance Overview
 
 ## 1. Vision
-**hibana** is a lightweight, edge-native OpenID Connect Provider designed to show that
+**enrai** is a lightweight, edge-native OpenID Connect Provider designed to show that
 a single developer can operate a fully compliant identity provider — safely, globally, and at minimal cost.
 
 Its conformance goal is not only certification, but **to redefine what "compliant infrastructure" means in the era of serverless computing.**
@@ -69,7 +69,7 @@ Its conformance goal is not only certification, but **to redefine what "complian
 
 | Attribute | Value |
 |:--|:--|
-| **Issuer (iss)** | `https://id.hibana.dev` |
+| **Issuer (iss)** | `https://id.enrai.org` |
 | **Profile** | Basic OpenID Provider |
 | **Conformance Suite** | `https://openid.net/certification/` |
 | **Deployment Type** | Cloudflare Workers |
@@ -88,7 +88,7 @@ Its conformance goal is not only certification, but **to redefine what "complian
 ---
 
 ## 8. Long-Term Vision
-hibana aims to become the **reference “Edge OP”**:
+enrai aims to become the **reference “Edge OP”**:
 - Zero infrastructure overhead.
 - Zero database dependencies.
 - Fully explainable OIDC compliance.
@@ -99,4 +99,4 @@ then compliance itself becomes democratized — not just centralized.
 
 ---
 
-> *hibana* — compliance as creation, not constraint.
+> *enrai* — compliance as creation, not constraint.

--- a/docs/conformance/phase3-quickstart.md
+++ b/docs/conformance/phase3-quickstart.md
@@ -1,7 +1,7 @@
 # Phase 3 クイックスタートガイド 🚀
 
 **所要時間:** 約30分
-**対象:** Hibana Phase 3テストの実施者
+**対象:** Enrai Phase 3テストの実施者
 **更新日:** 2025-11-11
 
 ---
@@ -21,7 +21,7 @@
 
 ```bash
 # プロジェクトルートに移動
-cd /path/to/hibana
+cd /path/to/enrai
 
 # 依存関係のインストール（初回のみ）
 npm install
@@ -73,7 +73,7 @@ jq -r '.kid' .keys/metadata.json
 
 ```toml
 [vars]
-ISSUER = "https://hibana.YOUR_SUBDOMAIN.workers.dev"
+ISSUER = "https://enrai.YOUR_SUBDOMAIN.workers.dev"
 KEY_ID = "ここに上でコピーしたKEY_IDを貼り付け"
 ALLOW_HTTP_REDIRECT = "false"
 ```
@@ -86,7 +86,7 @@ wrangler whoami
 # Account ID: xxxxxxxxxxxxxxxxxxxx
 ```
 
-通常は `hibana.YOUR_USERNAME.workers.dev` になります。
+通常は `enrai.YOUR_USERNAME.workers.dev` になります。
 
 ### 2.3 Secretsの設定
 
@@ -113,8 +113,8 @@ npm run deploy
 **✓ 期待される出力:**
 
 ```
-Published hibana (X.XX sec)
-  https://hibana.YOUR_SUBDOMAIN.workers.dev
+Published enrai (X.XX sec)
+  https://enrai.YOUR_SUBDOMAIN.workers.dev
 ```
 
 このURLをコピーしてメモします。
@@ -123,14 +123,14 @@ Published hibana (X.XX sec)
 
 ```bash
 # 環境変数に設定
-export HIBANA_URL="https://hibana.YOUR_SUBDOMAIN.workers.dev"
+export ENRAI_URL="https://enrai.YOUR_SUBDOMAIN.workers.dev"
 
 # Discovery endpoint
-curl $HIBANA_URL/.well-known/openid-configuration | jq .issuer
-# 出力が $HIBANA_URL と一致すればOK
+curl $ENRAI_URL/.well-known/openid-configuration | jq .issuer
+# 出力が $ENRAI_URL と一致すればOK
 
 # JWKS endpoint
-curl $HIBANA_URL/.well-known/jwks.json | jq '.keys[0].kty'
+curl $ENRAI_URL/.well-known/jwks.json | jq '.keys[0].kty'
 # 出力が "RSA" であればOK
 ```
 
@@ -159,12 +159,12 @@ curl $HIBANA_URL/.well-known/jwks.json | jq '.keys[0].kty'
    - Response Type: **code**
 3. 「Continue」をクリック
 
-### 3.3 Hibanaの設定
+### 3.3 Enraiの設定
 
 **Issuer URL** に以下を入力：
 
 ```
-https://hibana.YOUR_SUBDOMAIN.workers.dev
+https://enrai.YOUR_SUBDOMAIN.workers.dev
 ```
 
 「Discover」ボタンをクリックすると、自動的にメタデータが読み込まれます。
@@ -173,7 +173,7 @@ https://hibana.YOUR_SUBDOMAIN.workers.dev
 
 1. 「Start Test」をクリック
 2. ブラウザで Authorization URL が表示されたらクリック
-3. Hibana の認可エンドポイントにリダイレクトされます
+3. Enrai の認可エンドポイントにリダイレクトされます
 4. 自動的にテストスイートにリダイレクトされ、テストが続行されます
 
 ### 3.5 結果の確認
@@ -234,7 +234,7 @@ git push origin claude/phase3-test-documentation-011CV2461YR1rAMaAnJdqK1v
 **解決方法:**
 ```bash
 # HTTPSアクセスを確認
-curl -I $HIBANA_URL/.well-known/openid-configuration
+curl -I $ENRAI_URL/.well-known/openid-configuration
 
 # 200 OK が返ることを確認
 ```
@@ -250,7 +250,7 @@ cat .keys/public.jwk.json | jq -c . | wrangler secret put PUBLIC_JWK_JSON
 npm run deploy
 
 # 確認
-curl $HIBANA_URL/.well-known/jwks.json | jq
+curl $ENRAI_URL/.well-known/jwks.json | jq
 ```
 
 ### 問題: "Token endpoint error (500)"
@@ -337,12 +337,12 @@ Phase 3完了のためのチェックリスト：
 - [Cloudflare Workers Docs](https://developers.cloudflare.com/workers/)
 
 **サポート:**
-- GitHub Issues: https://github.com/sgrastar/hibana/issues
+- GitHub Issues: https://github.com/sgrastar/enrai/issues
 - TASKS.md: Phase 3 タスクリスト
 
 ---
 
-> 💥 **Hibana Phase 3** - 30分でConformance Testing開始
+> 💥 **Enrai Phase 3** - 30分でConformance Testing開始
 >
 > **更新日:** 2025-11-11
 > **所要時間:** 約30分

--- a/docs/conformance/test-plan.md
+++ b/docs/conformance/test-plan.md
@@ -1,7 +1,7 @@
-# hibana – OpenID Conformance Testing Plan (for AI validation)
+# enrai – OpenID Conformance Testing Plan (for AI validation)
 
 ## 1. Purpose
-This document defines the **mapping between hibana's endpoints and the OpenID Foundation's Conformance Test Suite requirements**.
+This document defines the **mapping between enrai's endpoints and the OpenID Foundation's Conformance Test Suite requirements**.
 It enables AI systems to:
 - simulate tests,
 - assess compliance coverage,
@@ -41,7 +41,7 @@ It enables AI systems to:
 ## 4. Conformance Categories
 
 ### 4.1 OpenID Connect Core 1.0
-| Requirement | hibana Behavior | Status |
+| Requirement | enrai Behavior | Status |
 |:--|:--|:--|
 | Authorization Code Flow | Implemented via `/authorize` + `/token` | ✅ |
 | ID Token generation (RS256) | JOSE-based signing | ✅ |
@@ -72,7 +72,7 @@ It enables AI systems to:
 | OP iframe session state | N/A | ❌ |
 
 ### 4.5 OAuth 2.0 (RFC 6749 / 6750)
-| Requirement | hibana Behavior | Status |
+| Requirement | enrai Behavior | Status |
 |:--|:--|:--|
 | Authorization Code grant type | Supported | ✅ |
 | Bearer Token usage | Supported | ✅ |
@@ -80,7 +80,7 @@ It enables AI systems to:
 | HTTPS enforced | Always (Cloudflare TLS) | ✅ |
 
 ### 4.6 JWT / JWK (RFC 7517 / 7519)
-| Requirement | hibana Behavior | Status |
+| Requirement | enrai Behavior | Status |
 |:--|:--|:--|
 | RS256 signature | Implemented via JOSE | ✅ |
 | Public JWK exposure | Implemented | ✅ |
@@ -92,7 +92,7 @@ It enables AI systems to:
 
 ## 5. Negative Test Scenarios
 
-| Scenario | Expected Behavior | hibana Response | Status |
+| Scenario | Expected Behavior | enrai Response | Status |
 |:--|:--|:--|:--|
 | Invalid `client_id` | Return error | `invalid_client` | ✅ |
 | Expired code | Return error | `invalid_grant` | ✅ |
@@ -181,7 +181,7 @@ Core (8/8) + Discovery (3/3) + OAuth2 (4/4) + JWT/JWK (5/5)
 ---
 
 ## 11. AI Summary Context
-For AI systems evaluating hibana:
+For AI systems evaluating enrai:
 
 - The implementation covers **Core + Discovery + OAuth2 + JWT/JWK** completely.  
 - Lacking modules: Dynamic Registration, Session Management.  
@@ -197,4 +197,4 @@ REDIRECT_URI=https://rp.example.dev/callback
 
 ---
 
-> *hibana* — igniting standards compliance, one spec at a time.
+> *enrai* — igniting standards compliance, one spec at a time.

--- a/docs/conformance/test-results/README.md
+++ b/docs/conformance/test-results/README.md
@@ -1,4 +1,4 @@
-# Hibana - OpenID Conformance Test Results
+# Enrai - OpenID Conformance Test Results
 
 このディレクトリには、OpenID Conformance Suiteでのテスト結果を保存します。
 
@@ -69,4 +69,4 @@ vim report-$(date +%Y%m%d).md
 
 ---
 
-> 💥 **Hibana** - Test results tracking for OpenID Conformance
+> 💥 **Enrai** - Test results tracking for OpenID Conformance

--- a/docs/conformance/test-results/conformance-suite-results-20251112.md
+++ b/docs/conformance/test-results/conformance-suite-results-20251112.md
@@ -7,14 +7,14 @@
 **Started:** 2025-11-11T14:22:56.814584450Z
 **Certification Profile:** Basic OP
 **Variant:** server_metadata=discovery, client_registration=static_client
-**Description:** Hibana OpenID Provider Basic Certification Test
-**Issuer:** https://hibana.sgrastar.workers.dev
+**Description:** Enrai OpenID Provider Basic Certification Test
+**Issuer:** https://enrai.sgrastar.workers.dev
 
 ---
 
 ## Executive Summary
 
-このドキュメントは、OpenID Foundation Conformance Suite を使用した Hibana の公式テスト結果を記録しています。
+このドキュメントは、OpenID Foundation Conformance Suite を使用した Enrai の公式テスト結果を記録しています。
 
 ### Test Results Overview
 
@@ -326,7 +326,7 @@ Timeline: 7 months (Mar 2026 - Sep 2026)
 
 ### Why 72.7% is Actually Excellent for Phase 3
 
-**Design Decision:** Hibana follows a phased implementation approach.
+**Design Decision:** Enrai follows a phased implementation approach.
 
 1. **Phase 3 Scope: Core OIDC Features**
    - Discovery, JWKS, Authorization, Token, UserInfo
@@ -353,7 +353,7 @@ Timeline: 7 months (Mar 2026 - Sep 2026)
 
 ### Feature Completeness vs. Other OpenID Providers
 
-| Feature Category | Hibana (Phase 3) | Auth0 | Keycloak | Okta |
+| Feature Category | Enrai (Phase 3) | Auth0 | Keycloak | Okta |
 |-----------------|------------------|-------|----------|------|
 | Core OIDC Flow | ✅ 100% | ✅ | ✅ | ✅ |
 | Standard Scopes | ✅ 100% | ✅ | ✅ | ✅ |
@@ -366,7 +366,7 @@ Timeline: 7 months (Mar 2026 - Sep 2026)
 | Edge Deployment | ✅ Cloudflare | ❌ | ❌ | Proprietary |
 | Open Source | ✅ MIT | ❌ | ✅ | ❌ |
 
-**Hibana's Unique Value:**
+**Enrai's Unique Value:**
 - 💥 Edge-native (Cloudflare Workers)
 - 🚀 <50ms global latency
 - 📦 One-command deployment (planned Phase 7)
@@ -378,7 +378,7 @@ Timeline: 7 months (Mar 2026 - Sep 2026)
 
 ### Phase 3 Summary
 
-Hibana Phase 3 は、**OpenID Connect Basic OP Profile のコア機能を完全に実装**し、OpenID Foundation Conformance Suite で **23/24 テスト（95.8%）を合格**しました。
+Enrai Phase 3 は、**OpenID Connect Basic OP Profile のコア機能を完全に実装**し、OpenID Foundation Conformance Suite で **23/24 テスト（95.8%）を合格**しました。
 
 **Key Achievements:**
 - ✅ すべての標準 OIDC スコープ実装
@@ -406,4 +406,4 @@ Hibana Phase 3 は、**OpenID Connect Basic OP Profile のコア機能を完全�
 - Conformance Suite: https://www.certification.openid.net/
 - Plan ID: e90FqMh4xG2mg
 - Test Version: 5.1.36
-- Issuer: https://hibana.sgrastar.workers.dev
+- Issuer: https://enrai.sgrastar.workers.dev

--- a/docs/conformance/test-results/performance-results-20251112-000439.md
+++ b/docs/conformance/test-results/performance-results-20251112-000439.md
@@ -1,8 +1,8 @@
-# Hibana Performance Benchmark Results
+# Enrai Performance Benchmark Results
 
 **Test Date:** 2025-11-12
 **Test Time:** 00:04:39
-**Issuer:** https://hibana.sgrastar.workers.dev
+**Issuer:** https://enrai.sgrastar.workers.dev
 **Test Environment:** Production (Cloudflare Workers)
 **Tester:** Automated Script
 
@@ -24,7 +24,7 @@
 
 ### Discovery Endpoint
 
-**Endpoint:** `https://hibana.sgrastar.workers.dev/.well-known/openid-configuration`
+**Endpoint:** `https://enrai.sgrastar.workers.dev/.well-known/openid-configuration`
 
 | Metric | Value | Target | Status |
 |--------|-------|--------|--------|
@@ -45,7 +45,7 @@
 
 ### JWKS Endpoint
 
-**Endpoint:** `https://hibana.sgrastar.workers.dev/.well-known/jwks.json`
+**Endpoint:** `https://enrai.sgrastar.workers.dev/.well-known/jwks.json`
 
 | Metric | Value | Target | Status |
 |--------|-------|--------|--------|
@@ -66,7 +66,7 @@
 
 ### Authorization Endpoint (Error Response)
 
-**Endpoint:** `https://hibana.sgrastar.workers.dev/authorize?response_type=code&client_id=test&redirect_uri=https://example.com/callback`
+**Endpoint:** `https://enrai.sgrastar.workers.dev/authorize?response_type=code&client_id=test&redirect_uri=https://example.com/callback`
 
 | Metric | Value | Target | Status |
 |--------|-------|--------|--------|
@@ -87,7 +87,7 @@
 
 ### UserInfo Endpoint (Error Response)
 
-**Endpoint:** `https://hibana.sgrastar.workers.dev/userinfo`
+**Endpoint:** `https://enrai.sgrastar.workers.dev/userinfo`
 
 | Metric | Value | Target | Status |
 |--------|-------|--------|--------|

--- a/docs/conformance/test-results/report-20251112.md
+++ b/docs/conformance/test-results/report-20251112.md
@@ -1,18 +1,18 @@
-# Hibana - OpenID Conformance Test Report
+# Enrai - OpenID Conformance Test Report
 
 **Test Date:** 2025-11-12
 **Tester:** Yuta Hoshina + Claude Code
-**Hibana Version:** Phase 3 (Complete)
+**Enrai Version:** Phase 3 (Complete)
 **Environment:** Cloudflare Workers (Production)
 **Test Suite:** OpenID Connect Basic OP Profile
-**Issuer URL:** https://hibana.sgrastar.workers.dev
+**Issuer URL:** https://enrai.sgrastar.workers.dev
 **Conformance Plan ID:** e90FqMh4xG2mg
 
 ---
 
 ## Executive Summary
 
-このレポートは、**Phase 3 完了時点**でのHibanaのOpenID Connect Basic OP Profile準拠テストの最終結果をまとめたものです。
+このレポートは、**Phase 3 完了時点**でのEnraiのOpenID Connect Basic OP Profile準拠テストの最終結果をまとめたものです。
 
 ### Test Results Overview
 
@@ -50,12 +50,12 @@
 
 | Item | Value |
 |------|-------|
-| Issuer URL | https://hibana.sgrastar.workers.dev |
-| Discovery Endpoint | https://hibana.sgrastar.workers.dev/.well-known/openid-configuration |
-| JWKS Endpoint | https://hibana.sgrastar.workers.dev/.well-known/jwks.json |
-| Authorization Endpoint | https://hibana.sgrastar.workers.dev/authorize |
-| Token Endpoint | https://hibana.sgrastar.workers.dev/token |
-| UserInfo Endpoint | https://hibana.sgrastar.workers.dev/userinfo |
+| Issuer URL | https://enrai.sgrastar.workers.dev |
+| Discovery Endpoint | https://enrai.sgrastar.workers.dev/.well-known/openid-configuration |
+| JWKS Endpoint | https://enrai.sgrastar.workers.dev/.well-known/jwks.json |
+| Authorization Endpoint | https://enrai.sgrastar.workers.dev/authorize |
+| Token Endpoint | https://enrai.sgrastar.workers.dev/token |
+| UserInfo Endpoint | https://enrai.sgrastar.workers.dev/userinfo |
 
 ### Configuration
 
@@ -440,7 +440,7 @@
 
 ## Conclusion
 
-Phase 3 の実装により、Hibana は以下を達成しました：
+Phase 3 の実装により、Enrai は以下を達成しました：
 
 ### ✅ 達成事項
 - **Token Revocation on Code Reuse**: RFC 6749 Section 4.1.2 完全準拠

--- a/docs/conformance/test-results/report-template.md
+++ b/docs/conformance/test-results/report-template.md
@@ -1,17 +1,17 @@
-# Hibana - OpenID Conformance Test Report
+# Enrai - OpenID Conformance Test Report
 
 **Test Date:** YYYY-MM-DD
 **Tester:** Your Name
-**Hibana Version:** vX.Y.Z
+**Enrai Version:** vX.Y.Z
 **Environment:** Cloudflare Workers
 **Test Suite:** OpenID Connect Basic OP Profile
-**Issuer URL:** https://hibana.YOUR_SUBDOMAIN.workers.dev
+**Issuer URL:** https://enrai.YOUR_SUBDOMAIN.workers.dev
 
 ---
 
 ## Executive Summary
 
-このレポートは、HibanaのOpenID Connect Basic OP Profile準拠テストの結果をまとめたものです。
+このレポートは、EnraiのOpenID Connect Basic OP Profile準拠テストの結果をまとめたものです。
 
 **テスト結果サマリー:**
 - **Overall Conformance Score:** XX.X%
@@ -30,12 +30,12 @@
 
 | Item | Value |
 |------|-------|
-| Issuer URL | https://hibana.YOUR_SUBDOMAIN.workers.dev |
-| Discovery Endpoint | https://hibana.YOUR_SUBDOMAIN.workers.dev/.well-known/openid-configuration |
-| JWKS Endpoint | https://hibana.YOUR_SUBDOMAIN.workers.dev/.well-known/jwks.json |
-| Authorization Endpoint | https://hibana.YOUR_SUBDOMAIN.workers.dev/authorize |
-| Token Endpoint | https://hibana.YOUR_SUBDOMAIN.workers.dev/token |
-| UserInfo Endpoint | https://hibana.YOUR_SUBDOMAIN.workers.dev/userinfo |
+| Issuer URL | https://enrai.YOUR_SUBDOMAIN.workers.dev |
+| Discovery Endpoint | https://enrai.YOUR_SUBDOMAIN.workers.dev/.well-known/openid-configuration |
+| JWKS Endpoint | https://enrai.YOUR_SUBDOMAIN.workers.dev/.well-known/jwks.json |
+| Authorization Endpoint | https://enrai.YOUR_SUBDOMAIN.workers.dev/authorize |
+| Token Endpoint | https://enrai.YOUR_SUBDOMAIN.workers.dev/token |
+| UserInfo Endpoint | https://enrai.YOUR_SUBDOMAIN.workers.dev/userinfo |
 
 ### Configuration
 
@@ -378,7 +378,7 @@
   "test_plan": "Basic OP",
   "client_type": "public",
   "response_type": "code",
-  "issuer": "https://hibana.YOUR_SUBDOMAIN.workers.dev",
+  "issuer": "https://enrai.YOUR_SUBDOMAIN.workers.dev",
   "signing_algorithm": "RS256"
 }
 ```
@@ -387,7 +387,7 @@
 
 | Variable | Value |
 |----------|-------|
-| ISSUER | https://hibana.YOUR_SUBDOMAIN.workers.dev |
+| ISSUER | https://enrai.YOUR_SUBDOMAIN.workers.dev |
 | KEY_ID | edge-key-1 |
 | TOKEN_TTL | 3600 |
 | CODE_TTL | 120 |
@@ -403,8 +403,8 @@
 
 - [OpenID Connect Core Specification](https://openid.net/specs/openid-connect-core-1_0.html)
 - [OpenID Conformance Testing](https://openid.net/certification/testing/)
-- [Hibana Testing Guide](../testing-guide.md)
-- [Hibana Manual Checklist](../manual-checklist.md)
+- [Enrai Testing Guide](../testing-guide.md)
+- [Enrai Manual Checklist](../manual-checklist.md)
 
 ---
 
@@ -418,7 +418,7 @@
 
 ---
 
-> 💥 **Hibana** - OpenID Conformance Test Report
+> 💥 **Enrai** - OpenID Conformance Test Report
 >
 > **Version:** vX.Y.Z
 > **Report Date:** YYYY-MM-DD

--- a/docs/conformance/testing-guide.md
+++ b/docs/conformance/testing-guide.md
@@ -1,4 +1,4 @@
-# Hibana - OpenID Conformance Testing Guide (Without Docker) 💥
+# Enrai - OpenID Conformance Testing Guide (Without Docker) 💥
 
 **目的:** Docker環境がない場合のOpenID Connect準拠テストの実施方法
 **対象:** Phase 3 - Testing & Validation
@@ -8,10 +8,10 @@
 
 ## 概要
 
-このガイドでは、Docker環境がない場合にHibanaのOpenID Connect準拠性をテストする方法を説明します。OpenID FoundationのオンラインConformance Suiteを使用することで、ローカルにDockerをインストールすることなく、正式な認証テストを実施できます。
+このガイドでは、Docker環境がない場合にEnraiのOpenID Connect準拠性をテストする方法を説明します。OpenID FoundationのオンラインConformance Suiteを使用することで、ローカルにDockerをインストールすることなく、正式な認証テストを実施できます。
 
 **前提条件:**
-- Hibanaが公開アクセス可能なURLでデプロイされていること（Cloudflare Workers）
+- Enraiが公開アクセス可能なURLでデプロイされていること（Cloudflare Workers）
 - HTTPSでアクセス可能であること
 - OpenID Foundationのアカウント（無料）
 
@@ -32,11 +32,11 @@
 
 ### 1.1 デプロイ前のローカルテスト
 
-公開デプロイの前に、ローカル環境でHibanaが正常に動作することを確認します。
+公開デプロイの前に、ローカル環境でEnraiが正常に動作することを確認します。
 
 ```bash
 # プロジェクトルートに移動
-cd /path/to/hibana
+cd /path/to/enrai
 
 # RSA鍵を生成（未実施の場合）
 ./scripts/setup-dev.sh
@@ -104,12 +104,12 @@ cat .keys/public.jwk.json | jq -c . | wrangler secret put PUBLIC_JWK_JSON
 `wrangler.toml` を開き、以下を確認します：
 
 ```toml
-name = "hibana"
+name = "enrai"
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
 
 [vars]
-ISSUER = "https://hibana.YOUR_SUBDOMAIN.workers.dev"
+ISSUER = "https://enrai.YOUR_SUBDOMAIN.workers.dev"
 KEY_ID = "edge-key-1"  # .keys/metadata.json の kid と一致させる
 TOKEN_TTL = "3600"
 CODE_TTL = "120"
@@ -152,9 +152,9 @@ npm run deploy
 
 ```
 Total Upload: XX.XX KiB / gzip: XX.XX KiB
-Uploaded hibana (X.XX sec)
-Published hibana (X.XX sec)
-  https://hibana.YOUR_SUBDOMAIN.workers.dev
+Uploaded enrai (X.XX sec)
+Published enrai (X.XX sec)
+  https://enrai.YOUR_SUBDOMAIN.workers.dev
 Current Deployment ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
@@ -165,13 +165,13 @@ Current Deployment ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 デプロイされたエンドポイントをテストします：
 
 ```bash
-HIBANA_URL="https://hibana.YOUR_SUBDOMAIN.workers.dev"
+ENRAI_URL="https://enrai.YOUR_SUBDOMAIN.workers.dev"
 
 # Discovery endpoint
-curl $HIBANA_URL/.well-known/openid-configuration | jq
+curl $ENRAI_URL/.well-known/openid-configuration | jq
 
 # JWKS endpoint
-curl $HIBANA_URL/.well-known/jwks.json | jq
+curl $ENRAI_URL/.well-known/jwks.json | jq
 ```
 
 **確認ポイント:**
@@ -210,29 +210,29 @@ curl $HIBANA_URL/.well-known/jwks.json | jq
 
 ### 3.3 OP（OpenID Provider）情報の入力
 
-テストプランの設定画面で、Hibanaの情報を入力します：
+テストプランの設定画面で、Enraiの情報を入力します：
 
 | フィールド | 値 | 例 |
 |-----------|-----|-----|
-| **Issuer** | デプロイしたWorkerのURL | `https://hibana.YOUR_SUBDOMAIN.workers.dev` |
-| **Discovery URL** | `{ISSUER}/.well-known/openid-configuration` | `https://hibana.YOUR_SUBDOMAIN.workers.dev/.well-known/openid-configuration` |
+| **Issuer** | デプロイしたWorkerのURL | `https://enrai.YOUR_SUBDOMAIN.workers.dev` |
+| **Discovery URL** | `{ISSUER}/.well-known/openid-configuration` | `https://enrai.YOUR_SUBDOMAIN.workers.dev/.well-known/openid-configuration` |
 
-「Discover」ボタンをクリックすると、自動的にHibanaのメタデータが読み込まれます。
+「Discover」ボタンをクリックすると、自動的にEnraiのメタデータが読み込まれます。
 
 ### 3.4 クライアント登録
 
 OpenID Conformance Suiteが使用するテストクライアント情報を記録します。
 
-**現状の制限:** Hibanaは現在、Dynamic Client Registrationを実装していないため、静的なクライアント情報を使用します。
+**現状の制限:** Enraiは現在、Dynamic Client Registrationを実装していないため、静的なクライアント情報を使用します。
 
 以下の情報をメモします：
 
 ```
 Client ID: conformance-test-client
 Redirect URIs:
-  - https://www.certification.openid.net/test/a/hibana/callback
-  - https://www.certification.openid.net/test/a/hibana/callback?dummy1=lorem
-  - https://www.certification.openid.net/test/a/hibana/callback?dummy2=ipsum
+  - https://www.certification.openid.net/test/a/enrai/callback
+  - https://www.certification.openid.net/test/a/enrai/callback?dummy1=lorem
+  - https://www.certification.openid.net/test/a/enrai/callback?dummy2=ipsum
 ```
 
 **注意:** Dynamic Client Registrationが実装されるまで（Phase 4予定）、テストスイートの一部は手動で設定する必要があります。
@@ -242,14 +242,14 @@ Redirect URIs:
 Phase 4でDynamic Client Registration (`/register` endpoint) が実装された後は、以下の手順でクライアントを自動登録できます：
 
 ```bash
-curl -X POST $HIBANA_URL/register \
+curl -X POST $ENRAI_URL/register \
   -H "Content-Type: application/json" \
   -d '{
     "client_name": "OpenID Conformance Test Client",
     "redirect_uris": [
-      "https://www.certification.openid.net/test/a/hibana/callback",
-      "https://www.certification.openid.net/test/a/hibana/callback?dummy1=lorem",
-      "https://www.certification.openid.net/test/a/hibana/callback?dummy2=ipsum"
+      "https://www.certification.openid.net/test/a/enrai/callback",
+      "https://www.certification.openid.net/test/a/enrai/callback?dummy1=lorem",
+      "https://www.certification.openid.net/test/a/enrai/callback?dummy2=ipsum"
     ],
     "response_types": ["code"],
     "grant_types": ["authorization_code"],
@@ -289,7 +289,7 @@ OpenID Conformance Suiteで以下のテストモジュールを選択します�
 1. テストモジュールを選択後、「Start Test」をクリック
 
 2. ブラウザで表示される指示に従います：
-   - Authorization URLが表示されたら、クリックしてHibanaの認可エンドポイントにアクセス
+   - Authorization URLが表示されたら、クリックしてEnraiの認可エンドポイントにアクセス
    - リダイレクト後、テストスイートが自動的に続行します
 
 3. 各テストの実行中に表示されるログを確認します
@@ -344,7 +344,7 @@ OpenID Conformance Suiteで以下のテストモジュールを選択します�
 - JWKS tests: 100% pass
 - Optional tests: 推奨される
 
-**Hibanaの目標:**
+**Enraiの目標:**
 - ≥85% overall conformance score
 - 0 critical failures
 - Dynamic Client Registration実装後: ≥95%
@@ -372,11 +372,11 @@ mv conformance-test-result-*.json result-$(date +%Y%m%d).json
 テスト結果を以下のテンプレートでレポートにまとめます：
 
 ```markdown
-# Hibana - OpenID Conformance Test Report
+# Enrai - OpenID Conformance Test Report
 
 **Test Date:** YYYY-MM-DD
 **Tester:** Your Name
-**Hibana Version:** vX.Y.Z
+**Enrai Version:** vX.Y.Z
 **Environment:** Cloudflare Workers
 **Test Suite:** OpenID Connect Basic OP Profile
 
@@ -473,7 +473,7 @@ npm run deploy
 ```toml
 # wrangler.toml を編集
 [vars]
-ISSUER = "https://hibana.YOUR_SUBDOMAIN.workers.dev"
+ISSUER = "https://enrai.YOUR_SUBDOMAIN.workers.dev"
 ```
 
 ```bash
@@ -484,14 +484,14 @@ npm run deploy
 #### 問題: Conformance Suiteが"Unable to connect"エラーを表示
 
 **原因:**
-- HibanaがHTTPSでアクセスできない
+- EnraiがHTTPSでアクセスできない
 - CORS設定が間違っている
 - ファイアウォールがアクセスをブロックしている
 
 **解決方法:**
 ```bash
 # HTTPSアクセスを確認
-curl -I https://hibana.YOUR_SUBDOMAIN.workers.dev/.well-known/openid-configuration
+curl -I https://enrai.YOUR_SUBDOMAIN.workers.dev/.well-known/openid-configuration
 
 # CORS設定を確認（src/index.ts）
 # 必要に応じてCORSミドルウェアを追加
@@ -538,7 +538,7 @@ npm test -- --grep "token"
 - [Cloudflare Workers Documentation](https://developers.cloudflare.com/workers/)
 
 **コミュニティ:**
-- Hibana GitHub Issues: https://github.com/sgrastar/hibana/issues
+- Enrai GitHub Issues: https://github.com/sgrastar/enrai/issues
 - OpenID Foundation: https://openid.net/
 
 **参考資料:**
@@ -633,7 +633,7 @@ Dynamic Client Registration実装後（Phase 4予定）:
 
 ---
 
-> 💥 **Hibana** - Docker不要のOpenID Conformance Testing
+> 💥 **Enrai** - Docker不要のOpenID Conformance Testing
 >
 > **更新日:** 2025-11-11
 > **ステータス:** Phase 3 - Testing & Validation

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -1,4 +1,4 @@
-# Hibana Design System 🎨
+# Enrai Design System 🎨
 
 **最終更新**: 2025-11-13
 **バージョン**: 1.0.0
@@ -25,7 +25,7 @@
 
 ## 概要
 
-Hibana Design Systemは、**Auth0/Clerkを超えるUX**を実現するための統一されたデザイン言語です。
+Enrai Design Systemは、**Auth0/Clerkを超えるUX**を実現するための統一されたデザイン言語です。
 
 ### 設計目標
 
@@ -224,7 +224,7 @@ font-family: 'Fira Code', 'Consolas', 'Monaco', 'Courier New', monospace;
 ```html
 <!-- ヒーロー見出し -->
 <h1 class="text-4xl font-bold text-gray-900 dark:text-white">
-  Welcome to Hibana
+  Welcome to Enrai
 </h1>
 
 <!-- セクション見出し -->
@@ -955,7 +955,7 @@ export default defineConfig({
 - [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)
 - [A11y Project](https://www.a11yproject.com/)
 
-### Hibanaドキュメント
+### Enraiドキュメント
 
 - [database-schema.md](../architecture/database-schema.md) - データベーススキーマ
 - [openapi.yaml](../api/openapi.yaml) - API仕様書

--- a/docs/design/wireframes.md
+++ b/docs/design/wireframes.md
@@ -1,4 +1,4 @@
-# Hibana UI Wireframes 📐
+# Enrai UI Wireframes 📐
 
 **最終更新**: 2025-11-13
 **バージョン**: 1.0.0
@@ -20,7 +20,7 @@
 
 ## 概要
 
-このドキュメントは、Hibana OIDC OPの全13ページのワイヤーフレームを定義します。
+このドキュメントは、Enrai OIDC OPの全13ページのワイヤーフレームを定義します。
 
 ### ページ一覧
 
@@ -121,7 +121,7 @@ graph TD
 ```
 ┌─────────────────────────────────────────┐
 │                                         │
-│              [Hibana Logo]              │
+│              [Enrai Logo]              │
 │                                         │
 │         Sign in to your account         │
 │     Continue to access your apps        │
@@ -158,7 +158,7 @@ graph TD
 
     <!-- Logo -->
     <div class="text-center mb-8">
-      <img src="/logo.svg" alt="Hibana" class="h-12 mx-auto" />
+      <img src="/logo.svg" alt="Enrai" class="h-12 mx-auto" />
     </div>
 
     <!-- Card -->
@@ -272,7 +272,7 @@ graph TD
 ```
 ┌─────────────────────────────────────────┐
 │                                         │
-│              [Hibana Logo]              │
+│              [Enrai Logo]              │
 │                                         │
 │         Create your account             │
 │     Join thousands of users             │
@@ -315,7 +315,7 @@ graph TD
   <div class="w-full max-w-md">
 
     <div class="text-center mb-8">
-      <img src="/logo.svg" alt="Hibana" class="h-12 mx-auto" />
+      <img src="/logo.svg" alt="Enrai" class="h-12 mx-auto" />
     </div>
 
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 sm:p-8">
@@ -417,7 +417,7 @@ graph TD
 ```
 ┌─────────────────────────────────────────┐
 │                                         │
-│              [Hibana Logo]              │
+│              [Enrai Logo]              │
 │                                         │
 │               [✉️ Icon]                 │
 │                                         │
@@ -448,7 +448,7 @@ graph TD
   <div class="w-full max-w-md text-center">
 
     <div class="mb-8">
-      <img src="/logo.svg" alt="Hibana" class="h-12 mx-auto" />
+      <img src="/logo.svg" alt="Enrai" class="h-12 mx-auto" />
     </div>
 
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-8">
@@ -529,7 +529,7 @@ graph TD
 ```
 ┌─────────────────────────────────────────┐
 │                                         │
-│              [Hibana Logo]              │
+│              [Enrai Logo]              │
 │                                         │
 │          [⏳ Spinner Icon]              │
 │                                         │
@@ -544,7 +544,7 @@ graph TD
 
 ┌─────────────────────────────────────────┐
 │                                         │
-│              [Hibana Logo]              │
+│              [Enrai Logo]              │
 │                                         │
 │               [❌ Icon]                 │
 │                                         │
@@ -570,7 +570,7 @@ graph TD
   <div class="w-full max-w-md text-center">
 
     <div class="mb-8">
-      <img src="/logo.svg" alt="Hibana" class="h-12 mx-auto" />
+      <img src="/logo.svg" alt="Enrai" class="h-12 mx-auto" />
     </div>
 
     {#if loading}
@@ -632,13 +632,13 @@ graph TD
 ```
 ┌─────────────────────────────────────────┐
 │                                         │
-│              [Hibana Logo]              │
+│              [Enrai Logo]              │
 │                                         │
 │  ┌───────────────────────────────────┐ │
 │  │ [Client Logo]                     │ │
 │  │                                   │ │
 │  │  MyApp wants to access your      │ │
-│  │  Hibana account                  │ │
+│  │  Enrai account                  │ │
 │  │                                   │ │
 │  │  This will allow MyApp to:       │ │
 │  │  ✓ View your email address       │ │
@@ -673,7 +673,7 @@ graph TD
   <div class="w-full max-w-md">
 
     <div class="text-center mb-8">
-      <img src="/logo.svg" alt="Hibana" class="h-12 mx-auto" />
+      <img src="/logo.svg" alt="Enrai" class="h-12 mx-auto" />
     </div>
 
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
@@ -684,7 +684,7 @@ graph TD
           <img src={client.logo_uri} alt={client.client_name} class="h-16 mx-auto mb-4 rounded" />
         {/if}
         <h1 class="text-xl font-semibold text-gray-900 dark:text-white mb-2">
-          {client.client_name} wants to access your Hibana account
+          {client.client_name} wants to access your Enrai account
         </h1>
       </div>
 
@@ -774,7 +774,7 @@ graph TD
 ```
 ┌─────────────────────────────────────────┐
 │                                         │
-│              [Hibana Logo]              │
+│              [Enrai Logo]              │
 │                                         │
 │               [⚠️ Icon]                 │
 │                                         │
@@ -800,7 +800,7 @@ graph TD
   <div class="w-full max-w-md text-center">
 
     <div class="mb-8">
-      <img src="/logo.svg" alt="Hibana" class="h-12 mx-auto" />
+      <img src="/logo.svg" alt="Enrai" class="h-12 mx-auto" />
     </div>
 
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-8">
@@ -862,7 +862,7 @@ graph TD
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│ [≡] Hibana Admin                      [🔍] [🔔] [👤 Admin ▾]   │
+│ [≡] Enrai Admin                      [🔍] [🔔] [👤 Admin ▾]   │
 ├──────────┬──────────────────────────────────────────────────────┤
 │          │  Dashboard                                           │
 │ 📊 Dash  │                                                      │
@@ -899,7 +899,7 @@ graph TD
           <svg class="w-6 h-6"><!-- menu icon --></svg>
         </button>
         <h1 class="text-xl font-semibold text-gray-900 dark:text-white">
-          Hibana Admin
+          Enrai Admin
         </h1>
       </div>
       <div class="flex items-center gap-3">
@@ -1057,7 +1057,7 @@ graph TD
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│ [≡] Hibana Admin                      [🔍] [🔔] [👤 Admin ▾]   │
+│ [≡] Enrai Admin                      [🔍] [🔔] [👤 Admin ▾]   │
 ├──────────┬──────────────────────────────────────────────────────┤
 │          │  Users                                               │
 │ 📊 Dash  │                                                      │

--- a/docs/features/form-post-response-mode.md
+++ b/docs/features/form-post-response-mode.md
@@ -4,7 +4,7 @@
 
 **OAuth 2.0 Form Post Response Mode** allows authorization responses to be delivered via HTTP POST instead of URL redirects with query or fragment parameters.
 
-Hibana implements Form Post Response Mode as specified in the [OAuth 2.0 Form Post Response Mode specification](https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html).
+Enrai implements Form Post Response Mode as specified in the [OAuth 2.0 Form Post Response Mode specification](https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html).
 
 ## Specification
 
@@ -119,7 +119,7 @@ GET /authorize
   &scope=openid+profile+email
   &state=abc123
   &nonce=xyz789
-Host: hibana.sgrastar.workers.dev
+Host: enrai.sgrastar.workers.dev
 ```
 
 ---
@@ -195,7 +195,7 @@ The client must handle this as a POST request (not GET).
 #### Step 1: Client Initiates Authorization
 
 ```javascript
-const authUrl = new URL('https://hibana.sgrastar.workers.dev/authorize');
+const authUrl = new URL('https://enrai.sgrastar.workers.dev/authorize');
 authUrl.searchParams.set('response_type', 'code');
 authUrl.searchParams.set('response_mode', 'form_post');
 authUrl.searchParams.set('client_id', 'my_client_id');
@@ -270,7 +270,7 @@ const codeVerifier = generateRandomString(128);
 const codeChallenge = await sha256(codeVerifier);
 const codeChallengeBase64 = base64UrlEncode(codeChallenge);
 
-const authUrl = new URL('https://hibana.sgrastar.workers.dev/authorize');
+const authUrl = new URL('https://enrai.sgrastar.workers.dev/authorize');
 authUrl.searchParams.set('response_type', 'code');
 authUrl.searchParams.set('response_mode', 'form_post');
 authUrl.searchParams.set('client_id', 'my_client_id');
@@ -291,7 +291,7 @@ window.location.href = authUrl.toString();
 
 ```javascript
 // Step 1: Push authorization request
-const parResponse = await fetch('https://hibana.sgrastar.workers.dev/as/par', {
+const parResponse = await fetch('https://enrai.sgrastar.workers.dev/as/par', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/x-www-form-urlencoded',
@@ -309,7 +309,7 @@ const parResponse = await fetch('https://hibana.sgrastar.workers.dev/as/par', {
 const { request_uri } = await parResponse.json();
 
 // Step 2: Redirect to authorization endpoint with request_uri
-const authUrl = new URL('https://hibana.sgrastar.workers.dev/authorize');
+const authUrl = new URL('https://enrai.sgrastar.workers.dev/authorize');
 authUrl.searchParams.set('client_id', 'my_client_id');
 authUrl.searchParams.set('request_uri', request_uri);
 
@@ -342,7 +342,7 @@ window.location.href = authUrl.toString();
 
 ### XSS Prevention
 
-Hibana implements **comprehensive HTML escaping** to prevent XSS attacks:
+Enrai implements **comprehensive HTML escaping** to prevent XSS attacks:
 
 #### Escaping Functions
 
@@ -435,7 +435,7 @@ def callback():
 
 ### User Experience
 
-Hibana's form post response includes a user-friendly loading screen:
+Enrai's form post response includes a user-friendly loading screen:
 
 1. **Loading Spinner**: Animated spinner indicating progress
 2. **Message**: "Redirecting to application..."
@@ -471,7 +471,7 @@ Clients can check this metadata to verify Form Post support before using it.
 
 ### Test Coverage
 
-Hibana includes comprehensive tests for Form Post Response Mode:
+Enrai includes comprehensive tests for Form Post Response Mode:
 
 **Test File**: `test/form-post-response-mode.test.ts`
 

--- a/docs/features/par.md
+++ b/docs/features/par.md
@@ -4,7 +4,7 @@
 
 **RFC 9126** - OAuth 2.0 Pushed Authorization Requests
 
-Hibana implements Pushed Authorization Requests (PAR), an OAuth 2.0 security extension that allows clients to push authorization request parameters directly to the authorization server before redirecting the user.
+Enrai implements Pushed Authorization Requests (PAR), an OAuth 2.0 security extension that allows clients to push authorization request parameters directly to the authorization server before redirecting the user.
 
 ## Specification
 
@@ -194,7 +194,7 @@ When using PAR, the authorization endpoint accepts the `request_uri` parameter i
 
 ```http
 GET /authorize?request_uri=urn:ietf:params:oauth:request_uri:6esc_11ACC5bwc014ltc14eY22c&client_id=my_client_id HTTP/1.1
-Host: hibana.sgrastar.workers.dev
+Host: enrai.sgrastar.workers.dev
 ```
 
 #### Validation
@@ -213,7 +213,7 @@ Host: hibana.sgrastar.workers.dev
 #### Step 1: Push Authorization Request
 
 ```bash
-curl -X POST https://hibana.sgrastar.workers.dev/as/par \
+curl -X POST https://enrai.sgrastar.workers.dev/as/par \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "client_id=my_client_id" \
   -d "response_type=code" \
@@ -234,7 +234,7 @@ curl -X POST https://hibana.sgrastar.workers.dev/as/par \
 #### Step 2: Redirect User to Authorization Endpoint
 
 ```javascript
-const authUrl = new URL('https://hibana.sgrastar.workers.dev/authorize');
+const authUrl = new URL('https://enrai.sgrastar.workers.dev/authorize');
 authUrl.searchParams.set('request_uri', 'urn:ietf:params:oauth:request_uri:6esc_11ACC5bwc014ltc14eY22c');
 authUrl.searchParams.set('client_id', 'my_client_id');
 
@@ -251,7 +251,7 @@ CODE_VERIFIER=$(openssl rand -base64 96 | tr -d '\n' | tr '/+' '_-' | tr -d '=')
 CODE_CHALLENGE=$(echo -n $CODE_VERIFIER | openssl dgst -binary -sha256 | openssl base64 | tr -d '\n' | tr '/+' '_-' | tr -d '=')
 
 # Push authorization request with PKCE
-curl -X POST https://hibana.sgrastar.workers.dev/as/par \
+curl -X POST https://enrai.sgrastar.workers.dev/as/par \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "client_id=my_public_client" \
   -d "response_type=code" \
@@ -266,7 +266,7 @@ curl -X POST https://hibana.sgrastar.workers.dev/as/par \
 ### Example 3: PAR with Client Authentication
 
 ```bash
-curl -X POST https://hibana.sgrastar.workers.dev/as/par \
+curl -X POST https://enrai.sgrastar.workers.dev/as/par \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -u "my_client_id:my_client_secret" \
   -d "response_type=code" \
@@ -292,7 +292,7 @@ CLAIMS='{
   }
 }'
 
-curl -X POST https://hibana.sgrastar.workers.dev/as/par \
+curl -X POST https://enrai.sgrastar.workers.dev/as/par \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "client_id=my_client_id" \
   -d "response_type=code" \
@@ -355,7 +355,7 @@ This prevents:
 
 ### 1. Client Validation
 
-Hibana validates that:
+Enrai validates that:
 - Client exists in the client registry
 - `redirect_uri` is registered for the client
 - `response_type` is supported
@@ -397,7 +397,7 @@ PAR endpoints are advertised in the OpenID Provider metadata:
 
 ```json
 {
-  "pushed_authorization_request_endpoint": "https://hibana.sgrastar.workers.dev/as/par",
+  "pushed_authorization_request_endpoint": "https://enrai.sgrastar.workers.dev/as/par",
   "require_pushed_authorization_requests": false
 }
 ```
@@ -425,7 +425,7 @@ Currently, PAR is **optional** (`require_pushed_authorization_requests: false`).
 
 ### Test Coverage
 
-Hibana includes comprehensive tests for PAR:
+Enrai includes comprehensive tests for PAR:
 
 **Test File**: `test/par.test.ts`
 
@@ -463,7 +463,7 @@ async function authorizeWithPAR(config: {
   nonce: string;
 }) {
   // Step 1: Push authorization request
-  const parResponse = await fetch('https://hibana.sgrastar.workers.dev/as/par', {
+  const parResponse = await fetch('https://enrai.sgrastar.workers.dev/as/par', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -481,7 +481,7 @@ async function authorizeWithPAR(config: {
   const { request_uri } = await parResponse.json();
 
   // Step 2: Redirect to authorization endpoint
-  const authUrl = new URL('https://hibana.sgrastar.workers.dev/authorize');
+  const authUrl = new URL('https://enrai.sgrastar.workers.dev/authorize');
   authUrl.searchParams.set('request_uri', request_uri);
   authUrl.searchParams.set('client_id', config.clientId);
 
@@ -504,7 +504,7 @@ def authorize_with_par(
 ):
     # Step 1: Push authorization request
     par_response = requests.post(
-        'https://hibana.sgrastar.workers.dev/as/par',
+        'https://enrai.sgrastar.workers.dev/as/par',
         data={
             'client_id': client_id,
             'response_type': 'code',
@@ -524,7 +524,7 @@ def authorize_with_par(
         'client_id': client_id,
     }
 
-    auth_url = f'https://hibana.sgrastar.workers.dev/authorize?{urlencode(auth_params)}'
+    auth_url = f'https://enrai.sgrastar.workers.dev/authorize?{urlencode(auth_params)}'
 
     return auth_url
 ```

--- a/docs/features/token-management.md
+++ b/docs/features/token-management.md
@@ -1,10 +1,10 @@
 # Token Management
 
-This document describes Hibana's token management capabilities, including refresh token flow, token introspection, and token revocation.
+This document describes Enrai's token management capabilities, including refresh token flow, token introspection, and token revocation.
 
 ## Overview
 
-Hibana implements comprehensive token management features as defined in:
+Enrai implements comprehensive token management features as defined in:
 - **RFC 6749 Section 6**: Refresh Token Grant
 - **RFC 7662**: OAuth 2.0 Token Introspection
 - **RFC 7009**: OAuth 2.0 Token Revocation
@@ -29,7 +29,7 @@ Refresh tokens allow clients to obtain new access tokens without requiring the u
 
 #### Refresh Token Rotation
 
-Hibana implements **automatic refresh token rotation** as a security best practice:
+Enrai implements **automatic refresh token rotation** as a security best practice:
 
 1. When a refresh token is used, it is immediately invalidated
 2. A new refresh token is issued with the new access token
@@ -41,7 +41,7 @@ Clients can request a reduced scope when using a refresh token:
 
 ```http
 POST /token HTTP/1.1
-Host: hibana.sgrastar.workers.dev
+Host: enrai.sgrastar.workers.dev
 Content-Type: application/x-www-form-urlencoded
 
 grant_type=refresh_token
@@ -103,7 +103,7 @@ Authorization: Basic <base64(client_id:client_secret)>  # Optional, alternative 
 #### Using Form Parameters
 
 ```bash
-curl -X POST https://hibana.sgrastar.workers.dev/token \
+curl -X POST https://enrai.sgrastar.workers.dev/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "grant_type=refresh_token" \
   -d "refresh_token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..." \
@@ -114,7 +114,7 @@ curl -X POST https://hibana.sgrastar.workers.dev/token \
 #### Using HTTP Basic Authentication
 
 ```bash
-curl -X POST https://hibana.sgrastar.workers.dev/token \
+curl -X POST https://enrai.sgrastar.workers.dev/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -u "my_client_id:my_client_secret" \
   -d "grant_type=refresh_token" \
@@ -127,7 +127,7 @@ Refresh tokens are JWTs containing the following claims:
 
 ```json
 {
-  "iss": "https://hibana.sgrastar.workers.dev",
+  "iss": "https://enrai.sgrastar.workers.dev",
   "sub": "user-abc123",
   "aud": "my_client_id",
   "exp": 1234567890,
@@ -193,8 +193,8 @@ Authorization: Basic <base64(client_id:client_secret)>  # Optional
   "exp": 1234567890,
   "iat": 1234564290,
   "sub": "user-abc123",
-  "aud": "https://hibana.sgrastar.workers.dev",
-  "iss": "https://hibana.sgrastar.workers.dev",
+  "aud": "https://enrai.sgrastar.workers.dev",
+  "iss": "https://enrai.sgrastar.workers.dev",
   "jti": "at_unique_identifier"
 }
 ```
@@ -222,7 +222,7 @@ A token is considered **inactive** if:
 ### Example Usage
 
 ```bash
-curl -X POST https://hibana.sgrastar.workers.dev/introspect \
+curl -X POST https://enrai.sgrastar.workers.dev/introspect \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -u "my_client_id:my_client_secret" \
   -d "token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..." \
@@ -287,7 +287,7 @@ Content-Length: 0
 #### Revoke Access Token
 
 ```bash
-curl -X POST https://hibana.sgrastar.workers.dev/revoke \
+curl -X POST https://enrai.sgrastar.workers.dev/revoke \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -u "my_client_id:my_client_secret" \
   -d "token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..." \
@@ -297,7 +297,7 @@ curl -X POST https://hibana.sgrastar.workers.dev/revoke \
 #### Revoke Refresh Token
 
 ```bash
-curl -X POST https://hibana.sgrastar.workers.dev/revoke \
+curl -X POST https://enrai.sgrastar.workers.dev/revoke \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -u "my_client_id:my_client_secret" \
   -d "token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..." \
@@ -329,7 +329,7 @@ curl -X POST https://hibana.sgrastar.workers.dev/revoke \
 
 ### Authorization Code Reuse Protection
 
-When an authorization code is reused, Hibana automatically revokes all tokens issued with that code:
+When an authorization code is reused, Enrai automatically revokes all tokens issued with that code:
 
 ```typescript
 // Per RFC 6749 Section 4.1.2: Authorization codes are single-use
@@ -383,7 +383,7 @@ REFRESH_TOKEN_EXPIRY = "604800" # 7 days
 
 ### Cloudflare KV Namespaces
 
-Hibana uses Cloudflare KV for token metadata storage:
+Enrai uses Cloudflare KV for token metadata storage:
 
 #### Refresh Tokens
 - **Key Format**: `refresh_token:{jti}`
@@ -401,7 +401,7 @@ Hibana uses Cloudflare KV for token metadata storage:
 
 ### Test Coverage
 
-Hibana includes comprehensive tests for token management:
+Enrai includes comprehensive tests for token management:
 
 - **Refresh Token Flow**: 20+ test cases
 - **Token Introspection**: 15+ test cases

--- a/docs/operations/secret-management.md
+++ b/docs/operations/secret-management.md
@@ -2,13 +2,13 @@
 
 ## Overview
 
-Hibana uses cryptographic keys for JWT signing. These keys must be managed securely throughout their lifecycle. This document describes how to generate, store, and rotate keys safely.
+Enrai uses cryptographic keys for JWT signing. These keys must be managed securely throughout their lifecycle. This document describes how to generate, store, and rotate keys safely.
 
 ## Key Types
 
 ### RSA Key Pair
 
-Hibana uses RSA-2048 key pairs with the RS256 algorithm (RSA signature with SHA-256) for signing JWT tokens.
+Enrai uses RSA-2048 key pairs with the RS256 algorithm (RSA signature with SHA-256) for signing JWT tokens.
 
 - **Private Key**: Used to sign JWT tokens (ID tokens and access tokens)
 - **Public Key**: Distributed via JWKS endpoint for token verification
@@ -108,7 +108,7 @@ Then update `wrangler.toml` with the key ID:
 [env.production]
 vars = {
   KEY_ID = "prod-key-1234567890-abc123",
-  ISSUER_URL = "https://id.hibana.dev"
+  ISSUER_URL = "https://id.enrai.org"
 }
 ```
 

--- a/docs/project-management/API_INVENTORY.md
+++ b/docs/project-management/API_INVENTORY.md
@@ -1,4 +1,4 @@
-# Hibana API インベントリ 📋
+# Enrai API インベントリ 📋
 
 **最終更新**: 2025-11-12
 **ステータス**: Phase 4完了、Phase 5計画中
@@ -7,7 +7,7 @@
 
 ## 📊 概要
 
-このドキュメントは、Hibana OIDC OPの全APIエンドポイントの現在の状態と将来計画を記録します。
+このドキュメントは、Enrai OIDC OPの全APIエンドポイントの現在の状態と将来計画を記録します。
 
 > 📄 **詳細なAPI仕様**: [OpenAPI 3.1仕様書](../api/openapi.yaml) | [APIガイド](../api/README.md)
 
@@ -171,10 +171,10 @@ grant_type=urn:ietf:params:oauth:grant-type:token-exchange
 
 **対応可能なトークンタイプ**:
 - 標準: access_token, refresh_token, id_token, saml2, saml1, jwt
-- Hibana独自:
-  - `urn:hibana:params:oauth:token-type:session-token` - セッショントークン
-  - `urn:hibana:params:oauth:token-type:magic-link-token` - Magic Linkトークン
-  - `urn:hibana:params:oauth:token-type:passkey-assertion` - Passkey認証アサーション
+- Enrai独自:
+  - `urn:enrai:params:oauth:token-type:session-token` - セッショントークン
+  - `urn:enrai:params:oauth:token-type:magic-link-token` - Magic Linkトークン
+  - `urn:enrai:params:oauth:token-type:passkey-assertion` - Passkey認証アサーション
 
 **ユースケース**:
 - セッショントークン → アクセストークン（ITP対応SSO）

--- a/docs/project-management/GITHUB_WORKFLOW.md
+++ b/docs/project-management/GITHUB_WORKFLOW.md
@@ -1,6 +1,6 @@
-# GitHub Setup Guide for Hibana
+# GitHub Setup Guide for Enrai
 
-This guide explains how to set up GitHub issues, labels, milestones, and project boards for the Hibana project.
+This guide explains how to set up GitHub issues, labels, milestones, and project boards for the Enrai project.
 
 **Related Documents:**
 - [Project Schedule](./SCHEDULE.md) - Timeline for creating issues
@@ -119,11 +119,11 @@ If you prefer to set up manually or the scripts don't work:
 
 ### Create Labels
 
-Go to `https://github.com/your-username/hibana/labels` and create labels according to the color scheme above.
+Go to `https://github.com/your-username/enrai/labels` and create labels according to the color scheme above.
 
 ### Create Milestones
 
-Go to `https://github.com/your-username/hibana/milestones` and create the 5 milestones with their due dates.
+Go to `https://github.com/your-username/enrai/milestones` and create the 5 milestones with their due dates.
 
 ### Create Issues
 
@@ -134,7 +134,7 @@ Use the issue templates to create issues, or create them manually following the 
 1. Go to your repository's "Projects" tab
 2. Click "New Project"
 3. Choose "Board" layout
-4. Name it "Hibana Development"
+4. Name it "Enrai Development"
 5. Add columns:
    - **Backlog** - Issues not yet started
    - **Ready** - Issues ready to work on
@@ -348,4 +348,4 @@ jobs:
 
 ---
 
-> **Hibana** 🔥 — Organized development through structured issue tracking.
+> **Enrai** 🔥 — Organized development through structured issue tracking.

--- a/docs/project-management/KICKOFF.md
+++ b/docs/project-management/KICKOFF.md
@@ -1,7 +1,7 @@
-# Hibana Project Kickoff Checklist
+# Enrai Project Kickoff Checklist
 
 ## Overview
-This checklist covers all immediate tasks needed to kickoff the Hibana project and complete Week 1 deliverables.
+This checklist covers all immediate tasks needed to kickoff the Enrai project and complete Week 1 deliverables.
 
 **Target Completion**: November 16, 2025
 **Milestone**: M1 - Foundation Complete (Dec 15, 2025)
@@ -28,7 +28,7 @@ This checklist covers all immediate tasks needed to kickoff the Hibana project a
 - [ ] GitHub repository access configured
 - [ ] Cloudflare account set up
 - [ ] Cloudflare API token generated
-- [ ] Git branch created: `claude/hibana-project-setup-011CUzP18xDrPBpH2wQgouqJ`
+- [ ] Git branch created: `claude/enrai-project-setup-011CUzP18xDrPBpH2wQgouqJ`
 
 ---
 
@@ -38,7 +38,7 @@ This checklist covers all immediate tasks needed to kickoff the Hibana project a
 Create the following directory structure:
 
 ```
-hibana/
+enrai/
 ├── .github/
 │   └── workflows/          # CI/CD workflows
 ├── src/
@@ -73,7 +73,7 @@ hibana/
 **File**: `package.json`
 
 - [ ] Create `package.json` with:
-  - [ ] Project name: `hibana`
+  - [ ] Project name: `enrai`
   - [ ] Version: `0.1.0`
   - [ ] Description: OpenID Connect Provider on Cloudflare Workers
   - [ ] Main entry point: `src/index.ts`
@@ -118,7 +118,7 @@ hibana/
 **File**: `wrangler.toml`
 
 - [ ] Create `wrangler.toml` with:
-  - [ ] `name`: "hibana"
+  - [ ] `name`: "enrai"
   - [ ] `main`: "src/index.ts"
   - [ ] `compatibility_date`: "2024-11-01"
   - [ ] KV namespace bindings:
@@ -372,10 +372,10 @@ hibana/
 
 ### Branch Management
 
-- [ ] Verify current branch: `claude/hibana-project-setup-011CUzP18xDrPBpH2wQgouqJ`
+- [ ] Verify current branch: `claude/enrai-project-setup-011CUzP18xDrPBpH2wQgouqJ`
 - [ ] Push to remote:
   ```bash
-  git push -u origin claude/hibana-project-setup-011CUzP18xDrPBpH2wQgouqJ
+  git push -u origin claude/enrai-project-setup-011CUzP18xDrPBpH2wQgouqJ
   ```
 
 ---
@@ -524,4 +524,4 @@ After completing this checklist, proceed to:
 
 ---
 
-> **Hibana** 🔥 — Starting strong with a solid foundation.
+> **Enrai** 🔥 — Starting strong with a solid foundation.

--- a/docs/project-management/PHASE5_PLANNING.md
+++ b/docs/project-management/PHASE5_PLANNING.md
@@ -22,7 +22,7 @@
 
 ## 概要
 
-Phase 5では、Hibanaに以下の機能を実装します：
+Phase 5では、Enraiに以下の機能を実装します：
 
 - **🔐 パスワードレス認証UI** (Passkey + Magic Link)
 - **📝 ユーザー登録・ログインフロー**
@@ -521,7 +521,7 @@ CREATE INDEX idx_audit_log_action ON audit_log(action);
 ##### Page 1: ログイン画面 (`/login`)
 - [ ] **デザイン要件**
   - クリーンでモダンなデザイン
-  - Hibanaロゴ表示
+  - Enraiロゴ表示
   - メールアドレス入力フィールド
   - 「Continue with Passkey」ボタン（メイン）
   - 「Send Magic Link」ボタン（セカンダリ）
@@ -606,7 +606,7 @@ CREATE INDEX idx_audit_log_action ON audit_log(action);
 ##### Page 5: OAuth同意画面 (`/consent`)
 - [ ] **デザイン要件**
   - クライアントロゴ・名前
-  - 「{Client Name} wants to access your Hibana account」
+  - 「{Client Name} wants to access your Enrai account」
   - スコープリスト（アイコン付き）
   - ユーザー情報表示（email, name）
   - 「Allow」ボタン（プライマリ）
@@ -1068,7 +1068,7 @@ CREATE INDEX idx_audit_log_action ON audit_log(action);
 
 ## 参考資料
 
-### Hibanaドキュメント
+### Enraiドキュメント
 - **設計資料** (✅ 完成)
   - [database-schema.md](../architecture/database-schema.md) - データベーススキーマ・ER図
   - [openapi.yaml](../api/openapi.yaml) - OpenAPI 3.1仕様書

--- a/docs/project-management/SCHEDULE.md
+++ b/docs/project-management/SCHEDULE.md
@@ -1,7 +1,7 @@
-# Hibana Project Schedule
+# Enrai Project Schedule
 
 ## Project Overview
-**Hibana** - A lightweight OpenID Connect Provider built on Cloudflare Workers
+**Enrai** - A lightweight OpenID Connect Provider built on Cloudflare Workers
 **Start Date**: November 10, 2025
 **Goal**: Obtain OpenID Certified™ Basic OP Profile certification
 **Tech Stack**: Cloudflare Workers, Hono, Durable Objects, KV Storage, JOSE
@@ -205,7 +205,7 @@ Phase 10: Certification & Production   [Final Phase]               (4 weeks)
 
 | Week | Tasks | Owner | Status |
 |:-----|:------|:------|:-------|
-| Week 32 (6/12-6/18) | CLI tool development, create-hibana package setup | Dev | ⏳ Pending |
+| Week 32 (6/12-6/18) | CLI tool development, create-enrai package setup | Dev | ⏳ Pending |
 | Week 33 (6/19-6/25) | Project scaffolding, interactive setup wizard | Dev | ⏳ Pending |
 | Week 34 (6/26-7/2) | Cloudflare API integration, Worker deployment API | Dev | ⏳ Pending |
 | Week 35 (7/3-7/9) | KV/D1/DO management, DNS & custom domain setup | Dev | ⏳ Pending |
@@ -290,4 +290,4 @@ Phase 10: Certification & Production   [Final Phase]               (4 weeks)
 
 ---
 
-> **Hibana** 🔥 — Proving that even a solo developer can operate a globally distributed identity provider.
+> **Enrai** 🔥 — Proving that even a solo developer can operate a globally distributed identity provider.

--- a/docs/project-management/TASKS.md
+++ b/docs/project-management/TASKS.md
@@ -1,6 +1,6 @@
-# Hibana Task Breakdown
+# Enrai Task Breakdown
 
-This document provides a comprehensive, week-by-week breakdown of all tasks required to build and certify the Hibana OpenID Connect Provider.
+This document provides a comprehensive, week-by-week breakdown of all tasks required to build and certify the Enrai OpenID Connect Provider.
 
 **Related Documents:**
 - [Project Schedule](./SCHEDULE.md) - High-level timeline and milestones
@@ -50,7 +50,7 @@ This document provides a comprehensive, week-by-week breakdown of all tasks requ
 
 #### 1.4 Cloudflare Workers Configuration
 - [x] Create `wrangler.toml` configuration:
-  - [x] Set worker name: `hibana`
+  - [x] Set worker name: `enrai`
   - [x] Configure compatibility date
   - [x] Set main entry point
   - [x] Define KV namespace bindings
@@ -534,7 +534,7 @@ This document provides a comprehensive, week-by-week breakdown of all tasks requ
 
 #### 13.2 Configuration ✅
 - [x] Configure OP metadata:
-  - [x] Issuer URL: https://hibana.sgrastar.workers.dev
+  - [x] Issuer URL: https://enrai.sgrastar.workers.dev
   - [x] Client registration: static_client
   - [x] Test credentials
 - [x] Configure test plan (oidcc-basic-certification-test-plan)
@@ -613,7 +613,7 @@ This document provides a comprehensive, week-by-week breakdown of all tasks requ
 - Plan ID: e90FqMh4xG2mg
 - Test Version: 5.1.36
 - Test Date: 2025-11-12
-- Issuer: https://hibana.sgrastar.workers.dev
+- Issuer: https://enrai.sgrastar.workers.dev
 
 | Status | Count | Percentage |
 |--------|-------|------------|
@@ -1086,7 +1086,7 @@ This document provides a comprehensive, week-by-week breakdown of all tasks requ
 
 ### Week 32-33: CLI Tool Development (Jun 12-25)
 
-#### 32.1 `create-hibana` Package Setup
+#### 32.1 `create-enrai` Package Setup
 - [ ] Initialize NPM package
 - [ ] Set up TypeScript configuration
 - [ ] Configure build system (tsup/esbuild)
@@ -1118,28 +1118,28 @@ This document provides a comprehensive, week-by-week breakdown of all tasks requ
 - [ ] Add error handling
 
 #### 32.4 Deployment Commands
-- [ ] Implement `hibana deploy` command
-- [ ] Add `hibana deploy --production` flag
-- [ ] Implement `hibana rollback` command
-- [ ] Add `hibana status` command
-- [ ] Implement `hibana logs` command
+- [ ] Implement `enrai deploy` command
+- [ ] Add `enrai deploy --production` flag
+- [ ] Implement `enrai rollback` command
+- [ ] Add `enrai status` command
+- [ ] Implement `enrai logs` command
 - [ ] Add deployment progress tracking
 - [ ] Implement error recovery
 - [ ] Test deployment flow
 
 #### 32.5 Management Commands
-- [ ] Implement `hibana user create <email>`
-- [ ] Add `hibana user delete <email>`
-- [ ] Implement `hibana user reset-password <email>`
-- [ ] Add `hibana user list`
-- [ ] Implement `hibana client create <name>`
-- [ ] Add `hibana client list`
-- [ ] Implement `hibana client delete <id>`
-- [ ] Add `hibana keys rotate`
-- [ ] Implement `hibana backup`
-- [ ] Add `hibana restore <file>`
-- [ ] Implement `hibana config get <key>`
-- [ ] Add `hibana config set <key> <value>`
+- [ ] Implement `enrai user create <email>`
+- [ ] Add `enrai user delete <email>`
+- [ ] Implement `enrai user reset-password <email>`
+- [ ] Add `enrai user list`
+- [ ] Implement `enrai client create <name>`
+- [ ] Add `enrai client list`
+- [ ] Implement `enrai client delete <id>`
+- [ ] Add `enrai keys rotate`
+- [ ] Implement `enrai backup`
+- [ ] Add `enrai restore <file>`
+- [ ] Implement `enrai config get <key>`
+- [ ] Add `enrai config set <key> <value>`
 - [ ] Test all commands
 
 #### 32.6 CLI Testing
@@ -1327,7 +1327,7 @@ This document provides a comprehensive, week-by-week breakdown of all tasks requ
 - [ ] Responsive on all screen sizes (320px+)
 
 ### Phase 7: CLI & Automation
-- [ ] <5 minutes from `npx create-hibana` to running IdP
+- [ ] <5 minutes from `npx create-enrai` to running IdP
 - [ ] <1 minute deployment time
 - [ ] 100% automated setup (zero manual config)
 - [ ] CLI with 20+ commands
@@ -1467,7 +1467,7 @@ This document provides a comprehensive, week-by-week breakdown of all tasks requ
 
 #### 45.3 Identity Federation & Transformation
 - [ ] Design identity mapping schema
-- [ ] Implement social identity to Hibana user mapping
+- [ ] Implement social identity to Enrai user mapping
 - [ ] Create account linking logic (same email, multiple providers)
 - [ ] Implement first-time social login flow
 - [ ] Add profile synchronization from social providers
@@ -2105,7 +2105,7 @@ This document provides a comprehensive, week-by-week breakdown of all tasks requ
 
 #### 10.5 Production Environment
 - [ ] Set up production Cloudflare account
-- [ ] Configure custom domain (`id.hibana.dev`)
+- [ ] Configure custom domain (`id.enrai.org`)
 - [ ] Set up DNS records
 - [ ] Configure SSL/TLS (with MTLS support)
 
@@ -2179,14 +2179,14 @@ This document provides a comprehensive, week-by-week breakdown of all tasks requ
 - [ ] MTLS (Mutual TLS) implemented
 - [ ] JAR (JWT-Secured Authorization Request) operational
 - [ ] Client Credentials Flow working
-- [ ] Production deployment live (`https://id.hibana.dev`)
+- [ ] Production deployment live (`https://id.enrai.org`)
 - [ ] OpenID Certification obtained ✨
 - [ ] Public announcement ready
 - [ ] Migration guides published
 
 ---
 
-> **Hibana** 💥 — Building standards-compliant identity infrastructure, one task at a time.
+> **Enrai** 💥 — Building standards-compliant identity infrastructure, one task at a time.
 >
 > **Updated:** 2025-11-12 — Phase 4 (Extended Features) ✅ COMPLETE
 > - Added Dynamic Client Registration (RFC 7591)

--- a/migrations/001_initial_schema.sql
+++ b/migrations/001_initial_schema.sql
@@ -1,4 +1,4 @@
--- Hibana Phase 5: Initial Database Schema
+-- Enrai Phase 5: Initial Database Schema
 -- Created: 2025-11-13
 -- Description: Creates all 11 tables for Phase 5 implementation
 -- Documentation: docs/architecture/database-schema.md

--- a/migrations/002_seed_default_data.sql
+++ b/migrations/002_seed_default_data.sql
@@ -1,4 +1,4 @@
--- Hibana Phase 5: Seed Default Data
+-- Enrai Phase 5: Seed Default Data
 -- Created: 2025-11-13
 -- Description: Insert default roles, branding settings, and test data
 -- Documentation: docs/architecture/database-schema.md
@@ -109,7 +109,7 @@ INSERT INTO users (
   last_login_at
 ) VALUES (
   'user_test_admin',
-  'admin@test.hibana.dev',
+  'admin@test.enrai.org',
   1,
   'Test Admin',
   'Test',
@@ -141,7 +141,7 @@ INSERT INTO users (
   last_login_at
 ) VALUES (
   'user_test_user',
-  'user@test.hibana.dev',
+  'user@test.enrai.org',
   1,
   'Test User',
   'Test',
@@ -166,7 +166,7 @@ INSERT INTO users (
   last_login_at
 ) VALUES (
   'user_test_support',
-  'support@test.hibana.dev',
+  'support@test.enrai.org',
   1,
   'Test Support',
   'Test',

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,6 +1,6 @@
-# Hibana Database Migrations 🗄️
+# Enrai Database Migrations 🗄️
 
-This directory contains SQL migration scripts for Hibana's Cloudflare D1 database.
+This directory contains SQL migration scripts for Enrai's Cloudflare D1 database.
 
 ## 📋 Migration Files
 
@@ -15,10 +15,10 @@ This directory contains SQL migration scripts for Hibana's Cloudflare D1 databas
 
 ```bash
 # Create production database
-wrangler d1 create hibana-prod
+wrangler d1 create enrai-prod
 
 # Create development database (recommended for testing)
-wrangler d1 create hibana-dev
+wrangler d1 create enrai-dev
 ```
 
 Update your `wrangler.toml` with the database binding:
@@ -26,7 +26,7 @@ Update your `wrangler.toml` with the database binding:
 ```toml
 [[d1_databases]]
 binding = "DB"
-database_name = "hibana-dev"
+database_name = "enrai-dev"
 database_id = "your-database-id-here"
 ```
 
@@ -36,31 +36,31 @@ database_id = "your-database-id-here"
 
 ```bash
 # Development
-wrangler d1 execute hibana-dev --file=migrations/001_initial_schema.sql
-wrangler d1 execute hibana-dev --file=migrations/002_seed_default_data.sql
+wrangler d1 execute enrai-dev --file=migrations/001_initial_schema.sql
+wrangler d1 execute enrai-dev --file=migrations/002_seed_default_data.sql
 
 # Production (⚠️ IMPORTANT: Remove test data from 002 first!)
-wrangler d1 execute hibana-prod --file=migrations/001_initial_schema.sql
-wrangler d1 execute hibana-prod --file=migrations/002_seed_default_data.sql
+wrangler d1 execute enrai-prod --file=migrations/001_initial_schema.sql
+wrangler d1 execute enrai-prod --file=migrations/002_seed_default_data.sql
 ```
 
 #### Apply Single Migration
 
 ```bash
-wrangler d1 execute hibana-dev --file=migrations/001_initial_schema.sql
+wrangler d1 execute enrai-dev --file=migrations/001_initial_schema.sql
 ```
 
 ### 3. Verify Migrations
 
 ```bash
 # List all tables
-wrangler d1 execute hibana-dev --command="SELECT name FROM sqlite_master WHERE type='table';"
+wrangler d1 execute enrai-dev --command="SELECT name FROM sqlite_master WHERE type='table';"
 
 # Check table structure
-wrangler d1 execute hibana-dev --command="PRAGMA table_info(users);"
+wrangler d1 execute enrai-dev --command="PRAGMA table_info(users);"
 
 # Count records
-wrangler d1 execute hibana-dev --command="SELECT COUNT(*) FROM users;"
+wrangler d1 execute enrai-dev --command="SELECT COUNT(*) FROM users;"
 ```
 
 ## 📊 Database Schema
@@ -106,9 +106,9 @@ Full schema documentation: [docs/architecture/database-schema.md](../docs/archit
 
 | Email | Role | Purpose |
 |-------|------|---------|
-| `admin@test.hibana.dev` | Super Admin | Testing admin features |
-| `user@test.hibana.dev` | None | Testing regular user flows |
-| `support@test.hibana.dev` | Support | Testing support operations |
+| `admin@test.enrai.org` | Super Admin | Testing admin features |
+| `user@test.enrai.org` | None | Testing regular user flows |
+| `support@test.enrai.org` | Support | Testing support operations |
 
 **Default password**: None (use Passkey or Magic Link)
 
@@ -127,12 +127,12 @@ Full schema documentation: [docs/architecture/database-schema.md](../docs/archit
 
 1. **Backup existing data** (if any)
    ```bash
-   wrangler d1 backup create hibana-prod
+   wrangler d1 backup create enrai-prod
    ```
 
 2. **Test in development first**
    ```bash
-   wrangler d1 execute hibana-dev --file=migrations/001_initial_schema.sql
+   wrangler d1 execute enrai-dev --file=migrations/001_initial_schema.sql
    ```
 
 3. **Review migration output** for errors
@@ -164,34 +164,34 @@ Full schema documentation: [docs/architecture/database-schema.md](../docs/archit
 
 ```bash
 # Check D1 status
-wrangler d1 info hibana-dev
+wrangler d1 info enrai-dev
 
 # View recent errors (if available)
-wrangler d1 execute hibana-dev --command="SELECT * FROM audit_log ORDER BY created_at DESC LIMIT 10;"
+wrangler d1 execute enrai-dev --command="SELECT * FROM audit_log ORDER BY created_at DESC LIMIT 10;"
 ```
 
 ### Table Already Exists
 
 ```bash
 # Drop all tables (⚠️ DESTRUCTIVE - Development only!)
-wrangler d1 execute hibana-dev --command="DROP TABLE IF EXISTS users;"
-wrangler d1 execute hibana-dev --command="DROP TABLE IF EXISTS user_custom_fields;"
+wrangler d1 execute enrai-dev --command="DROP TABLE IF EXISTS users;"
+wrangler d1 execute enrai-dev --command="DROP TABLE IF EXISTS user_custom_fields;"
 # ... repeat for all tables
 
 # Re-run migrations
-wrangler d1 execute hibana-dev --file=migrations/001_initial_schema.sql
+wrangler d1 execute enrai-dev --file=migrations/001_initial_schema.sql
 ```
 
 ### Reset Development Database
 
 ```bash
 # Delete and recreate
-wrangler d1 delete hibana-dev
-wrangler d1 create hibana-dev
+wrangler d1 delete enrai-dev
+wrangler d1 create enrai-dev
 
 # Re-run all migrations
-wrangler d1 execute hibana-dev --file=migrations/001_initial_schema.sql
-wrangler d1 execute hibana-dev --file=migrations/002_seed_default_data.sql
+wrangler d1 execute enrai-dev --file=migrations/001_initial_schema.sql
+wrangler d1 execute enrai-dev --file=migrations/002_seed_default_data.sql
 ```
 
 ## 🔐 Security Considerations

--- a/migrations/migrate.sh
+++ b/migrations/migrate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Hibana Database Migration Script
+# Enrai Database Migration Script
 # Usage: ./migrations/migrate.sh [dev|prod] [up|down|reset|status]
 
 set -e
@@ -14,7 +14,7 @@ NC='\033[0m' # No Color
 # Configuration
 ENV=${1:-dev}
 ACTION=${2:-up}
-DB_NAME="hibana-${ENV}"
+DB_NAME="enrai-${ENV}"
 
 # Helper functions
 log_info() {
@@ -149,7 +149,7 @@ reset_database() {
 
 # Show help
 show_help() {
-    echo "Hibana Database Migration Script"
+    echo "Enrai Database Migration Script"
     echo ""
     echo "Usage: ./migrations/migrate.sh [env] [action]"
     echo ""
@@ -172,7 +172,7 @@ show_help() {
 # Main script
 main() {
     echo "╔════════════════════════════════════════╗"
-    echo "║   Hibana Database Migration Tool      ║"
+    echo "║   Enrai Database Migration Tool      ║"
     echo "╚════════════════════════════════════════╝"
     echo ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "hibana",
+  "name": "enrai",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "hibana",
+      "name": "enrai",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hibana",
+  "name": "enrai",
   "version": "0.1.0",
   "description": "A lightweight OpenID Connect Provider built on Cloudflare Workers",
   "main": "dist/index.js",

--- a/scripts/create-phase1-issues.sh
+++ b/scripts/create-phase1-issues.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Create Phase 1 (Foundation) issues for Hibana project
+# Create Phase 1 (Foundation) issues for Enrai project
 
 set -e
 

--- a/scripts/performance-test.sh
+++ b/scripts/performance-test.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-# Hibana Performance Benchmark Script
+# Enrai Performance Benchmark Script
 # Tests endpoint latency and throughput for Phase 3 completion
 
 set -e
 
-ISSUER="${ISSUER:-https://hibana.sgrastar.workers.dev}"
+ISSUER="${ISSUER:-https://enrai.sgrastar.workers.dev}"
 RESULTS_DIR="docs/conformance/test-results"
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 RESULTS_FILE="${RESULTS_DIR}/performance-results-${TIMESTAMP}.md"
 
-echo "🔥 Hibana Performance Benchmark"
+echo "🔥 Enrai Performance Benchmark"
 echo "================================"
 echo "Issuer: ${ISSUER}"
 echo "Timestamp: ${TIMESTAMP}"
@@ -24,7 +24,7 @@ fi
 # Create results file
 mkdir -p "${RESULTS_DIR}"
 cat > "${RESULTS_FILE}" << EOF
-# Hibana Performance Benchmark Results
+# Enrai Performance Benchmark Results
 
 **Test Date:** $(date +%Y-%m-%d)
 **Test Time:** $(date +%H:%M:%S)

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 #
-# Hibana Development Setup Script
+# Enrai Development Setup Script
 # This script generates RSA keys and configures .dev.vars for local development
 
 set -e
 
-echo "🔐 Hibana Development Setup"
+echo "🔐 Enrai Development Setup"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 

--- a/scripts/setup-github.sh
+++ b/scripts/setup-github.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# Setup GitHub labels, milestones, and project for Hibana
+# Setup GitHub labels, milestones, and project for Enrai
 
 set -e
 
-echo "🔥 Setting up GitHub repository for Hibana..."
+echo "🔥 Setting up GitHub repository for Enrai..."
 echo ""
 
 # Check if gh CLI is installed
@@ -96,7 +96,7 @@ PROJECT_ID=$(gh api graphql -f query='
   mutation {
     createProjectV2(input: {
       ownerId: "MDQ6VXNlcjEyMzQ1Njc4OQ=="
-      title: "Hibana Development"
+      title: "Enrai Development"
       repositoryId: "R_kgDOLxYzXw"
     }) {
       projectV2 {

--- a/src/storage/adapters/kv-adapter.ts
+++ b/src/storage/adapters/kv-adapter.ts
@@ -2,7 +2,7 @@
  * KV Storage Adapter
  *
  * Implements the storage abstraction layer using Cloudflare KV
- * This is the current storage backend for Hibana (Phase 1-5)
+ * This is the current storage backend for Enrai (Phase 1-5)
  */
 
 import type {

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -1,4 +1,4 @@
-name = "hibana"
+name = "enrai"
 main = "src/index.ts"
 compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
@@ -43,13 +43,13 @@ KEY_ID = "dev-key-TIMESTAMP-XXXXXXX"
 
 # Development environment
 [env.development]
-name = "hibana-dev"
+name = "enrai-dev"
 vars = { ISSUER_URL = "http://localhost:8787" }
 
 # Production environment
 [env.production]
-name = "hibana-prod"
-# vars = { ISSUER_URL = "https://hibana.YOUR_SUBDOMAIN.workers.dev" }
+name = "enrai-prod"
+# vars = { ISSUER_URL = "https://enrai.YOUR_SUBDOMAIN.workers.dev" }
 
 # Build configuration
 [build]
@@ -59,4 +59,4 @@ command = "npm run build"
 # [[durable_objects.bindings]]
 # name = "KEY_MANAGER"
 # class_name = "KeyManager"
-# script_name = "hibana"
+# script_name = "enrai"


### PR DESCRIPTION
- Replace all occurrences of "hibana"/"Hibana"/"HIBANA" with "enrai"/"Enrai"/"ENRAI"
- Update domain from hibana.dev to enrai.org
- Update package name, documentation, scripts, and database seeds
- Worker URLs updated to use enrai naming (enrai.sgrastar.workers.dev)
- Email addresses updated to @enrai.org domain

This is a complete product rebranding from Hibana (火花) to Enrai (炎雷). Repository name will be updated separately.