### PR TITLE
Debug WSL environment error

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,4 +4,5 @@ auto-install-peers=true
 
 # Support both Windows and Linux platforms
 # This ensures esbuild binaries for both platforms are installed
-supported-architectures={"os":["linux","win32"],"cpu":["x64"]}
+supportedArchitectures[os]=["linux","win32"]
+supportedArchitectures[cpu]=["x64"]

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -313,6 +313,28 @@ wrangler dev --port 8788
 
 **Solution:** Ensure TypeScript paths are correctly configured in `vitest.config.ts` and `tsconfig.json`.
 
+### Issue: esbuild platform mismatch in WSL
+
+**Error:**
+```
+Error [TransformError]: You installed esbuild for another platform than the one you're currently using.
+Specifically the "@esbuild/win32-x64" package is present but this platform needs the "@esbuild/linux-x64" package instead.
+```
+
+**Cause:** This happens when `node_modules` is installed on Windows but then accessed from WSL (Windows Subsystem for Linux), or vice versa. WSL is a Linux environment and requires Linux binaries, not Windows binaries.
+
+**Solution:** Reinstall dependencies in the WSL environment:
+
+```bash
+# Remove node_modules and lock file
+rm -rf node_modules pnpm-lock.yaml
+
+# Reinstall dependencies in WSL
+pnpm install
+```
+
+**Prevention:** Always install dependencies in the environment where you will run the code. Don't share `node_modules` between Windows and WSL.
+
 ## Debugging
 
 ### Enable Verbose Logging

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240117.0",
+    "@esbuild/win32-x64": "^0.25.12",
     "@eslint/js": "^9.39.1",
     "@types/node": "^20.11.5",
     "@typescript-eslint/eslint-plugin": "^8.46.4",
@@ -49,6 +50,9 @@
     "typescript": "^5.3.3",
     "vitest": "^4.0.8",
     "wrangler": "^4.46.0"
+  },
+  "optionalDependencies": {
+    "@esbuild/linux-x64": "^0.25.12"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,10 +14,17 @@ importers:
       jose:
         specifier: ^5.2.0
         version: 5.10.0
+    optionalDependencies:
+      '@esbuild/linux-x64':
+        specifier: ^0.25.12
+        version: 0.25.12
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20240117.0
         version: 4.20251111.0
+      '@esbuild/win32-x64':
+        specifier: ^0.25.12
+        version: 0.25.12
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.1
@@ -1935,8 +1942,7 @@ snapshots:
   '@esbuild/win32-ia32@0.25.4':
     optional: true
 
-  '@esbuild/win32-x64@0.25.12':
-    optional: true
+  '@esbuild/win32-x64@0.25.12': {}
 
   '@esbuild/win32-x64@0.25.4':
     optional: true


### PR DESCRIPTION
…m binaries

This commit fixes the esbuild platform mismatch error that occurs when switching between Windows and WSL environments by ensuring both Linux and Windows esbuild binaries are installed.

Changes:
- Fix .npmrc syntax for supportedArchitectures (correct pnpm format)
- Add @esbuild/win32-x64 as devDependency to ensure Windows binary is installed
- Add @esbuild/linux-x64 as optionalDependency for Linux binary
- Update DEVELOPMENT.md with WSL troubleshooting section explaining the issue and solution

This allows node_modules to be shared between Windows and WSL without reinstalling dependencies, while the documentation also provides guidance for users who encounter the platform mismatch error.