### PR TITLE
Fix deployment error issues

### DIFF
--- a/packages/op-auth/package.json
+++ b/packages/op-auth/package.json
@@ -17,7 +17,8 @@
     "@simplewebauthn/server": "^13.2.2",
     "hono": "^4.0.0",
     "jose": "^5.2.0",
-    "resend": "^6.4.2"
+    "resend": "^6.4.2",
+    "tslib": "^2.8.1"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240117.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       resend:
         specifier: ^6.4.2
         version: 6.4.2
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20240117.0


### PR DESCRIPTION
Resolves deployment build error where @peculiar packages (used by @simplewebauthn/server) couldn't resolve tslib during bundling.

- Added tslib@^2.8.1 to op-auth dependencies
- Updated pnpm-lock.yaml
- Verified build succeeds with dry-run deployment test