### PR TITLE
docs: Add third-party license notice for development dependencies

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -87,3 +87,39 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+================================================================================
+
+NOTICE: Third-Party Development Dependencies
+
+This project uses the following third-party libraries for development and
+testing purposes only. These libraries are not included in production builds
+or distributed with the software.
+
+--------------------------------------------------------------------------------
+Accessibility Testing Tools
+--------------------------------------------------------------------------------
+
+axe-core (v4.11.0)
+  License: MPL-2.0 (Mozilla Public License 2.0)
+  Copyright: Deque Systems, Inc.
+  URL: https://github.com/dequelabs/axe-core
+  Purpose: Automated accessibility testing engine used in end-to-end tests
+  Note: Used as a development dependency for accessibility compliance testing.
+        Not included in production builds.
+
+@axe-core/playwright (v4.11.0)
+  License: MPL-2.0 (Mozilla Public License 2.0)
+  Copyright: Deque Systems, Inc.
+  URL: https://github.com/dequelabs/axe-core-npm
+  Purpose: Playwright integration for axe-core accessibility testing
+  Note: Used as a development dependency for accessibility compliance testing.
+        Not included in production builds.
+
+The MPL-2.0 licensed libraries listed above are used solely for testing and
+development purposes. They are not incorporated into, distributed with, or
+required for the operation of the production software. The source code of
+these libraries has not been modified. For the full text of the MPL-2.0
+license, please visit: https://www.mozilla.org/en-US/MPL/2.0/
+
+================================================================================


### PR DESCRIPTION
## Summary

Add notice section to LICENSE file documenting MPL-2.0 licensed development dependencies used for accessibility testing.

## Changes

- Added **Third-Party Development Dependencies** section to LICENSE file
- Documented the following MPL-2.0 licensed libraries:
  - `axe-core` (v4.11.0) - Accessibility testing engine
  - `@axe-core/playwright` (v4.11.0) - Playwright integration for axe-core
- Clarified that these are development-only dependencies not included in production builds
- Included copyright information (Deque Systems, Inc.)
- Added links to source repositories and MPL-2.0 license text

## Rationale

While these libraries are only used as development dependencies for testing and are not distributed with the production software, documenting them in the LICENSE file provides:

1. **Transparency** - Clear disclosure of all third-party dependencies
2. **Compliance** - Proper acknowledgment of MPL-2.0 licensed software
3. **Legal clarity** - Explicit statement that these are not incorporated into production builds

## Testing

- [x] Verified LICENSE file formatting
- [x] Confirmed all information is accurate
- [x] Checked that no production dependencies require similar notices

## Related

- Related to accessibility testing setup in `test-e2e/accessibility.spec.ts`
- Addresses license compliance for development tools