### PR TITLE
feat(setup): add configurable user ID format (UUID v4 or NanoID)

### DIFF
--- a/packages/ar-auth/src/anon-login.ts
+++ b/packages/ar-auth/src/anon-login.ts
@@ -27,6 +27,7 @@ import {
   getChallengeStoreByChallengeId,
   getTenantIdFromContext,
   generateId,
+  generateUserIdFromSettings,
   createAuthContextFromHono,
   createErrorResponse,
   AR_ERROR_CODES,
@@ -422,7 +423,7 @@ export async function anonLoginVerifyHandler(c: Context<{ Bindings: Env }>) {
       // Create new anonymous user if not found
       if (!userId) {
         isNewUser = true;
-        const newUserId = generateId();
+        const newUserId = await generateUserIdFromSettings(c.env.AUTHRIM_CONFIG, tenantId);
 
         // Load client contract for expiration settings
         const clientContract = await loadClientContractCached(

--- a/packages/ar-auth/src/direct-auth.ts
+++ b/packages/ar-auth/src/direct-auth.ts
@@ -30,6 +30,7 @@ import {
   getChallengeStoreByUserId,
   getTenantIdFromContext,
   generateId,
+  generateUserIdFromSettings,
   createAuthContextFromHono,
   createPIIContextFromHono,
   createErrorResponse,
@@ -792,7 +793,7 @@ export async function directPasskeySignupStartHandler(c: Context<{ Bindings: Env
 
     if (!user) {
       // Create new user
-      const newUserId = generateId();
+      const newUserId = await generateUserIdFromSettings(c.env.AUTHRIM_CONFIG, tenantId);
       const defaultName = display_name || null;
       const preferredUsername = email.split('@')[0];
 
@@ -1173,7 +1174,7 @@ export async function directEmailCodeSendHandler(c: Context<{ Bindings: Env }>) 
     }
 
     if (!user) {
-      const userId = generateId();
+      const userId = await generateUserIdFromSettings(c.env.AUTHRIM_CONFIG, tenantId);
       const preferredUsername = email.split('@')[0];
 
       await authCtx.repositories.userCore.createUser({

--- a/packages/ar-auth/src/email-code.ts
+++ b/packages/ar-auth/src/email-code.ts
@@ -22,6 +22,7 @@ import {
   getChallengeStoreByChallengeId,
   getTenantIdFromContext,
   generateId,
+  generateUserIdFromSettings,
   createAuthContextFromHono,
   createPIIContextFromHono,
   createErrorResponse,
@@ -172,7 +173,7 @@ export async function emailCodeSendHandler(c: Context<{ Bindings: Env }>) {
       }
 
       if (!user) {
-        const userId = generateId();
+        const userId = await generateUserIdFromSettings(c.env.AUTHRIM_CONFIG, tenantId);
         const defaultName = name || null;
         const preferredUsername = email.split('@')[0];
 

--- a/packages/ar-auth/src/passkey.ts
+++ b/packages/ar-auth/src/passkey.ts
@@ -14,6 +14,7 @@ import {
   getChallengeStoreByUserId,
   getTenantIdFromContext,
   generateId,
+  generateUserIdFromSettings,
   createAuthContextFromHono,
   createPIIContextFromHono,
   createErrorResponse,
@@ -221,7 +222,7 @@ export async function passkeyRegisterOptionsHandler(c: Context<{ Bindings: Env }
 
     // If user doesn't exist, create a new user via Repository
     if (!user) {
-      const newUserId = generateId();
+      const newUserId = await generateUserIdFromSettings(c.env.AUTHRIM_CONFIG, tenantId);
       const now = Date.now();
       const defaultName = name || null;
       const preferredUsername = email.split('@')[0];

--- a/packages/ar-auth/src/setup.ts
+++ b/packages/ar-auth/src/setup.ts
@@ -27,6 +27,7 @@ import {
   assignSystemAdminRole,
   // Helpers
   generateId,
+  generateUserIdFromSettings,
   createAuthContextFromHono,
   createPIIContextFromHono,
   getTenantIdFromContext,
@@ -566,7 +567,7 @@ setupApp.post('/api/admin-init-setup/initialize', async (c) => {
 
     // Create user in database
     const tenantId = getTenantIdFromContext(c);
-    const userId = generateId();
+    const userId = await generateUserIdFromSettings(c.env.AUTHRIM_CONFIG, tenantId);
 
     // Use DB_ADMIN when available (new Admin/EndUser separation architecture)
     if (c.env.DB_ADMIN) {

--- a/packages/ar-lib-core/package.json
+++ b/packages/ar-lib-core/package.json
@@ -53,7 +53,8 @@
   },
   "dependencies": {
     "hono": "^4.11.7",
-    "jose": "^6.1.2"
+    "jose": "^6.1.2",
+    "nanoid": "^5.0.9"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251121.0",

--- a/packages/ar-lib-core/src/repositories/index.ts
+++ b/packages/ar-lib-core/src/repositories/index.ts
@@ -40,6 +40,16 @@ export {
   type RepositoryConfig,
 } from './base';
 
+// User ID generation utilities
+export {
+  generateUserId,
+  isValidUserId,
+  getUserIdFormatFromSettings,
+  generateUserIdFromSettings,
+  DEFAULT_USER_ID_FORMAT,
+  type UserIdFormat,
+} from '../utils/id';
+
 // Core repositories (Non-PII)
 export {
   UserCoreRepository,

--- a/packages/ar-lib-core/src/types/settings/tenant.ts
+++ b/packages/ar-lib-core/src/types/settings/tenant.ts
@@ -7,6 +7,7 @@
  */
 
 import type { CategoryMeta, SettingMeta } from '../../utils/settings-manager';
+import type { UserIdFormat } from '../../utils/id';
 
 /**
  * Tenant Settings Interface
@@ -16,6 +17,7 @@ export interface TenantSettings {
   'tenant.base_domain': string;
   'tenant.default_id': string;
   'tenant.isolation_enabled': boolean;
+  'tenant.user_id_format': UserIdFormat;
 
   // CORS Settings
   'tenant.allowed_origins': string;
@@ -65,6 +67,17 @@ export const TENANT_SETTINGS_META: Record<keyof TenantSettings, SettingMeta> = {
     label: 'Tenant Isolation',
     description: 'Enable strict tenant isolation',
     visibility: 'admin',
+  },
+  'tenant.user_id_format': {
+    key: 'tenant.user_id_format',
+    type: 'enum',
+    default: 'nanoid',
+    envKey: 'USER_ID_FORMAT',
+    label: 'User ID Format',
+    description:
+      'Format for generating user IDs. "nanoid" (default) generates URL-safe 21-character IDs. "uuid" generates standard UUID v4 format. This setting is configured during setup and cannot be changed after users are created.',
+    enum: ['nanoid', 'uuid'],
+    visibility: 'internal',
   },
 
   // CORS Settings
@@ -182,6 +195,7 @@ export const TENANT_DEFAULTS: TenantSettings = {
   'tenant.base_domain': '',
   'tenant.default_id': 'default',
   'tenant.isolation_enabled': false,
+  'tenant.user_id_format': 'nanoid',
   // CORS Settings
   'tenant.allowed_origins': '',
   // Branding

--- a/packages/ar-lib-core/src/utils/__tests__/id.test.ts
+++ b/packages/ar-lib-core/src/utils/__tests__/id.test.ts
@@ -1,0 +1,228 @@
+/**
+ * ID Generation Utilities Tests
+ *
+ * Tests for generateUserId, isValidUserId, and related functions.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+// Direct import from TypeScript source (vitest handles TS natively)
+import {
+  generateId,
+  generateUserId,
+  isValidUserId,
+  getUserIdFormatFromSettings,
+  generateUserIdFromSettings,
+  DEFAULT_USER_ID_FORMAT,
+  type UserIdFormat,
+} from '../id';
+
+describe('ID Generation Utilities', () => {
+  describe('generateId', () => {
+    it('should generate a valid UUID v4', () => {
+      const id = generateId();
+
+      // UUID v4 format: 8-4-4-4-12
+      expect(id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      );
+    });
+
+    it('should generate unique IDs', () => {
+      const id1 = generateId();
+      const id2 = generateId();
+
+      expect(id1).not.toBe(id2);
+    });
+  });
+
+  describe('generateUserId', () => {
+    it('should generate NanoID by default', () => {
+      const id = generateUserId();
+
+      // NanoID default length is 21 characters
+      expect(id).toHaveLength(21);
+      // NanoID uses URL-safe characters
+      expect(id).toMatch(/^[A-Za-z0-9_-]{21}$/);
+    });
+
+    it('should generate NanoID when format is "nanoid"', () => {
+      const id = generateUserId('nanoid');
+
+      expect(id).toHaveLength(21);
+      expect(id).toMatch(/^[A-Za-z0-9_-]{21}$/);
+    });
+
+    it('should generate UUID v4 when format is "uuid"', () => {
+      const id = generateUserId('uuid');
+
+      expect(id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      );
+    });
+
+    it('should generate unique NanoIDs', () => {
+      const ids = new Set<string>();
+      for (let i = 0; i < 100; i++) {
+        ids.add(generateUserId('nanoid'));
+      }
+
+      expect(ids.size).toBe(100);
+    });
+
+    it('should generate unique UUIDs', () => {
+      const ids = new Set<string>();
+      for (let i = 0; i < 100; i++) {
+        ids.add(generateUserId('uuid'));
+      }
+
+      expect(ids.size).toBe(100);
+    });
+
+    it('should fallback to nanoid for unknown format', () => {
+      const id = generateUserId('unknown' as UserIdFormat);
+
+      // Should fallback to NanoID
+      expect(id).toHaveLength(21);
+      expect(id).toMatch(/^[A-Za-z0-9_-]{21}$/);
+    });
+  });
+
+  describe('isValidUserId', () => {
+    it('should validate UUID v4 format', () => {
+      const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+      expect(isValidUserId(validUuid, 'uuid')).toBe(true);
+    });
+
+    it('should reject invalid UUID format', () => {
+      expect(isValidUserId('not-a-uuid', 'uuid')).toBe(false);
+      expect(isValidUserId('550e8400-e29b-51d4-a716-446655440000', 'uuid')).toBe(false); // Wrong version
+    });
+
+    it('should validate NanoID format', () => {
+      const validNanoid = 'V1StGXR8_Z5jdHi6B-myT';
+      expect(isValidUserId(validNanoid, 'nanoid')).toBe(true);
+    });
+
+    it('should reject invalid NanoID format', () => {
+      expect(isValidUserId('too-short', 'nanoid')).toBe(false);
+      expect(isValidUserId('invalid!chars!@#$%^&*()', 'nanoid')).toBe(false);
+    });
+
+    it('should accept either format when no format specified', () => {
+      const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+      const validNanoid = 'V1StGXR8_Z5jdHi6B-myT';
+
+      expect(isValidUserId(validUuid)).toBe(true);
+      expect(isValidUserId(validNanoid)).toBe(true);
+    });
+
+    it('should reject null and undefined', () => {
+      expect(isValidUserId(null as unknown as string)).toBe(false);
+      expect(isValidUserId(undefined as unknown as string)).toBe(false);
+    });
+
+    it('should reject empty string', () => {
+      expect(isValidUserId('')).toBe(false);
+    });
+  });
+
+  describe('DEFAULT_USER_ID_FORMAT', () => {
+    it('should be "nanoid"', () => {
+      expect(DEFAULT_USER_ID_FORMAT).toBe('nanoid');
+    });
+  });
+
+  describe('getUserIdFormatFromSettings', () => {
+    it('should return default format when KV is undefined', async () => {
+      const format = await getUserIdFormatFromSettings(undefined);
+      expect(format).toBe(DEFAULT_USER_ID_FORMAT);
+    });
+
+    it('should return nanoid when setting is "nanoid"', async () => {
+      const mockKv = {
+        get: vi.fn().mockResolvedValue(JSON.stringify({ 'tenant.user_id_format': 'nanoid' })),
+      };
+
+      const format = await getUserIdFormatFromSettings(mockKv, 'default');
+      expect(format).toBe('nanoid');
+      expect(mockKv.get).toHaveBeenCalledWith('settings:tenant:default:tenant');
+    });
+
+    it('should return uuid when setting is "uuid"', async () => {
+      const mockKv = {
+        get: vi.fn().mockResolvedValue(JSON.stringify({ 'tenant.user_id_format': 'uuid' })),
+      };
+
+      const format = await getUserIdFormatFromSettings(mockKv, 'default');
+      expect(format).toBe('uuid');
+    });
+
+    it('should return default when setting is not found', async () => {
+      const mockKv = {
+        get: vi.fn().mockResolvedValue(null),
+      };
+
+      const format = await getUserIdFormatFromSettings(mockKv, 'default');
+      expect(format).toBe(DEFAULT_USER_ID_FORMAT);
+    });
+
+    it('should return default when JSON is invalid', async () => {
+      const mockKv = {
+        get: vi.fn().mockResolvedValue('invalid-json'),
+      };
+
+      const format = await getUserIdFormatFromSettings(mockKv, 'default');
+      expect(format).toBe(DEFAULT_USER_ID_FORMAT);
+    });
+
+    it('should return default when setting value is invalid', async () => {
+      const mockKv = {
+        get: vi.fn().mockResolvedValue(JSON.stringify({ 'tenant.user_id_format': 'invalid' })),
+      };
+
+      const format = await getUserIdFormatFromSettings(mockKv, 'default');
+      expect(format).toBe(DEFAULT_USER_ID_FORMAT);
+    });
+
+    it('should use the provided tenant ID', async () => {
+      const mockKv = {
+        get: vi.fn().mockResolvedValue(JSON.stringify({ 'tenant.user_id_format': 'uuid' })),
+      };
+
+      await getUserIdFormatFromSettings(mockKv, 'custom-tenant');
+      expect(mockKv.get).toHaveBeenCalledWith('settings:tenant:custom-tenant:tenant');
+    });
+  });
+
+  describe('generateUserIdFromSettings', () => {
+    it('should generate NanoID when KV is undefined', async () => {
+      const id = await generateUserIdFromSettings(undefined);
+
+      expect(id).toHaveLength(21);
+      expect(id).toMatch(/^[A-Za-z0-9_-]{21}$/);
+    });
+
+    it('should generate NanoID when setting is "nanoid"', async () => {
+      const mockKv = {
+        get: vi.fn().mockResolvedValue(JSON.stringify({ 'tenant.user_id_format': 'nanoid' })),
+      };
+
+      const id = await generateUserIdFromSettings(mockKv, 'default');
+
+      expect(id).toHaveLength(21);
+      expect(id).toMatch(/^[A-Za-z0-9_-]{21}$/);
+    });
+
+    it('should generate UUID when setting is "uuid"', async () => {
+      const mockKv = {
+        get: vi.fn().mockResolvedValue(JSON.stringify({ 'tenant.user_id_format': 'uuid' })),
+      };
+
+      const id = await generateUserIdFromSettings(mockKv, 'default');
+
+      expect(id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      );
+    });
+  });
+});

--- a/packages/ar-lib-core/src/utils/id.ts
+++ b/packages/ar-lib-core/src/utils/id.ts
@@ -1,12 +1,137 @@
 /**
  * ID Generation Utilities
+ *
+ * Supports multiple ID formats for user IDs:
+ * - uuid: UUID v4 (default for internal IDs, 36 chars with hyphens)
+ * - nanoid: NanoID (URL-safe, 21 chars, default for user IDs)
  */
+
+import { nanoid } from 'nanoid';
+
+/**
+ * Supported user ID formats
+ */
+export type UserIdFormat = 'uuid' | 'nanoid';
+
+/**
+ * Default user ID format
+ */
+export const DEFAULT_USER_ID_FORMAT: UserIdFormat = 'nanoid';
+
+/**
+ * NanoID length (21 characters = 126 bits of entropy, similar to UUID v4's 122 bits)
+ */
+const NANOID_LENGTH = 21;
 
 /**
  * Generate a unique ID using UUID v4
+ * Use this for internal IDs (tokens, sessions, challenges, etc.)
  *
  * @returns UUID v4 string
  */
 export function generateId(): string {
   return crypto.randomUUID();
+}
+
+/**
+ * Generate a user ID based on the specified format
+ * Use this for end-user identifiable IDs (user_id in OIDC sub claim, etc.)
+ *
+ * @param format - The ID format to use ('uuid' or 'nanoid')
+ * @returns Generated user ID string
+ */
+export function generateUserId(format: UserIdFormat = DEFAULT_USER_ID_FORMAT): string {
+  switch (format) {
+    case 'nanoid':
+      return nanoid(NANOID_LENGTH);
+    case 'uuid':
+      return crypto.randomUUID();
+    default:
+      // Fallback to default format for unknown values
+      return nanoid(NANOID_LENGTH);
+  }
+}
+
+/**
+ * Validate if a string matches a user ID format
+ *
+ * @param id - The ID to validate
+ * @param format - The expected format (optional, validates against any format if not specified)
+ * @returns true if the ID matches the expected format
+ */
+export function isValidUserId(id: string, format?: UserIdFormat): boolean {
+  if (!id || typeof id !== 'string') {
+    return false;
+  }
+
+  // UUID v4 pattern: 8-4-4-4-12 hex characters
+  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+  // NanoID pattern: URL-safe characters (A-Za-z0-9_-), typically 21 chars
+  const nanoidPattern = /^[A-Za-z0-9_-]{21}$/;
+
+  if (format === 'uuid') {
+    return uuidPattern.test(id);
+  }
+
+  if (format === 'nanoid') {
+    return nanoidPattern.test(id);
+  }
+
+  // If no format specified, accept either
+  return uuidPattern.test(id) || nanoidPattern.test(id);
+}
+
+/**
+ * KV namespace interface for user ID format retrieval
+ */
+interface KVNamespace {
+  get(key: string): Promise<string | null>;
+}
+
+/**
+ * Get user ID format from tenant settings in KV storage
+ *
+ * @param kv - The KV namespace (AUTHRIM_CONFIG)
+ * @param tenantId - The tenant ID (defaults to 'default')
+ * @returns The configured user ID format, or default if not set
+ */
+export async function getUserIdFormatFromSettings(
+  kv: KVNamespace | undefined,
+  tenantId: string = 'default'
+): Promise<UserIdFormat> {
+  if (!kv) {
+    return DEFAULT_USER_ID_FORMAT;
+  }
+
+  try {
+    const kvData = await kv.get(`settings:tenant:${tenantId}:tenant`);
+    if (kvData) {
+      const settings = JSON.parse(kvData) as Record<string, unknown>;
+      const format = settings['tenant.user_id_format'];
+      if (format === 'uuid' || format === 'nanoid') {
+        return format;
+      }
+    }
+  } catch {
+    // Fall back to default on any error
+  }
+
+  return DEFAULT_USER_ID_FORMAT;
+}
+
+/**
+ * Generate a user ID based on tenant settings
+ * Convenience function that reads the format from KV and generates the ID
+ *
+ * @param kv - The KV namespace (AUTHRIM_CONFIG)
+ * @param tenantId - The tenant ID (defaults to 'default')
+ * @returns Generated user ID string
+ */
+export async function generateUserIdFromSettings(
+  kv: KVNamespace | undefined,
+  tenantId: string = 'default'
+): Promise<string> {
+  const format = await getUserIdFormatFromSettings(kv, tenantId);
+  return generateUserId(format);
 }

--- a/packages/ar-management/src/admin.ts
+++ b/packages/ar-management/src/admin.ts
@@ -19,6 +19,7 @@ import {
   createPIIContextFromHono,
   createAuthContextFromHono,
   generateId,
+  generateUserIdFromSettings,
   D1Adapter,
   type DatabaseAdapter,
   createErrorResponse,
@@ -936,7 +937,7 @@ export async function adminUserCreateHandler(c: Context<{ Bindings: Env }>) {
       }
     }
 
-    const userId = generateId();
+    const userId = await generateUserIdFromSettings(c.env.AUTHRIM_CONFIG, tenantId);
 
     // Step 1: Insert into users_core (Core DB) with pii_status='pending'
     await authCtx.repositories.userCore.createUser({

--- a/packages/ar-management/src/scim.ts
+++ b/packages/ar-management/src/scim.ts
@@ -30,7 +30,7 @@ import {
   createPIIContextFromHono,
   getLogger,
 } from '@authrim/ar-lib-core';
-import { D1Adapter, type DatabaseAdapter, generateId, hashPassword } from '@authrim/ar-lib-core';
+import { D1Adapter, type DatabaseAdapter, generateId, generateUserIdFromSettings, hashPassword } from '@authrim/ar-lib-core';
 import { logScimAudit } from '@authrim/ar-lib-scim';
 
 /**
@@ -1234,7 +1234,7 @@ app.post('/Users', async (c) => {
     const internalUser = scimToUser(scimUser);
 
     // Generate ID
-    const userId = generateId();
+    const userId = await generateUserIdFromSettings(c.env.AUTHRIM_CONFIG, tenantId);
 
     // Hash password if provided
     if (scimUser.password) {
@@ -2551,7 +2551,7 @@ async function processUserOperation(
 
       // Convert and create
       const internalUser = scimToUser(scimUser);
-      const userId = generateId();
+      const userId = await generateUserIdFromSettings(c.env.AUTHRIM_CONFIG, tenantId);
       const now = new Date().toISOString();
       const nowUnix = Math.floor(Date.now() / 1000);
       internalUser.created_at = now;

--- a/packages/setup/src/cli/commands/init.ts
+++ b/packages/setup/src/cli/commands/init.ts
@@ -1501,6 +1501,7 @@ async function runNormalSetup(options: InitOptions): Promise<void> {
   let tenantName = 'default';
   let tenantDisplayName = 'Default Tenant';
   let baseDomain: string | undefined;
+  let userIdFormat: 'nanoid' | 'uuid' = 'nanoid';
 
   // Step 6: URL configuration (depends on tenant mode)
   let apiDomain: string | null = null;
@@ -1553,6 +1554,33 @@ async function runNormalSetup(options: InitOptions): Promise<void> {
       default: 'Default Tenant',
     });
 
+    // User ID format selection
+    console.log('');
+    console.log(chalk.blue('━━━ ' + t('userId.title') + ' ━━━'));
+    console.log('');
+    console.log(chalk.gray('  ' + t('userId.note')));
+    console.log('');
+
+    userIdFormat = await select<'nanoid' | 'uuid'>({
+      message: t('userId.prompt'),
+      choices: [
+        {
+          name: t('userId.nanoid'),
+          value: 'nanoid' as const,
+          description: t('userId.nanoidDesc'),
+        },
+        {
+          name: t('userId.uuid'),
+          value: 'uuid' as const,
+          description: t('userId.uuidDesc'),
+        },
+      ],
+      default: 'nanoid',
+    });
+
+    console.log('');
+    console.log(chalk.green('  ✓ ' + t('userId.selected', { format: userIdFormat })));
+
     // UI domains for multi-tenant
     console.log('');
     console.log(chalk.blue('━━━ ' + t('tenant.uiDomainTitle') + ' ━━━'));
@@ -1588,6 +1616,33 @@ async function runNormalSetup(options: InitOptions): Promise<void> {
       message: t('tenant.organizationName'),
       default: 'Default Tenant',
     });
+
+    // User ID format selection
+    console.log('');
+    console.log(chalk.blue('━━━ ' + t('userId.title') + ' ━━━'));
+    console.log('');
+    console.log(chalk.gray('  ' + t('userId.note')));
+    console.log('');
+
+    userIdFormat = await select<'nanoid' | 'uuid'>({
+      message: t('userId.prompt'),
+      choices: [
+        {
+          name: t('userId.nanoid'),
+          value: 'nanoid' as const,
+          description: t('userId.nanoidDesc'),
+        },
+        {
+          name: t('userId.uuid'),
+          value: 'uuid' as const,
+          description: t('userId.uuidDesc'),
+        },
+      ],
+      default: 'nanoid',
+    });
+
+    console.log('');
+    console.log(chalk.green('  ✓ ' + t('userId.selected', { format: userIdFormat })));
 
     const useCustomDomain = await confirm({
       message: t('domain.prompt'),
@@ -1929,6 +1984,7 @@ async function runNormalSetup(options: InitOptions): Promise<void> {
     displayName: tenantDisplayName,
     multiTenant,
     baseDomain,
+    userIdFormat,
   };
   config.components = {
     ...config.components,

--- a/packages/setup/src/core/config.ts
+++ b/packages/setup/src/core/config.ts
@@ -71,6 +71,13 @@ export const EnvironmentConfigSchema = z.object({
 // Tenant Configuration
 // =============================================================================
 
+/**
+ * User ID format options
+ * - nanoid: URL-safe 21-character IDs (default, recommended)
+ * - uuid: Standard UUID v4 format
+ */
+export const UserIdFormatSchema = z.enum(['nanoid', 'uuid']).default('nanoid');
+
 export const TenantConfigSchema = z.object({
   /** Default tenant identifier (used in single-tenant mode) */
   name: z.string().default('default'),
@@ -87,6 +94,14 @@ export const TenantConfigSchema = z.object({
    * Issuer URL will be: https://{tenant}.{baseDomain}
    */
   baseDomain: z.string().optional(),
+  /**
+   * User ID format for new users
+   * - nanoid: URL-safe 21-character IDs (default, recommended)
+   * - uuid: Standard UUID v4 format (36 characters with hyphens)
+   *
+   * Note: This setting cannot be changed after users are created.
+   */
+  userIdFormat: UserIdFormatSchema,
 });
 
 // =============================================================================

--- a/packages/setup/src/core/wrangler.ts
+++ b/packages/setup/src/core/wrangler.ts
@@ -436,6 +436,9 @@ function generateEnvVars(
   if (component === 'ar-auth' || component === 'ar-management' || component === 'ar-router') {
     vars['DEFAULT_TENANT_ID'] = config.tenant?.name || 'default';
 
+    // User ID format (nanoid or uuid)
+    vars['USER_ID_FORMAT'] = config.tenant?.userIdFormat || 'nanoid';
+
     if (config.tenant?.multiTenant && config.tenant?.baseDomain) {
       vars['BASE_DOMAIN'] = config.tenant.baseDomain;
       vars['ENABLE_TENANT_ISOLATION'] = 'true';

--- a/packages/setup/src/i18n/locales/en.ts
+++ b/packages/setup/src/i18n/locales/en.ts
@@ -389,6 +389,16 @@ const en: Translations = {
   'tenant.loginUiDomain': 'Login UI domain (e.g., login.example.com)',
   'tenant.adminUiDomain': 'Admin UI domain (e.g., admin.example.com)',
 
+  // User ID format
+  'userId.title': 'User ID Format',
+  'userId.prompt': 'Select user ID format',
+  'userId.nanoid': 'NanoID (recommended)',
+  'userId.nanoidDesc': 'URL-safe 21-character IDs, compact and secure',
+  'userId.uuid': 'UUID v4',
+  'userId.uuidDesc': 'Standard 36-character UUIDs with hyphens',
+  'userId.note': 'Note: This setting cannot be changed after users are created.',
+  'userId.selected': 'User ID format: {{format}}',
+
   // Optional components
   'components.title': 'Optional Components',
   'components.note': 'Note: Social Login and Policy Engine are standard components',

--- a/packages/setup/src/i18n/locales/ja.ts
+++ b/packages/setup/src/i18n/locales/ja.ts
@@ -388,6 +388,16 @@ const ja: Translations = {
   'tenant.loginUiDomain': 'ログインUIドメイン（例: login.example.com）',
   'tenant.adminUiDomain': '管理UIドメイン（例: admin.example.com）',
 
+  // User ID format
+  'userId.title': 'ユーザーID形式',
+  'userId.prompt': 'ユーザーIDの形式を選択してください',
+  'userId.nanoid': 'NanoID（推奨）',
+  'userId.nanoidDesc': 'URL安全な21文字のID、コンパクトで安全',
+  'userId.uuid': 'UUID v4',
+  'userId.uuidDesc': 'ハイフン付き36文字の標準UUID',
+  'userId.note': '注意: この設定はユーザー作成後に変更できません。',
+  'userId.selected': 'ユーザーID形式: {{format}}',
+
   // Optional components
   'components.title': 'オプションコンポーネント',
   'components.note': '注: ソーシャルログインとポリシーエンジンは標準コンポーネントです',

--- a/packages/setup/src/web/ui.ts
+++ b/packages/setup/src/web/ui.ts
@@ -2089,6 +2089,15 @@ export function getHtmlTemplate(
           <input type="text" id="tenant-display" placeholder="My Company" value="Default Tenant" data-i18n-placeholder="web.form.tenantDisplayPlaceholder">
           <small style="color: var(--text-muted)" data-i18n="web.form.tenantDisplayHint">Name shown on login page and consent screen</small>
         </div>
+
+        <div class="form-group" style="margin-bottom: 0;">
+          <label for="user-id-format" data-i18n="web.form.userIdFormat">User ID Format</label>
+          <select id="user-id-format">
+            <option value="nanoid" selected data-i18n="web.form.userIdNanoid">NanoID (recommended)</option>
+            <option value="uuid" data-i18n="web.form.userIdUuid">UUID v4</option>
+          </select>
+          <small style="color: var(--text-muted)" data-i18n="web.form.userIdFormatHint">Format for generating user IDs. Cannot be changed after users are created.</small>
+        </div>
       </div>
 
       <!-- 3.2 UI Domains -->
@@ -3399,6 +3408,9 @@ export function getHtmlTemplate(
       document.getElementById('tenant-name').value = config.tenant?.name || 'default';
       document.getElementById('tenant-display').value = config.tenant?.displayName || 'Default Tenant';
       document.getElementById('naked-domain').checked = config.tenant?.nakedDomain || false;
+      if (document.getElementById('user-id-format')) {
+        document.getElementById('user-id-format').value = config.tenant?.userIdFormat || 'nanoid';
+      }
 
       // Set component checkboxes
       if (document.getElementById('comp-login-ui')) {
@@ -3645,6 +3657,7 @@ export function getHtmlTemplate(
       const nakedDomain = document.getElementById('naked-domain').checked;
       const tenantName = document.getElementById('tenant-name').value.trim() || 'default';
       const tenantDisplayName = document.getElementById('tenant-display').value.trim() || 'Default Tenant';
+      const userIdFormat = document.getElementById('user-id-format').value || 'nanoid';
       const loginDomain = document.getElementById('login-domain').value.trim();
       const adminDomain = document.getElementById('admin-domain').value.trim();
 
@@ -3662,6 +3675,7 @@ export function getHtmlTemplate(
           multiTenant: baseDomain ? true : false,  // Only multi-tenant with custom domain
           baseDomain: baseDomain || undefined,
           nakedDomain: baseDomain ? nakedDomain : false,
+          userIdFormat: userIdFormat,
         },
         components: {
           api: true,
@@ -4479,6 +4493,7 @@ export function getHtmlTemplate(
           displayName: config.tenant?.displayName || 'Default Tenant',
           multiTenant: config.tenant?.multiTenant || false,
           baseDomain: config.tenant?.baseDomain || undefined,
+          userIdFormat: config.tenant?.userIdFormat || 'nanoid',
         },
         components: config.components || {
           api: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,6 +307,9 @@ importers:
       jose:
         specifier: ^6.1.2
         version: 6.1.3
+      nanoid:
+        specifier: ^5.0.9
+        version: 5.1.6
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20251121.0


### PR DESCRIPTION
Add ability to select user ID generation format during setup:
- Add nanoid dependency to ar-lib-core
- Implement generateUserId() with format parameter
- Add tenant.user_id_format setting (default: nanoid)
- Add ID format selection to CLI and Web setup tools
- Update all user ID generation call sites to use new format

User ID generation points updated:
- ar-auth/setup.ts (initial admin)
- ar-auth/anon-login.ts
- ar-auth/email-code.ts
- ar-auth/direct-auth.ts
- ar-auth/passkey.ts
- ar-management/admin.ts
- ar-management/scim.ts

https://claude.ai/code/session_011XTKNw5xrZRx4K9VrnEoix