### PR TITLE
Implement Advanced OAuth Hybrid Flows

### DIFF
--- a/docs/hybrid-flow.md
+++ b/docs/hybrid-flow.md
@@ -1,0 +1,527 @@
+# Hybrid Flow - OIDC Core 3.3
+
+## 概要
+
+Authrimは、OpenID Connect Core 1.0仕様の3.3節で定義されているHybrid Flowを完全にサポートしています。Hybrid Flowは、Authorization Code FlowとImplicit Flowの利点を組み合わせたフローで、以下の3つのresponse_typeをサポートします：
+
+1. **`code id_token`** - Authorization Codeと ID Tokenを返す
+2. **`code token`** - Authorization Codeと Access Tokenを返す
+3. **`code id_token token`** - Authorization Code、ID Token、Access Tokenを返す
+
+## 仕様準拠
+
+- **OIDC Core 3.3**: Hybrid Flow
+- **OIDC Core 3.3.2.11**: ID Token validation (c_hash, at_hash)
+- **OAuth 2.0 Multiple Response Type Encoding Practices**: Fragment encoding
+
+## 使用方法
+
+### 基本的なHybrid Flowリクエスト
+
+```http
+GET /authorize?
+  response_type=code%20id_token&
+  client_id=YOUR_CLIENT_ID&
+  redirect_uri=https://example.com/callback&
+  scope=openid%20profile%20email&
+  state=xyz&
+  nonce=abc123
+```
+
+### レスポンス
+
+Hybrid Flowでは、レスポンスはデフォルトでfragmentエンコーディングを使用してリダイレクトURIに返されます：
+
+```
+https://example.com/callback#
+  code=SplxlOBeZQQYbYS6WxSbIA&
+  id_token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...&
+  state=xyz
+```
+
+## Response Typeの詳細
+
+### 1. `code id_token`
+
+Authorization Codeと ID Tokenの両方を返します。
+
+**リクエスト例：**
+```http
+GET /authorize?
+  response_type=code%20id_token&
+  client_id=YOUR_CLIENT_ID&
+  redirect_uri=https://example.com/callback&
+  scope=openid%20profile&
+  state=xyz&
+  nonce=abc123
+```
+
+**レスポンス例：**
+```
+https://example.com/callback#
+  code=SplxlOBeZQQYbYS6WxSbIA&
+  id_token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...&
+  state=xyz
+```
+
+**ID Tokenのクレーム：**
+```json
+{
+  "iss": "https://your-issuer.com",
+  "sub": "user123",
+  "aud": "YOUR_CLIENT_ID",
+  "exp": 1516239022,
+  "iat": 1516235422,
+  "auth_time": 1516235400,
+  "nonce": "abc123",
+  "c_hash": "LDktKdoQak3Pk0cnXxCltA"
+}
+```
+
+`c_hash`は、Authorization Codeのハッシュ値で、ID Tokenとcodeが同じ発行元であることを検証するために使用されます。
+
+**使用ケース：**
+- フロントエンドでユーザー情報をすぐに表示したい場合
+- バックエンドでアクセストークンとリフレッシュトークンを取得したい場合
+
+### 2. `code token`
+
+Authorization Codeと Access Tokenの両方を返します。
+
+**リクエスト例：**
+```http
+GET /authorize?
+  response_type=code%20token&
+  client_id=YOUR_CLIENT_ID&
+  redirect_uri=https://example.com/callback&
+  scope=openid%20profile&
+  state=xyz&
+  nonce=abc123
+```
+
+**レスポンス例：**
+```
+https://example.com/callback#
+  code=SplxlOBeZQQYbYS6WxSbIA&
+  access_token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...&
+  token_type=Bearer&
+  expires_in=3600&
+  state=xyz
+```
+
+**使用ケース：**
+- フロントエンドでAPIにすぐにアクセスしたい場合
+- バックエンドで長期的なアクセス（リフレッシュトークン）が必要な場合
+
+### 3. `code id_token token`
+
+Authorization Code、ID Token、Access Tokenのすべてを返します。
+
+**リクエスト例：**
+```http
+GET /authorize?
+  response_type=code%20id_token%20token&
+  client_id=YOUR_CLIENT_ID&
+  redirect_uri=https://example.com/callback&
+  scope=openid%20profile&
+  state=xyz&
+  nonce=abc123
+```
+
+**レスポンス例：**
+```
+https://example.com/callback#
+  code=SplxlOBeZQQYbYS6WxSbIA&
+  id_token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...&
+  access_token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...&
+  token_type=Bearer&
+  expires_in=3600&
+  state=xyz
+```
+
+**ID Tokenのクレーム：**
+```json
+{
+  "iss": "https://your-issuer.com",
+  "sub": "user123",
+  "aud": "YOUR_CLIENT_ID",
+  "exp": 1516239022,
+  "iat": 1516235422,
+  "auth_time": 1516235400,
+  "nonce": "abc123",
+  "c_hash": "LDktKdoQak3Pk0cnXxCltA",
+  "at_hash": "77QmUPtjPfzWtF2AnpK9RQ"
+}
+```
+
+`at_hash`は、Access Tokenのハッシュ値で、ID TokenとAccess Tokenが同じ発行元であることを検証するために使用されます。
+
+**使用ケース：**
+- フロントエンドでユーザー情報を表示し、APIにアクセスしたい場合
+- バックエンドで長期的なアクセスが必要な場合
+- 最も包括的なHybrid Flow
+
+## Response Mode
+
+Hybrid Flowでは、以下のresponse_modeがサポートされています：
+
+### Fragment (デフォルト)
+
+デフォルトでは、Hybrid FlowはfragmentエンコーディングでレスポンスパラメータをURLフラグメントに含めます。
+
+```
+https://example.com/callback#
+  code=...&
+  id_token=...&
+  state=xyz
+```
+
+### Form Post
+
+`response_mode=form_post`を指定すると、レスポンスパラメータはPOSTリクエストでクライアントに送信されます。
+
+**リクエスト例：**
+```http
+GET /authorize?
+  response_type=code%20id_token&
+  client_id=YOUR_CLIENT_ID&
+  redirect_uri=https://example.com/callback&
+  scope=openid&
+  state=xyz&
+  nonce=abc123&
+  response_mode=form_post
+```
+
+**レスポンス：**
+クライアントのredirect_uriに、以下のパラメータを含むHTML formが自動的にPOSTされます：
+
+```html
+<form method="post" action="https://example.com/callback">
+  <input type="hidden" name="code" value="..." />
+  <input type="hidden" name="id_token" value="..." />
+  <input type="hidden" name="state" value="xyz" />
+</form>
+```
+
+### Query (非推奨)
+
+`response_mode=query`は、Hybrid Flowでは推奨されません。セキュリティ上の理由から、トークンはURLクエリパラメータに含めるべきではありません。
+
+## Nonce検証
+
+**重要**: Hybrid FlowおよびImplicit Flowでは、`nonce`パラメータが**必須**です。
+
+```http
+GET /authorize?
+  response_type=code%20id_token&
+  client_id=YOUR_CLIENT_ID&
+  redirect_uri=https://example.com/callback&
+  scope=openid&
+  state=xyz&
+  nonce=abc123  ← 必須
+```
+
+nonceは、リプレイアタックを防ぐために使用されます。クライアントは、ランダムな値を生成し、リクエストに含める必要があります。ID Tokenのnonceクレームがリクエストのnonceと一致することを確認してください。
+
+### Nonceの生成
+
+```javascript
+// ランダムなnonceを生成
+const nonce = crypto.randomUUID() + '-' + Date.now();
+
+// Authorization requestに含める
+const authUrl = `https://your-issuer.com/authorize?` +
+  `response_type=code+id_token&` +
+  `client_id=${clientId}&` +
+  `redirect_uri=${redirectUri}&` +
+  `scope=openid&` +
+  `state=${state}&` +
+  `nonce=${nonce}`;
+
+// nonceをセッションに保存
+sessionStorage.setItem('oauth_nonce', nonce);
+```
+
+### Nonceの検証
+
+```javascript
+// Callbackでnonceを検証
+const idToken = parseJwt(params.id_token);
+const savedNonce = sessionStorage.getItem('oauth_nonce');
+
+if (idToken.nonce !== savedNonce) {
+  throw new Error('Nonce mismatch');
+}
+
+// 検証後、nonceを削除
+sessionStorage.removeItem('oauth_nonce');
+```
+
+## ハッシュクレーム検証
+
+### c_hash (Code Hash)
+
+`c_hash`は、ID Tokenに含まれるAuthorization Codeのハッシュ値です。以下の場合に含まれます：
+- `response_type=code id_token`
+- `response_type=code id_token token`
+
+**検証方法：**
+
+```javascript
+import { createHash } from 'crypto';
+
+function verifyCHash(code, cHash) {
+  // SHA-256でコードをハッシュ化
+  const hash = createHash('sha256').update(code).digest();
+
+  // 左半分を取得
+  const leftHalf = hash.slice(0, hash.length / 2);
+
+  // Base64url エンコード
+  const computed = base64UrlEncode(leftHalf);
+
+  return computed === cHash;
+}
+```
+
+### at_hash (Access Token Hash)
+
+`at_hash`は、ID Tokenに含まれるAccess Tokenのハッシュ値です。以下の場合に含まれます：
+- `response_type=id_token token` (Implicit Flow)
+- `response_type=code id_token token` (Hybrid Flow)
+
+**検証方法：**
+
+```javascript
+function verifyAtHash(accessToken, atHash) {
+  // SHA-256でトークンをハッシュ化
+  const hash = createHash('sha256').update(accessToken).digest();
+
+  // 左半分を取得
+  const leftHalf = hash.slice(0, hash.length / 2);
+
+  // Base64url エンコード
+  const computed = base64UrlEncode(leftHalf);
+
+  return computed === atHash;
+}
+```
+
+## Token Exchange
+
+Hybrid Flowで取得したAuthorization Codeは、Token Endpointで交換してアクセストークンとリフレッシュトークンを取得できます。
+
+**リクエスト例：**
+
+```http
+POST /token
+Content-Type: application/x-www-form-urlencoded
+Authorization: Basic BASE64(client_id:client_secret)
+
+grant_type=authorization_code&
+code=SplxlOBeZQQYbYS6WxSbIA&
+redirect_uri=https://example.com/callback
+```
+
+**レスポンス例：**
+
+```json
+{
+  "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA",
+  "id_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+}
+```
+
+このトークンは、Authorization Endpointで取得したトークンとは異なる場合がありますが、同じユーザーに対して発行されます。
+
+## セキュリティ考慮事項
+
+### 1. Nonceの使用
+
+Hybrid FlowおよびImplicit Flowでは、nonceが必須です。これにより、リプレイアタックを防ぎます。
+
+### 2. State パラメータ
+
+CSRFアタックを防ぐために、常に`state`パラメータを使用してください。
+
+### 3. ハッシュクレームの検証
+
+`c_hash`と`at_hash`を検証して、ID Tokenと他のトークンが同じ発行元であることを確認してください。
+
+### 4. HTTPS必須
+
+本番環境では、必ずHTTPSを使用してください。トークンがURLフラグメントに含まれるため、TLSによる保護が重要です。
+
+### 5. トークンの保存
+
+- **ID Token**: ローカルストレージまたはセッションストレージに保存可能
+- **Access Token**: メモリまたはセッションストレージに保存（できるだけ短時間）
+- **Refresh Token**: セキュアなHTTP-onlyクッキーまたはサーバーサイドに保存
+
+### 6. トークンの有効期限
+
+- Authorization Endpointで発行されるAccess Tokenは短命（1時間）
+- 長期的なアクセスが必要な場合は、Token Endpointでリフレッシュトークンを取得
+
+## クライアント実装例
+
+### JavaScript/TypeScript
+
+```typescript
+// Authorization request
+function initiateHybridFlow() {
+  const state = crypto.randomUUID();
+  const nonce = crypto.randomUUID();
+
+  // Save state and nonce
+  sessionStorage.setItem('oauth_state', state);
+  sessionStorage.setItem('oauth_nonce', nonce);
+
+  const params = new URLSearchParams({
+    response_type: 'code id_token token',
+    client_id: 'YOUR_CLIENT_ID',
+    redirect_uri: 'https://example.com/callback',
+    scope: 'openid profile email',
+    state,
+    nonce,
+  });
+
+  window.location.href = `https://your-issuer.com/authorize?${params}`;
+}
+
+// Callback handler
+function handleCallback() {
+  // Parse fragment
+  const hash = window.location.hash.slice(1);
+  const params = new URLSearchParams(hash);
+
+  const code = params.get('code');
+  const idToken = params.get('id_token');
+  const accessToken = params.get('access_token');
+  const state = params.get('state');
+
+  // Validate state
+  const savedState = sessionStorage.getItem('oauth_state');
+  if (state !== savedState) {
+    throw new Error('State mismatch');
+  }
+
+  // Validate nonce
+  const idTokenPayload = parseJwt(idToken);
+  const savedNonce = sessionStorage.getItem('oauth_nonce');
+  if (idTokenPayload.nonce !== savedNonce) {
+    throw new Error('Nonce mismatch');
+  }
+
+  // Validate c_hash
+  if (!verifyCHash(code, idTokenPayload.c_hash)) {
+    throw new Error('c_hash validation failed');
+  }
+
+  // Validate at_hash
+  if (accessToken && !verifyAtHash(accessToken, idTokenPayload.at_hash)) {
+    throw new Error('at_hash validation failed');
+  }
+
+  // Clean up
+  sessionStorage.removeItem('oauth_state');
+  sessionStorage.removeItem('oauth_nonce');
+
+  // Exchange code for tokens
+  exchangeCode(code);
+}
+
+// Token exchange
+async function exchangeCode(code) {
+  const response = await fetch('https://your-issuer.com/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Authorization': `Basic ${btoa('CLIENT_ID:CLIENT_SECRET')}`,
+    },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: 'https://example.com/callback',
+    }),
+  });
+
+  const tokens = await response.json();
+  // Store tokens securely
+  return tokens;
+}
+
+// Helper functions
+function parseJwt(token) {
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const jsonPayload = decodeURIComponent(
+    atob(base64)
+      .split('')
+      .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+      .join('')
+  );
+  return JSON.parse(jsonPayload);
+}
+```
+
+## トラブルシューティング
+
+### エラー: "nonce is required for implicit and hybrid flows"
+
+**原因**: Hybrid FlowまたはImplicit Flowのリクエストに`nonce`パラメータが含まれていない。
+
+**解決方法**: リクエストに`nonce`パラメータを追加してください。
+
+```http
+GET /authorize?
+  response_type=code%20id_token&
+  ...
+  nonce=YOUR_RANDOM_NONCE
+```
+
+### エラー: "Unsupported response_type"
+
+**原因**: サポートされていない`response_type`が指定されている。
+
+**解決方法**: 以下のいずれかを使用してください：
+- `code`
+- `id_token`
+- `id_token token`
+- `code id_token`
+- `code token`
+- `code id_token token`
+
+注意: `response_type`の値はスペース区切りです。URLエンコードすると`+`または`%20`になります。
+
+### c_hash/at_hash の検証失敗
+
+**原因**: ハッシュクレームの計算が正しくない。
+
+**確認事項**:
+1. SHA-256アルゴリズムを使用していますか？
+2. ハッシュの左半分（16バイト）を取得していますか？
+3. Base64url エンコーディング（パディングなし）を使用していますか？
+
+## 参考資料
+
+- [OpenID Connect Core 1.0 - Section 3.3: Hybrid Flow](https://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth)
+- [OAuth 2.0 Multiple Response Type Encoding Practices](https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html)
+- [OpenID Connect Core 1.0 - Section 3.3.2.11: ID Token Validation](https://openid.net/specs/openid-connect-core-1_0.html#HybridIDToken)
+
+## まとめ
+
+Authrimの Hybrid Flow 実装は、OIDC Core 1.0仕様に完全に準拠しており、以下の機能を提供します：
+
+✅ 3つのHybrid Flow response_type (`code id_token`, `code token`, `code id_token token`)
+✅ Fragment encoding（デフォルト）
+✅ Form Post response mode
+✅ Nonce検証（必須）
+✅ c_hash および at_hash の生成と検証
+✅ セキュアなトークン発行
+✅ 包括的なテストカバレッジ
+
+Hybrid Flowを使用することで、フロントエンドでのユーザー情報の即時表示と、バックエンドでの安全なトークン交換の両方を実現できます。

--- a/packages/shared/src/utils/validation.ts
+++ b/packages/shared/src/utils/validation.ts
@@ -330,7 +330,15 @@ export function validateResponseType(responseType: string | undefined): Validati
     };
   }
 
-  const supportedResponseTypes = ['code'];
+  // Supported response types per OIDC Core 3.3 (Hybrid Flow)
+  const supportedResponseTypes = [
+    'code',                    // Authorization Code Flow
+    'id_token',                // Implicit Flow (ID Token only)
+    'id_token token',          // Implicit Flow (ID Token + Access Token)
+    'code id_token',           // Hybrid Flow 1
+    'code token',              // Hybrid Flow 2
+    'code id_token token',     // Hybrid Flow 3
+  ];
 
   if (!supportedResponseTypes.includes(responseType)) {
     return {

--- a/test/handlers/authorize-hybrid-flow.test.ts
+++ b/test/handlers/authorize-hybrid-flow.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { parseJwt } from '../../packages/shared/src/utils/jwt';
+
+/**
+ * Hybrid Flow Tests
+ *
+ * Tests for OIDC Core 3.3 Hybrid Flow implementation:
+ * - response_type=code id_token
+ * - response_type=code token
+ * - response_type=code id_token token
+ *
+ * These tests verify:
+ * - Fragment encoding for responses
+ * - ID token generation with c_hash
+ * - Access token generation
+ * - Nonce validation (required for hybrid flows)
+ */
+
+describe('Hybrid Flow - OIDC Core 3.3', () => {
+  const BASE_URL = 'http://localhost:8787';
+  const TEST_CLIENT_ID = 'test-client-hybrid';
+  const TEST_REDIRECT_URI = 'https://example.com/callback';
+  const TEST_SCOPE = 'openid profile email';
+  const TEST_NONCE = 'test-nonce-' + Date.now();
+  const TEST_STATE = 'test-state-' + Date.now();
+
+  // Helper function to parse fragment parameters
+  function parseFragment(url: string): Record<string, string> {
+    const hash = new URL(url).hash.slice(1); // Remove #
+    const params: Record<string, string> = {};
+    for (const [key, value] of new URLSearchParams(hash)) {
+      params[key] = value;
+    }
+    return params;
+  }
+
+  describe('Response Type Validation', () => {
+    it('should accept response_type=code id_token', async () => {
+      const response = await fetch(
+        `${BASE_URL}/authorize?response_type=code+id_token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${TEST_STATE}&nonce=${TEST_NONCE}`,
+        { redirect: 'manual' }
+      );
+
+      // Should not return error
+      expect(response.status).not.toBe(400);
+    });
+
+    it('should accept response_type=code token', async () => {
+      const response = await fetch(
+        `${BASE_URL}/authorize?response_type=code+token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${TEST_STATE}&nonce=${TEST_NONCE}`,
+        { redirect: 'manual' }
+      );
+
+      expect(response.status).not.toBe(400);
+    });
+
+    it('should accept response_type=code id_token token', async () => {
+      const response = await fetch(
+        `${BASE_URL}/authorize?response_type=code+id_token+token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${TEST_STATE}&nonce=${TEST_NONCE}`,
+        { redirect: 'manual' }
+      );
+
+      expect(response.status).not.toBe(400);
+    });
+
+    it('should reject implicit/hybrid flows without nonce', async () => {
+      const response = await fetch(
+        `${BASE_URL}/authorize?response_type=code+id_token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${TEST_STATE}`,
+        { redirect: 'manual' }
+      );
+
+      // Should redirect with error
+      expect(response.status).toBe(302);
+      const location = response.headers.get('Location');
+      expect(location).toContain('error=invalid_request');
+      expect(location).toContain('nonce');
+    });
+  });
+
+  describe('Hybrid Flow 1: code id_token', () => {
+    it('should return code and id_token in fragment', async () => {
+      const response = await fetch(
+        `${BASE_URL}/authorize?response_type=code+id_token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${TEST_STATE}&nonce=${TEST_NONCE}`,
+        { redirect: 'manual' }
+      );
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get('Location');
+      expect(location).toBeTruthy();
+
+      // Verify fragment encoding
+      expect(location).toContain('#');
+
+      const params = parseFragment(location!);
+
+      // Verify code is present
+      expect(params.code).toBeTruthy();
+      expect(params.code.length).toBeGreaterThanOrEqual(128);
+
+      // Verify id_token is present
+      expect(params.id_token).toBeTruthy();
+
+      // Verify state
+      expect(params.state).toBe(TEST_STATE);
+
+      // Verify no access_token
+      expect(params.access_token).toBeUndefined();
+
+      // Decode and verify ID token
+      const idTokenPayload = parseJwt(params.id_token);
+      expect(idTokenPayload.nonce).toBe(TEST_NONCE);
+      expect(idTokenPayload.c_hash).toBeTruthy(); // c_hash must be present
+      expect(idTokenPayload.at_hash).toBeUndefined(); // at_hash should not be present
+    });
+
+    it('should use fragment as default response_mode', async () => {
+      const response = await fetch(
+        `${BASE_URL}/authorize?response_type=code+id_token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${TEST_STATE}&nonce=${TEST_NONCE}`,
+        { redirect: 'manual' }
+      );
+
+      const location = response.headers.get('Location');
+      expect(location).toContain('#');
+      expect(location).not.toContain('?code=');
+    });
+  });
+
+  describe('Hybrid Flow 2: code token', () => {
+    it('should return code and access_token in fragment', async () => {
+      const response = await fetch(
+        `${BASE_URL}/authorize?response_type=code+token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${TEST_STATE}&nonce=${TEST_NONCE}`,
+        { redirect: 'manual' }
+      );
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get('Location');
+      expect(location).toBeTruthy();
+
+      const params = parseFragment(location!);
+
+      // Verify code is present
+      expect(params.code).toBeTruthy();
+
+      // Verify access_token is present
+      expect(params.access_token).toBeTruthy();
+      expect(params.token_type).toBe('Bearer');
+      expect(params.expires_in).toBe('3600');
+
+      // Verify state
+      expect(params.state).toBe(TEST_STATE);
+
+      // Verify no id_token
+      expect(params.id_token).toBeUndefined();
+    });
+  });
+
+  describe('Hybrid Flow 3: code id_token token', () => {
+    it('should return code, id_token, and access_token in fragment', async () => {
+      const response = await fetch(
+        `${BASE_URL}/authorize?response_type=code+id_token+token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${TEST_STATE}&nonce=${TEST_NONCE}`,
+        { redirect: 'manual' }
+      );
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get('Location');
+      expect(location).toBeTruthy();
+
+      const params = parseFragment(location!);
+
+      // Verify all three are present
+      expect(params.code).toBeTruthy();
+      expect(params.access_token).toBeTruthy();
+      expect(params.id_token).toBeTruthy();
+
+      // Verify token metadata
+      expect(params.token_type).toBe('Bearer');
+      expect(params.expires_in).toBe('3600');
+
+      // Verify state
+      expect(params.state).toBe(TEST_STATE);
+
+      // Decode and verify ID token
+      const idTokenPayload = parseJwt(params.id_token);
+      expect(idTokenPayload.nonce).toBe(TEST_NONCE);
+      expect(idTokenPayload.c_hash).toBeTruthy(); // c_hash must be present
+      expect(idTokenPayload.at_hash).toBeTruthy(); // at_hash must be present
+    });
+
+    it('should generate valid JWT tokens', async () => {
+      const response = await fetch(
+        `${BASE_URL}/authorize?response_type=code+id_token+token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${TEST_STATE}&nonce=${TEST_NONCE}`,
+        { redirect: 'manual' }
+      );
+
+      const location = response.headers.get('Location')!;
+      const params = parseFragment(location);
+
+      // Verify ID token structure
+      const idTokenPayload = parseJwt(params.id_token);
+      expect(idTokenPayload.iss).toBeTruthy();
+      expect(idTokenPayload.sub).toBeTruthy();
+      expect(idTokenPayload.aud).toBe(TEST_CLIENT_ID);
+      expect(idTokenPayload.exp).toBeGreaterThan(Date.now() / 1000);
+      expect(idTokenPayload.iat).toBeLessThanOrEqual(Date.now() / 1000);
+      expect(idTokenPayload.auth_time).toBeTruthy();
+
+      // Verify access token structure
+      const accessTokenPayload = parseJwt(params.access_token);
+      expect(accessTokenPayload.iss).toBeTruthy();
+      expect(accessTokenPayload.sub).toBeTruthy();
+      expect(accessTokenPayload.aud).toBeTruthy();
+      expect(accessTokenPayload.scope).toContain('openid');
+      expect(accessTokenPayload.client_id).toBe(TEST_CLIENT_ID);
+    });
+  });
+
+  describe('Response Mode Override', () => {
+    it('should support response_mode=form_post for hybrid flow', async () => {
+      const response = await fetch(
+        `${BASE_URL}/authorize?response_type=code+id_token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${TEST_STATE}&nonce=${TEST_NONCE}&response_mode=form_post`,
+        { redirect: 'manual' }
+      );
+
+      expect(response.status).toBe(200);
+      const html = await response.text();
+
+      // Verify form_post HTML response
+      expect(html).toContain('<form');
+      expect(html).toContain('method="post"');
+      expect(html).toContain(`action="${TEST_REDIRECT_URI}"`);
+      expect(html).toContain('name="code"');
+      expect(html).toContain('name="id_token"');
+      expect(html).toContain('name="state"');
+    });
+
+    it('should allow explicit response_mode=fragment', async () => {
+      const response = await fetch(
+        `${BASE_URL}/authorize?response_type=code+id_token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${TEST_STATE}&nonce=${TEST_NONCE}&response_mode=fragment`,
+        { redirect: 'manual' }
+      );
+
+      const location = response.headers.get('Location');
+      expect(location).toContain('#');
+    });
+  });
+
+  describe('Hash Validation', () => {
+    it('should include c_hash in ID token when code is present', async () => {
+      const response = await fetch(
+        `${BASE_URL}/authorize?response_type=code+id_token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${TEST_STATE}&nonce=${TEST_NONCE}`,
+        { redirect: 'manual' }
+      );
+
+      const location = response.headers.get('Location')!;
+      const params = parseFragment(location);
+      const idTokenPayload = parseJwt(params.id_token);
+
+      expect(idTokenPayload.c_hash).toBeTruthy();
+      expect(idTokenPayload.c_hash).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    it('should include at_hash in ID token when access_token is present', async () => {
+      const response = await fetch(
+        `${BASE_URL}/authorize?response_type=code+id_token+token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${TEST_STATE}&nonce=${TEST_NONCE}`,
+        { redirect: 'manual' }
+      );
+
+      const location = response.headers.get('Location')!;
+      const params = parseFragment(location);
+      const idTokenPayload = parseJwt(params.id_token);
+
+      expect(idTokenPayload.at_hash).toBeTruthy();
+      expect(idTokenPayload.at_hash).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+  });
+});
+
+describe('Implicit Flow - OIDC Core 3.2', () => {
+  const BASE_URL = 'http://localhost:8787';
+  const TEST_CLIENT_ID = 'test-client-implicit';
+  const TEST_REDIRECT_URI = 'https://example.com/callback';
+  const TEST_SCOPE = 'openid profile';
+  const TEST_NONCE = 'test-nonce-implicit-' + Date.now();
+  const TEST_STATE = 'test-state-implicit-' + Date.now();
+
+  function parseFragment(url: string): Record<string, string> {
+    const hash = new URL(url).hash.slice(1);
+    const params: Record<string, string> = {};
+    for (const [key, value] of new URLSearchParams(hash)) {
+      params[key] = value;
+    }
+    return params;
+  }
+
+  describe('Implicit Flow 1: id_token', () => {
+    it('should return only id_token in fragment', async () => {
+      const response = await fetch(
+        `${BASE_URL}/authorize?response_type=id_token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${TEST_STATE}&nonce=${TEST_NONCE}`,
+        { redirect: 'manual' }
+      );
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get('Location');
+      expect(location).toContain('#');
+
+      const params = parseFragment(location!);
+
+      // Verify id_token is present
+      expect(params.id_token).toBeTruthy();
+
+      // Verify no code or access_token
+      expect(params.code).toBeUndefined();
+      expect(params.access_token).toBeUndefined();
+
+      // Verify state
+      expect(params.state).toBe(TEST_STATE);
+
+      // Decode and verify ID token
+      const idTokenPayload = parseJwt(params.id_token);
+      expect(idTokenPayload.nonce).toBe(TEST_NONCE);
+      expect(idTokenPayload.c_hash).toBeUndefined();
+      expect(idTokenPayload.at_hash).toBeUndefined();
+    });
+  });
+
+  describe('Implicit Flow 2: id_token token', () => {
+    it('should return id_token and access_token in fragment', async () => {
+      const response = await fetch(
+        `${BASE_URL}/authorize?response_type=id_token+token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${TEST_STATE}&nonce=${TEST_NONCE}`,
+        { redirect: 'manual' }
+      );
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get('Location');
+      const params = parseFragment(location!);
+
+      // Verify both tokens are present
+      expect(params.id_token).toBeTruthy();
+      expect(params.access_token).toBeTruthy();
+      expect(params.token_type).toBe('Bearer');
+
+      // Verify no code
+      expect(params.code).toBeUndefined();
+
+      // Decode and verify ID token
+      const idTokenPayload = parseJwt(params.id_token);
+      expect(idTokenPayload.nonce).toBe(TEST_NONCE);
+      expect(idTokenPayload.at_hash).toBeTruthy(); // at_hash must be present
+      expect(idTokenPayload.c_hash).toBeUndefined();
+    });
+  });
+});

--- a/test/integration/hybrid-flow-integration.test.ts
+++ b/test/integration/hybrid-flow-integration.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { parseJwt } from '../../packages/shared/src/utils/jwt';
+
+/**
+ * Hybrid Flow Integration Tests
+ *
+ * End-to-end tests for Hybrid Flow:
+ * 1. Authorization endpoint returns code + tokens
+ * 2. Token endpoint can exchange code for additional tokens
+ * 3. Hash validation (c_hash, at_hash) is correct
+ * 4. Tokens are valid and verifiable
+ */
+
+describe('Hybrid Flow Integration Tests', () => {
+  const BASE_URL = process.env.TEST_BASE_URL || 'http://localhost:8787';
+  const TEST_CLIENT_ID = 'test-client-hybrid-integration';
+  const TEST_CLIENT_SECRET = 'test-secret';
+  const TEST_REDIRECT_URI = 'https://example.com/callback';
+  const TEST_SCOPE = 'openid profile email';
+
+  // Helper to parse fragment
+  function parseFragment(url: string): Record<string, string> {
+    const hash = new URL(url).hash.slice(1);
+    const params: Record<string, string> = {};
+    for (const [key, value] of new URLSearchParams(hash)) {
+      params[key] = value;
+    }
+    return params;
+  }
+
+  describe('Full Hybrid Flow: code id_token token', () => {
+    it('should complete full flow with token exchange', async () => {
+      const nonce = 'integration-test-nonce-' + Date.now();
+      const state = 'integration-test-state-' + Date.now();
+
+      // Step 1: Authorization request
+      const authResponse = await fetch(
+        `${BASE_URL}/authorize?response_type=code+id_token+token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${state}&nonce=${nonce}`,
+        { redirect: 'manual' }
+      );
+
+      expect(authResponse.status).toBe(302);
+      const authLocation = authResponse.headers.get('Location')!;
+      const authParams = parseFragment(authLocation);
+
+      // Verify authorization response
+      expect(authParams.code).toBeTruthy();
+      expect(authParams.id_token).toBeTruthy();
+      expect(authParams.access_token).toBeTruthy();
+      expect(authParams.state).toBe(state);
+
+      // Verify ID token from authorization endpoint
+      const authIdToken = parseJwt(authParams.id_token);
+      expect(authIdToken.nonce).toBe(nonce);
+      expect(authIdToken.c_hash).toBeTruthy();
+      expect(authIdToken.at_hash).toBeTruthy();
+
+      // Step 2: Token exchange (exchange code for tokens)
+      const tokenResponse = await fetch(`${BASE_URL}/token`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${TEST_CLIENT_ID}:${TEST_CLIENT_SECRET}`)}`,
+        },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: authParams.code,
+          redirect_uri: TEST_REDIRECT_URI,
+        }),
+      });
+
+      expect(tokenResponse.status).toBe(200);
+      const tokenData = await tokenResponse.json();
+
+      // Verify token response
+      expect(tokenData.access_token).toBeTruthy();
+      expect(tokenData.id_token).toBeTruthy();
+      expect(tokenData.refresh_token).toBeTruthy();
+      expect(tokenData.token_type).toBe('Bearer');
+      expect(tokenData.expires_in).toBe(3600);
+
+      // Verify ID token from token endpoint
+      const tokenIdToken = parseJwt(tokenData.id_token);
+      expect(tokenIdToken.nonce).toBe(nonce);
+      expect(tokenIdToken.at_hash).toBeTruthy();
+
+      // Verify both access tokens are for the same subject
+      const authAccessToken = parseJwt(authParams.access_token);
+      const tokenAccessToken = parseJwt(tokenData.access_token);
+      expect(authAccessToken.sub).toBe(tokenAccessToken.sub);
+
+      // Step 3: Use access token to access UserInfo endpoint
+      const userInfoResponse = await fetch(`${BASE_URL}/userinfo`, {
+        headers: {
+          Authorization: `Bearer ${tokenData.access_token}`,
+        },
+      });
+
+      expect(userInfoResponse.status).toBe(200);
+      const userInfo = await userInfoResponse.json();
+      expect(userInfo.sub).toBe(tokenAccessToken.sub);
+    });
+  });
+
+  describe('Hybrid Flow: code id_token', () => {
+    it('should issue id_token at authorization and token endpoints', async () => {
+      const nonce = 'test-nonce-' + Date.now();
+      const state = 'test-state-' + Date.now();
+
+      // Authorization request
+      const authResponse = await fetch(
+        `${BASE_URL}/authorize?response_type=code+id_token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${state}&nonce=${nonce}`,
+        { redirect: 'manual' }
+      );
+
+      const authLocation = authResponse.headers.get('Location')!;
+      const authParams = parseFragment(authLocation);
+
+      expect(authParams.code).toBeTruthy();
+      expect(authParams.id_token).toBeTruthy();
+      expect(authParams.access_token).toBeUndefined();
+
+      // Verify c_hash
+      const authIdToken = parseJwt(authParams.id_token);
+      expect(authIdToken.c_hash).toBeTruthy();
+      expect(authIdToken.at_hash).toBeUndefined();
+
+      // Token exchange
+      const tokenResponse = await fetch(`${BASE_URL}/token`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${btoa(`${TEST_CLIENT_ID}:${TEST_CLIENT_SECRET}`)}`,
+        },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: authParams.code,
+          redirect_uri: TEST_REDIRECT_URI,
+        }),
+      });
+
+      const tokenData = await tokenResponse.json();
+      expect(tokenData.id_token).toBeTruthy();
+
+      // Verify both ID tokens have same subject
+      const tokenIdToken = parseJwt(tokenData.id_token);
+      expect(authIdToken.sub).toBe(tokenIdToken.sub);
+    });
+  });
+
+  describe('Hybrid Flow: code token', () => {
+    it('should issue access_token at authorization endpoint only', async () => {
+      const nonce = 'test-nonce-' + Date.now();
+      const state = 'test-state-' + Date.now();
+
+      // Authorization request
+      const authResponse = await fetch(
+        `${BASE_URL}/authorize?response_type=code+token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${state}&nonce=${nonce}`,
+        { redirect: 'manual' }
+      );
+
+      const authLocation = authResponse.headers.get('Location')!;
+      const authParams = parseFragment(authLocation);
+
+      expect(authParams.code).toBeTruthy();
+      expect(authParams.access_token).toBeTruthy();
+      expect(authParams.id_token).toBeUndefined();
+
+      // Verify access token is usable
+      const authAccessToken = parseJwt(authParams.access_token);
+      expect(authAccessToken.scope).toContain('openid');
+
+      // Use access token immediately
+      const userInfoResponse = await fetch(`${BASE_URL}/userinfo`, {
+        headers: {
+          Authorization: `Bearer ${authParams.access_token}`,
+        },
+      });
+
+      expect(userInfoResponse.status).toBe(200);
+      const userInfo = await userInfoResponse.json();
+      expect(userInfo.sub).toBe(authAccessToken.sub);
+    });
+  });
+
+  describe('Hash Validation', () => {
+    it('should compute c_hash correctly', async () => {
+      const nonce = 'test-nonce-' + Date.now();
+      const state = 'test-state-' + Date.now();
+
+      const authResponse = await fetch(
+        `${BASE_URL}/authorize?response_type=code+id_token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${state}&nonce=${nonce}`,
+        { redirect: 'manual' }
+      );
+
+      const authLocation = authResponse.headers.get('Location')!;
+      const authParams = parseFragment(authLocation);
+      const idToken = parseJwt(authParams.id_token);
+
+      // c_hash should be present and valid
+      expect(idToken.c_hash).toBeTruthy();
+      expect(idToken.c_hash).toMatch(/^[A-Za-z0-9_-]+$/);
+
+      // Verify c_hash length (should be half of SHA-256 hash, base64url encoded)
+      // SHA-256 produces 32 bytes, half is 16 bytes, base64url encodes to 22 chars (without padding)
+      expect(idToken.c_hash.length).toBeGreaterThanOrEqual(20);
+      expect(idToken.c_hash.length).toBeLessThanOrEqual(24);
+    });
+
+    it('should compute at_hash correctly', async () => {
+      const nonce = 'test-nonce-' + Date.now();
+      const state = 'test-state-' + Date.now();
+
+      const authResponse = await fetch(
+        `${BASE_URL}/authorize?response_type=code+id_token+token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${state}&nonce=${nonce}`,
+        { redirect: 'manual' }
+      );
+
+      const authLocation = authResponse.headers.get('Location')!;
+      const authParams = parseFragment(authLocation);
+      const idToken = parseJwt(authParams.id_token);
+
+      // at_hash should be present and valid
+      expect(idToken.at_hash).toBeTruthy();
+      expect(idToken.at_hash).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(idToken.at_hash.length).toBeGreaterThanOrEqual(20);
+      expect(idToken.at_hash.length).toBeLessThanOrEqual(24);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should reject hybrid flow without nonce', async () => {
+      const state = 'test-state-' + Date.now();
+
+      const authResponse = await fetch(
+        `${BASE_URL}/authorize?response_type=code+id_token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${state}`,
+        { redirect: 'manual' }
+      );
+
+      expect(authResponse.status).toBe(302);
+      const location = authResponse.headers.get('Location')!;
+      expect(location).toContain('error=invalid_request');
+      expect(location).toContain('nonce');
+    });
+
+    it('should handle invalid response_type combinations', async () => {
+      const nonce = 'test-nonce-' + Date.now();
+      const state = 'test-state-' + Date.now();
+
+      const authResponse = await fetch(
+        `${BASE_URL}/authorize?response_type=invalid&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${state}&nonce=${nonce}`,
+        { redirect: 'manual' }
+      );
+
+      expect(authResponse.status).toBe(302);
+      const location = authResponse.headers.get('Location')!;
+      expect(location).toContain('error=');
+    });
+  });
+
+  describe('Response Mode Variations', () => {
+    it('should support form_post with hybrid flow', async () => {
+      const nonce = 'test-nonce-' + Date.now();
+      const state = 'test-state-' + Date.now();
+
+      const authResponse = await fetch(
+        `${BASE_URL}/authorize?response_type=code+id_token&client_id=${TEST_CLIENT_ID}&redirect_uri=${encodeURIComponent(TEST_REDIRECT_URI)}&scope=${encodeURIComponent(TEST_SCOPE)}&state=${state}&nonce=${nonce}&response_mode=form_post`,
+        { redirect: 'manual' }
+      );
+
+      expect(authResponse.status).toBe(200);
+      const html = await authResponse.text();
+      expect(html).toContain('<form');
+      expect(html).toContain('method="post"');
+      expect(html).toContain('name="code"');
+      expect(html).toContain('name="id_token"');
+    });
+  });
+});


### PR DESCRIPTION
This commit implements full support for OpenID Connect Hybrid Flow as defined in OIDC Core 3.3.

Features:
- Support for response_type=code id_token
- Support for response_type=code token
- Support for response_type=code id_token token
- Fragment encoding for responses (default for hybrid/implicit flows)
- Nonce validation (required for hybrid/implicit flows)
- c_hash generation and validation
- at_hash generation and validation
- Token generation at authorization endpoint
- Form post response mode support

Implementation Details:
1. Extended validateResponseType to support:
   - code id_token
   - code token
   - code id_token token
   - id_token (implicit flow)
   - id_token token (implicit flow)

2. Enhanced authorize.ts:
   - Parse response_type to determine what tokens to issue
   - Generate access tokens and ID tokens at authorization endpoint
   - Calculate c_hash for ID tokens when code is present
   - Calculate at_hash for ID tokens when access_token is present
   - Default to fragment response_mode for hybrid/implicit flows

3. Added helper functions:
   - createFragmentResponse: Fragment encoding redirect
   - createQueryResponse: Query encoding redirect
   - createFormPostResponse: Updated to support multiple parameters

4. Security enhancements:
   - Nonce is now required for all implicit and hybrid flows
   - Proper validation of response_mode compatibility

Tests:
- Unit tests for all three hybrid flow variants
- Integration tests for full hybrid flow with token exchange
- Hash validation tests (c_hash, at_hash)
- Response mode tests (fragment, form_post)
- Nonce validation tests

Documentation:
- Comprehensive hybrid-flow.md documentation
- Usage examples in Japanese
- Security considerations
- Client implementation examples
- Troubleshooting guide

Estimated size: +50KB (op-auth package)

Refs: OIDC Core 3.3, OAuth 2.0 Multiple Response Type Encoding Practices