### PR TITLE
fix(ui): use @apply to define button classes instead of shortcuts

### DIFF
--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -3,8 +3,24 @@
 
 /* UnoCSS Utilities */
 @unocss preflights;
-@unocss shortcuts;
 @unocss default;
+
+/* Button Components (from shortcuts) */
+.btn-base {
+	@apply px-4 py-2 font-medium text-sm rounded-lg transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed;
+}
+
+.btn-primary {
+	@apply btn-base bg-primary-500 text-white hover:bg-primary-600 focus:ring-primary-500;
+}
+
+.btn-secondary {
+	@apply btn-base bg-gray-200 text-gray-700 hover:bg-gray-300 focus:ring-gray-400;
+}
+
+.btn-ghost {
+	@apply btn-base text-primary-600 hover:bg-primary-50 focus:ring-primary-500;
+}
 
 /* Custom Base Styles */
 :root {


### PR DESCRIPTION
- Replace @unocss shortcuts directive with explicit @apply definitions
- Define btn-primary, btn-secondary, btn-ghost using @apply
- This ensures button styles are always generated and included in CSS
- Resolves issue where button classes were not being applied