### PR TITLE
Review and clarify project licenses

### DIFF
--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -410,7 +410,7 @@ app.get('/callback', async (req, res) => {
 
 ## 🤝 Open Source Philosophy
 
-Enrai is **open source** (MIT License):
+Enrai is **open source** (Apache License 2.0):
 - ✅ Full source code available
 - ✅ Community-driven development
 - ✅ No vendor lock-in
@@ -490,7 +490,7 @@ npm run deploy
 
 ## 📄 License
 
-MIT License - Use it however you want!
+Apache License 2.0 - Use it however you want!
 
 ---
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -22,8 +22,8 @@ info:
     name: Enrai Development Team
     url: https://github.com/sgrastar/enrai
   license:
-    name: MIT
-    url: https://opensource.org/licenses/MIT
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
 
 servers:
   - url: https://auth.example.com

--- a/docs/architecture/technical-specs.md
+++ b/docs/architecture/technical-specs.md
@@ -249,7 +249,7 @@ Payload:
 
 ## 11. License
 
-MIT License © 2025 [sgrastar](https://github.com/sgrastar)
+Apache License 2.0 © 2025 [sgrastar](https://github.com/sgrastar)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "authentication"
   ],
   "author": "",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "hono": "^4.0.0",
     "jose": "^5.2.0"


### PR DESCRIPTION
- Update package.json license field to Apache-2.0
- Update docs/VISION.md license references
- Update docs/architecture/technical-specs.md license
- Update docs/api/openapi.yaml license metadata

The LICENSE file already contains Apache 2.0 license text. This commit ensures all documentation and metadata files consistently reference Apache License 2.0.