### PR TITLE
Deploy current code and explore Phase 5

### DIFF
--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -49,7 +49,7 @@ app.use(
   '*',
   cors({
     origin: '*',
-    allowMethods: ['GET', 'POST', 'OPTIONS'],
+    allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
     allowHeaders: ['Content-Type', 'Authorization'],
     exposeHeaders: ['X-RateLimit-Limit', 'X-RateLimit-Remaining', 'X-RateLimit-Reset'],
     maxAge: 86400,
@@ -121,10 +121,23 @@ app.post('/userinfo', async (c) => {
 });
 
 /**
+ * Authentication endpoints - Route to OP_AUTH worker
+ * - /auth/passkey/* - WebAuthn/Passkey authentication
+ * - /auth/magic-link/* - Magic link authentication
+ * - /auth/consent - OAuth consent screen
+ */
+app.all('/auth/*', async (c) => {
+  const request = new Request(c.req.url, c.req.raw);
+  return c.env.OP_AUTH.fetch(request);
+});
+
+/**
  * Management endpoints - Route to OP_MANAGEMENT worker
  * - /register (POST) - Dynamic Client Registration
  * - /introspect (POST) - Token Introspection
  * - /revoke (POST) - Token Revocation
+ * - /admin/* - Admin API (users, clients, stats)
+ * - /avatars/* - Avatar images
  */
 app.post('/register', async (c) => {
   const request = new Request(c.req.url, c.req.raw);
@@ -137,6 +150,16 @@ app.post('/introspect', async (c) => {
 });
 
 app.post('/revoke', async (c) => {
+  const request = new Request(c.req.url, c.req.raw);
+  return c.env.OP_MANAGEMENT.fetch(request);
+});
+
+app.all('/admin/*', async (c) => {
+  const request = new Request(c.req.url, c.req.raw);
+  return c.env.OP_MANAGEMENT.fetch(request);
+});
+
+app.get('/avatars/*', async (c) => {
   const request = new Request(c.req.url, c.req.raw);
   return c.env.OP_MANAGEMENT.fetch(request);
 });


### PR DESCRIPTION
Add routing for Phase 5 features to Router Worker:
- Add /auth/* routing for Passkey, Magic Link, and Consent APIs
- Add /admin/* routing for admin APIs (users, clients, stats)
- Add /avatars/* routing for avatar image serving
- Update CORS to allow PUT and DELETE methods

This enables access to Phase 5 backend APIs through the unified Router Worker endpoint (https://enrai.sgrastar.workers.dev).