### PR TITLE
style: compact navigation padding

### DIFF
--- a/packages/ar-admin-ui/src/lib/components/admin/NavItem.svelte
+++ b/packages/ar-admin-ui/src/lib/components/admin/NavItem.svelte
@@ -34,7 +34,7 @@
 		display: flex;
 		align-items: center;
 		gap: 14px;
-		padding: 8px 12px;
+		padding: 4px 12px;
 		margin-bottom: 1px;
 		border-radius: var(--radius-md);
 		color: var(--nav-text, rgba(255, 255, 255, 0.6));

--- a/packages/ar-admin-ui/src/lib/components/admin/NavItemGroup.svelte
+++ b/packages/ar-admin-ui/src/lib/components/admin/NavItemGroup.svelte
@@ -62,7 +62,7 @@
 		display: flex;
 		align-items: center;
 		gap: 14px;
-		padding: 8px 12px;
+		padding: 4px 12px;
 		margin-bottom: 1px;
 		border-radius: var(--radius-md);
 		color: var(--nav-text, rgba(255, 255, 255, 0.6));
@@ -136,7 +136,7 @@
 
 	/* Child items */
 	.nav-child {
-		padding: 6px 12px;
+		padding: 4px 12px;
 		font-size: 0.875rem;
 	}
 


### PR DESCRIPTION
## Changes

Reduce padding on navigation items for a more compact sidebar layout.

### Modified
- `NavItem.svelte`: padding 8px 12px → 4px 12px
- `NavItemGroup.svelte`: parent padding 8px 12px → 4px 12px  
- `NavItemGroup.svelte`: child padding 6px 12px → 4px 12px

### Benefits
- More space-efficient navigation sidebar
- Allows more menu items to be visible without scrolling
- Maintains readability and clickability