### PR TITLE
fix: use dynamic env import in login-ui hooks.server.ts

### DIFF
--- a/packages/ar-login-ui/src/hooks.server.ts
+++ b/packages/ar-login-ui/src/hooks.server.ts
@@ -7,7 +7,7 @@
  * - Accept-Language based locale detection
  */
 
-import { PUBLIC_API_BASE_URL } from '$env/static/public';
+import { env } from '$env/dynamic/public';
 import type { Handle } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
 
@@ -15,7 +15,7 @@ import { sequence } from '@sveltejs/kit/hooks';
  * Build connect-src directive with API origin if cross-origin
  */
 function buildConnectSrc(): string {
-	const apiBaseUrl = PUBLIC_API_BASE_URL;
+	const apiBaseUrl = env.PUBLIC_API_BASE_URL;
 	if (apiBaseUrl) {
 		try {
 			const apiOrigin = new URL(apiBaseUrl).origin;


### PR DESCRIPTION
## Summary
- Switch `$env/static/public` → `$env/dynamic/public` for `PUBLIC_API_BASE_URL` in `hooks.server.ts`
- `static` imports require the variable in `.env` at build/typecheck time, but `.env` is gitignored
- `dynamic` imports resolve at runtime, fixing the typecheck error

## Test plan
- [x] `pnpm --filter=@authrim/ar-login-ui typecheck` passes (0 errors)
- [x] Full `pnpm turbo run typecheck --force` passes (23/23 tasks successful)