### PR TITLE
fix: migrate Durable Objects to SQLite storage backend

### DIFF
--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -141,7 +141,7 @@ class_name = "KeyManager"
 # Durable Objects migrations
 [[migrations]]
 tag = "v1"
-new_classes = [
+new_sqlite_classes = [
   "SessionStore",
   "AuthorizationCodeStore",
   "RefreshTokenRotator",
@@ -182,7 +182,7 @@ class_name = "KeyManager"
 # Durable Objects migrations
 [[migrations]]
 tag = "v1"
-new_classes = [
+new_sqlite_classes = [
   "SessionStore",
   "AuthorizationCodeStore",
   "RefreshTokenRotator",


### PR DESCRIPTION
- Change migrations from new_classes to new_sqlite_classes
- SQLite backend is recommended by Cloudflare for better performance
- Fixes deployment error on Free plan (new_classes requires Paid plan)
- SQLite provides zero-latency queries, 10GB storage, and advanced features