### PR TITLE
Create cleanup scripts for worker deletion

### DIFF
--- a/scripts/delete-all.sh
+++ b/scripts/delete-all.sh
@@ -1,0 +1,308 @@
+#!/bin/bash
+#
+# Enrai Complete Deletion Script
+# This script safely deletes ALL Cloudflare resources for the Enrai project
+#
+# This is a master script that orchestrates the deletion of:
+#   - Workers (and associated Durable Objects)
+#   - KV Namespaces
+#   - D1 Databases
+#
+# Usage:
+#   ./delete-all.sh                 - Interactive mode (prompts for environment and confirmation)
+#   ./delete-all.sh dev             - Delete all dev resources with confirmation
+#   ./delete-all.sh prod            - Delete all prod resources with confirmation
+#   ./delete-all.sh --dry-run       - Dry run mode (shows what would be deleted)
+#   ./delete-all.sh dev --force     - Force deletion without confirmation (USE WITH EXTREME CAUTION)
+#
+
+set -e
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+MAGENTA='\033[0;35m'
+NC='\033[0m' # No Color
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Parse command line arguments
+DRY_RUN=false
+FORCE=false
+ENV=""
+
+for arg in "$@"; do
+    case $arg in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --force)
+            FORCE=true
+            shift
+            ;;
+        dev|prod|staging)
+            ENV=$arg
+            shift
+            ;;
+        *)
+            if [ -n "$arg" ]; then
+                echo -e "${RED}❌ Unknown option: $arg${NC}"
+                echo "Usage: $0 [dev|prod|staging] [--dry-run] [--force]"
+                exit 1
+            fi
+            ;;
+    esac
+done
+
+echo ""
+echo -e "${MAGENTA}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${MAGENTA}⚡️  Enrai Complete Resource Deletion${NC}"
+echo -e "${MAGENTA}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${YELLOW}🔍 DRY RUN MODE - No actual deletions will occur${NC}"
+    echo ""
+fi
+
+# If environment not specified, prompt for it
+if [ -z "$ENV" ]; then
+    echo "This script will delete ALL Enrai resources for a specific environment."
+    echo ""
+    echo "Select environment to delete:"
+    echo "  1) dev"
+    echo "  2) prod"
+    echo "  3) staging"
+    echo "  4) Cancel"
+    echo ""
+    read -p "Enter your choice (1-4): " -r choice
+
+    case $choice in
+        1)
+            ENV="dev"
+            ;;
+        2)
+            ENV="prod"
+            ;;
+        3)
+            ENV="staging"
+            ;;
+        4|*)
+            echo -e "${BLUE}❌ Cancelled${NC}"
+            exit 0
+            ;;
+    esac
+    echo ""
+fi
+
+echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${YELLOW}⚠️  DELETION PLAN${NC}"
+echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+echo "Environment: $ENV"
+echo ""
+echo "The following resources will be deleted in this order:"
+echo ""
+echo "  1. 🔧 Cloudflare Workers (and Durable Objects)"
+echo "     • enrai-shared"
+echo "     • enrai-op-auth"
+echo "     • enrai-op-discovery"
+echo "     • enrai-op-management"
+echo "     • enrai-op-token"
+echo "     • enrai-op-userinfo"
+echo "     • enrai-router"
+echo ""
+echo "  2. 📦 KV Namespaces (production and preview)"
+echo "     • AUTH_CODES"
+echo "     • STATE_STORE"
+echo "     • NONCE_STORE"
+echo "     • CLIENTS"
+echo "     • RATE_LIMIT"
+echo "     • REFRESH_TOKENS"
+echo "     • REVOKED_TOKENS"
+echo "     • INITIAL_ACCESS_TOKENS"
+echo ""
+echo "  3. 🗄️  D1 Database"
+echo "     • enrai-${ENV}"
+echo ""
+echo -e "${RED}⚠️  WARNING: This action CANNOT be undone!${NC}"
+echo -e "${RED}⚠️  ALL data will be permanently deleted!${NC}"
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${YELLOW}🔍 DRY RUN MODE - Showing what would be deleted...${NC}"
+    echo ""
+
+    # Run dry-run for each deletion script
+    echo -e "${BLUE}━━━ Workers (Dry Run) ━━━${NC}"
+    if [ -f "$SCRIPT_DIR/delete-workers.sh" ]; then
+        bash "$SCRIPT_DIR/delete-workers.sh" --dry-run --all
+    else
+        echo -e "${YELLOW}⚠️  delete-workers.sh not found${NC}"
+    fi
+    echo ""
+
+    echo -e "${BLUE}━━━ KV Namespaces (Dry Run) ━━━${NC}"
+    if [ -f "$SCRIPT_DIR/delete-kv.sh" ]; then
+        bash "$SCRIPT_DIR/delete-kv.sh" --dry-run
+    else
+        echo -e "${YELLOW}⚠️  delete-kv.sh not found${NC}"
+    fi
+    echo ""
+
+    echo -e "${BLUE}━━━ D1 Database (Dry Run) ━━━${NC}"
+    if [ -f "$SCRIPT_DIR/delete-d1.sh" ]; then
+        bash "$SCRIPT_DIR/delete-d1.sh" "$ENV" --dry-run
+    else
+        echo -e "${YELLOW}⚠️  delete-d1.sh not found${NC}"
+    fi
+    echo ""
+
+    echo -e "${YELLOW}🔍 DRY RUN COMPLETE - No actual deletions occurred${NC}"
+    exit 0
+fi
+
+# Final confirmation (skip if --force is used)
+if [ "$FORCE" = false ]; then
+    echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+
+    if [ "$ENV" = "prod" ]; then
+        echo -e "${RED}⚠️  YOU ARE ABOUT TO DELETE ALL PRODUCTION RESOURCES!${NC}"
+        echo -e "${RED}⚠️  THIS WILL COMPLETELY DESTROY YOUR PRODUCTION ENVIRONMENT!${NC}"
+        echo ""
+        read -p "Type 'DELETE PRODUCTION' to confirm, or anything else to cancel: " -r
+        echo ""
+        if [ "$REPLY" != "DELETE PRODUCTION" ]; then
+            echo -e "${BLUE}❌ Deletion cancelled${NC}"
+            exit 0
+        fi
+    else
+        echo -e "${YELLOW}⚠️  You are about to delete all $ENV resources!${NC}"
+        echo ""
+        read -p "Type 'DELETE ALL' to confirm, or anything else to cancel: " -r
+        echo ""
+        if [ "$REPLY" != "DELETE ALL" ]; then
+            echo -e "${BLUE}❌ Deletion cancelled${NC}"
+            exit 0
+        fi
+    fi
+
+    # Double confirmation for production
+    if [ "$ENV" = "prod" ]; then
+        echo ""
+        echo -e "${RED}⚠️  FINAL WARNING FOR PRODUCTION!${NC}"
+        echo ""
+        read -p "Are you absolutely sure? Type 'YES' to proceed: " -r
+        echo ""
+        if [ "$REPLY" != "YES" ]; then
+            echo -e "${BLUE}❌ Deletion cancelled${NC}"
+            exit 0
+        fi
+    fi
+fi
+
+echo ""
+echo -e "${MAGENTA}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${MAGENTA}🗑️  Starting Deletion Process${NC}"
+echo -e "${MAGENTA}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+
+OVERALL_SUCCESS=true
+
+# Step 1: Delete Workers (this also deletes Durable Objects)
+echo ""
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${BLUE}Step 1/3: Deleting Workers and Durable Objects${NC}"
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+
+if [ -f "$SCRIPT_DIR/delete-workers.sh" ]; then
+    if bash "$SCRIPT_DIR/delete-workers.sh" --all --force; then
+        echo -e "${GREEN}✅ Workers deleted successfully${NC}"
+    else
+        echo -e "${RED}❌ Failed to delete some or all workers${NC}"
+        OVERALL_SUCCESS=false
+    fi
+else
+    echo -e "${RED}❌ Error: delete-workers.sh not found in $SCRIPT_DIR${NC}"
+    OVERALL_SUCCESS=false
+fi
+
+# Wait a bit for Cloudflare to propagate the changes
+echo ""
+echo -e "${YELLOW}⏳ Waiting 10 seconds for Cloudflare to propagate changes...${NC}"
+sleep 10
+
+# Step 2: Delete KV Namespaces
+echo ""
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${BLUE}Step 2/3: Deleting KV Namespaces${NC}"
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+
+if [ -f "$SCRIPT_DIR/delete-kv.sh" ]; then
+    if bash "$SCRIPT_DIR/delete-kv.sh" --force; then
+        echo -e "${GREEN}✅ KV namespaces deleted successfully${NC}"
+    else
+        echo -e "${RED}❌ Failed to delete some or all KV namespaces${NC}"
+        OVERALL_SUCCESS=false
+    fi
+else
+    echo -e "${RED}❌ Error: delete-kv.sh not found in $SCRIPT_DIR${NC}"
+    OVERALL_SUCCESS=false
+fi
+
+# Step 3: Delete D1 Database
+echo ""
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${BLUE}Step 3/3: Deleting D1 Database${NC}"
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+
+if [ -f "$SCRIPT_DIR/delete-d1.sh" ]; then
+    if bash "$SCRIPT_DIR/delete-d1.sh" "$ENV" --force; then
+        echo -e "${GREEN}✅ D1 database deleted successfully${NC}"
+    else
+        echo -e "${RED}❌ Failed to delete D1 database${NC}"
+        OVERALL_SUCCESS=false
+    fi
+else
+    echo -e "${RED}❌ Error: delete-d1.sh not found in $SCRIPT_DIR${NC}"
+    OVERALL_SUCCESS=false
+fi
+
+# Final summary
+echo ""
+echo -e "${MAGENTA}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${MAGENTA}📊 Deletion Process Complete${NC}"
+echo -e "${MAGENTA}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+
+if [ "$OVERALL_SUCCESS" = true ]; then
+    echo -e "${GREEN}✅ All resources for environment '$ENV' have been deleted successfully!${NC}"
+    echo ""
+    echo "To redeploy from scratch:"
+    echo "  1. Run setup scripts:"
+    echo "     ./scripts/setup-dev.sh"
+    echo "     ./scripts/setup-kv.sh"
+    echo "     ./scripts/setup-d1.sh"
+    echo "     ./scripts/setup-durable-objects.sh"
+    echo "  2. Deploy workers:"
+    echo "     pnpm run deploy:retry"
+else
+    echo -e "${YELLOW}⚠️  Deletion process completed with some errors${NC}"
+    echo ""
+    echo "Please review the error messages above and:"
+    echo "  1. Check which resources failed to delete"
+    echo "  2. Try running individual deletion scripts for those resources"
+    echo "  3. Verify resources in the Cloudflare dashboard"
+fi
+
+echo ""
+echo -e "${MAGENTA}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""

--- a/scripts/delete-d1.sh
+++ b/scripts/delete-d1.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+#
+# Enrai D1 Database Deletion Script
+# This script safely deletes D1 databases for the Enrai project
+#
+# Usage:
+#   ./delete-d1.sh                 - Interactive mode (prompts for environment and confirmation)
+#   ./delete-d1.sh dev             - Delete dev database with confirmation
+#   ./delete-d1.sh prod            - Delete prod database with confirmation
+#   ./delete-d1.sh --dry-run       - Dry run mode (shows what would be deleted)
+#   ./delete-d1.sh dev --force     - Force deletion without confirmation (USE WITH CAUTION)
+#
+
+set -e
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Parse command line arguments
+DRY_RUN=false
+FORCE=false
+ENV=""
+
+for arg in "$@"; do
+    case $arg in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --force)
+            FORCE=true
+            shift
+            ;;
+        dev|prod|staging)
+            ENV=$arg
+            shift
+            ;;
+        *)
+            if [ -n "$arg" ]; then
+                echo -e "${RED}❌ Unknown option: $arg${NC}"
+                echo "Usage: $0 [dev|prod|staging] [--dry-run] [--force]"
+                exit 1
+            fi
+            ;;
+    esac
+done
+
+echo -e "${BLUE}⚡️ Enrai D1 Database Deletion${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${YELLOW}🔍 DRY RUN MODE - No actual deletions will occur${NC}"
+    echo ""
+fi
+
+# Check if npx is available
+if ! command -v npx &> /dev/null; then
+    echo -e "${RED}❌ Error: npx is not installed${NC}"
+    echo "Please install Node.js and npm"
+    exit 1
+fi
+
+# Check if user is logged in to Cloudflare
+if ! npx wrangler whoami &> /dev/null; then
+    echo -e "${RED}❌ Error: Not logged in to Cloudflare${NC}"
+    echo "Please run: npx wrangler login"
+    exit 1
+fi
+
+# If environment not specified, prompt for it
+if [ -z "$ENV" ]; then
+    echo "Select environment to delete:"
+    echo "  1) dev"
+    echo "  2) prod"
+    echo "  3) staging"
+    echo "  4) Cancel"
+    echo ""
+    read -p "Enter your choice (1-4): " -r choice
+
+    case $choice in
+        1)
+            ENV="dev"
+            ;;
+        2)
+            ENV="prod"
+            ;;
+        3)
+            ENV="staging"
+            ;;
+        4|*)
+            echo -e "${BLUE}❌ Cancelled${NC}"
+            exit 0
+            ;;
+    esac
+    echo ""
+fi
+
+DB_NAME="enrai-${ENV}"
+
+echo -e "${BLUE}📊 Checking for D1 database: $DB_NAME${NC}"
+echo ""
+
+# Check if database exists
+DB_EXISTS=false
+DB_INFO=""
+if npx wrangler d1 info "$DB_NAME" &> /dev/null; then
+    DB_EXISTS=true
+    DB_INFO=$(npx wrangler d1 info "$DB_NAME" 2>&1)
+fi
+
+if [ "$DB_EXISTS" = false ]; then
+    echo -e "${YELLOW}ℹ️  Database not found: $DB_NAME${NC}"
+    echo ""
+    echo "If you expected to find this database, please check:"
+    echo "  1. You are logged in to the correct Cloudflare account"
+    echo "  2. The database was created using the setup scripts"
+    echo "  3. The database name is correct (enrai-${ENV})"
+    echo ""
+    exit 0
+fi
+
+# Try to extract database ID
+DB_LIST_JSON=$(npx wrangler d1 list --json 2>/dev/null || echo "")
+DB_ID=""
+
+if [ -n "$DB_LIST_JSON" ]; then
+    if command -v jq &> /dev/null; then
+        DB_ID=$(echo "$DB_LIST_JSON" | jq -r ".[] | select(.name == \"$DB_NAME\") | .uuid" 2>/dev/null | head -1)
+    else
+        DB_ID=$(echo "$DB_LIST_JSON" | grep -A 1 "\"name\": \"$DB_NAME\"" | grep -oE '"uuid": "([a-f0-9-]{36})"' | grep -oE '[a-f0-9-]{36}')
+    fi
+fi
+
+# Fallback: extract from info output
+if [ -z "$DB_ID" ]; then
+    DB_ID=$(echo "$DB_INFO" | grep -oE '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}' | head -1)
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo -e "${YELLOW}⚠️  DELETION SUMMARY${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "The following D1 database will be deleted:"
+echo ""
+echo -e "  ${RED}✗${NC} Database Name: $DB_NAME"
+if [ -n "$DB_ID" ]; then
+    echo "    Database ID: $DB_ID"
+fi
+echo "    Environment: $ENV"
+echo ""
+echo -e "${RED}⚠️  WARNING: This action cannot be undone!${NC}"
+echo -e "${RED}⚠️  All data in this database will be permanently deleted!${NC}"
+
+# Try to show table information
+echo ""
+echo -e "${BLUE}📊 Database contents:${NC}"
+TABLES=$(npx wrangler d1 execute "$DB_NAME" --command="SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;" 2>/dev/null || echo "")
+if [ -n "$TABLES" ]; then
+    echo "$TABLES"
+else
+    echo "  (Unable to retrieve table information)"
+fi
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${YELLOW}🔍 DRY RUN MODE - No actual deletions occurred${NC}"
+    exit 0
+fi
+
+# Confirmation prompt (skip if --force is used)
+if [ "$FORCE" = false ]; then
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    if [ "$ENV" = "prod" ]; then
+        echo -e "${RED}⚠️  YOU ARE ABOUT TO DELETE THE PRODUCTION DATABASE!${NC}"
+        echo ""
+        read -p "Type 'DELETE PRODUCTION' to confirm, or anything else to cancel: " -r
+        echo ""
+        if [ "$REPLY" != "DELETE PRODUCTION" ]; then
+            echo -e "${BLUE}❌ Deletion cancelled${NC}"
+            exit 0
+        fi
+    else
+        read -p "Type 'DELETE' to confirm deletion, or anything else to cancel: " -r
+        echo ""
+        if [ "$REPLY" != "DELETE" ]; then
+            echo -e "${BLUE}❌ Deletion cancelled${NC}"
+            exit 0
+        fi
+    fi
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo -e "${BLUE}🗑️  Deleting D1 database...${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Delete the database using wrangler
+if npx wrangler d1 delete "$DB_NAME" --skip-confirmation; then
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo -e "${GREEN}✅ Database deleted successfully!${NC}"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    echo "Database deleted: $DB_NAME"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Remove D1 bindings from wrangler.toml files if needed"
+    echo "  2. To recreate the database, run: ./scripts/setup-d1.sh"
+    echo ""
+else
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo -e "${RED}❌ Failed to delete database${NC}"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    echo "Possible reasons:"
+    echo "  1. The database is currently being used by deployed workers"
+    echo "  2. You don't have permission to delete this database"
+    echo "  3. Network or API error"
+    echo ""
+    echo "Try:"
+    echo "  1. Delete or undeploy workers using this database first"
+    echo "  2. Check your Cloudflare account permissions"
+    echo "  3. Wait a few minutes and try again"
+    echo ""
+    exit 1
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/scripts/delete-kv.sh
+++ b/scripts/delete-kv.sh
@@ -1,0 +1,223 @@
+#!/bin/bash
+#
+# Enrai KV Namespace Deletion Script
+# This script safely deletes KV namespaces for the Enrai project
+#
+# Usage:
+#   ./delete-kv.sh                 - Interactive mode (prompts for confirmation)
+#   ./delete-kv.sh --dry-run       - Dry run mode (shows what would be deleted)
+#   ./delete-kv.sh --force         - Force deletion without confirmation (USE WITH CAUTION)
+#
+
+set -e
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Parse command line arguments
+DRY_RUN=false
+FORCE=false
+for arg in "$@"; do
+    case $arg in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --force)
+            FORCE=true
+            shift
+            ;;
+        *)
+            echo -e "${RED}❌ Unknown option: $arg${NC}"
+            echo "Usage: $0 [--dry-run] [--force]"
+            exit 1
+            ;;
+    esac
+done
+
+echo -e "${BLUE}⚡️ Enrai KV Namespace Deletion${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${YELLOW}🔍 DRY RUN MODE - No actual deletions will occur${NC}"
+    echo ""
+fi
+
+# Check if npx is available
+if ! command -v npx &> /dev/null; then
+    echo -e "${RED}❌ Error: npx is not installed${NC}"
+    echo "Please install Node.js and npm"
+    exit 1
+fi
+
+# Check if user is logged in to Cloudflare
+if ! npx wrangler whoami &> /dev/null; then
+    echo -e "${RED}❌ Error: Not logged in to Cloudflare${NC}"
+    echo "Please run: npx wrangler login"
+    exit 1
+fi
+
+echo -e "${BLUE}📊 Fetching list of KV namespaces...${NC}"
+echo ""
+
+# Get list of all KV namespaces in JSON format
+KV_LIST_JSON=$(npx wrangler kv namespace list 2>&1)
+
+if [ $? -ne 0 ]; then
+    echo -e "${RED}❌ Error: Failed to fetch KV namespace list${NC}"
+    echo "$KV_LIST_JSON"
+    exit 1
+fi
+
+# Define the KV namespace names we expect to find for Enrai
+ENRAI_KV_NAMES=(
+    "AUTH_CODES"
+    "STATE_STORE"
+    "NONCE_STORE"
+    "CLIENTS"
+    "RATE_LIMIT"
+    "REFRESH_TOKENS"
+    "REVOKED_TOKENS"
+    "INITIAL_ACCESS_TOKENS"
+)
+
+# Arrays to store namespaces to delete
+declare -a NAMESPACES_TO_DELETE_IDS=()
+declare -a NAMESPACES_TO_DELETE_TITLES=()
+
+echo -e "${BLUE}🔍 Searching for Enrai KV namespaces...${NC}"
+echo ""
+
+# Function to extract namespace ID by title
+get_namespace_id_by_title() {
+    local title=$1
+    local list_output=$2
+
+    # Try using jq if available for robust JSON parsing
+    if command -v jq &> /dev/null; then
+        echo "$list_output" | jq -r ".[] | select(.title == \"$title\") | .id" 2>/dev/null | head -1
+    else
+        # Fallback to grep-based parsing
+        echo "$list_output" | grep -A 2 "\"title\"[[:space:]]*:[[:space:]]*\"$title\"" | grep "\"id\"" | grep -o '"[a-f0-9]\{32\}"' | tr -d '"' | head -1
+    fi
+}
+
+# Search for both production and preview namespaces
+for kv_name in "${ENRAI_KV_NAMES[@]}"; do
+    # Check for production namespace
+    prod_id=$(get_namespace_id_by_title "$kv_name" "$KV_LIST_JSON")
+    if [ -n "$prod_id" ]; then
+        NAMESPACES_TO_DELETE_IDS+=("$prod_id")
+        NAMESPACES_TO_DELETE_TITLES+=("$kv_name (production)")
+        echo -e "${GREEN}  ✓ Found: $kv_name (production) - ID: $prod_id${NC}"
+    fi
+
+    # Check for preview namespace (can have various suffixes)
+    if command -v jq &> /dev/null; then
+        preview_id=$(echo "$KV_LIST_JSON" | jq -r ".[] | select(.title | test(\"^${kv_name}_preview\"; \"i\")) | .id" 2>/dev/null | head -1)
+    else
+        preview_id=$(echo "$KV_LIST_JSON" | grep -i "\"title\".*$kv_name" | grep -i "preview" | grep -o '"[a-f0-9]\{32\}"' | tr -d '"' | head -1)
+    fi
+
+    if [ -n "$preview_id" ]; then
+        NAMESPACES_TO_DELETE_IDS+=("$preview_id")
+        NAMESPACES_TO_DELETE_TITLES+=("$kv_name (preview)")
+        echo -e "${GREEN}  ✓ Found: $kv_name (preview) - ID: $preview_id${NC}"
+    fi
+done
+
+echo ""
+
+# Check if any namespaces were found
+if [ ${#NAMESPACES_TO_DELETE_IDS[@]} -eq 0 ]; then
+    echo -e "${YELLOW}ℹ️  No Enrai KV namespaces found to delete${NC}"
+    echo ""
+    echo "If you expected to find namespaces, please check:"
+    echo "  1. You are logged in to the correct Cloudflare account"
+    echo "  2. The namespaces were created using the setup scripts"
+    echo ""
+    exit 0
+fi
+
+# Display summary
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo -e "${YELLOW}⚠️  DELETION SUMMARY${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "The following KV namespaces will be deleted:"
+echo ""
+for i in "${!NAMESPACES_TO_DELETE_IDS[@]}"; do
+    echo -e "  ${RED}✗${NC} ${NAMESPACES_TO_DELETE_TITLES[$i]}"
+    echo "    ID: ${NAMESPACES_TO_DELETE_IDS[$i]}"
+done
+echo ""
+echo -e "${RED}⚠️  WARNING: This action cannot be undone!${NC}"
+echo -e "${RED}⚠️  All data in these namespaces will be permanently deleted!${NC}"
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${YELLOW}🔍 DRY RUN MODE - No actual deletions occurred${NC}"
+    exit 0
+fi
+
+# Confirmation prompt (skip if --force is used)
+if [ "$FORCE" = false ]; then
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    read -p "Type 'DELETE' to confirm deletion, or anything else to cancel: " -r
+    echo ""
+
+    if [ "$REPLY" != "DELETE" ]; then
+        echo -e "${BLUE}❌ Deletion cancelled${NC}"
+        exit 0
+    fi
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo -e "${BLUE}🗑️  Deleting KV namespaces...${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+DELETED_COUNT=0
+FAILED_COUNT=0
+
+for i in "${!NAMESPACES_TO_DELETE_IDS[@]}"; do
+    namespace_id="${NAMESPACES_TO_DELETE_IDS[$i]}"
+    namespace_title="${NAMESPACES_TO_DELETE_TITLES[$i]}"
+
+    echo -e "${BLUE}🗑️  Deleting: $namespace_title${NC}"
+
+    # Delete the namespace using wrangler
+    if npx wrangler kv namespace delete --namespace-id="$namespace_id" --skip-confirmation 2>&1; then
+        echo -e "${GREEN}  ✅ Successfully deleted: $namespace_title${NC}"
+        ((DELETED_COUNT++))
+    else
+        echo -e "${RED}  ❌ Failed to delete: $namespace_title${NC}"
+        echo -e "${YELLOW}     This may be because the namespace is still bound to deployed workers${NC}"
+        echo -e "${YELLOW}     Consider deleting the workers first or removing the bindings${NC}"
+        ((FAILED_COUNT++))
+    fi
+    echo ""
+done
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo -e "${BLUE}📊 Deletion Complete${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "Summary:"
+echo -e "  ${GREEN}✅ Successfully deleted: $DELETED_COUNT namespaces${NC}"
+if [ $FAILED_COUNT -gt 0 ]; then
+    echo -e "  ${RED}❌ Failed to delete: $FAILED_COUNT namespaces${NC}"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Delete or undeploy workers that are using these namespaces"
+    echo "  2. Run this script again to delete remaining namespaces"
+fi
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/scripts/delete-workers.sh
+++ b/scripts/delete-workers.sh
@@ -1,0 +1,322 @@
+#!/bin/bash
+#
+# Enrai Workers Deletion Script
+# This script safely deletes Cloudflare Workers for the Enrai project
+#
+# Usage:
+#   ./delete-workers.sh                      - Interactive mode (prompts for workers and confirmation)
+#   ./delete-workers.sh --dry-run            - Dry run mode (shows what would be deleted)
+#   ./delete-workers.sh --force              - Force deletion without confirmation (USE WITH CAUTION)
+#   ./delete-workers.sh --all                - Delete all Enrai workers
+#   ./delete-workers.sh --worker enrai-auth  - Delete specific worker
+#
+
+set -e
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Parse command line arguments
+DRY_RUN=false
+FORCE=false
+DELETE_ALL=false
+SPECIFIC_WORKER=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --force)
+            FORCE=true
+            shift
+            ;;
+        --all)
+            DELETE_ALL=true
+            shift
+            ;;
+        --worker)
+            SPECIFIC_WORKER="$2"
+            shift 2
+            ;;
+        *)
+            echo -e "${RED}❌ Unknown option: $1${NC}"
+            echo "Usage: $0 [--dry-run] [--force] [--all] [--worker WORKER_NAME]"
+            exit 1
+            ;;
+    esac
+done
+
+echo -e "${BLUE}⚡️ Enrai Workers Deletion${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${YELLOW}🔍 DRY RUN MODE - No actual deletions will occur${NC}"
+    echo ""
+fi
+
+# Check if npx is available
+if ! command -v npx &> /dev/null; then
+    echo -e "${RED}❌ Error: npx is not installed${NC}"
+    echo "Please install Node.js and npm"
+    exit 1
+fi
+
+# Check if user is logged in to Cloudflare
+if ! npx wrangler whoami &> /dev/null; then
+    echo -e "${RED}❌ Error: Not logged in to Cloudflare${NC}"
+    echo "Please run: npx wrangler login"
+    exit 1
+fi
+
+# Get Cloudflare account ID and API token from wrangler
+ACCOUNT_ID=$(npx wrangler whoami 2>&1 | grep -oE "Account ID: [a-f0-9]+" | grep -oE "[a-f0-9]{32}" | head -1)
+
+if [ -z "$ACCOUNT_ID" ]; then
+    echo -e "${RED}❌ Error: Could not determine Cloudflare Account ID${NC}"
+    echo "Please ensure you are logged in with: npx wrangler login"
+    exit 1
+fi
+
+echo -e "${BLUE}📊 Fetching list of Workers...${NC}"
+echo "Account ID: $ACCOUNT_ID"
+echo ""
+
+# Get API token from wrangler config
+WRANGLER_CONFIG_DIR="${HOME}/.wrangler/config"
+API_TOKEN=""
+
+# Try to get token from wrangler config
+if [ -f "$WRANGLER_CONFIG_DIR/default.toml" ]; then
+    API_TOKEN=$(grep -oE 'api_token = "[^"]+"' "$WRANGLER_CONFIG_DIR/default.toml" | cut -d'"' -f2)
+fi
+
+# If we couldn't get the token from config, check environment
+if [ -z "$API_TOKEN" ]; then
+    if [ -n "$CLOUDFLARE_API_TOKEN" ]; then
+        API_TOKEN="$CLOUDFLARE_API_TOKEN"
+    elif [ -n "$CF_API_TOKEN" ]; then
+        API_TOKEN="$CF_API_TOKEN"
+    fi
+fi
+
+# If still no token, we need to inform the user
+if [ -z "$API_TOKEN" ]; then
+    echo -e "${RED}❌ Error: Could not find Cloudflare API token${NC}"
+    echo ""
+    echo "To use this script, you need to provide a Cloudflare API token."
+    echo ""
+    echo "Option 1: Set environment variable"
+    echo "  export CLOUDFLARE_API_TOKEN=your_token_here"
+    echo "  ./delete-workers.sh"
+    echo ""
+    echo "Option 2: Get token from Cloudflare dashboard"
+    echo "  1. Go to: https://dash.cloudflare.com/profile/api-tokens"
+    echo "  2. Create a token with 'Workers Scripts:Edit' permission"
+    echo "  3. Set as environment variable: export CLOUDFLARE_API_TOKEN=your_token"
+    echo ""
+    exit 1
+fi
+
+# Fetch workers using Cloudflare API
+WORKERS_JSON=$(curl -s -X GET "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/workers/scripts" \
+    -H "Authorization: Bearer ${API_TOKEN}" \
+    -H "Content-Type: application/json")
+
+# Check if API call was successful
+if ! echo "$WORKERS_JSON" | grep -q '"success":true'; then
+    echo -e "${RED}❌ Error: Failed to fetch workers list from Cloudflare API${NC}"
+    echo ""
+    echo "API Response:"
+    echo "$WORKERS_JSON" | head -20
+    echo ""
+    echo "Please check:"
+    echo "  1. Your API token has 'Workers Scripts:Read' permission"
+    echo "  2. Your account ID is correct: $ACCOUNT_ID"
+    echo "  3. You have workers deployed in this account"
+    echo ""
+    exit 1
+fi
+
+# Define the worker names for Enrai project
+ENRAI_WORKER_NAMES=(
+    "enrai-shared"
+    "enrai-op-auth"
+    "enrai-op-discovery"
+    "enrai-op-management"
+    "enrai-op-token"
+    "enrai-op-userinfo"
+    "enrai-router"
+)
+
+# Arrays to store workers to delete
+declare -a WORKERS_TO_DELETE=()
+
+echo -e "${BLUE}🔍 Searching for Enrai workers...${NC}"
+echo ""
+
+# Extract worker names from JSON response
+if [ -n "$SPECIFIC_WORKER" ]; then
+    # Check if specific worker exists
+    if echo "$WORKERS_JSON" | grep -q "\"id\":\"$SPECIFIC_WORKER\""; then
+        WORKERS_TO_DELETE+=("$SPECIFIC_WORKER")
+        echo -e "${GREEN}  ✓ Found: $SPECIFIC_WORKER${NC}"
+    else
+        echo -e "${YELLOW}⚠️  Worker not found: $SPECIFIC_WORKER${NC}"
+        exit 0
+    fi
+elif [ "$DELETE_ALL" = true ]; then
+    # Search for all Enrai workers
+    for worker_name in "${ENRAI_WORKER_NAMES[@]}"; do
+        if echo "$WORKERS_JSON" | grep -q "\"id\":\"$worker_name\""; then
+            WORKERS_TO_DELETE+=("$worker_name")
+            echo -e "${GREEN}  ✓ Found: $worker_name${NC}"
+        fi
+    done
+else
+    # Interactive mode - let user select workers
+    echo "Available Enrai workers:"
+    echo ""
+
+    worker_index=1
+    declare -a AVAILABLE_WORKERS=()
+
+    for worker_name in "${ENRAI_WORKER_NAMES[@]}"; do
+        if echo "$WORKERS_JSON" | grep -q "\"id\":\"$worker_name\""; then
+            AVAILABLE_WORKERS+=("$worker_name")
+            echo "  $worker_index) $worker_name"
+            ((worker_index++))
+        fi
+    done
+
+    if [ ${#AVAILABLE_WORKERS[@]} -eq 0 ]; then
+        echo -e "${YELLOW}ℹ️  No Enrai workers found${NC}"
+        exit 0
+    fi
+
+    echo "  A) Delete all Enrai workers"
+    echo "  C) Cancel"
+    echo ""
+    read -p "Enter your choice (number, A, or C): " -r choice
+    echo ""
+
+    if [[ "$choice" =~ ^[Aa]$ ]]; then
+        WORKERS_TO_DELETE=("${AVAILABLE_WORKERS[@]}")
+    elif [[ "$choice" =~ ^[Cc]$ ]]; then
+        echo -e "${BLUE}❌ Cancelled${NC}"
+        exit 0
+    elif [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le ${#AVAILABLE_WORKERS[@]} ]; then
+        WORKERS_TO_DELETE+=("${AVAILABLE_WORKERS[$((choice-1))]}")
+    else
+        echo -e "${RED}❌ Invalid choice${NC}"
+        exit 1
+    fi
+fi
+
+echo ""
+
+# Check if any workers were found
+if [ ${#WORKERS_TO_DELETE[@]} -eq 0 ]; then
+    echo -e "${YELLOW}ℹ️  No Enrai workers found to delete${NC}"
+    echo ""
+    echo "If you expected to find workers, please check:"
+    echo "  1. You are logged in to the correct Cloudflare account"
+    echo "  2. The workers are deployed"
+    echo "  3. The worker names match the expected pattern (enrai-*)"
+    echo ""
+    exit 0
+fi
+
+# Display summary
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo -e "${YELLOW}⚠️  DELETION SUMMARY${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "The following workers will be deleted:"
+echo ""
+for worker in "${WORKERS_TO_DELETE[@]}"; do
+    echo -e "  ${RED}✗${NC} $worker"
+done
+echo ""
+echo -e "${RED}⚠️  WARNING: This will delete the workers and their associated Durable Objects!${NC}"
+echo -e "${RED}⚠️  This action cannot be undone!${NC}"
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${YELLOW}🔍 DRY RUN MODE - No actual deletions occurred${NC}"
+    exit 0
+fi
+
+# Confirmation prompt (skip if --force is used)
+if [ "$FORCE" = false ]; then
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    read -p "Type 'DELETE' to confirm deletion, or anything else to cancel: " -r
+    echo ""
+
+    if [ "$REPLY" != "DELETE" ]; then
+        echo -e "${BLUE}❌ Deletion cancelled${NC}"
+        exit 0
+    fi
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo -e "${BLUE}🗑️  Deleting workers...${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+DELETED_COUNT=0
+FAILED_COUNT=0
+
+for worker in "${WORKERS_TO_DELETE[@]}"; do
+    echo -e "${BLUE}🗑️  Deleting: $worker${NC}"
+
+    # Delete the worker using Cloudflare API with force=true to delete associated Durable Objects
+    DELETE_RESPONSE=$(curl -s -X DELETE \
+        "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/workers/scripts/${worker}?force=true" \
+        -H "Authorization: Bearer ${API_TOKEN}" \
+        -H "Content-Type: application/json")
+
+    # Check if deletion was successful
+    if echo "$DELETE_RESPONSE" | grep -q '"success":true'; then
+        echo -e "${GREEN}  ✅ Successfully deleted: $worker${NC}"
+        ((DELETED_COUNT++))
+    else
+        echo -e "${RED}  ❌ Failed to delete: $worker${NC}"
+
+        # Try to extract error message
+        ERROR_MSG=$(echo "$DELETE_RESPONSE" | grep -oE '"message":"[^"]*"' | head -1 | cut -d'"' -f4)
+        if [ -n "$ERROR_MSG" ]; then
+            echo -e "${YELLOW}     Error: $ERROR_MSG${NC}"
+        fi
+
+        ((FAILED_COUNT++))
+    fi
+    echo ""
+done
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo -e "${BLUE}📊 Deletion Complete${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "Summary:"
+echo -e "  ${GREEN}✅ Successfully deleted: $DELETED_COUNT workers${NC}"
+if [ $FAILED_COUNT -gt 0 ]; then
+    echo -e "  ${RED}❌ Failed to delete: $FAILED_COUNT workers${NC}"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Check the error messages above"
+    echo "  2. Verify your API token has the correct permissions"
+    echo "  3. Try deleting from the Cloudflare dashboard if the issue persists"
+fi
+echo ""
+echo "Note: Associated Durable Objects were also deleted with the workers"
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
Add safe deletion scripts for cleaning up Enrai deployment resources:

- delete-kv.sh: Delete KV namespaces (production and preview)
- delete-d1.sh: Delete D1 databases by environment (dev/prod/staging)
- delete-workers.sh: Delete Workers via Cloudflare API (includes Durable Objects)
- delete-all.sh: Master script to delete all resources in correct order

Key features:
- Interactive mode with confirmation prompts
- Dry-run mode to preview deletions
- Force mode for automation (use with caution)
- JSON API responses for accurate resource identification
- Safety checks to prevent accidental deletion of all account resources
- Environment-specific deletion (dev/prod/staging)
- Proper deletion order: Workers → KV → D1

These scripts complement the existing setup scripts and enable clean redeployment from scratch for testing and development.