### PR TITLE
Fix esbuild platform mismatch in WSL environment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Disable automatic CRLF conversion
+# All text files should use LF line endings
+
+# Set default behavior to automatically normalize line endings to LF
+* text=auto eol=lf
+
+# Explicitly set line endings for specific file types
+*.ts text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.toml text eol=lf
+*.sh text eol=lf
+*.bash text eol=lf
+
+# Denote binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,7 @@
 node-linker=hoisted
 strict-peer-dependencies=false
 auto-install-peers=true
+
+# Support both Windows and Linux platforms
+# This ensures esbuild binaries for both platforms are installed
+supported-architectures={"os":["linux","win32"],"cpu":["x64"]}

--- a/scripts/generate-keys.ts
+++ b/scripts/generate-keys.ts
@@ -14,7 +14,7 @@
 
 import { writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
-import { generateKeySet } from '../src/utils/keys';
+import { generateKeySet } from '../packages/shared/src/utils/keys';
 
 async function main() {
   const args = process.argv.slice(2);


### PR DESCRIPTION
- Fix generate-keys.ts import path for monorepo structure
- Add multi-platform support in .npmrc for Windows/Linux compatibility
- Create .gitattributes to enforce LF line endings across all platforms

This resolves the esbuild platform mismatch error when using node_modules across Windows and WSL environments, and prevents future CRLF/LF issues.