### PR TITLE
Fix warning in setup-kv.sh script

### DIFF
--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -182,6 +182,11 @@ preview_id = "placeholder"
 [[kv_namespaces]]
 binding = "RATE_LIMIT"
 id = "placeholder"
+preview_id = "placeholder"
+
+[[kv_namespaces]]
+binding = "INITIAL_ACCESS_TOKENS"
+id = "placeholder"
 preview_id = "placeholder"'
 
 # Generate wrangler.toml for router (with Service Bindings)

--- a/scripts/setup-kv.sh
+++ b/scripts/setup-kv.sh
@@ -377,12 +377,20 @@ update_wrangler_toml() {
     # Check if file exists
     if [ ! -f "$file" ]; then
         echo "    ⚠️  Warning: File not found: $file"
+        echo "    💡 Hint: Run './scripts/setup-dev.sh' first to generate wrangler.toml files"
         return 1
     fi
 
     # Check if IDs are provided
     if [ -z "$id" ] || [ -z "$preview_id" ]; then
         echo "    ⚠️  Warning: Empty ID provided for $binding (id: '$id', preview_id: '$preview_id')"
+        return 1
+    fi
+
+    # Check if the binding exists in the file
+    if ! grep -q "binding = \"$binding\"" "$file"; then
+        echo "    ⚠️  Warning: Binding '$binding' not found in $file"
+        echo "    💡 Hint: The wrangler.toml file may need to be regenerated with './scripts/setup-dev.sh'"
         return 1
     fi
 


### PR DESCRIPTION
…rror handling in setup scripts

This commit fixes the warning "Failed to update INITIAL_ACCESS_TOKENS in packages/op-management/wrangler.toml" that occurs when running setup-kv.sh.

Changes made:
1. Added INITIAL_ACCESS_TOKENS KV namespace binding to op-management wrangler.toml generation in setup-dev.sh
2. Improved error handling in setup-kv.sh to:
   - Check if wrangler.toml files exist before attempting to update them
   - Verify that the binding exists in the file before attempting to update
   - Provide helpful hints when errors occur (e.g., "Run './scripts/setup-dev.sh' first")

Root cause:
- setup-dev.sh was generating op-management wrangler.toml without INITIAL_ACCESS_TOKENS binding
- setup-kv.sh was trying to update a binding that didn't exist
- This caused the warning message during KV namespace setup

Impact:
- The INITIAL_ACCESS_TOKENS namespace will now be properly configured for the op-management worker
- Better error messages will help users understand setup script dependencies