### PR TITLE
fix(ui): ensure UnoCSS shortcuts are generated and fix turbo outputs

### DIFF
--- a/packages/ui/uno.config.ts
+++ b/packages/ui/uno.config.ts
@@ -141,6 +141,11 @@ export default defineConfig({
 			'badge-base bg-error-100 text-error-800 dark:bg-error-800/20 dark:text-error-300',
 		'badge-info': 'badge-base bg-info-100 text-info-800 dark:bg-info-800/20 dark:text-info-300'
 	},
-	safelist: [],
+	safelist: [
+		// Ensure button shortcuts are always generated
+		'btn-primary',
+		'btn-secondary',
+		'btn-ghost'
+	],
 	rules: []
 });

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**", ".svelte-kit/**", "build/**"]
     },
     "dev": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
- Add btn-primary, btn-secondary, btn-ghost to UnoCSS safelist to guarantee generation
- Update turbo.json outputs to include .svelte-kit/** and build/** for proper caching
- Resolves WARNING about missing output files in turbo build