### PR TITLE
docs: update all documentation from npm to pnpm

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,7 +33,7 @@ cd enrai
 ### 2. Install Dependencies
 
 ```bash
-npm install
+pnpm install
 ```
 
 This will install:
@@ -47,7 +47,7 @@ This will install:
 ### 3. Install Wrangler CLI (if not already installed globally)
 
 ```bash
-npm install -g wrangler
+pnpm install -g wrangler
 ```
 
 ## Configuration
@@ -77,7 +77,7 @@ Update `wrangler.toml` with the generated namespace IDs.
 Generate RSA keys for JWT signing (development):
 
 ```bash
-npm run generate-keys
+pnpm run generate-keys
 ```
 
 This will:
@@ -117,7 +117,7 @@ Update these as needed for your environment.
 ### Start Development Server
 
 ```bash
-npm run dev
+pnpm run dev
 ```
 
 This starts Wrangler in development mode on `http://localhost:8787`.
@@ -126,28 +126,28 @@ This starts Wrangler in development mode on `http://localhost:8787`.
 
 ```bash
 # Development
-npm run dev              # Start dev server with hot reload
+pnpm run dev              # Start dev server with hot reload
 
 # Building
-npm run build            # Compile TypeScript to JavaScript
+pnpm run build            # Compile TypeScript to JavaScript
 
 # Testing
-npm run test             # Run tests once
-npm run test:watch       # Run tests in watch mode
-npm run test:coverage    # Run tests with coverage report
+pnpm run test             # Run tests once
+pnpm run test:watch       # Run tests in watch mode
+pnpm run test:coverage    # Run tests with coverage report
 
 # Code Quality
-npm run lint             # Run ESLint
-npm run lint:fix         # Fix ESLint errors automatically
-npm run format           # Format code with Prettier
-npm run format:check     # Check code formatting
-npm run typecheck        # Run TypeScript type checking
+pnpm run lint             # Run ESLint
+pnpm run lint:fix         # Fix ESLint errors automatically
+pnpm run format           # Format code with Prettier
+pnpm run format:check     # Check code formatting
+pnpm run typecheck        # Run TypeScript type checking
 
 # Deployment
-npm run deploy           # Deploy to Cloudflare Workers
+pnpm run deploy           # Deploy to Cloudflare Workers
 
 # Utilities
-npm run generate-keys    # Generate RSA key pair
+pnpm run generate-keys    # Generate RSA key pair
 ```
 
 ### Project Structure
@@ -197,19 +197,19 @@ enrai/
 ### Run All Tests
 
 ```bash
-npm run test
+pnpm run test
 ```
 
 ### Run Tests in Watch Mode
 
 ```bash
-npm run test:watch
+pnpm run test:watch
 ```
 
 ### Run Tests with Coverage
 
 ```bash
-npm run test:coverage
+pnpm run test:coverage
 ```
 
 Coverage reports are generated in `coverage/` directory.
@@ -286,7 +286,7 @@ wrangler secret put PRIVATE_KEY --env development
 **Solution:** Run type checking and fix errors:
 
 ```bash
-npm run typecheck
+pnpm run typecheck
 ```
 
 ### Issue: Tests failing
@@ -294,7 +294,7 @@ npm run typecheck
 **Solution:** Check test output for details:
 
 ```bash
-npm run test
+pnpm run test
 ```
 
 ### Issue: Port 8787 already in use

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ Enrai is an **enterprise-grade OpenID Connect Provider** built for:
 
 | Layer | Technology | Purpose |
 |-------|------------|---------|
-| **Runtime** | Cloudflare Workers | Global edge deployment |
+| **Runtime** | Cloudflare Workers | Global edge deployment (5 specialized workers) |
 | **Framework** | Hono | Fast, lightweight web framework |
+| **Build** | Turborepo + pnpm | Monorepo, parallel builds, caching |
 | **Storage** | KV / D1 / Durable Objects | Flexible data persistence |
 | **Crypto** | JOSE | JWT/JWK standards (RS256) |
 | **Language** | TypeScript | Type safety, great DX |
@@ -172,7 +173,7 @@ Enrai is an **enterprise-grade OpenID Connect Provider** built for:
 ### Prerequisites
 
 - Node.js 18+
-- npm or pnpm
+- pnpm
 - Cloudflare account (free tier works)
 
 ### Quick Start (Development)
@@ -182,14 +183,25 @@ Enrai is an **enterprise-grade OpenID Connect Provider** built for:
 git clone https://github.com/sgrastar/enrai.git
 cd enrai
 
-# 2. Install dependencies
-npm install
+# 2. Install dependencies (monorepo setup)
+pnpm install
 
-# 3. Start development server
-npm run dev
+# 3. Build all packages
+pnpm run build
 
-# Server starts at http://localhost:8787
+# 4. Start all workers in parallel
+pnpm run dev
+
+# Workers start at:
+# - op-discovery: http://localhost:8787
+# - op-auth: http://localhost:8788
+# - op-token: http://localhost:8789
+# - op-userinfo: http://localhost:8790
+# - op-management: http://localhost:8791
 ```
+
+> **Note:** Enrai now uses a monorepo structure with 5 specialized workers.
+> See [WORKERS.md](./WORKERS.md) for detailed architecture.
 
 ### Test the API
 
@@ -317,35 +329,37 @@ Deploy Enrai to Cloudflare's global edge network and get a production-ready Open
 
 ```bash
 # 1. Install dependencies
-npm install
+pnpm install
 
 # 2. Set up RSA keys
 ./scripts/setup-dev.sh
 
 # 3. Build TypeScript
-npm run build
+pnpm run build
 
 # 4. Deploy to Cloudflare
-npm run deploy
+pnpm run deploy
 ```
 
-**After deployment, you'll get:**
-- 🌍 **Public URL**: `https://enrai.{your-subdomain}.workers.dev`
-- ✅ **Live Endpoints**:
-  - Discovery: `/.well-known/openid-configuration`
-  - JWKS: `/.well-known/jwks.json`
-  - Authorization: `/authorize`
-  - Token: `/token`
-  - UserInfo: `/userinfo`
+**After deployment, you'll get 5 specialized workers:**
+- 🌍 **op-discovery**: `https://enrai-op-discovery.{subdomain}.workers.dev`
+- 🌍 **op-auth**: `https://enrai-op-auth.{subdomain}.workers.dev`
+- 🌍 **op-token**: `https://enrai-op-token.{subdomain}.workers.dev`
+- 🌍 **op-userinfo**: `https://enrai-op-userinfo.{subdomain}.workers.dev`
+- 🌍 **op-management**: `https://enrai-op-management.{subdomain}.workers.dev`
+
+> **Note:** Configure routing to unify all workers under a single domain.
+> See [WORKERS.md](./WORKERS.md) for routing configuration.
 
 📖 **See [DEPLOYMENT.md](./docs/DEPLOYMENT.md) for detailed setup instructions**
 
 ### GitHub Actions (CI/CD)
 
 Automatic deployment is configured for the `main` branch:
-- ✅ Tests run on every push
-- 🚀 Deploys to Cloudflare Workers on merge to main
+- ✅ Tests run on every push (using pnpm)
+- 🚀 Deploys all 5 workers to Cloudflare on merge to main
 - 🔐 Requires `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets
+- ⚡ Turborepo caching for faster builds
 
 **Future (Phase 6):**
 ```bash

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -25,7 +25,7 @@ Before deploying Enrai, ensure you have:
 
 2. **Wrangler CLI** installed globally
    ```bash
-   npm install -g wrangler
+   ppnpm install -g wrangler
    ```
 
 3. **Cloudflare API Token**
@@ -33,7 +33,7 @@ Before deploying Enrai, ensure you have:
    - Create token with "Edit Cloudflare Workers" template
    - Save the token securely
 
-4. **Node.js 18+** and npm installed
+4. **Node.js 18+** and ppnpm installed
 
 ---
 
@@ -80,7 +80,7 @@ git clone https://github.com/sgrastar/enrai.git
 cd enrai
 
 # Install dependencies
-npm install
+ppnpm install
 ```
 
 ### 2. Authenticate with Cloudflare
@@ -180,14 +180,14 @@ cat .keys/public.jwk.json | jq -c . | wrangler secret put PUBLIC_JWK_JSON --env 
 ### 7. Build the Project
 
 ```bash
-npm run build
+ppnpm run build
 ```
 
 ### 8. Deploy to Cloudflare Workers
 
 ```bash
 # Deploy to production
-npm run deploy
+ppnpm run deploy
 
 # Or use wrangler directly
 wrangler deploy --env production
@@ -397,7 +397,7 @@ If your domain is managed by Cloudflare:
 
 ```bash
 # 1. Generate new key pair
-npm run generate-keys
+ppnpm run generate-keys
 
 # 2. Deploy with new KEY_ID
 # Update KEY_ID in wrangler.toml

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -220,7 +220,7 @@ Support: https://github.com/enrai/enrai/issues
 
 ```javascript
 // 1. Install client library
-npm install @enrai/client
+pnpm install @enrai/client
 
 // 2. Configure
 import { EnraiClient } from '@enrai/client';
@@ -473,8 +473,8 @@ npx create-enrai my-identity-provider
 # Or clone and deploy manually
 git clone https://github.com/sgrastar/enrai.git
 cd enrai
-npm install
-npm run deploy
+pnpm install
+pnpm run deploy
 ```
 
 ---

--- a/docs/conformance/SETUP.md
+++ b/docs/conformance/SETUP.md
@@ -28,7 +28,7 @@ If you prefer to set up manually:
 ### 1. Generate RSA Keys
 
 ```bash
-npm run generate-keys
+pnpm run generate-keys
 ```
 
 This creates:
@@ -65,7 +65,7 @@ KEY_ID = "dev-key-1234567890-xxxxx"
 Start the development server:
 
 ```bash
-npm run dev
+pnpm run dev
 ```
 
 The server will be available at `http://localhost:8787`.
@@ -135,7 +135,7 @@ npm test
 To run tests with coverage:
 
 ```bash
-npm run test:coverage
+pnpm run test:coverage
 ```
 
 ## Troubleshooting
@@ -186,7 +186,7 @@ cat .keys/private.pem | wrangler secret put PRIVATE_KEY_PEM
 cat .keys/public.jwk.json | jq -c . | wrangler secret put PUBLIC_JWK_JSON
 
 # Deploy
-npm run deploy
+pnpm run deploy
 ```
 
 ## Additional Resources

--- a/docs/conformance/phase3-quickstart.md
+++ b/docs/conformance/phase3-quickstart.md
@@ -24,13 +24,13 @@ This guide explains the quickest way to start Phase 3 OpenID Conformance Testing
 cd /path/to/enrai
 
 # Install dependencies (first time only)
-npm install
+pnpm install
 
 # Generate and configure RSA keys
 ./scripts/setup-dev.sh
 
 # Start development server
-npm run dev
+pnpm run dev
 ```
 
 Verify in another terminal:
@@ -61,7 +61,7 @@ curl http://localhost:8787/.well-known/jwks.json | jq '.keys | length'
 cp -r .keys .keys.dev
 
 # Generate new keys
-npm run generate-keys
+pnpm run generate-keys
 
 # Verify generated KEY_ID
 jq -r '.kid' .keys/metadata.json
@@ -104,10 +104,10 @@ cat .keys/public.jwk.json | jq -c . | wrangler secret put PUBLIC_JWK_JSON
 
 ```bash
 # Build TypeScript
-npm run build
+pnpm run build
 
 # Deploy to Cloudflare Workers
-npm run deploy
+pnpm run deploy
 ```
 
 **✓ Expected Output:**
@@ -247,7 +247,7 @@ curl -I $ENRAI_URL/.well-known/openid-configuration
 cat .keys/public.jwk.json | jq -c . | wrangler secret put PUBLIC_JWK_JSON
 
 # Redeploy
-npm run deploy
+pnpm run deploy
 
 # Verify
 curl $ENRAI_URL/.well-known/jwks.json | jq
@@ -261,7 +261,7 @@ curl $ENRAI_URL/.well-known/jwks.json | jq
 cat .keys/private.pem | wrangler secret put PRIVATE_KEY_PEM
 
 # Redeploy
-npm run deploy
+pnpm run deploy
 ```
 
 ---

--- a/docs/conformance/testing-guide.md
+++ b/docs/conformance/testing-guide.md
@@ -42,7 +42,7 @@ cd /path/to/enrai
 ./scripts/setup-dev.sh
 
 # Start development server
-npm run dev
+pnpm run dev
 ```
 
 ### 1.2 Verify Local Operation
@@ -82,7 +82,7 @@ Generate a new RSA key pair for the production environment:
 cp -r .keys .keys.dev
 
 # Generate new keys
-npm run generate-keys
+pnpm run generate-keys
 ```
 
 ### 2.2 Configure Wrangler Secrets
@@ -135,7 +135,7 @@ jq -r '.kid' .keys/metadata.json
 デプロイ前にTypeScriptをビルドします：
 
 ```bash
-npm run build
+pnpm run build
 ```
 
 エラーがないことを確認してください。
@@ -145,7 +145,7 @@ npm run build
 Cloudflare Workersにデプロイします：
 
 ```bash
-npm run deploy
+pnpm run deploy
 ```
 
 **期待される出力:**
@@ -431,7 +431,7 @@ wrangler deployments list
 
 # 最新のデプロイメントが active であることを確認
 # 必要に応じて再デプロイ
-npm run deploy
+pnpm run deploy
 ```
 
 #### 問題: JWKS endpointが空のkeys配列を返す
@@ -461,7 +461,7 @@ wrangler secret list
 cat .keys/private.pem | wrangler secret put PRIVATE_KEY_PEM
 
 # 再デプロイ
-npm run deploy
+pnpm run deploy
 ```
 
 #### 問題: Issuer URLの不一致
@@ -478,7 +478,7 @@ ISSUER = "https://enrai.YOUR_SUBDOMAIN.workers.dev"
 
 ```bash
 # 再デプロイ
-npm run deploy
+pnpm run deploy
 ```
 
 #### 問題: Conformance Suiteが"Unable to connect"エラーを表示
@@ -513,7 +513,7 @@ wrangler tail > logs.txt
 
 ```bash
 # 開発サーバーを起動
-npm run dev
+pnpm run dev
 
 # 別のターミナルで同じリクエストを送信
 curl -v http://localhost:8787/.well-known/openid-configuration
@@ -595,7 +595,7 @@ npm test -- --grep "token"
 
 1. **デプロイの実行**
    ```bash
-   npm run deploy
+   pnpm run deploy
    ```
 
 2. **OpenID Conformance Suiteでアカウント作成**

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -594,7 +594,7 @@ font-family: 'Fira Code', 'Consolas', 'Monaco', 'Courier New', monospace;
 **Lucide Icons** - Lightweight, open source, SVG
 
 ```bash
-npm install lucide-svelte
+pnpm install lucide-svelte
 ```
 
 ### よく使うアイコン

--- a/docs/operations/secret-management.md
+++ b/docs/operations/secret-management.md
@@ -42,7 +42,7 @@ In production, keys are stored as Cloudflare Workers secrets:
 The project includes a script to generate RSA key pairs:
 
 ```bash
-npm run generate-keys
+pnpm run generate-keys
 ```
 
 This will:
@@ -57,7 +57,7 @@ This will:
 You can specify a custom key ID:
 
 ```bash
-npm run generate-keys -- --kid=my-custom-key-1
+pnpm run generate-keys -- --kid=my-custom-key-1
 ```
 
 ### Manual Generation
@@ -120,7 +120,7 @@ During the initial phases, key rotation is manual:
 
 1. **Generate new key pair**:
    ```bash
-   npm run generate-keys -- --kid=prod-key-new
+   pnpm run generate-keys -- --kid=prod-key-new
    ```
 
 2. **Add new key to production**:
@@ -136,7 +136,7 @@ During the initial phases, key rotation is manual:
 
 4. **Deploy**:
    ```bash
-   npm run deploy
+   pnpm run deploy
    ```
 
 5. **Keep old public key available for verification** (if using Durable Objects)
@@ -230,7 +230,7 @@ See [Durable Objects Architecture](../architecture/durable-objects.md) for detai
 3. **Verify restoration**:
    ```bash
    # Test JWT signing with restored key
-   npm run test
+   pnpm run test
    ```
 
 4. **Delete decrypted file**:

--- a/docs/project-management/KICKOFF.md
+++ b/docs/project-management/KICKOFF.md
@@ -18,11 +18,11 @@ This checklist covers all immediate tasks needed to kickoff the Enrai project an
 
 ### Development Environment
 - [ ] Node.js 18+ installed
-- [ ] pnpm or npm installed
+- [ ] pnpm or pnpm installed
 - [ ] Git configured
 - [ ] Code editor installed (VS Code recommended)
 - [ ] Cloudflare account created
-- [ ] Wrangler CLI installed globally (`npm install -g wrangler`)
+- [ ] Wrangler CLI installed globally (`pnpm install -g wrangler`)
 
 ### Accounts & Access
 - [ ] GitHub repository access configured
@@ -321,7 +321,7 @@ enrai/
 
 ### Install Dependencies
 
-- [ ] Run: `pnpm install` (or `npm install`)
+- [ ] Run: `ppnpm install` (or `pnpm install`)
 - [ ] Verify all dependencies installed successfully
 - [ ] Check for any security vulnerabilities: `pnpm audit`
 


### PR DESCRIPTION
- Update README.md with monorepo architecture details
- Add Turborepo + pnpm to Technical Stack
- Update Getting Started section for 5 workers
- Update Deployment section for specialized workers
- Replace all npm commands with pnpm across documentation
- Update CI/CD section to reflect pnpm usage

Changes:
- README.md: monorepo structure, 5 workers deployment info
- DEVELOPMENT.md: all npm → pnpm commands
- docs/DEPLOYMENT.md: pnpm installation and commands
- docs/conformance/*: testing commands updated
- docs/operations/*: secret management commands updated
- Other docs: consistent pnpm usage throughout

This completes the migration from npm to pnpm across all documentation.