### PR TITLE
fix: apply Prettier formatting to consent and passkey modules

### DIFF
--- a/packages/op-auth/src/consent.ts
+++ b/packages/op-auth/src/consent.ts
@@ -41,7 +41,8 @@ const SCOPE_DESCRIPTIONS: Record<string, { title: string; description: string }>
 export async function consentGetHandler(c: Context<{ Bindings: Env }>) {
   try {
     // Get session ID from query or cookie
-    const sessionId = c.req.query('session_id') || c.req.header('cookie')?.match(/session_id=([^;]+)/)?.[1];
+    const sessionId =
+      c.req.query('session_id') || c.req.header('cookie')?.match(/session_id=([^;]+)/)?.[1];
 
     if (!sessionId) {
       return c.json(

--- a/packages/op-auth/src/passkey.ts
+++ b/packages/op-auth/src/passkey.ts
@@ -211,12 +211,16 @@ export async function passkeyRegisterVerifyHandler(c: Context<{ Bindings: Env }>
 
     const registrationInfoAny = registrationInfo as any;
     const credentialID = registrationInfoAny.credentialID || registrationInfoAny.credential?.id;
-    const credentialPublicKey = registrationInfoAny.credentialPublicKey || registrationInfoAny.credential?.publicKey;
+    const credentialPublicKey =
+      registrationInfoAny.credentialPublicKey || registrationInfoAny.credential?.publicKey;
     const counter = registrationInfoAny.counter || registrationInfoAny.credential?.counter || 0;
 
     // Convert credentialPublicKey (Uint8Array) to base64
     const publicKeyBase64 = Buffer.from(credentialPublicKey).toString('base64');
-    const credentialIDBase64 = typeof credentialID === 'string' ? credentialID : Buffer.from(credentialID).toString('base64');
+    const credentialIDBase64 =
+      typeof credentialID === 'string'
+        ? credentialID
+        : Buffer.from(credentialID).toString('base64');
 
     // Store passkey in D1
     const passkeyId = crypto.randomUUID();


### PR DESCRIPTION
Fixed formatting issues in op-auth package:
- Wrapped long lines in consent.ts
- Wrapped long lines and improved readability in passkey.ts

This resolves CI failures from the format:check step.