### PR TITLE
fix: update test import paths for monorepo structure

### DIFF
--- a/test/durable-objects/KeyManager.test.ts
+++ b/test/durable-objects/KeyManager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { KeyManager } from '../../src/durable-objects/KeyManager';
-import type { Env } from '../../src/types/env';
+import { KeyManager } from '../packages/shared/src/durable-objects/KeyManager';
+import type { Env } from '../packages/shared/src/types/env';
 
 /**
  * Mock implementation of DurableObjectState for testing

--- a/test/handlers/authorize.test.ts
+++ b/test/handlers/authorize.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Hono } from 'hono';
-import { authorizeHandler } from '../../src/handlers/authorize';
-import type { Env } from '../../src/types/env';
+import { authorizeHandler } from '../packages/op-auth/src/authorize';
+import type { Env } from '../packages/shared/src/types/env';
 
 /**
  * Mock KV namespace for testing

--- a/test/handlers/discovery.test.ts
+++ b/test/handlers/discovery.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { Hono } from 'hono';
-import { discoveryHandler } from '../../src/handlers/discovery';
-import type { Env } from '../../src/types/env';
+import { discoveryHandler } from '../packages/op-discovery/src/discovery';
+import type { Env } from '../packages/shared/src/types/env';
 
 /**
  * Create a mock environment for testing

--- a/test/handlers/jwks.test.ts
+++ b/test/handlers/jwks.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
 import { Hono } from 'hono';
-import { jwksHandler } from '../../src/handlers/jwks';
-import type { Env } from '../../src/types/env';
-import { generateKeySet } from '../../src/utils/keys';
+import { jwksHandler } from '../packages/op-discovery/src/jwks';
+import type { Env } from '../packages/shared/src/types/env';
+import { generateKeySet } from '../packages/shared/src/utils/keys';
 
 // Store generated test key
 let testPrivateKey: string;

--- a/test/handlers/register.test.ts
+++ b/test/handlers/register.test.ts
@@ -5,8 +5,8 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { Hono } from 'hono';
-import type { Env } from '../../src/types/env';
-import { registerHandler } from '../../src/handlers/register';
+import type { Env } from '../packages/shared/src/types/env';
+import { registerHandler } from '../packages/op-management/src/register';
 
 // Mock environment
 const mockEnv: Env = {

--- a/test/handlers/token-refresh-introspect-revoke.test.ts
+++ b/test/handlers/token-refresh-introspect-revoke.test.ts
@@ -7,12 +7,12 @@
 
 import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
 import { Hono } from 'hono';
-import type { Env } from '../../src/types/env';
-import { tokenHandler } from '../../src/handlers/token';
-import { introspectHandler } from '../../src/handlers/introspect';
-import { revokeHandler } from '../../src/handlers/revoke';
-import { generateKeySet } from '../../src/utils/keys';
-import { generateSecureRandomString } from '../../src/utils/crypto';
+import type { Env } from '../packages/shared/src/types/env';
+import { tokenHandler } from '../packages/op-token/src/token';
+import { introspectHandler } from '../packages/op-management/src/introspect';
+import { revokeHandler } from '../packages/op-management/src/revoke';
+import { generateKeySet } from '../packages/shared/src/utils/keys';
+import { generateSecureRandomString } from '../packages/shared/src/utils/crypto';
 
 // Store generated test key
 let testPrivateKey: string;

--- a/test/integration/authorization-flow.test.ts
+++ b/test/integration/authorization-flow.test.ts
@@ -22,7 +22,7 @@ import {
   parseAuthorizationResponse,
   buildTokenRequestBody,
 } from './fixtures';
-import type { Env } from '../../src/types/env';
+import type { Env } from '../packages/shared/src/types/env';
 
 describe('Authorization Code Flow', () => {
   let env: Env;

--- a/test/integration/fixtures.ts
+++ b/test/integration/fixtures.ts
@@ -5,8 +5,8 @@
  * for integration testing of OIDC flows.
  */
 
-import type { Env } from '../../src/types/env';
-import { generateSecureRandomString } from '../../src/utils/crypto';
+import type { Env } from '../packages/shared/src/types/env';
+import { generateSecureRandomString } from '../packages/shared/src/utils/crypto';
 
 /**
  * Mock client configuration

--- a/test/integration/security-headers.test.ts
+++ b/test/integration/security-headers.test.ts
@@ -3,8 +3,8 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import type { Env } from '../../src/types/env';
-import app from '../../src/index';
+import type { Env } from '../packages/shared/src/types/env';
+import app from '../packages/op-discovery/src/index';
 
 // Mock environment
 const mockEnv: Env = {

--- a/test/middleware/rate-limit.test.ts
+++ b/test/middleware/rate-limit.test.ts
@@ -4,8 +4,8 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { Hono } from 'hono';
-import type { Env } from '../../src/types/env';
-import { rateLimitMiddleware, RateLimitProfiles } from '../../src/middleware/rate-limit';
+import type { Env } from '../packages/shared/src/types/env';
+import { rateLimitMiddleware, RateLimitProfiles } from '../packages/shared/src/middleware/rate-limit';
 
 // Mock environment
 const mockEnv: Env = {

--- a/test/utils/jwt.test.ts
+++ b/test/utils/jwt.test.ts
@@ -8,8 +8,8 @@ import {
   importPublicKeyFromJWK,
   type IDTokenClaims,
   type AccessTokenClaims,
-} from '../../src/utils/jwt';
-import { generateKeySet } from '../../src/utils/keys';
+} from '../packages/shared/src/utils/jwt';
+import { generateKeySet } from '../packages/shared/src/utils/keys';
 import type { KeyLike, JWK } from 'jose';
 
 describe('JWT Utilities', () => {

--- a/test/utils/keys.test.ts
+++ b/test/utils/keys.test.ts
@@ -4,7 +4,7 @@ import {
   exportPublicJWK,
   exportPrivateKey,
   generateKeySet,
-} from '../../src/utils/keys';
+} from '../packages/shared/src/utils/keys';
 
 describe('Key Generation Utilities', () => {
   describe('generateRSAKeyPair', () => {

--- a/test/utils/kv.test.ts
+++ b/test/utils/kv.test.ts
@@ -12,8 +12,8 @@ import {
   storeClient,
   getClient,
   type AuthCodeData,
-} from '../../src/utils/kv';
-import type { Env } from '../../src/types/env';
+} from '../packages/shared/src/utils/kv';
+import type { Env } from '../packages/shared/src/types/env';
 
 // Mock KV namespace
 class MockKVNamespace implements KVNamespace {

--- a/test/utils/validation.test.ts
+++ b/test/utils/validation.test.ts
@@ -9,7 +9,7 @@ import {
   validateResponseType,
   validateAuthCode,
   validateToken,
-} from '../../src/utils/validation';
+} from '../packages/shared/src/utils/validation';
 
 describe('Validation Utilities', () => {
   describe('validateClientId', () => {


### PR DESCRIPTION
- Update all test files to use correct import paths
- Change from ../../src/ to ../packages/{package-name}/src/
- Fix imports for handlers, utils, middleware, and durable objects
- Ensure all tests work with current monorepo structure

This resolves import errors in test files after monorepo refactoring.