### PR TITLE
fix: correct ID extraction from wrangler JSON output in setup-kv.sh

### DIFF
--- a/scripts/setup-kv.sh
+++ b/scripts/setup-kv.sh
@@ -231,7 +231,8 @@ create_kv_namespace() {
     fi
 
     # Extract ID from successful creation output
-    local id=$(echo "$output" | grep -o 'id = "[^"]*"' | cut -d'"' -f2)
+    # Wrangler outputs in JSON format: "id": "abc123..."
+    local id=$(echo "$output" | grep -o '"id"[[:space:]]*:[[:space:]]*"[a-f0-9]\{32\}"' | grep -o '[a-f0-9]\{32\}')
 
     if [ -z "$id" ]; then
         echo "❌ Could not extract ID from wrangler output" >&2


### PR DESCRIPTION
The wrangler CLI outputs namespace IDs in JSON format ("id": "..."), but the script was looking for the old format (id = "..."). Updated the regex to properly extract IDs from JSON output.