### PR TITLE
Debug local environment setup error

### DIFF
--- a/packages/op-auth/src/par.ts
+++ b/packages/op-auth/src/par.ts
@@ -235,7 +235,7 @@ export async function parHandler(c: Context<{ Bindings: Env }>): Promise<Respons
       },
       201
     );
-  } catch (error) {
+  } catch (error: unknown) {
     console.error('PAR error:', error);
 
     if (error instanceof OIDCError) {

--- a/turbo.json
+++ b/turbo.json
@@ -7,6 +7,7 @@
       "outputs": ["dist/**"]
     },
     "dev": {
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
This commit fixes the build errors that occur when running `pnpm run dev` locally.

Changes:
1. **turbo.json**: Added `dependsOn: ["^build"]` to the `dev` task to ensure that the @enrai/shared package is built before other packages that depend on it.

2. **packages/op-auth/src/par.ts**: Added explicit `unknown` type annotation to catch block error parameter to satisfy TypeScript's strict error handling requirements.

Previously, when running `pnpm run dev`, all packages would attempt to build simultaneously without waiting for @enrai/shared to complete, resulting in "Cannot find module '@enrai/shared'" errors across all packages.

With these changes, the build order is now enforced, and @enrai/shared is built first, allowing all other packages to successfully import from it.

Fixes local development environment setup issue.