### PR TITLE
feat: Phase 2-B multi-tenant management (invitations, custom registration fields, domain mappings)

### DIFF
--- a/migrations/000_fresh_schema.sql
+++ b/migrations/000_fresh_schema.sql
@@ -3,6 +3,47 @@
 -- Generated from conformance environment
 -- =============================================================================
 
+-- tenants table must be created first as other tables reference it via FK
+CREATE TABLE tenants (
+  id          TEXT PRIMARY KEY,           -- slug形式: ^[a-z0-9-]+$, max 63chars
+  name        TEXT NOT NULL,              -- 表示名
+  description TEXT,
+  is_active   INTEGER NOT NULL DEFAULT 1, -- 0=無効, 1=有効
+  is_default  INTEGER NOT NULL DEFAULT 0, -- デフォルトテナント（1つのみ）
+  created_at  INTEGER NOT NULL,
+  updated_at  INTEGER NOT NULL
+);
+
+-- is_default=1 は1行のみ（SQLite partial unique index）
+CREATE UNIQUE INDEX idx_tenants_is_default ON tenants(is_default)
+  WHERE is_default = 1;
+
+-- 既存の 'default' テナントを初期挿入
+INSERT INTO tenants (id, name, is_active, is_default, created_at, updated_at)
+VALUES ('default', 'Default', 1, 1, unixepoch(), unixepoch());
+
+-- Platform-level email domain → tenant routing (system_admin only)
+CREATE TABLE tenant_domain_mappings (
+  id                      TEXT PRIMARY KEY,
+  domain_hash             TEXT NOT NULL,
+  hash_version            INTEGER NOT NULL DEFAULT 1,
+  tenant_id               TEXT NOT NULL,
+  priority                INTEGER NOT NULL DEFAULT 0,
+  is_active               INTEGER NOT NULL DEFAULT 1,
+  verified                INTEGER NOT NULL DEFAULT 0,
+  verification_token      TEXT,
+  verification_expires_at INTEGER,
+  created_by              TEXT,
+  created_at              INTEGER NOT NULL,
+  updated_at              INTEGER NOT NULL,
+  FOREIGN KEY (tenant_id) REFERENCES tenants(id)
+);
+
+CREATE UNIQUE INDEX idx_tdm_domain_hash ON tenant_domain_mappings(domain_hash)
+  WHERE is_active = 1;
+CREATE INDEX idx_tdm_tenant ON tenant_domain_mappings(tenant_id);
+CREATE INDEX idx_tdm_verified ON tenant_domain_mappings(verified, is_active, priority DESC);
+
 CREATE TABLE access_review_items (
   id TEXT PRIMARY KEY,
   review_id TEXT NOT NULL REFERENCES access_reviews(id) ON DELETE CASCADE,
@@ -2149,7 +2190,11 @@ CREATE TABLE custom_claim_schemas (
   is_system INTEGER NOT NULL DEFAULT 0,
   created_by TEXT,
   created_at INTEGER NOT NULL,
-  updated_at INTEGER NOT NULL
+  updated_at INTEGER NOT NULL,
+  show_on_registration    INTEGER NOT NULL DEFAULT 0,
+  registration_required   INTEGER NOT NULL DEFAULT 0,
+  registration_order      INTEGER NOT NULL DEFAULT 0,
+  registration_placeholder TEXT
 );
 
 CREATE UNIQUE INDEX uniq_ccs_active_key ON custom_claim_schemas(tenant_id, field_key) WHERE is_active = 1;
@@ -2178,3 +2223,27 @@ CREATE TABLE custom_claim_schema_history (
 
 CREATE INDEX idx_ccsh_schema ON custom_claim_schema_history(tenant_id, schema_id, version DESC);
 CREATE INDEX idx_ccsh_cleanup ON custom_claim_schema_history(tenant_id, created_at);
+
+-- =============================================================================
+-- From 059: Tenant Invitations
+-- =============================================================================
+
+CREATE TABLE tenant_invitations (
+  id             TEXT PRIMARY KEY,
+  token          TEXT NOT NULL UNIQUE,         -- 256-bit entropy token
+  tenant_id      TEXT NOT NULL,
+  invited_email  TEXT,                         -- NULL=anyone, NON-NULL=specific email only
+  invited_by     TEXT NOT NULL,                -- Admin user ID who created the invitation
+  role_id        TEXT,                         -- Optional: auto-assign this role on signup
+  org_id         TEXT,                         -- Optional: auto-assign to this org on signup
+  max_uses       INTEGER NOT NULL DEFAULT 1,   -- -1=unlimited
+  use_count      INTEGER NOT NULL DEFAULT 0,
+  expires_at     INTEGER NOT NULL,
+  created_at     INTEGER NOT NULL,
+  updated_at     INTEGER NOT NULL,
+  FOREIGN KEY (tenant_id) REFERENCES tenants(id)
+);
+
+CREATE INDEX idx_ti_token  ON tenant_invitations(token)
+  WHERE expires_at > unixepoch();
+CREATE INDEX idx_ti_tenant ON tenant_invitations(tenant_id, created_at DESC);

--- a/migrations/057_add_tenants_table.sql
+++ b/migrations/057_add_tenants_table.sql
@@ -1,0 +1,21 @@
+-- =============================================================================
+-- Migration 057: Add tenants table
+-- =============================================================================
+
+CREATE TABLE tenants (
+  id          TEXT PRIMARY KEY,           -- slug形式: ^[a-z0-9-]+$, max 63chars
+  name        TEXT NOT NULL,              -- 表示名
+  description TEXT,
+  is_active   INTEGER NOT NULL DEFAULT 1, -- 0=無効, 1=有効
+  is_default  INTEGER NOT NULL DEFAULT 0, -- デフォルトテナント（1つのみ）
+  created_at  INTEGER NOT NULL,
+  updated_at  INTEGER NOT NULL
+);
+
+-- is_default=1 は1行のみ（SQLite partial unique index）
+CREATE UNIQUE INDEX idx_tenants_is_default ON tenants(is_default)
+  WHERE is_default = 1;
+
+-- 既存の 'default' テナントを初期挿入（既に存在する場合はスキップ）
+INSERT OR IGNORE INTO tenants (id, name, is_active, is_default, created_at, updated_at)
+VALUES ('default', 'Default', 1, 1, unixepoch(), unixepoch());

--- a/migrations/058_add_tenant_domain_mappings.sql
+++ b/migrations/058_add_tenant_domain_mappings.sql
@@ -1,0 +1,27 @@
+-- Migration 058: Add tenant domain mappings table
+-- Platform-level email domain → tenant routing (system_admin only)
+-- Allows users with @company.com emails to be auto-routed to the 'acme' tenant
+
+CREATE TABLE IF NOT EXISTS tenant_domain_mappings (
+  id                      TEXT PRIMARY KEY,
+  domain_hash             TEXT NOT NULL,
+  hash_version            INTEGER NOT NULL DEFAULT 1,
+  tenant_id               TEXT NOT NULL,
+  priority                INTEGER NOT NULL DEFAULT 0,
+  is_active               INTEGER NOT NULL DEFAULT 1,
+  verified                INTEGER NOT NULL DEFAULT 0,
+  verification_token      TEXT,
+  verification_expires_at INTEGER,
+  created_by              TEXT,
+  created_at              INTEGER NOT NULL,
+  updated_at              INTEGER NOT NULL,
+  FOREIGN KEY (tenant_id) REFERENCES tenants(id)
+);
+
+-- Unique index on active domain hashes to prevent duplicate routing
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tdm_domain_hash
+  ON tenant_domain_mappings(domain_hash)
+  WHERE is_active = 1;
+
+CREATE INDEX IF NOT EXISTS idx_tdm_tenant ON tenant_domain_mappings(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_tdm_verified ON tenant_domain_mappings(verified, is_active, priority DESC);

--- a/migrations/059_add_tenant_invitations.sql
+++ b/migrations/059_add_tenant_invitations.sql
@@ -1,0 +1,22 @@
+-- Migration 059: Add tenant invitations table
+-- Token-based invitation flow for tenant-specific signup routing
+
+CREATE TABLE IF NOT EXISTS tenant_invitations (
+  id             TEXT PRIMARY KEY,
+  token          TEXT NOT NULL UNIQUE,         -- 256-bit entropy token
+  tenant_id      TEXT NOT NULL,
+  invited_email  TEXT,                         -- NULL=anyone, NON-NULL=specific email only
+  invited_by     TEXT NOT NULL,                -- Admin user ID who created the invitation
+  role_id        TEXT,                         -- Optional: auto-assign this role on signup
+  org_id         TEXT,                         -- Optional: auto-assign to this org on signup
+  max_uses       INTEGER NOT NULL DEFAULT 1,   -- -1=unlimited
+  use_count      INTEGER NOT NULL DEFAULT 0,
+  expires_at     INTEGER NOT NULL,
+  created_at     INTEGER NOT NULL,
+  updated_at     INTEGER NOT NULL,
+  FOREIGN KEY (tenant_id) REFERENCES tenants(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ti_token  ON tenant_invitations(token)
+  WHERE expires_at > unixepoch();
+CREATE INDEX IF NOT EXISTS idx_ti_tenant ON tenant_invitations(tenant_id, created_at DESC);

--- a/migrations/060_add_registration_fields_to_custom_claim_schemas.sql
+++ b/migrations/060_add_registration_fields_to_custom_claim_schemas.sql
@@ -1,0 +1,11 @@
+-- Migration 060: Add registration form fields to custom_claim_schemas
+-- Enables per-tenant custom registration form with dynamic field rendering
+
+ALTER TABLE custom_claim_schemas
+  ADD COLUMN show_on_registration    INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE custom_claim_schemas
+  ADD COLUMN registration_required   INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE custom_claim_schemas
+  ADD COLUMN registration_order      INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE custom_claim_schemas
+  ADD COLUMN registration_placeholder TEXT;

--- a/packages/ar-admin-ui/src/lib/api/admin-custom-claims.ts
+++ b/packages/ar-admin-ui/src/lib/api/admin-custom-claims.ts
@@ -80,6 +80,10 @@ export interface CustomClaimSchema {
 	created_by: string | null;
 	created_at: number;
 	updated_at: number;
+	show_on_registration?: number;
+	registration_required?: number;
+	registration_order?: number;
+	registration_placeholder?: string | null;
 }
 
 /** Pagination info */
@@ -143,6 +147,10 @@ export interface CustomClaimSchemaInput {
 	claim_namespace?: string | null;
 	description?: string | null;
 	display_order?: number;
+	show_on_registration?: boolean;
+	registration_required?: boolean;
+	registration_order?: number;
+	registration_placeholder?: string | null;
 }
 
 // =============================================================================

--- a/packages/ar-admin-ui/src/lib/api/admin-settings.ts
+++ b/packages/ar-admin-ui/src/lib/api/admin-settings.ts
@@ -99,7 +99,7 @@ export interface SettingsPatchResult {
 	cleared: string[];
 	disabled: string[];
 	rejected: Record<string, string>;
-	newVersion: string;
+	version: string;
 }
 
 /**

--- a/packages/ar-admin-ui/src/lib/api/admin-tenants.ts
+++ b/packages/ar-admin-ui/src/lib/api/admin-tenants.ts
@@ -1,0 +1,157 @@
+/**
+ * Admin Tenants API Client
+ *
+ * Provides methods for managing tenants:
+ * - List, get, create, update, delete tenants
+ * - Set default tenant
+ */
+
+const API_BASE_URL = import.meta.env.PUBLIC_API_BASE_URL || '';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface Tenant {
+	id: string;
+	name: string;
+	description: string | null;
+	is_active: boolean;
+	is_default: boolean;
+	created_at: number;
+	updated_at: number;
+}
+
+export interface TenantListResponse {
+	tenants: Tenant[];
+	total: number;
+}
+
+export interface TenantDeleteResponse {
+	job_id: string;
+	status: 'pending';
+	estimated_completion: number;
+}
+
+export interface CreateTenantRequest {
+	id: string;
+	name: string;
+	description?: string;
+}
+
+export interface UpdateTenantRequest {
+	name?: string;
+	description?: string | null;
+	is_active?: boolean;
+}
+
+// =============================================================================
+// API Client
+// =============================================================================
+
+export const adminTenantsAPI = {
+	/**
+	 * List all tenants
+	 */
+	async list(): Promise<TenantListResponse> {
+		const response = await fetch(`${API_BASE_URL}/api/admin/tenants`, {
+			credentials: 'include'
+		});
+
+		if (!response.ok) {
+			const error = await response.json().catch(() => ({}));
+			throw new Error(error.error_description || error.message || 'Failed to fetch tenants');
+		}
+		return response.json();
+	},
+
+	/**
+	 * Get a single tenant by ID
+	 */
+	async get(id: string): Promise<Tenant> {
+		const response = await fetch(`${API_BASE_URL}/api/admin/tenants/${encodeURIComponent(id)}`, {
+			credentials: 'include'
+		});
+
+		if (!response.ok) {
+			const error = await response.json().catch(() => ({}));
+			throw new Error(error.error_description || error.message || 'Failed to fetch tenant');
+		}
+		return response.json();
+	},
+
+	/**
+	 * Create a new tenant
+	 */
+	async create(data: CreateTenantRequest): Promise<Tenant> {
+		const response = await fetch(`${API_BASE_URL}/api/admin/tenants`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			credentials: 'include',
+			body: JSON.stringify(data)
+		});
+
+		if (!response.ok) {
+			const error = await response.json().catch(() => ({}));
+			throw new Error(error.error_description || error.message || 'Failed to create tenant');
+		}
+		return response.json();
+	},
+
+	/**
+	 * Update an existing tenant
+	 * Note: id and is_default cannot be changed via this endpoint
+	 */
+	async update(id: string, data: UpdateTenantRequest): Promise<Tenant> {
+		const response = await fetch(`${API_BASE_URL}/api/admin/tenants/${encodeURIComponent(id)}`, {
+			method: 'PATCH',
+			headers: { 'Content-Type': 'application/json' },
+			credentials: 'include',
+			body: JSON.stringify(data)
+		});
+
+		if (!response.ok) {
+			const error = await response.json().catch(() => ({}));
+			throw new Error(error.error_description || error.message || 'Failed to update tenant');
+		}
+		return response.json();
+	},
+
+	/**
+	 * Schedule a tenant deletion as an async job.
+	 * The tenant is immediately deactivated; all data is deleted by the Cron job.
+	 * Returns 202 Accepted with the job ID.
+	 * The 'default' tenant cannot be deleted.
+	 */
+	async delete(id: string): Promise<TenantDeleteResponse> {
+		const response = await fetch(`${API_BASE_URL}/api/admin/tenants/${encodeURIComponent(id)}`, {
+			method: 'DELETE',
+			credentials: 'include'
+		});
+
+		if (!response.ok) {
+			const error = await response.json().catch(() => ({}));
+			throw new Error(error.error_description || error.message || 'Failed to delete tenant');
+		}
+		return response.json();
+	},
+
+	/**
+	 * Set a tenant as the default tenant
+	 */
+	async setDefault(id: string): Promise<Tenant> {
+		const response = await fetch(
+			`${API_BASE_URL}/api/admin/tenants/${encodeURIComponent(id)}/set-default`,
+			{
+				method: 'POST',
+				credentials: 'include'
+			}
+		);
+
+		if (!response.ok) {
+			const error = await response.json().catch(() => ({}));
+			throw new Error(error.error_description || error.message || 'Failed to set default tenant');
+		}
+		return response.json();
+	}
+};

--- a/packages/ar-admin-ui/src/lib/components/WorldMap.svelte
+++ b/packages/ar-admin-ui/src/lib/components/WorldMap.svelte
@@ -612,7 +612,7 @@
 			<!-- World map countries -->
 			{#if geoData}
 				<g class="countries">
-					{#each geoData.features as feature (feature.properties?.ISO_A3 || Math.random())}
+					{#each geoData.features as feature, i (feature.properties?.ISO_A3 && feature.properties.ISO_A3 !== '-99' ? feature.properties.ISO_A3 : `unknown-${i}`)}
 						{@const region = getRegionFromFeature(feature as Feature<Geometry, CountryProperties>)}
 						{@const isSelected = isRegionSelected(region)}
 						{@const isDoCapable = DO_CAPABLE_REGIONS.includes(region)}

--- a/packages/ar-admin-ui/src/lib/components/admin/AdminHeader.svelte
+++ b/packages/ar-admin-ui/src/lib/components/admin/AdminHeader.svelte
@@ -104,7 +104,7 @@
 	</div>
 
 	<div class="header-right">
-		{#if tenants.length > 0}
+		{#if tenants.length > 1}
 			<div class="header-tenant-selector">
 				<span class="tenant-selector-label">Tenant:</span>
 				<select

--- a/packages/ar-admin-ui/src/lib/components/admin/NavGroupLabel.svelte
+++ b/packages/ar-admin-ui/src/lib/components/admin/NavGroupLabel.svelte
@@ -10,7 +10,7 @@
 
 <style>
 	.nav-group-label {
-		padding: 16px 12px 8px 12px;
+		padding: 8px 12px 8px 12px;
 		font-size: 0.625rem;
 		font-weight: 700;
 		text-transform: uppercase;

--- a/packages/ar-admin-ui/src/lib/components/admin/NavSection.svelte
+++ b/packages/ar-admin-ui/src/lib/components/admin/NavSection.svelte
@@ -1,27 +1,21 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 
-	type HierarchyLevel = 'tenant' | 'system' | 'client' | 'compliance';
+	type HierarchyLevel = 'enduser' | 'client' | 'tenant' | 'platform';
 
 	interface Props {
 		label?: string;
 		level?: HierarchyLevel;
-		tenantName?: string;
 		children: Snippet;
 	}
 
-	let { label, level = 'tenant', tenantName, children }: Props = $props();
+	let { label, level = 'enduser', children }: Props = $props();
 </script>
 
 <div class="nav-section" data-level={level}>
-	{#if label || tenantName}
+	{#if label}
 		<div class="nav-section-header">
-			<span class="section-indicator"></span>
-			{#if tenantName}
-				<span class="current-tenant-name">{tenantName}</span>
-			{:else}
-				{label}
-			{/if}
+			{label}
 		</div>
 	{/if}
 
@@ -30,63 +24,44 @@
 
 <style>
 	.nav-section {
-		margin-bottom: 16px;
+		margin-bottom: 4px;
 	}
 
-	.nav-section[data-level='system'] {
-		border-top: 1px solid var(--nav-border);
-		padding-top: 16px;
-		margin-top: 12px;
-	}
-
+	/* Section header with left accent bar */
 	.nav-section-header {
 		display: flex;
 		align-items: center;
-		gap: 8px;
-		padding: 8px;
+		margin-top: 12px;
+		padding: 5px 12px 5px 10px;
 		font-size: 0.625rem;
 		font-weight: 700;
 		text-transform: uppercase;
-		letter-spacing: 0.1em;
-		color: var(--text-muted);
-		min-height: 30px;
+		letter-spacing: 0.12em;
+		min-height: 26px;
+		margin-bottom: 4px;
+		border-left: 2px solid transparent;
+		border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
 	}
 
-	/* Section indicator dot */
-	.section-indicator {
-		width: 6px;
-		height: 6px;
-		border-radius: 50%;
-		flex-shrink: 0;
+	/* Level-specific accent colors */
+	.nav-section[data-level='enduser'] .nav-section-header {
+		border-left-color: var(--level-enduser-color);
+		color: var(--level-enduser-color);
 	}
 
-	.nav-section[data-level='system'] .section-indicator {
-		background: var(--system-color);
+	.nav-section[data-level='client'] .nav-section-header {
+		border-left-color: var(--level-client-color);
+		color: var(--level-client-color);
 	}
 
-	.nav-section[data-level='tenant'] .section-indicator {
-		background: var(--tenant-color);
+	.nav-section[data-level='tenant'] .nav-section-header {
+		border-left-color: var(--level-tenant-color);
+		color: var(--level-tenant-color);
 	}
 
-	.nav-section[data-level='client'] .section-indicator {
-		background: var(--client-color);
-	}
-
-	.nav-section[data-level='compliance'] .section-indicator {
-		background: var(--compliance-color);
-	}
-
-	/* Tenant name styling */
-	.current-tenant-name {
-		font-size: 0.875rem;
-		font-weight: 700;
-		color: #ffffff;
-		text-transform: none;
-		letter-spacing: 0;
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		min-width: 0;
+	.nav-section[data-level='platform'] .nav-section-header {
+		border-left-color: var(--level-platform-color);
+		color: var(--level-platform-color);
 	}
 
 	/* Global visibility control - handled by parent */

--- a/packages/ar-admin-ui/src/lib/stores/tenants.svelte.ts
+++ b/packages/ar-admin-ui/src/lib/stores/tenants.svelte.ts
@@ -1,0 +1,75 @@
+/**
+ * Tenant Store (Svelte 5 Runes)
+ *
+ * Shared reactive state for the tenant list.
+ * Used by +layout.svelte (AdminHeader selector) and
+ * admin/tenants/+page.svelte (management page) to stay in sync.
+ */
+
+import { adminTenantsAPI, type Tenant } from '$lib/api/admin-tenants';
+
+function createTenantStore() {
+	let tenants = $state<Tenant[]>([]);
+	let loaded = $state(false);
+
+	return {
+		get tenants() {
+			return tenants;
+		},
+		get loaded() {
+			return loaded;
+		},
+
+		/** Active tenants suitable for the header selector */
+		get activeTenants(): { id: string; name: string }[] {
+			return tenants.filter((t) => t.is_active).map((t) => ({ id: t.id, name: t.name }));
+		},
+
+		/** The current default tenant id */
+		get defaultTenantId(): string {
+			return tenants.find((t) => t.is_default)?.id ?? 'default';
+		},
+
+		/** Fetch the full tenant list from the API */
+		async load() {
+			try {
+				const response = await adminTenantsAPI.list();
+				tenants = response.tenants;
+				loaded = true;
+			} catch {
+				// Non-critical: selector simply won't appear
+			}
+		},
+
+		/** Reload the tenant list (e.g. after create/update/delete operations) */
+		async reload() {
+			await this.load();
+		},
+
+		/** Optimistically update a single tenant in the list */
+		update(updated: Tenant) {
+			tenants = tenants.map((t) => (t.id === updated.id ? updated : t));
+		},
+
+		/** Optimistically add a tenant to the list */
+		add(tenant: Tenant) {
+			tenants = [...tenants, tenant].sort((a, b) => {
+				if (a.is_default) return -1;
+				if (b.is_default) return 1;
+				return a.name.localeCompare(b.name);
+			});
+		},
+
+		/** Optimistically remove a tenant from the list */
+		remove(id: string) {
+			tenants = tenants.filter((t) => t.id !== id);
+		},
+
+		/** Mark a tenant as default and clear the flag from all others */
+		setDefault(id: string) {
+			tenants = tenants.map((t) => ({ ...t, is_default: t.id === id }));
+		}
+	};
+}
+
+export const tenantStore = createTenantStore();

--- a/packages/ar-admin-ui/src/lib/styles/themes.css
+++ b/packages/ar-admin-ui/src/lib/styles/themes.css
@@ -4,6 +4,20 @@
                Dark (Brown, Navy, Slate)
    ============================================ */
 
+/* ============================================
+   NAV SECTION LEVEL COLORS
+   Applied against always-dark nav backgrounds.
+   Tuned per theme variant for harmony.
+   ============================================ */
+
+/* Default (Beige / warm dark nav) */
+:root {
+	--level-enduser-color: #7aadcc;   /* dusty blue */
+	--level-client-color: #68b89a;    /* sage teal */
+	--level-tenant-color: #c9a05a;    /* warm gold */
+	--level-platform-color: #9b84c4;  /* soft violet */
+}
+
 /* === Light Theme - Beige Variant (Default) === */
 :root,
 [data-theme='light'],
@@ -50,6 +64,12 @@
 
 /* === Light Theme - Blue-Gray Variant === */
 [data-theme='light'][data-variant='blue-gray'] {
+	/* Level colors (cooler tones to match blue-gray nav) */
+	--level-enduser-color: #82bfe0;
+	--level-client-color: #60c4a8;
+	--level-tenant-color: #d4ab60;
+	--level-platform-color: #a08fd4;
+
 	/* Navigation */
 	--bg-nav: rgba(51, 65, 85, 0.95);
 	--nav-active-bg: rgba(255, 255, 255, 0.15);
@@ -84,6 +104,12 @@
 
 /* === Light Theme - Green Variant === */
 [data-theme='light'][data-variant='green'] {
+	/* Level colors (shifted so client teal stands out from green nav) */
+	--level-enduser-color: #78b8d8;
+	--level-client-color: #7ac8a0;
+	--level-tenant-color: #c8a050;
+	--level-platform-color: #9880c0;
+
 	/* Navigation */
 	--bg-nav: rgba(34, 51, 34, 0.95);
 	--nav-active-bg: rgba(255, 255, 255, 0.15);
@@ -119,6 +145,12 @@
 /* === Dark Theme - Brown Variant (Default Dark) === */
 [data-theme='dark'],
 [data-theme='dark'][data-variant='brown'] {
+	/* Level colors (slightly brighter for dark mode legibility) */
+	--level-enduser-color: #88bedd;
+	--level-client-color: #72c4a6;
+	--level-tenant-color: #d4ae68;
+	--level-platform-color: #a890cc;
+
 	color-scheme: dark;
 
 	/* Navigation */
@@ -171,6 +203,12 @@
 
 /* === Dark Theme - Navy Variant === */
 [data-theme='dark'][data-variant='navy'] {
+	/* Level colors (cooler blue shifted to avoid clashing with navy nav) */
+	--level-enduser-color: #90ccee;
+	--level-client-color: #6ecaaa;
+	--level-tenant-color: #dab870;
+	--level-platform-color: #b09ad8;
+
 	/* Navigation */
 	--bg-nav: rgba(28, 37, 48, 0.98);
 	--nav-active-bg: rgba(100, 149, 237, 0.25);
@@ -207,6 +245,12 @@
 
 /* === Dark Theme - Slate Variant === */
 [data-theme='dark'][data-variant='slate'] {
+	/* Level colors (neutral slate palette) */
+	--level-enduser-color: #86bcd8;
+	--level-client-color: #6ec0a2;
+	--level-tenant-color: #d0ac62;
+	--level-platform-color: #a694cc;
+
 	/* Navigation */
 	--bg-nav: rgba(38, 42, 48, 0.98);
 	--nav-active-bg: rgba(148, 163, 184, 0.25);
@@ -384,13 +428,7 @@
 	color: var(--text-primary);
 }
 
-[data-theme='dark'] .nav-section-header {
-	color: rgba(245, 243, 240, 0.9);
-}
-
-[data-theme='dark'] .section-indicator {
-	opacity: 0.7;
-}
+/* nav-section-header color is controlled per level via CSS vars, not overridden here */
 
 [data-theme='dark'] .header-icon-btn {
 	color: var(--text-secondary);
@@ -423,9 +461,7 @@
 	border-color: var(--border);
 }
 
-[data-theme='dark'] .nav-section[data-level='system'] {
-	border-top-color: var(--nav-border);
-}
+/* nav-section[data-level='system'] border removed - sections now use left accent bars */
 
 /* Activity Icons */
 [data-theme='dark'] .activity-icon.stat-icon.green {

--- a/packages/ar-admin-ui/src/routes/admin/+layout.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/+layout.svelte
@@ -11,8 +11,12 @@
 	import NavGroupLabel from '$lib/components/admin/NavGroupLabel.svelte';
 	import AdminHeader from '$lib/components/admin/AdminHeader.svelte';
 	import type { Snippet } from 'svelte';
+	import { tenantStore } from '$lib/stores/tenants.svelte';
 
 	let { children }: { children: Snippet } = $props();
+
+	// Tenant selector state — derived from shared store
+	let selectedTenantId = $state('default');
 
 	// Check if current page is login page
 	const isLoginPage = $derived($page.url.pathname === '/admin/login');
@@ -195,8 +199,17 @@
 		// Redirect to login if not authenticated and still on the same page
 		if (!adminAuth.isAuthenticated && $page.url.pathname === currentPath) {
 			goto('/admin/login');
+			return;
 		}
+
+		// Load tenant list into the shared store for the header selector
+		await tenantStore.load();
+		selectedTenantId = tenantStore.defaultTenantId;
 	});
+
+	function handleTenantChange(tenantId: string) {
+		selectedTenantId = tenantId;
+	}
 
 	function toggleMobileMenu() {
 		mobileMenuOpen = !mobileMenuOpen;
@@ -368,6 +381,9 @@
 		<main class="main-content">
 			<AdminHeader
 				breadcrumbs={currentBreadcrumb()}
+				tenants={tenantStore.activeTenants}
+				{selectedTenantId}
+				onTenantChange={handleTenantChange}
 				onMobileMenuClick={toggleMobileMenu}
 				userEmail={adminAuth.user?.email}
 				userName={adminAuth.user?.name}

--- a/packages/ar-admin-ui/src/routes/admin/+layout.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/+layout.svelte
@@ -29,22 +29,15 @@
 		mobileMenuOpen = false;
 	});
 
-	// Navigation structure - Tenant scope (managed by tenant admins)
-	// Note: "End Users" refers to application users (not admin operators)
-	const tenantNavItems = {
-		// End Users - Identity Management
-		endUsers: [
+	// END USER section - identity management for application users
+	const navEndUser = {
+		identity: [
 			{ path: '/admin/users', label: 'End Users', icon: 'i-ph-users' },
 			{ path: '/admin/sessions', label: 'User Sessions', icon: 'i-ph-clock' },
 			{ path: '/admin/organizations', label: 'Organizations', icon: 'i-ph-buildings' }
 		],
-		// End User Access Control (RBAC/ABAC/ReBAC)
-		endUserAccessControl: {
-			parent: {
-				href: '/admin/access-control',
-				icon: 'i-ph-shield-star',
-				label: 'Access Control'
-			},
+		accessControl: {
+			parent: { href: '/admin/access-control', icon: 'i-ph-shield-star', label: 'Access Control' },
 			children: [
 				{ href: '/admin/roles', label: 'RBAC (Roles)' },
 				{ href: '/admin/attributes', label: 'ABAC (Attributes)' },
@@ -52,120 +45,110 @@
 				{ href: '/admin/policies', label: 'Policies' }
 			]
 		},
-		// End User Monitoring
-		endUserMonitoring: [
+		monitoring: [
 			{ path: '/admin/audit-logs', label: 'User Audit Logs', icon: 'i-ph-file-text' },
 			{ path: '/admin/access-trace', label: 'Access Trace', icon: 'i-ph-path' },
 			{ path: '/admin/diagnostic-logging', label: 'Diagnostic Logging', icon: 'i-ph-bug' }
-		],
-		// Applications
+		]
+	};
+
+	// CLIENT section - application/client management
+	const navClient = {
 		applications: [
 			{ path: '/admin/clients', label: 'Clients', icon: 'i-ph-monitor' },
-			{ path: '/admin/iat-tokens', label: 'IAT Tokens', icon: 'i-ph-key' },
-			{ path: '/admin/webhooks', label: 'Webhooks', icon: 'i-ph-webhooks-logo' }
-		],
-		// Authentication
+			{ path: '/admin/webhooks', label: 'Webhooks', icon: 'i-ph-webhooks-logo' },
+			{ path: '/admin/iat-tokens', label: 'IAT Tokens', icon: 'i-ph-key' }
+		]
+	};
+
+	// TENANT section - tenant-level configuration
+	const navTenant = {
 		authentication: [
-			{ path: '/admin/flows', label: 'Flows', icon: 'i-ph-flow-arrow' },
+			{ path: '/admin/external-idp', label: 'External IdP', icon: 'i-ph-globe' },
 			{ path: '/admin/consents', label: 'Consents', icon: 'i-ph-handshake' },
 			{ path: '/admin/consent-statements', label: 'Consent Statements', icon: 'i-ph-list-checks' },
-			{ path: '/admin/external-idp', label: 'External IdP', icon: 'i-ph-globe' }
+			{ path: '/admin/flows', label: 'Flows', icon: 'i-ph-flow-arrow' }
 		],
-		// Configuration
+		identitySchema: [
+			{ path: '/admin/custom-claims', label: 'Custom Claims', icon: 'i-ph-tag' },
+			{ path: '/admin/scim-tokens', label: 'SCIM Tokens', icon: 'i-ph-identification-card' }
+		],
+		branding: [{ path: '/admin/login-ui', label: 'Login UI', icon: 'i-ph-paint-brush' }],
 		configuration: [
-			{ path: '/admin/login-ui', label: 'Login UI', icon: 'i-ph-paint-brush' },
 			{ path: '/admin/settings', label: 'Settings', icon: 'i-ph-gear' },
 			{ path: '/admin/plugins', label: 'Plugins', icon: 'i-ph-puzzle-piece' }
 		]
 	};
 
-	// Navigation structure - Platform scope (managed by system admins)
-	// Note: Admin management is for admin operators (not end users)
-	const platformNavItems = {
-		// Identity Schema
-		identitySchema: [
-			{ path: '/admin/custom-claims', label: 'Custom Claims', icon: 'i-ph-tag' },
-			{ path: '/admin/scim-tokens', label: 'SCIM Tokens', icon: 'i-ph-identification-card' }
-		],
-		// Security & Compliance
-		securityCompliance: [
+	// PLATFORM section - system administration
+	const navPlatform = {
+		tenantManagement: [{ path: '/admin/tenants', label: 'Tenants', icon: 'i-ph-buildings' }],
+		security: [
 			{ path: '/admin/security', label: 'Security', icon: 'i-ph-lock-key' },
 			{ path: '/admin/compliance', label: 'Compliance', icon: 'i-ph-certificate' }
 		],
-		// System Operations
 		operations: [
 			{ path: '/admin/scale', label: 'Scale', icon: 'i-ph-chart-bar' },
 			{ path: '/admin/jobs', label: 'Jobs', icon: 'i-ph-queue' }
 		],
-		// Admin Management (Admin operators, not end users)
-		adminManagement: [
-			{ path: '/admin/admins', label: 'Admin Users', icon: 'i-ph-user-gear' },
-			{
-				parent: {
-					href: '/admin/admin-access-control',
-					icon: 'i-ph-shield-star',
-					label: 'Admin Access Control'
-				},
-				children: [
-					{ href: '/admin/admin-rbac', label: 'RBAC (Roles)' },
-					{ href: '/admin/admin-abac', label: 'ABAC (Attributes)' },
-					{ href: '/admin/admin-rebac', label: 'ReBAC' },
-					{ href: '/admin/admin-policies', label: 'Policies' }
-				]
+		adminUsers: { path: '/admin/admins', label: 'Admin Users', icon: 'i-ph-user-gear' },
+		adminAccessControl: {
+			parent: {
+				href: '/admin/admin-access-control',
+				icon: 'i-ph-shield-star',
+				label: 'Admin Access Control'
 			},
+			children: [
+				{ href: '/admin/admin-rbac', label: 'RBAC (Roles)' },
+				{ href: '/admin/admin-abac', label: 'ABAC (Attributes)' },
+				{ href: '/admin/admin-rebac', label: 'ReBAC' },
+				{ href: '/admin/admin-policies', label: 'Policies' }
+			]
+		},
+		adminOthers: [
 			{ path: '/admin/ip-allowlist', label: 'IP Allowlist', icon: 'i-ph-shield-check' },
 			{ path: '/admin/admin-audit', label: 'Admin Audit Log', icon: 'i-ph-clipboard-text' }
 		]
 	};
 
-	// Extract admin management items for type safety
-	const [adminUsersItem, adminAccessControlItem, ...adminOtherItems] = platformNavItems.adminManagement;
-
 	// All nav items flattened for breadcrumb lookup
 	const allNavItems = [
-		// End Users section
-		...tenantNavItems.endUsers,
-		// End User Access Control Hub parent and children
+		// End User
+		...navEndUser.identity,
 		{
-			path: tenantNavItems.endUserAccessControl.parent.href,
-			label: tenantNavItems.endUserAccessControl.parent.label,
-			icon: tenantNavItems.endUserAccessControl.parent.icon
+			path: navEndUser.accessControl.parent.href,
+			label: navEndUser.accessControl.parent.label,
+			icon: navEndUser.accessControl.parent.icon
 		},
-		...tenantNavItems.endUserAccessControl.children.map((c) => ({
+		...navEndUser.accessControl.children.map((c) => ({
 			path: c.href,
 			label: c.label,
 			icon: 'i-ph-arrow-right'
 		})),
-		...tenantNavItems.endUserMonitoring,
-		...tenantNavItems.applications,
-		...tenantNavItems.authentication,
-		...tenantNavItems.configuration,
-		// Platform section
-		...platformNavItems.identitySchema,
-		...platformNavItems.securityCompliance,
-		...platformNavItems.operations,
-		// Admin Management with Access Control Hub
+		...navEndUser.monitoring,
+		// Client
+		...navClient.applications,
+		// Tenant
+		...navTenant.authentication,
+		...navTenant.identitySchema,
+		...navTenant.branding,
+		...navTenant.configuration,
+		// Platform
+		...navPlatform.tenantManagement,
+		...navPlatform.security,
+		...navPlatform.operations,
+		navPlatform.adminUsers,
 		{
-			path: adminUsersItem.path!,
-			label: adminUsersItem.label!,
-			icon: adminUsersItem.icon!
+			path: navPlatform.adminAccessControl.parent.href,
+			label: navPlatform.adminAccessControl.parent.label,
+			icon: navPlatform.adminAccessControl.parent.icon
 		},
-		{
-			path: adminAccessControlItem.parent!.href,
-			label: adminAccessControlItem.parent!.label,
-			icon: adminAccessControlItem.parent!.icon
-		},
-		...adminAccessControlItem.children!.map((c) => ({
+		...navPlatform.adminAccessControl.children.map((c) => ({
 			path: c.href,
 			label: c.label,
 			icon: 'i-ph-arrow-right'
 		})),
-		// IP Allowlist, Admin Audit
-		...adminOtherItems.map((item) => ({
-			path: item.path!,
-			label: item.label!,
-			icon: item.icon!
-		}))
+		...navPlatform.adminOthers
 	];
 
 	// Check if nav item is active
@@ -235,19 +218,18 @@
 	<!-- Authenticated - layout with floating sidebar -->
 	<div class="app-layout">
 		<FloatingNav mobileOpen={mobileMenuOpen} onMobileClose={() => (mobileMenuOpen = false)}>
-			<!-- Tenant Section -->
-			<NavSection level="tenant" tenantName="Default">
-				<!-- Dashboard -->
-				<NavItem
-					href="/admin"
-					icon="i-ph-squares-four"
-					label="Dashboard"
-					active={isActive('/admin', true)}
-				/>
+			<!-- Dashboard (above all sections) -->
+			<NavItem
+				href="/admin"
+				icon="i-ph-squares-four"
+				label="Dashboard"
+				active={isActive('/admin', true)}
+			/>
 
-				<!-- End Users (Application Users) -->
-				<NavGroupLabel label="End Users" />
-				{#each tenantNavItems.endUsers as item (item.path)}
+			<!-- END USER Section -->
+			<NavSection level="enduser" label="End User">
+				<NavGroupLabel label="Identity" />
+				{#each navEndUser.identity as item (item.path)}
 					<NavItem
 						href={item.path}
 						icon={item.icon}
@@ -256,48 +238,13 @@
 					/>
 				{/each}
 
-				<!-- End User Access Control (RBAC/ABAC/ReBAC) -->
 				<NavItemGroup
-					parent={tenantNavItems.endUserAccessControl.parent}
-					children={tenantNavItems.endUserAccessControl.children}
+					parent={navEndUser.accessControl.parent}
+					children={navEndUser.accessControl.children}
 				/>
 
-				<!-- End User Monitoring -->
-				<NavGroupLabel label="User Monitoring" />
-				{#each tenantNavItems.endUserMonitoring as item (item.path)}
-					<NavItem
-						href={item.path}
-						icon={item.icon}
-						label={item.label}
-						active={isActive(item.path)}
-					/>
-				{/each}
-
-				<!-- Applications -->
-				<NavGroupLabel label="Applications" />
-				{#each tenantNavItems.applications as item (item.path)}
-					<NavItem
-						href={item.path}
-						icon={item.icon}
-						label={item.label}
-						active={isActive(item.path)}
-					/>
-				{/each}
-
-				<!-- Authentication -->
-				<NavGroupLabel label="Authentication" />
-				{#each tenantNavItems.authentication as item (item.path)}
-					<NavItem
-						href={item.path}
-						icon={item.icon}
-						label={item.label}
-						active={isActive(item.path)}
-					/>
-				{/each}
-
-				<!-- Configuration -->
-				<NavGroupLabel label="Configuration" />
-				{#each tenantNavItems.configuration as item (item.path)}
+				<NavGroupLabel label="Monitoring" />
+				{#each navEndUser.monitoring as item (item.path)}
 					<NavItem
 						href={item.path}
 						icon={item.icon}
@@ -307,11 +254,23 @@
 				{/each}
 			</NavSection>
 
-			<!-- Platform Section -->
-			<NavSection level="system" label="Platform">
-				<!-- Operations -->
-				<NavGroupLabel label="Operations" />
-				{#each platformNavItems.operations as item (item.path)}
+			<!-- CLIENT Section -->
+			<NavSection level="client" label="Client">
+				<NavGroupLabel label="Applications" />
+				{#each navClient.applications as item (item.path)}
+					<NavItem
+						href={item.path}
+						icon={item.icon}
+						label={item.label}
+						active={isActive(item.path)}
+					/>
+				{/each}
+			</NavSection>
+
+			<!-- TENANT Section -->
+			<NavSection level="tenant" label="Tenant">
+				<NavGroupLabel label="Authentication" />
+				{#each navTenant.authentication as item (item.path)}
 					<NavItem
 						href={item.path}
 						icon={item.icon}
@@ -320,20 +279,8 @@
 					/>
 				{/each}
 
-				<!-- Security & Compliance -->
-				<NavGroupLabel label="Security" />
-				{#each platformNavItems.securityCompliance as item (item.path)}
-					<NavItem
-						href={item.path}
-						icon={item.icon}
-						label={item.label}
-						active={isActive(item.path)}
-					/>
-				{/each}
-
-				<!-- Identity Schema -->
 				<NavGroupLabel label="Identity Schema" />
-				{#each platformNavItems.identitySchema as item (item.path)}
+				{#each navTenant.identitySchema as item (item.path)}
 					<NavItem
 						href={item.path}
 						icon={item.icon}
@@ -342,24 +289,76 @@
 					/>
 				{/each}
 
-				<!-- Admin Management (Admin Operators) -->
+				<NavGroupLabel label="Branding" />
+				{#each navTenant.branding as item (item.path)}
+					<NavItem
+						href={item.path}
+						icon={item.icon}
+						label={item.label}
+						active={isActive(item.path)}
+					/>
+				{/each}
+
+				<NavGroupLabel label="Configuration" />
+				{#each navTenant.configuration as item (item.path)}
+					<NavItem
+						href={item.path}
+						icon={item.icon}
+						label={item.label}
+						active={isActive(item.path)}
+					/>
+				{/each}
+			</NavSection>
+
+			<!-- PLATFORM Section -->
+			<NavSection level="platform" label="Platform">
+				<NavGroupLabel label="Tenant Management" />
+				{#each navPlatform.tenantManagement as item (item.path)}
+					<NavItem
+						href={item.path}
+						icon={item.icon}
+						label={item.label}
+						active={isActive(item.path)}
+					/>
+				{/each}
+
+				<NavGroupLabel label="Security & Compliance" />
+				{#each navPlatform.security as item (item.path)}
+					<NavItem
+						href={item.path}
+						icon={item.icon}
+						label={item.label}
+						active={isActive(item.path)}
+					/>
+				{/each}
+
+				<NavGroupLabel label="Operations" />
+				{#each navPlatform.operations as item (item.path)}
+					<NavItem
+						href={item.path}
+						icon={item.icon}
+						label={item.label}
+						active={isActive(item.path)}
+					/>
+				{/each}
+
 				<NavGroupLabel label="Admin Operators" />
 				<NavItem
-					href={adminUsersItem.path!}
-					icon={adminUsersItem.icon!}
-					label={adminUsersItem.label!}
-					active={isActive(adminUsersItem.path!)}
+					href={navPlatform.adminUsers.path}
+					icon={navPlatform.adminUsers.icon}
+					label={navPlatform.adminUsers.label}
+					active={isActive(navPlatform.adminUsers.path)}
 				/>
 				<NavItemGroup
-					parent={adminAccessControlItem.parent!}
-					children={adminAccessControlItem.children!}
+					parent={navPlatform.adminAccessControl.parent}
+					children={navPlatform.adminAccessControl.children}
 				/>
-				{#each adminOtherItems as item (item.path)}
+				{#each navPlatform.adminOthers as item (item.path)}
 					<NavItem
-						href={item.path!}
-						icon={item.icon!}
-						label={item.label!}
-						active={isActive(item.path!)}
+						href={item.path}
+						icon={item.icon}
+						label={item.label}
+						active={isActive(item.path)}
 					/>
 				{/each}
 			</NavSection>

--- a/packages/ar-admin-ui/src/routes/admin/+layout.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/+layout.svelte
@@ -12,6 +12,7 @@
 	import AdminHeader from '$lib/components/admin/AdminHeader.svelte';
 	import type { Snippet } from 'svelte';
 	import { tenantStore } from '$lib/stores/tenants.svelte';
+	import { settingsContext } from '$lib/stores/settings-context.svelte';
 
 	let { children }: { children: Snippet } = $props();
 
@@ -207,8 +208,9 @@
 		selectedTenantId = tenantStore.defaultTenantId;
 	});
 
-	function handleTenantChange(tenantId: string) {
+	async function handleTenantChange(tenantId: string) {
 		selectedTenantId = tenantId;
+		await settingsContext.setTenantId(tenantId);
 	}
 
 	function toggleMobileMenu() {

--- a/packages/ar-admin-ui/src/routes/admin/attributes/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/attributes/+page.svelte
@@ -258,7 +258,7 @@
 				set: { 'feature.enable_abac': newValue }
 			});
 			abacEnabled = newValue;
-			featureFlagsVersion = result.newVersion;
+			featureFlagsVersion = result.version;
 		} catch (err) {
 			console.error('Failed to update ABAC status:', err);
 			abacError = err instanceof Error ? err.message : 'Failed to update ABAC status';

--- a/packages/ar-admin-ui/src/routes/admin/custom-claims/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/custom-claims/+page.svelte
@@ -701,7 +701,7 @@
 					<input type="checkbox" bind:checked={createForm.include_in_introspection} />
 					Introspection
 					<small style="color: var(--color-warning, #b08800); display: block; font-size: 0.75rem;"
-						>現在、Introspectionレスポンスへのカスタムクレーム埋め込みは無効です。UserInfoエンドポイントをご利用ください。</small
+						>Custom claim embedding in Introspection responses is currently disabled. Please use the UserInfo endpoint instead.</small
 					>
 				</label>
 			</div>

--- a/packages/ar-admin-ui/src/routes/admin/custom-claims/[id]/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/custom-claims/[id]/+page.svelte
@@ -44,7 +44,11 @@
 		claim_namespace: '',
 		is_searchable: false,
 		is_exportable: false,
-		is_vc_claim: false
+		is_vc_claim: false,
+		show_on_registration: false,
+		registration_required: false,
+		registration_order: 0,
+		registration_placeholder: ''
 	});
 
 	// Delete dialog
@@ -99,7 +103,11 @@
 			claim_namespace: s.claim_namespace || '',
 			is_searchable: !!s.is_searchable,
 			is_exportable: !!s.is_exportable,
-			is_vc_claim: !!s.is_vc_claim
+			is_vc_claim: !!s.is_vc_claim,
+			show_on_registration: !!s.show_on_registration,
+			registration_required: !!s.registration_required,
+			registration_order: (s.registration_order as number) ?? 0,
+			registration_placeholder: (s.registration_placeholder as string) || ''
 		};
 	}
 
@@ -150,7 +158,11 @@
 				claim_namespace: editForm.claim_namespace || null,
 				is_searchable: editForm.is_searchable,
 				is_exportable: editForm.is_exportable,
-				is_vc_claim: editForm.is_vc_claim
+				is_vc_claim: editForm.is_vc_claim,
+				show_on_registration: editForm.show_on_registration,
+				registration_required: editForm.registration_required,
+				registration_order: editForm.registration_order,
+				registration_placeholder: editForm.registration_placeholder || null
 			});
 
 			schema = result.schema;
@@ -455,7 +467,7 @@
 										Introspection
 									</span>
 									<small style="color: var(--color-warning, #b08800); font-size: 0.75rem;"
-										>現在、Introspectionレスポンスへのカスタムクレーム埋め込みは無効です。</small
+										>Custom claim embedding in Introspection responses is currently disabled.</small
 									>
 								</label>
 							</div>
@@ -538,6 +550,55 @@
 							Verifiable Credential claim
 						</label>
 					</div>
+				</div>
+
+				<!-- Section: Registration Form -->
+				<div class="panel mb-4">
+					<h2 class="panel-title">Registration Form</h2>
+					<div class="flex gap-6 flex-wrap mb-4">
+						<label class="form-label">
+							<input
+								type="checkbox"
+								bind:checked={editForm.show_on_registration}
+								disabled={!isEditable}
+							/>
+							Show on signup form
+						</label>
+						<label class="form-label">
+							<input
+								type="checkbox"
+								bind:checked={editForm.registration_required}
+								disabled={!isEditable || !editForm.show_on_registration}
+							/>
+							Required on signup
+						</label>
+					</div>
+					{#if editForm.show_on_registration}
+						<div class="flex gap-4 flex-wrap">
+							<div style="min-width:120px;">
+								<label class="form-label" for="reg-order">Display order</label>
+								<input
+									id="reg-order"
+									type="number"
+									bind:value={editForm.registration_order}
+									disabled={!isEditable}
+									min="0"
+									class="form-input"
+								/>
+							</div>
+							<div style="flex:1; min-width:200px;">
+								<label class="form-label" for="reg-placeholder">Placeholder text</label>
+								<input
+									id="reg-placeholder"
+									type="text"
+									bind:value={editForm.registration_placeholder}
+									disabled={!isEditable}
+									placeholder="e.g. Enter your department"
+									class="form-input"
+								/>
+							</div>
+						</div>
+					{/if}
 				</div>
 
 				<!-- Save button -->

--- a/packages/ar-admin-ui/src/routes/admin/diagnostic-logging/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/diagnostic-logging/+page.svelte
@@ -131,7 +131,7 @@
 		// Only check Storage tab for unsaved changes
 		if (hasUnsavedStorageChanges) {
 			const confirmChange = confirm(
-				'未保存の変更があります。タブを切り替えると変更が失われますが、よろしいですか?'
+				'You have unsaved changes. Switching tabs will discard them. Continue?'
 			);
 			if (!confirmChange) return;
 			// Reset to initial values
@@ -262,7 +262,7 @@
 
 			loggingSettings = {
 				...loggingSettings,
-				version: result.newVersion,
+				version: result.version,
 				values: {
 					...loggingSettings.values,
 					'diagnostic-logging.enabled': enabled
@@ -296,7 +296,7 @@
 
 			loggingSettings = {
 				...loggingSettings,
-				version: result.newVersion,
+				version: result.version,
 				values: {
 					...loggingSettings.values,
 					'diagnostic-logging.r2_output_enabled': enabled
@@ -330,7 +330,7 @@
 
 			loggingSettings = {
 				...loggingSettings,
-				version: result.newVersion,
+				version: result.version,
 				values: {
 					...loggingSettings.values,
 					'diagnostic-logging.sdk_ingest_enabled': enabled
@@ -364,7 +364,7 @@
 
 			loggingSettings = {
 				...loggingSettings,
-				version: result.newVersion,
+				version: result.version,
 				values: {
 					...loggingSettings.values,
 					'diagnostic-logging.merged_output_enabled': enabled
@@ -467,7 +467,7 @@
 
 			loggingSettings = {
 				...loggingSettings,
-				version: result.newVersion,
+				version: result.version,
 				values: {
 					...loggingSettings.values,
 					'diagnostic-logging.storage_mode.default': storageModeDefault,
@@ -885,7 +885,7 @@
 							/>
 							<div class="category-content">
 								<span class="category-checkbox-text">HTTP Request</span>
-								<span class="category-description">Authorization headerを含むリクエスト全体</span>
+								<span class="category-description">Full request including Authorization header</span>
 							</div>
 						</label>
 						<label class="category-checkbox-card" class:checked={categories['http-response']}>
@@ -896,7 +896,7 @@
 							/>
 							<div class="category-content">
 								<span class="category-checkbox-text">HTTP Response</span>
-								<span class="category-description">Status code、headers、response body</span>
+								<span class="category-description">Status code, headers, response body</span>
 							</div>
 						</label>
 						<label class="category-checkbox-card" class:checked={categories['token-validation']}>
@@ -907,7 +907,7 @@
 							/>
 							<div class="category-content">
 								<span class="category-checkbox-text">Token Validation</span>
-								<span class="category-description">JWT検証、署名確認、claims検証</span>
+								<span class="category-description">JWT validation, signature verification, claims validation</span>
 							</div>
 						</label>
 						<label class="category-checkbox-card" class:checked={categories['auth-decision']}>
@@ -918,7 +918,7 @@
 							/>
 							<div class="category-content">
 								<span class="category-checkbox-text">Auth Decision</span>
-								<span class="category-description">認可判定ロジック、ポリシー評価結果</span>
+								<span class="category-description">Authorization logic, policy evaluation results</span>
 							</div>
 						</label>
 					</div>

--- a/packages/ar-admin-ui/src/routes/admin/diagnostic-logging/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/diagnostic-logging/+page.svelte
@@ -157,6 +157,23 @@
 		await loadClientOptions();
 	});
 
+	// Reload when tenant changes via the header selector
+	let prevContextTenantId = $state<string | null>(null);
+	$effect(() => {
+		const ctxTenantId = settingsContext.tenantId;
+		if (prevContextTenantId === null) {
+			prevContextTenantId = ctxTenantId;
+			return;
+		}
+		if (ctxTenantId === prevContextTenantId) return;
+		prevContextTenantId = ctxTenantId;
+		tenantId = ctxTenantId;
+		testTenantId = ctxTenantId;
+		selectedClientIds = [];
+		loadLoggingSettings();
+		loadClientOptions();
+	});
+
 	async function loadLoggingSettings() {
 		settingsLoading = true;
 		settingsError = '';

--- a/packages/ar-admin-ui/src/routes/admin/flows/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/flows/+page.svelte
@@ -76,7 +76,7 @@
 				set: { 'feature.enable_flow_engine': newValue }
 			});
 			flowEngineEnabled = newValue;
-			featureFlagsVersion = result.newVersion;
+			featureFlagsVersion = result.version;
 		} catch (err) {
 			console.error('Failed to update Flow Engine status:', err);
 			flowEngineError = err instanceof Error ? err.message : 'Failed to update Flow Engine status';

--- a/packages/ar-admin-ui/src/routes/admin/login/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/login/+page.svelte
@@ -60,39 +60,163 @@
 	<title>Admin Login - Authrim</title>
 </svelte:head>
 
-<div style="max-width: 400px; margin: 100px auto; padding: 20px; text-align: center;">
-	<h1 style="margin-bottom: 30px;">Admin Login</h1>
+<div class="login-page">
+	<!-- Background watermark -->
+	<div class="bg-watermark" aria-hidden="true">Authrim</div>
 
-	{#if error}
-		<div
-			style="background-color: #fee2e2; border: 1px solid #ef4444; color: #b91c1c; padding: 12px; border-radius: 6px; margin-bottom: 20px;"
-		>
-			{error}
+	<div class="login-container">
+		<div class="login-card">
+			<div class="login-header">
+				<h1 class="login-title">Authrim</h1>
+				<p class="login-subtitle">Admin Panel</p>
+			</div>
+
+			{#if error}
+				<div class="error-message">
+					<i class="i-ph-warning-circle w-4 h-4 flex-shrink-0"></i>
+					<span>{error}</span>
+				</div>
+			{/if}
+
+			<button class="passkey-btn" onclick={handlePasskeyLogin} disabled={loading}>
+				{#if loading}
+					<i class="i-ph-circle-notch animate-spin w-5 h-5"></i>
+					<span>Authenticating...</span>
+				{:else}
+					<i class="i-ph-fingerprint w-5 h-5"></i>
+					<span>Login with Passkey</span>
+				{/if}
+			</button>
+
+			<p class="login-hint">Only administrators with registered Passkeys can access this area.</p>
 		</div>
-	{/if}
-
-	<button
-		onclick={handlePasskeyLogin}
-		disabled={loading}
-		style="
-			width: 100%;
-			padding: 12px 24px;
-			font-size: 16px;
-			background-color: {loading ? '#9ca3af' : '#2563eb'};
-			color: white;
-			border: none;
-			border-radius: 6px;
-			cursor: {loading ? 'not-allowed' : 'pointer'};
-		"
-	>
-		{#if loading}
-			Authenticating...
-		{:else}
-			Login with Passkey
-		{/if}
-	</button>
-
-	<p style="margin-top: 20px; color: #6b7280; font-size: 14px;">
-		Only administrators with registered Passkeys can access this area.
-	</p>
+	</div>
 </div>
+
+<style>
+	.login-page {
+		position: relative;
+		min-height: 100vh;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		overflow: hidden;
+	}
+
+	.bg-watermark {
+		position: fixed;
+		top: -16%;
+		left: -5%;
+		font-family: Didot, 'Didot LT STD', 'Palatino Linotype', Palatino, 'Book Antiqua', serif;
+		font-size: clamp(26rem, 25vw, 28rem);
+		font-weight: 300;
+		color: var(--text-primary);
+		opacity: 0.04;
+		letter-spacing: 0.1em;
+		white-space: nowrap;
+		pointer-events: none;
+		z-index: 0;
+		user-select: none;
+		line-height: 1;
+	}
+
+	.login-container {
+		position: relative;
+		z-index: 1;
+		width: 100%;
+		max-width: 420px;
+		padding: 24px;
+	}
+
+	.login-card {
+		background: var(--bg-card);
+		border: 1px solid var(--border-glass);
+		border-radius: var(--radius-xl);
+		padding: 48px 40px;
+		box-shadow: var(--shadow-xl);
+		backdrop-filter: var(--blur-md);
+		text-align: center;
+	}
+
+	.login-header {
+		margin-bottom: 40px;
+	}
+
+	.login-title {
+		font-family: Didot, 'Didot LT STD', 'Palatino Linotype', Palatino, 'Book Antiqua', serif;
+		font-size: 2.25rem;
+		font-weight: 300;
+		color: var(--text-primary);
+		letter-spacing: 0.3em;
+		margin: 0 0 10px 0.3em; /* letter-spacing分だけ右にオフセット */
+		line-height: 1.2;
+	}
+
+	.login-subtitle {
+		font-size: 0.875rem;
+		color: var(--text-secondary);
+		margin: 0;
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+		font-weight: 500;
+	}
+
+	.error-message {
+		display: flex;
+		align-items: flex-start;
+		gap: 8px;
+		background: var(--danger-light);
+		border: 1px solid rgba(239, 68, 68, 0.3);
+		color: var(--danger);
+		padding: 12px 16px;
+		border-radius: var(--radius-md);
+		margin-bottom: 24px;
+		font-size: 0.875rem;
+		text-align: left;
+	}
+
+	.passkey-btn {
+		width: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 10px;
+		padding: 14px 24px;
+		font-size: 1rem;
+		font-weight: 600;
+		background: var(--gradient-primary);
+		color: #fff;
+		border: none;
+		border-radius: var(--radius-md);
+		cursor: pointer;
+		transition:
+			opacity var(--transition-fast),
+			transform var(--transition-fast),
+			box-shadow var(--transition-fast);
+		letter-spacing: -0.01em;
+		box-shadow: 0 4px 16px var(--primary-glow);
+	}
+
+	.passkey-btn:hover:not(:disabled) {
+		opacity: 0.9;
+		transform: translateY(-1px);
+		box-shadow: 0 8px 24px var(--primary-glow);
+	}
+
+	.passkey-btn:active:not(:disabled) {
+		transform: translateY(0);
+		box-shadow: 0 2px 8px var(--primary-glow);
+	}
+
+	.passkey-btn:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.login-hint {
+		margin: 24px 0 0;
+		color: var(--text-muted);
+		font-size: 0.8rem;
+		line-height: 1.6;
+	}
+</style>

--- a/packages/ar-admin-ui/src/routes/admin/platform/tenant-domain-mappings/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/platform/tenant-domain-mappings/+page.svelte
@@ -1,0 +1,930 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	// ==========================================================================
+	// Types
+	// ==========================================================================
+
+	interface TenantDomainMapping {
+		id: string;
+		tenant_id: string;
+		hash_version: number;
+		priority: number;
+		is_active: boolean;
+		verified: boolean;
+		verification_expires_at: number | null;
+		created_by: string | null;
+		created_at: number;
+		updated_at: number;
+	}
+
+	// ==========================================================================
+	// State
+	// ==========================================================================
+
+	let mappings = $state<TenantDomainMapping[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+	let successMessage = $state('');
+
+	// Create dialog
+	let showCreateDialog = $state(false);
+	let creating = $state(false);
+	let createError = $state('');
+	let newDomain = $state('');
+	let newTenantId = $state('');
+	let newPriority = $state(0);
+
+	// Verify dialog
+	let showVerifyDialog = $state(false);
+	let verifying = $state(false);
+	let verifyError = $state('');
+	let verifyingMapping: TenantDomainMapping | null = $state(null);
+	let verifyDomain = $state('');
+	let verifyDnsRecord: { name: string; value: string; type: string } | null = $state(null);
+	let confirmingVerification = $state(false);
+
+	// Delete confirm
+	let deletingId = $state('');
+
+	// ==========================================================================
+	// API
+	// ==========================================================================
+
+	const API_BASE = '';
+
+	async function apiFetch(path: string, options?: Parameters<typeof fetch>[1]) {
+		const response = await fetch(`${API_BASE}${path}`, {
+			credentials: 'include',
+			...options,
+			headers: {
+				'Content-Type': 'application/json',
+				...(options?.headers ?? {})
+			}
+		});
+
+		if (!response.ok) {
+			const err = await response.json().catch(() => ({}));
+			throw new Error(
+				(err as { error_description?: string; message?: string }).error_description ||
+					(err as { error_description?: string; message?: string }).message ||
+					`HTTP ${response.status}`
+			);
+		}
+		return response.json();
+	}
+
+	// ==========================================================================
+	// Load
+	// ==========================================================================
+
+	async function loadMappings() {
+		loading = true;
+		error = '';
+		try {
+			const result = (await apiFetch('/api/admin/platform/tenant-domain-mappings')) as {
+				mappings: TenantDomainMapping[];
+			};
+			mappings = result.mappings;
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to load mappings';
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(loadMappings);
+
+	// ==========================================================================
+	// Create
+	// ==========================================================================
+
+	function openCreateDialog() {
+		newDomain = '';
+		newTenantId = '';
+		newPriority = 0;
+		createError = '';
+		showCreateDialog = true;
+	}
+
+	async function handleCreate() {
+		if (!newDomain.trim() || !newTenantId.trim()) {
+			createError = 'Domain and Tenant ID are required';
+			return;
+		}
+		creating = true;
+		createError = '';
+		try {
+			await apiFetch('/api/admin/platform/tenant-domain-mappings', {
+				method: 'POST',
+				body: JSON.stringify({
+					domain: newDomain.trim().toLowerCase(),
+					tenant_id: newTenantId.trim(),
+					priority: newPriority
+				})
+			});
+			showCreateDialog = false;
+			successMessage = `Domain mapping for "${newDomain.trim()}" created successfully.`;
+			await loadMappings();
+		} catch (err) {
+			createError = err instanceof Error ? err.message : 'Failed to create mapping';
+		} finally {
+			creating = false;
+		}
+	}
+
+	// ==========================================================================
+	// Verify
+	// ==========================================================================
+
+	function openVerifyDialog(mapping: TenantDomainMapping) {
+		verifyingMapping = mapping;
+		verifyDomain = '';
+		verifyDnsRecord = null;
+		verifyError = '';
+		showVerifyDialog = true;
+	}
+
+	async function handleInitiateVerification() {
+		if (!verifyingMapping || !verifyDomain.trim()) {
+			verifyError = 'Domain is required';
+			return;
+		}
+		verifying = true;
+		verifyError = '';
+		try {
+			const result = (await apiFetch('/api/admin/platform/tenant-domain-mappings/verify', {
+				method: 'POST',
+				body: JSON.stringify({ id: verifyingMapping.id, domain: verifyDomain.trim() })
+			})) as { dns_record_name: string; dns_record_value: string; dns_record_type: string };
+			verifyDnsRecord = {
+				name: result.dns_record_name,
+				value: result.dns_record_value,
+				type: result.dns_record_type
+			};
+		} catch (err) {
+			verifyError = err instanceof Error ? err.message : 'Failed to initiate verification';
+		} finally {
+			verifying = false;
+		}
+	}
+
+	async function handleConfirmVerification() {
+		if (!verifyingMapping || !verifyDomain.trim()) return;
+		confirmingVerification = true;
+		verifyError = '';
+		try {
+			await apiFetch('/api/admin/platform/tenant-domain-mappings/verify/confirm', {
+				method: 'POST',
+				body: JSON.stringify({ id: verifyingMapping.id, domain: verifyDomain.trim() })
+			});
+			showVerifyDialog = false;
+			successMessage = `Domain "${verifyDomain.trim()}" verified successfully.`;
+			await loadMappings();
+		} catch (err) {
+			verifyError = err instanceof Error ? err.message : 'Verification failed. Check DNS record.';
+		} finally {
+			confirmingVerification = false;
+		}
+	}
+
+	// ==========================================================================
+	// Delete
+	// ==========================================================================
+
+	async function handleDelete(id: string) {
+		if (!confirm('Delete this domain mapping? This cannot be undone.')) return;
+		deletingId = id;
+		try {
+			await apiFetch(`/api/admin/platform/tenant-domain-mappings/${id}`, { method: 'DELETE' });
+			mappings = mappings.filter((m) => m.id !== id);
+			successMessage = 'Domain mapping deleted.';
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to delete mapping';
+		} finally {
+			deletingId = '';
+		}
+	}
+
+	// ==========================================================================
+	// Helpers
+	// ==========================================================================
+
+	function formatDate(ts: number) {
+		return new Date(ts * 1000).toLocaleDateString();
+	}
+</script>
+
+<div class="page">
+	<div class="page-header">
+		<div>
+			<h1 class="page-title">Tenant Domain Mappings</h1>
+			<p class="page-description">
+				Map email domains to tenants for automatic routing during signup. Requires <strong
+					>system admin</strong
+				> privileges.
+			</p>
+		</div>
+		<button class="btn btn-primary" onclick={openCreateDialog}>
+			<i class="i-ph-plus"></i>
+			Add Mapping
+		</button>
+	</div>
+
+	{#if error}
+		<div class="alert alert-error">
+			<i class="i-ph-warning-circle"></i>
+			{error}
+		</div>
+	{/if}
+
+	{#if successMessage}
+		<div class="alert alert-success">
+			<i class="i-ph-check-circle"></i>
+			{successMessage}
+		</div>
+	{/if}
+
+	<div class="info-box">
+		<i class="i-ph-info"></i>
+		<div>
+			<strong>How it works:</strong> When a user signs up with an email like
+			<code>user@company.com</code>, and <code>company.com</code> is mapped to the
+			<code>acme</code> tenant (verified, active), they will be automatically routed to that tenant. Host
+			header resolution takes priority over this mapping.
+		</div>
+	</div>
+
+	{#if loading}
+		<div class="loading-state">
+			<i class="i-ph-circle-notch animate-spin"></i>
+			Loading mappings...
+		</div>
+	{:else if mappings.length === 0}
+		<div class="empty-state">
+			<i class="i-ph-globe"></i>
+			<p>No tenant domain mappings configured.</p>
+		</div>
+	{:else}
+		<div class="table-container">
+			<table class="table">
+				<thead>
+					<tr>
+						<th>Tenant</th>
+						<th>Priority</th>
+						<th>Status</th>
+						<th>Verified</th>
+						<th>Created</th>
+						<th>Actions</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each mappings as mapping (mapping.id)}
+						<tr>
+							<td class="mono">{mapping.tenant_id}</td>
+							<td>{mapping.priority}</td>
+							<td>
+								{#if mapping.is_active}
+									<span class="badge badge-active">Active</span>
+								{:else}
+									<span class="badge badge-inactive">Inactive</span>
+								{/if}
+							</td>
+							<td>
+								{#if mapping.verified}
+									<span class="badge badge-verified">
+										<i class="i-ph-check"></i>
+										Verified
+									</span>
+								{:else}
+									<span class="badge badge-unverified">Unverified</span>
+								{/if}
+							</td>
+							<td>{formatDate(mapping.created_at)}</td>
+							<td class="actions">
+								{#if !mapping.verified}
+									<button
+										class="btn btn-sm btn-secondary"
+										onclick={() => openVerifyDialog(mapping)}
+									>
+										Verify DNS
+									</button>
+								{/if}
+								<button
+									class="btn btn-sm btn-danger-outline"
+									disabled={deletingId === mapping.id}
+									onclick={() => handleDelete(mapping.id)}
+								>
+									{#if deletingId === mapping.id}
+										<i class="i-ph-circle-notch animate-spin"></i>
+									{:else}
+										Delete
+									{/if}
+								</button>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	{/if}
+</div>
+
+<!-- Create Dialog -->
+{#if showCreateDialog}
+	<div
+		class="modal-overlay"
+		onclick={() => (showCreateDialog = false)}
+		role="button"
+		tabindex="-1"
+		aria-label="Close dialog"
+		onkeydown={(e) => e.key === 'Escape' && (showCreateDialog = false)}
+	></div>
+	<div class="modal" role="dialog" aria-modal="true" aria-labelledby="create-dialog-title">
+		<div class="modal-header">
+			<h2 id="create-dialog-title">Add Domain Mapping</h2>
+			<button class="modal-close" onclick={() => (showCreateDialog = false)} aria-label="Close">
+				<i class="i-ph-x"></i>
+			</button>
+		</div>
+		<div class="modal-body">
+			{#if createError}
+				<div class="alert alert-error">{createError}</div>
+			{/if}
+			<div class="form-group">
+				<label for="new-domain" class="form-label">Domain <span class="required">*</span></label>
+				<input
+					id="new-domain"
+					type="text"
+					class="form-input"
+					bind:value={newDomain}
+					placeholder="e.g. company.com"
+					autocomplete="off"
+				/>
+				<p class="field-hint">
+					Lowercase domain. Users with this email domain will be routed to the tenant.
+				</p>
+			</div>
+			<div class="form-group">
+				<label for="new-tenant" class="form-label">Tenant ID <span class="required">*</span></label>
+				<input
+					id="new-tenant"
+					type="text"
+					class="form-input"
+					bind:value={newTenantId}
+					placeholder="e.g. acme"
+					autocomplete="off"
+				/>
+			</div>
+			<div class="form-group">
+				<label for="new-priority" class="form-label">Priority</label>
+				<input
+					id="new-priority"
+					type="number"
+					class="form-input"
+					bind:value={newPriority}
+					min="0"
+					max="1000"
+				/>
+				<p class="field-hint">Higher value = higher priority. Used when multiple mappings match.</p>
+			</div>
+		</div>
+		<div class="modal-footer">
+			<button
+				class="btn btn-secondary"
+				onclick={() => (showCreateDialog = false)}
+				disabled={creating}
+			>
+				Cancel
+			</button>
+			<button class="btn btn-primary" onclick={handleCreate} disabled={creating}>
+				{#if creating}
+					<i class="i-ph-circle-notch animate-spin"></i>
+					Creating...
+				{:else}
+					Create Mapping
+				{/if}
+			</button>
+		</div>
+	</div>
+{/if}
+
+<!-- Verify Dialog -->
+{#if showVerifyDialog && verifyingMapping}
+	<div
+		class="modal-overlay"
+		onclick={() => (showVerifyDialog = false)}
+		role="button"
+		tabindex="-1"
+		aria-label="Close dialog"
+		onkeydown={(e) => e.key === 'Escape' && (showVerifyDialog = false)}
+	></div>
+	<div
+		class="modal modal-wide"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="verify-dialog-title"
+	>
+		<div class="modal-header">
+			<h2 id="verify-dialog-title">Verify Domain Ownership</h2>
+			<button class="modal-close" onclick={() => (showVerifyDialog = false)} aria-label="Close">
+				<i class="i-ph-x"></i>
+			</button>
+		</div>
+		<div class="modal-body">
+			{#if verifyError}
+				<div class="alert alert-error">{verifyError}</div>
+			{/if}
+			<p class="verify-intro">
+				Verify that you own the domain for tenant <strong>{verifyingMapping.tenant_id}</strong>.
+				Enter the domain and add the DNS TXT record shown below.
+			</p>
+			<div class="form-group">
+				<label for="verify-domain" class="form-label">Domain <span class="required">*</span></label>
+				<input
+					id="verify-domain"
+					type="text"
+					class="form-input"
+					bind:value={verifyDomain}
+					placeholder="e.g. company.com"
+					autocomplete="off"
+				/>
+			</div>
+			{#if !verifyDnsRecord}
+				<button
+					class="btn btn-primary"
+					onclick={handleInitiateVerification}
+					disabled={verifying || !verifyDomain.trim()}
+				>
+					{#if verifying}
+						<i class="i-ph-circle-notch animate-spin"></i>
+						Generating...
+					{:else}
+						Generate DNS Record
+					{/if}
+				</button>
+			{:else}
+				<div class="dns-record">
+					<p class="dns-record-title">Add this DNS TXT record to your domain:</p>
+					<div class="dns-row">
+						<span class="dns-label">Type</span>
+						<code class="dns-value">{verifyDnsRecord.type}</code>
+					</div>
+					<div class="dns-row">
+						<span class="dns-label">Name</span>
+						<code class="dns-value">{verifyDnsRecord.name}</code>
+					</div>
+					<div class="dns-row">
+						<span class="dns-label">Value</span>
+						<code class="dns-value dns-value-long">{verifyDnsRecord.value}</code>
+					</div>
+					<p class="field-hint">
+						DNS propagation can take up to 48 hours. Click "Confirm Verification" once the record is
+						added.
+					</p>
+				</div>
+				<button
+					class="btn btn-primary"
+					onclick={handleConfirmVerification}
+					disabled={confirmingVerification}
+				>
+					{#if confirmingVerification}
+						<i class="i-ph-circle-notch animate-spin"></i>
+						Checking DNS...
+					{:else}
+						Confirm Verification
+					{/if}
+				</button>
+			{/if}
+		</div>
+		<div class="modal-footer">
+			<button class="btn btn-secondary" onclick={() => (showVerifyDialog = false)}> Close </button>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.page {
+		display: flex;
+		flex-direction: column;
+		gap: 24px;
+	}
+
+	.page-header {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 16px;
+	}
+
+	.page-title {
+		font-family: var(--font-display);
+		font-size: 1.5rem;
+		font-weight: 700;
+		color: var(--text-primary);
+		margin: 0 0 4px;
+	}
+
+	.page-description {
+		font-size: 0.875rem;
+		color: var(--text-secondary);
+		margin: 0;
+	}
+
+	.info-box {
+		display: flex;
+		gap: 12px;
+		padding: 14px 16px;
+		background: var(--primary-light, var(--bg-subtle));
+		border: 1px solid var(--primary-border, var(--border));
+		border-radius: var(--radius-md);
+		font-size: 0.875rem;
+		color: var(--text-secondary);
+	}
+
+	.info-box :global(i) {
+		width: 18px;
+		height: 18px;
+		color: var(--primary);
+		flex-shrink: 0;
+		margin-top: 1px;
+	}
+
+	.info-box code {
+		font-family: var(--font-mono);
+		font-size: 0.8125rem;
+		background: var(--bg-card);
+		padding: 1px 4px;
+		border-radius: var(--radius-sm);
+		border: 1px solid var(--border);
+	}
+
+	.table-container {
+		background: var(--bg-card);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		overflow: hidden;
+	}
+
+	.table {
+		width: 100%;
+		border-collapse: collapse;
+	}
+
+	.table th {
+		padding: 12px 16px;
+		text-align: left;
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+		background: var(--bg-subtle);
+		border-bottom: 1px solid var(--border);
+	}
+
+	.table td {
+		padding: 14px 16px;
+		font-size: 0.875rem;
+		color: var(--text-primary);
+		border-bottom: 1px solid var(--border-subtle);
+		vertical-align: middle;
+	}
+
+	.table tr:last-child td {
+		border-bottom: none;
+	}
+
+	.mono {
+		font-family: var(--font-mono);
+		font-size: 0.8125rem;
+	}
+
+	.badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 2px 8px;
+		border-radius: var(--radius-full);
+		font-size: 0.75rem;
+		font-weight: 500;
+	}
+
+	.badge :global(i) {
+		width: 12px;
+		height: 12px;
+	}
+
+	.badge-active {
+		background: var(--success-subtle);
+		color: var(--success);
+	}
+
+	.badge-inactive {
+		background: var(--bg-subtle);
+		color: var(--text-muted);
+	}
+
+	.badge-verified {
+		background: var(--success-subtle);
+		color: var(--success);
+	}
+
+	.badge-unverified {
+		background: var(--warning-subtle);
+		color: var(--warning-dark);
+	}
+
+	.actions {
+		display: flex;
+		gap: 8px;
+		align-items: center;
+	}
+
+	/* Buttons */
+	.btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 8px 16px;
+		border-radius: var(--radius-md);
+		font-size: 0.875rem;
+		font-weight: 500;
+		cursor: pointer;
+		transition: all var(--transition-fast);
+		border: none;
+		text-decoration: none;
+	}
+
+	.btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.btn :global(i) {
+		width: 16px;
+		height: 16px;
+	}
+
+	.btn-primary {
+		background: var(--primary);
+		color: white;
+	}
+
+	.btn-primary:hover:not(:disabled) {
+		background: var(--primary-dark);
+	}
+
+	.btn-secondary {
+		background: var(--bg-subtle);
+		color: var(--text-primary);
+		border: 1px solid var(--border);
+	}
+
+	.btn-secondary:hover:not(:disabled) {
+		background: var(--bg-card);
+	}
+
+	.btn-danger-outline {
+		background: transparent;
+		color: var(--danger);
+		border: 1px solid var(--danger);
+	}
+
+	.btn-danger-outline:hover:not(:disabled) {
+		background: var(--danger-subtle);
+	}
+
+	.btn-sm {
+		padding: 4px 10px;
+		font-size: 0.8125rem;
+	}
+
+	/* Alert */
+	.alert {
+		display: flex;
+		align-items: flex-start;
+		gap: 10px;
+		padding: 12px 16px;
+		border-radius: var(--radius-md);
+		font-size: 0.875rem;
+	}
+
+	.alert :global(i) {
+		width: 18px;
+		height: 18px;
+		flex-shrink: 0;
+		margin-top: 1px;
+	}
+
+	.alert-error {
+		background: var(--danger-subtle);
+		color: var(--danger);
+		border: 1px solid var(--danger-border);
+	}
+
+	.alert-success {
+		background: var(--success-subtle);
+		color: var(--success);
+		border: 1px solid var(--success-border, var(--success-subtle));
+	}
+
+	/* Loading / Empty */
+	.loading-state,
+	.empty-state {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 12px;
+		padding: 48px;
+		color: var(--text-muted);
+		font-size: 0.875rem;
+	}
+
+	.loading-state :global(i),
+	.empty-state :global(i) {
+		width: 32px;
+		height: 32px;
+	}
+
+	/* Modal */
+	.modal-overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+		z-index: 100;
+		border: none;
+		cursor: default;
+	}
+
+	.modal {
+		position: fixed;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		width: 100%;
+		max-width: 480px;
+		background: var(--bg-card);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		box-shadow: var(--shadow-xl);
+		z-index: 101;
+		display: flex;
+		flex-direction: column;
+		max-height: 90vh;
+	}
+
+	.modal-wide {
+		max-width: 600px;
+	}
+
+	.modal-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 20px 24px 16px;
+		border-bottom: 1px solid var(--border);
+	}
+
+	.modal-header h2 {
+		font-size: 1.125rem;
+		font-weight: 600;
+		color: var(--text-primary);
+		margin: 0;
+	}
+
+	.modal-close {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border: none;
+		background: transparent;
+		color: var(--text-muted);
+		cursor: pointer;
+		border-radius: var(--radius-sm);
+		transition: all var(--transition-fast);
+	}
+
+	.modal-close:hover {
+		background: var(--bg-subtle);
+		color: var(--text-primary);
+	}
+
+	.modal-close :global(i) {
+		width: 18px;
+		height: 18px;
+	}
+
+	.modal-body {
+		padding: 20px 24px;
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+		overflow-y: auto;
+	}
+
+	.modal-footer {
+		display: flex;
+		justify-content: flex-end;
+		gap: 12px;
+		padding: 16px 24px 20px;
+		border-top: 1px solid var(--border);
+	}
+
+	/* Form */
+	.form-group {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	.form-label {
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--text-primary);
+	}
+
+	.required {
+		color: var(--danger);
+	}
+
+	.form-input {
+		padding: 8px 12px;
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md);
+		background: var(--bg-card);
+		color: var(--text-primary);
+		font-size: 0.875rem;
+		font-family: var(--font-body);
+		transition: border-color var(--transition-fast);
+		outline: none;
+		width: 100%;
+		box-sizing: border-box;
+	}
+
+	.form-input:focus {
+		border-color: var(--primary);
+		box-shadow: 0 0 0 3px var(--primary-light);
+	}
+
+	.field-hint {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		margin: 0;
+	}
+
+	/* DNS record display */
+	.verify-intro {
+		font-size: 0.875rem;
+		color: var(--text-secondary);
+		margin: 0;
+	}
+
+	.dns-record {
+		background: var(--bg-subtle);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md);
+		padding: 16px;
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+
+	.dns-record-title {
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--text-primary);
+		margin: 0;
+	}
+
+	.dns-row {
+		display: flex;
+		align-items: baseline;
+		gap: 12px;
+	}
+
+	.dns-label {
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		color: var(--text-muted);
+		min-width: 48px;
+	}
+
+	.dns-value {
+		font-family: var(--font-mono);
+		font-size: 0.8125rem;
+		background: var(--bg-card);
+		padding: 4px 8px;
+		border-radius: var(--radius-sm);
+		border: 1px solid var(--border);
+		color: var(--text-primary);
+		word-break: break-all;
+	}
+
+	.dns-value-long {
+		font-size: 0.75rem;
+	}
+</style>

--- a/packages/ar-admin-ui/src/routes/admin/policies/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/policies/+page.svelte
@@ -377,7 +377,7 @@
 				set: { 'feature.enable_custom_rules': newValue }
 			});
 			customRulesEnabled = newValue;
-			featureFlagsVersion = result.newVersion;
+			featureFlagsVersion = result.version;
 		} catch (err) {
 			console.error('Failed to update Custom Rules status:', err);
 			customRulesError =

--- a/packages/ar-admin-ui/src/routes/admin/rebac/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/rebac/+page.svelte
@@ -102,7 +102,7 @@
 				set: { 'feature.enable_rebac': newValue }
 			});
 			rebacEnabled = newValue;
-			featureFlagsVersion = result.newVersion;
+			featureFlagsVersion = result.version;
 		} catch (err) {
 			console.error('Failed to update ReBAC status:', err);
 			rebacError = err instanceof Error ? err.message : 'Failed to update ReBAC status';

--- a/packages/ar-admin-ui/src/routes/admin/tenants/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/tenants/+page.svelte
@@ -1,0 +1,1042 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { adminTenantsAPI, type Tenant } from '$lib/api/admin-tenants';
+	import { tenantStore } from '$lib/stores/tenants.svelte';
+
+	// ==========================================================================
+	// State
+	// ==========================================================================
+
+	// Use the shared store so AdminHeader selector stays in sync
+	let tenants = $derived(tenantStore.tenants);
+	let loading = $state(!tenantStore.loaded);
+	let error = $state('');
+	let infoMessage = $state('');
+
+	// Create dialog
+	let showCreateDialog = $state(false);
+	let creating = $state(false);
+	let createError = $state('');
+	let newId = $state('');
+	let newName = $state('');
+	let newDescription = $state('');
+	let idValidationError = $state('');
+
+	// Edit dialog
+	let showEditDialog = $state(false);
+	let editingTenant: Tenant | null = $state(null);
+	let editing = $state(false);
+	let editError = $state('');
+	let editName = $state('');
+	let editDescription = $state('');
+	let editIsActive = $state(true);
+
+	// Delete dialog
+	let showDeleteDialog = $state(false);
+	let deletingTenant: Tenant | null = $state(null);
+	let deleting = $state(false);
+	let deleteError = $state('');
+	let deleteConfirmInput = $state('');
+
+	// Track tenant IDs that have pending deletion jobs
+	let pendingDeletions = $state<Set<string>>(new Set());
+
+	// Set default
+	let settingDefault = $state('');
+
+	// ==========================================================================
+	// Validation
+	// ==========================================================================
+
+	// DNS label format: starts and ends with alphanumeric, hyphens allowed in the middle
+	const TENANT_ID_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+
+	function validateTenantId(value: string): string {
+		if (!value) return 'ID is required';
+		if (value.length > 63) return 'ID must be 63 characters or fewer';
+		if (!TENANT_ID_REGEX.test(value))
+			return 'ID must start and end with a lowercase letter or digit (hyphens allowed in between)';
+		return '';
+	}
+
+	function handleIdInput() {
+		idValidationError = validateTenantId(newId);
+	}
+
+	// ==========================================================================
+	// Data Loading
+	// ==========================================================================
+
+	async function loadTenants() {
+		loading = true;
+		error = '';
+
+		try {
+			await tenantStore.reload();
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to load tenants';
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(async () => {
+		// If the store already has data (loaded by layout), skip the initial fetch
+		if (!tenantStore.loaded) {
+			await loadTenants();
+		} else {
+			loading = false;
+		}
+	});
+
+	// ==========================================================================
+	// Create
+	// ==========================================================================
+
+	function openCreateDialog() {
+		newId = '';
+		newName = '';
+		newDescription = '';
+		createError = '';
+		idValidationError = '';
+		showCreateDialog = true;
+	}
+
+	function closeCreateDialog() {
+		showCreateDialog = false;
+	}
+
+	async function handleCreate() {
+		idValidationError = validateTenantId(newId);
+		if (idValidationError) return;
+		if (!newName.trim()) {
+			createError = 'Name is required';
+			return;
+		}
+
+		creating = true;
+		createError = '';
+
+		try {
+			const created = await adminTenantsAPI.create({
+				id: newId,
+				name: newName.trim(),
+				description: newDescription.trim() || undefined
+			});
+			tenantStore.add(created);
+			closeCreateDialog();
+		} catch (err) {
+			createError = err instanceof Error ? err.message : 'Failed to create tenant';
+		} finally {
+			creating = false;
+		}
+	}
+
+	// ==========================================================================
+	// Edit
+	// ==========================================================================
+
+	function openEditDialog(tenant: Tenant) {
+		editingTenant = tenant;
+		editName = tenant.name;
+		editDescription = tenant.description ?? '';
+		editIsActive = tenant.is_active;
+		editError = '';
+		showEditDialog = true;
+	}
+
+	function closeEditDialog() {
+		showEditDialog = false;
+		editingTenant = null;
+	}
+
+	async function handleEdit() {
+		if (!editingTenant) return;
+		if (!editName.trim()) {
+			editError = 'Name is required';
+			return;
+		}
+
+		editing = true;
+		editError = '';
+
+		try {
+			const updated = await adminTenantsAPI.update(editingTenant.id, {
+				name: editName.trim(),
+				description: editDescription.trim() || null,
+				is_active: editIsActive
+			});
+			tenantStore.update(updated);
+			closeEditDialog();
+		} catch (err) {
+			editError = err instanceof Error ? err.message : 'Failed to update tenant';
+		} finally {
+			editing = false;
+		}
+	}
+
+	// ==========================================================================
+	// Delete
+	// ==========================================================================
+
+	function openDeleteDialog(tenant: Tenant) {
+		deletingTenant = tenant;
+		deleteConfirmInput = '';
+		deleteError = '';
+		showDeleteDialog = true;
+	}
+
+	function closeDeleteDialog() {
+		showDeleteDialog = false;
+		deletingTenant = null;
+	}
+
+	async function handleDelete() {
+		if (!deletingTenant) return;
+		if (deleteConfirmInput !== deletingTenant.id) {
+			deleteError = 'Tenant ID does not match';
+			return;
+		}
+
+		deleting = true;
+		deleteError = '';
+
+		try {
+			const result = await adminTenantsAPI.delete(deletingTenant.id);
+			// 202 Accepted: deletion is async. Deactivate in store and mark as pending.
+			tenantStore.update({ ...deletingTenant, is_active: false });
+			pendingDeletions = new Set([...pendingDeletions, deletingTenant.id]);
+			closeDeleteDialog();
+			// Show job info in page-level info message
+			infoMessage = `Tenant "${deletingTenant.id}" deletion queued (job: ${result.job_id}). Data will be removed within the hour.`;
+		} catch (err) {
+			deleteError = err instanceof Error ? err.message : 'Failed to delete tenant';
+		} finally {
+			deleting = false;
+		}
+	}
+
+	// ==========================================================================
+	// Set Default
+	// ==========================================================================
+
+	async function handleSetDefault(tenant: Tenant) {
+		if (tenant.is_default || settingDefault) return;
+
+		settingDefault = tenant.id;
+
+		try {
+			await adminTenantsAPI.setDefault(tenant.id);
+			tenantStore.setDefault(tenant.id);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to set default tenant';
+		} finally {
+			settingDefault = '';
+		}
+	}
+</script>
+
+<div class="page">
+	<div class="page-header">
+		<div>
+			<h1 class="page-title">Tenants</h1>
+			<p class="page-description">Manage tenants for this Authrim instance.</p>
+		</div>
+		<button class="btn btn-primary" onclick={openCreateDialog}>
+			<i class="i-ph-plus"></i>
+			Add Tenant
+		</button>
+	</div>
+
+	{#if error}
+		<div class="alert alert-error">
+			<i class="i-ph-warning-circle"></i>
+			{error}
+		</div>
+	{/if}
+
+	{#if infoMessage}
+		<div class="alert alert-info">
+			<i class="i-ph-info"></i>
+			{infoMessage}
+		</div>
+	{/if}
+
+	{#if loading}
+		<div class="loading-state">
+			<i class="i-ph-circle-notch animate-spin"></i>
+			Loading tenants...
+		</div>
+	{:else if tenants.length === 0}
+		<div class="empty-state">
+			<i class="i-ph-buildings"></i>
+			<p>No tenants found.</p>
+		</div>
+	{:else}
+		<div class="table-container">
+			<table class="table">
+				<thead>
+					<tr>
+						<th>ID</th>
+						<th>Name</th>
+						<th>Description</th>
+						<th>Status</th>
+						<th>Default</th>
+						<th>Actions</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each tenants as tenant (tenant.id)}
+						<tr>
+							<td class="tenant-id">{tenant.id}</td>
+							<td class="tenant-name">{tenant.name}</td>
+							<td class="tenant-description">{tenant.description ?? '—'}</td>
+							<td>
+								{#if pendingDeletions.has(tenant.id)}
+									<span class="badge badge-deleting">Deleting...</span>
+								{:else if tenant.is_active}
+									<span class="badge badge-active">Active</span>
+								{:else}
+									<span class="badge badge-inactive">Disabled</span>
+								{/if}
+							</td>
+							<td>
+								<button
+									class="default-star"
+									class:is-default={tenant.is_default}
+									class:loading={settingDefault === tenant.id}
+									disabled={tenant.is_default ||
+										!!settingDefault ||
+										pendingDeletions.has(tenant.id)}
+									onclick={() => handleSetDefault(tenant)}
+									title={tenant.is_default ? 'Default tenant' : 'Set as default'}
+									aria-label={tenant.is_default ? 'Default tenant' : 'Set as default'}
+								>
+									{#if settingDefault === tenant.id}
+										<i class="i-ph-circle-notch animate-spin"></i>
+									{:else if tenant.is_default}
+										<i class="i-ph-star-fill"></i>
+									{:else}
+										<i class="i-ph-star"></i>
+									{/if}
+								</button>
+							</td>
+							<td class="actions">
+								<button
+									class="btn btn-sm btn-secondary"
+									disabled={pendingDeletions.has(tenant.id)}
+									onclick={() => openEditDialog(tenant)}
+								>
+									Edit
+								</button>
+								{#if !tenant.is_default}
+									<button
+										class="btn btn-sm btn-danger-outline"
+										disabled={pendingDeletions.has(tenant.id)}
+										onclick={() => openDeleteDialog(tenant)}
+									>
+										Delete
+									</button>
+								{/if}
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	{/if}
+</div>
+
+<!-- Create Dialog -->
+{#if showCreateDialog}
+	<div
+		class="modal-overlay"
+		onclick={closeCreateDialog}
+		role="button"
+		tabindex="-1"
+		aria-label="Close dialog"
+		onkeydown={(e) => e.key === 'Escape' && closeCreateDialog()}
+	></div>
+	<div class="modal" role="dialog" aria-modal="true" aria-labelledby="create-dialog-title">
+		<div class="modal-header">
+			<h2 id="create-dialog-title">Add Tenant</h2>
+			<button class="modal-close" onclick={closeCreateDialog} aria-label="Close">
+				<i class="i-ph-x"></i>
+			</button>
+		</div>
+		<div class="modal-body">
+			{#if createError}
+				<div class="alert alert-error">{createError}</div>
+			{/if}
+			<div class="form-group">
+				<label for="new-id" class="form-label">Tenant ID <span class="required">*</span></label>
+				<input
+					id="new-id"
+					type="text"
+					class="form-input"
+					class:error={!!idValidationError}
+					bind:value={newId}
+					oninput={handleIdInput}
+					placeholder="e.g. acme-corp"
+					maxlength="63"
+					autocomplete="off"
+				/>
+				{#if idValidationError}
+					<p class="field-error">{idValidationError}</p>
+				{:else}
+					<p class="field-hint">Lowercase letters, numbers, hyphens. Max 63 characters.</p>
+				{/if}
+			</div>
+			<div class="form-group">
+				<label for="new-name" class="form-label">Name <span class="required">*</span></label>
+				<input
+					id="new-name"
+					type="text"
+					class="form-input"
+					bind:value={newName}
+					placeholder="e.g. Acme Corporation"
+					maxlength="200"
+				/>
+			</div>
+			<div class="form-group">
+				<label for="new-description" class="form-label">Description</label>
+				<textarea
+					id="new-description"
+					class="form-input"
+					bind:value={newDescription}
+					placeholder="Optional description"
+					rows="3"
+					maxlength="500"
+				></textarea>
+			</div>
+		</div>
+		<div class="modal-footer">
+			<button class="btn btn-secondary" onclick={closeCreateDialog} disabled={creating}>
+				Cancel
+			</button>
+			<button
+				class="btn btn-primary"
+				onclick={handleCreate}
+				disabled={creating || !!idValidationError}
+			>
+				{#if creating}
+					<i class="i-ph-circle-notch animate-spin"></i>
+					Creating...
+				{:else}
+					Create Tenant
+				{/if}
+			</button>
+		</div>
+	</div>
+{/if}
+
+<!-- Edit Dialog -->
+{#if showEditDialog && editingTenant}
+	<div
+		class="modal-overlay"
+		onclick={closeEditDialog}
+		role="button"
+		tabindex="-1"
+		aria-label="Close dialog"
+		onkeydown={(e) => e.key === 'Escape' && closeEditDialog()}
+	></div>
+	<div class="modal" role="dialog" aria-modal="true" aria-labelledby="edit-dialog-title">
+		<div class="modal-header">
+			<h2 id="edit-dialog-title">Edit Tenant</h2>
+			<button class="modal-close" onclick={closeEditDialog} aria-label="Close">
+				<i class="i-ph-x"></i>
+			</button>
+		</div>
+		<div class="modal-body">
+			{#if editError}
+				<div class="alert alert-error">{editError}</div>
+			{/if}
+			<div class="form-group">
+				<p class="form-label">Tenant ID</p>
+				<div class="form-static" aria-label="Tenant ID">{editingTenant.id}</div>
+				<p class="field-hint">Tenant ID cannot be changed.</p>
+			</div>
+			<div class="form-group">
+				<label for="edit-name" class="form-label">Name <span class="required">*</span></label>
+				<input
+					id="edit-name"
+					type="text"
+					class="form-input"
+					bind:value={editName}
+					placeholder="Display name"
+					maxlength="200"
+				/>
+			</div>
+			<div class="form-group">
+				<label for="edit-description" class="form-label">Description</label>
+				<textarea
+					id="edit-description"
+					class="form-input"
+					bind:value={editDescription}
+					placeholder="Optional description"
+					rows="3"
+					maxlength="500"
+				></textarea>
+			</div>
+			<div class="form-group">
+				<label class="form-label toggle-label">
+					<span>Active</span>
+					<div class="toggle-switch" class:checked={editIsActive}>
+						<input
+							type="checkbox"
+							bind:checked={editIsActive}
+							class="toggle-input"
+							id="edit-active"
+						/>
+						<label for="edit-active" class="toggle-slider"></label>
+					</div>
+				</label>
+				<p class="field-hint">Inactive tenants are hidden from the tenant selector.</p>
+			</div>
+		</div>
+		<div class="modal-footer">
+			<button class="btn btn-secondary" onclick={closeEditDialog} disabled={editing}>
+				Cancel
+			</button>
+			<button class="btn btn-primary" onclick={handleEdit} disabled={editing}>
+				{#if editing}
+					<i class="i-ph-circle-notch animate-spin"></i>
+					Saving...
+				{:else}
+					Save Changes
+				{/if}
+			</button>
+		</div>
+	</div>
+{/if}
+
+<!-- Delete Confirmation Dialog -->
+{#if showDeleteDialog && deletingTenant}
+	<div
+		class="modal-overlay"
+		onclick={closeDeleteDialog}
+		role="button"
+		tabindex="-1"
+		aria-label="Close dialog"
+		onkeydown={(e) => e.key === 'Escape' && closeDeleteDialog()}
+	></div>
+	<div class="modal" role="dialog" aria-modal="true" aria-labelledby="delete-dialog-title">
+		<div class="modal-header">
+			<h2 id="delete-dialog-title" class="danger-title">Delete Tenant</h2>
+			<button class="modal-close" onclick={closeDeleteDialog} aria-label="Close">
+				<i class="i-ph-x"></i>
+			</button>
+		</div>
+		<div class="modal-body">
+			{#if deleteError}
+				<div class="alert alert-error">{deleteError}</div>
+			{/if}
+			<div class="alert alert-warning">
+				<i class="i-ph-warning"></i>
+				<strong>Warning:</strong> This action is irreversible. All data associated with tenant
+				<strong>{deletingTenant.id}</strong> will be permanently deleted.
+			</div>
+			<div class="form-group">
+				<label for="delete-confirm" class="form-label">
+					Type <strong>{deletingTenant.id}</strong> to confirm deletion:
+				</label>
+				<input
+					id="delete-confirm"
+					type="text"
+					class="form-input"
+					bind:value={deleteConfirmInput}
+					placeholder={deletingTenant.id}
+					autocomplete="off"
+				/>
+			</div>
+		</div>
+		<div class="modal-footer">
+			<button class="btn btn-secondary" onclick={closeDeleteDialog} disabled={deleting}>
+				Cancel
+			</button>
+			<button
+				class="btn btn-danger"
+				onclick={handleDelete}
+				disabled={deleting || deleteConfirmInput !== deletingTenant.id}
+			>
+				{#if deleting}
+					<i class="i-ph-circle-notch animate-spin"></i>
+					Deleting...
+				{:else}
+					Delete Tenant
+				{/if}
+			</button>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.page {
+		display: flex;
+		flex-direction: column;
+		gap: 24px;
+	}
+
+	.page-header {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 16px;
+	}
+
+	.page-title {
+		font-family: var(--font-display);
+		font-size: 1.5rem;
+		font-weight: 700;
+		color: var(--text-primary);
+		margin: 0 0 4px;
+	}
+
+	.page-description {
+		font-size: 0.875rem;
+		color: var(--text-secondary);
+		margin: 0;
+	}
+
+	/* Table */
+	.table-container {
+		background: var(--bg-card);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		overflow: hidden;
+	}
+
+	.table {
+		width: 100%;
+		border-collapse: collapse;
+	}
+
+	.table th {
+		padding: 12px 16px;
+		text-align: left;
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+		background: var(--bg-subtle);
+		border-bottom: 1px solid var(--border);
+	}
+
+	.table td {
+		padding: 14px 16px;
+		font-size: 0.875rem;
+		color: var(--text-primary);
+		border-bottom: 1px solid var(--border-subtle);
+		vertical-align: middle;
+	}
+
+	.table tr:last-child td {
+		border-bottom: none;
+	}
+
+	.tenant-id {
+		font-family: var(--font-mono);
+		font-size: 0.8125rem;
+		color: var(--text-secondary);
+	}
+
+	.tenant-name {
+		font-weight: 500;
+	}
+
+	.tenant-description {
+		color: var(--text-secondary);
+		max-width: 240px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	/* Badges */
+	.badge {
+		display: inline-flex;
+		align-items: center;
+		padding: 2px 8px;
+		border-radius: var(--radius-full);
+		font-size: 0.75rem;
+		font-weight: 500;
+	}
+
+	.badge-active {
+		background: var(--success-subtle);
+		color: var(--success);
+	}
+
+	.badge-inactive {
+		background: var(--bg-subtle);
+		color: var(--text-muted);
+	}
+
+	.badge-deleting {
+		background: var(--warning-subtle);
+		color: var(--warning-dark);
+	}
+
+	/* Default star */
+	.default-star {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border: none;
+		background: transparent;
+		cursor: pointer;
+		border-radius: var(--radius-sm);
+		transition: all var(--transition-fast);
+		color: var(--text-muted);
+	}
+
+	.default-star:hover:not(:disabled) {
+		color: var(--warning);
+		background: var(--warning-subtle);
+	}
+
+	.default-star.is-default {
+		color: var(--warning);
+		cursor: default;
+	}
+
+	.default-star:disabled:not(.is-default) {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.default-star :global(i) {
+		width: 18px;
+		height: 18px;
+	}
+
+	/* Actions */
+	.actions {
+		display: flex;
+		gap: 8px;
+		align-items: center;
+	}
+
+	/* Buttons */
+	.btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 8px 16px;
+		border-radius: var(--radius-md);
+		font-size: 0.875rem;
+		font-weight: 500;
+		cursor: pointer;
+		transition: all var(--transition-fast);
+		border: none;
+		text-decoration: none;
+	}
+
+	.btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.btn :global(i) {
+		width: 16px;
+		height: 16px;
+	}
+
+	.btn-primary {
+		background: var(--primary);
+		color: white;
+	}
+
+	.btn-primary:hover:not(:disabled) {
+		background: var(--primary-dark);
+	}
+
+	.btn-secondary {
+		background: var(--bg-subtle);
+		color: var(--text-primary);
+		border: 1px solid var(--border);
+	}
+
+	.btn-secondary:hover:not(:disabled) {
+		background: var(--bg-card);
+	}
+
+	.btn-danger {
+		background: var(--danger);
+		color: white;
+	}
+
+	.btn-danger:hover:not(:disabled) {
+		background: var(--danger-dark);
+	}
+
+	.btn-danger-outline {
+		background: transparent;
+		color: var(--danger);
+		border: 1px solid var(--danger);
+	}
+
+	.btn-danger-outline:hover:not(:disabled) {
+		background: var(--danger-subtle);
+	}
+
+	.btn-sm {
+		padding: 4px 10px;
+		font-size: 0.8125rem;
+	}
+
+	/* Alert */
+	.alert {
+		display: flex;
+		align-items: flex-start;
+		gap: 10px;
+		padding: 12px 16px;
+		border-radius: var(--radius-md);
+		font-size: 0.875rem;
+	}
+
+	.alert :global(i) {
+		width: 18px;
+		height: 18px;
+		flex-shrink: 0;
+		margin-top: 1px;
+	}
+
+	.alert-error {
+		background: var(--danger-subtle);
+		color: var(--danger);
+		border: 1px solid var(--danger-border);
+	}
+
+	.alert-warning {
+		background: var(--warning-subtle);
+		color: var(--warning-dark);
+		border: 1px solid var(--warning-border);
+	}
+
+	.alert-info {
+		background: var(--info-subtle, var(--primary-light));
+		color: var(--info, var(--primary));
+		border: 1px solid var(--info-border, var(--primary-light));
+	}
+
+	/* Loading / Empty */
+	.loading-state,
+	.empty-state {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 12px;
+		padding: 48px;
+		color: var(--text-muted);
+		font-size: 0.875rem;
+	}
+
+	.loading-state :global(i),
+	.empty-state :global(i) {
+		width: 32px;
+		height: 32px;
+	}
+
+	/* Modal */
+	.modal-overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+		z-index: 100;
+		border: none;
+		cursor: default;
+	}
+
+	.modal {
+		position: fixed;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		width: 100%;
+		max-width: 480px;
+		background: var(--bg-card);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		box-shadow: var(--shadow-xl);
+		z-index: 101;
+		display: flex;
+		flex-direction: column;
+		max-height: 90vh;
+	}
+
+	.modal-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 20px 24px 16px;
+		border-bottom: 1px solid var(--border);
+	}
+
+	.modal-header h2 {
+		font-size: 1.125rem;
+		font-weight: 600;
+		color: var(--text-primary);
+		margin: 0;
+	}
+
+	.danger-title {
+		color: var(--danger) !important;
+	}
+
+	.modal-close {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border: none;
+		background: transparent;
+		color: var(--text-muted);
+		cursor: pointer;
+		border-radius: var(--radius-sm);
+		transition: all var(--transition-fast);
+	}
+
+	.modal-close:hover {
+		background: var(--bg-subtle);
+		color: var(--text-primary);
+	}
+
+	.modal-close :global(i) {
+		width: 18px;
+		height: 18px;
+	}
+
+	.modal-body {
+		padding: 20px 24px;
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+		overflow-y: auto;
+	}
+
+	.modal-footer {
+		display: flex;
+		justify-content: flex-end;
+		gap: 12px;
+		padding: 16px 24px 20px;
+		border-top: 1px solid var(--border);
+	}
+
+	/* Form */
+	.form-group {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	.form-label {
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--text-primary);
+	}
+
+	.required {
+		color: var(--danger);
+	}
+
+	.form-input {
+		padding: 8px 12px;
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md);
+		background: var(--bg-card);
+		color: var(--text-primary);
+		font-size: 0.875rem;
+		font-family: var(--font-body);
+		transition: border-color var(--transition-fast);
+		outline: none;
+		width: 100%;
+		box-sizing: border-box;
+	}
+
+	.form-input:focus {
+		border-color: var(--primary);
+		box-shadow: 0 0 0 3px var(--primary-light);
+	}
+
+	.form-input.error {
+		border-color: var(--danger);
+	}
+
+	.form-static {
+		padding: 8px 12px;
+		background: var(--bg-subtle);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md);
+		font-family: var(--font-mono);
+		font-size: 0.875rem;
+		color: var(--text-secondary);
+	}
+
+	.field-hint {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		margin: 0;
+	}
+
+	.field-error {
+		font-size: 0.75rem;
+		color: var(--danger);
+		margin: 0;
+	}
+
+	/* Toggle switch */
+	.toggle-label {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		cursor: pointer;
+	}
+
+	.toggle-switch {
+		position: relative;
+	}
+
+	.toggle-input {
+		position: absolute;
+		opacity: 0;
+		width: 0;
+		height: 0;
+	}
+
+	.toggle-slider {
+		display: block;
+		width: 40px;
+		height: 22px;
+		background: var(--bg-tertiary);
+		border-radius: var(--radius-full);
+		position: relative;
+		cursor: pointer;
+		transition: background var(--transition-fast);
+	}
+
+	.toggle-slider::after {
+		content: '';
+		position: absolute;
+		top: 3px;
+		left: 3px;
+		width: 16px;
+		height: 16px;
+		background: white;
+		border-radius: var(--radius-full);
+		transition: transform var(--transition-fast);
+		box-shadow: var(--shadow-sm);
+	}
+
+	.toggle-switch.checked .toggle-slider {
+		background: var(--primary);
+	}
+
+	.toggle-switch.checked .toggle-slider::after {
+		transform: translateX(18px);
+	}
+</style>

--- a/packages/ar-admin-ui/src/routes/admin/tenants/[id]/invitations/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/tenants/[id]/invitations/+page.svelte
@@ -1,0 +1,699 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
+
+	// ==========================================================================
+	// Types
+	// ==========================================================================
+
+	interface TenantInvitation {
+		id: string;
+		tenant_id: string;
+		invited_email: string | null;
+		invited_by: string;
+		role_id: string | null;
+		org_id: string | null;
+		max_uses: number;
+		use_count: number;
+		expires_at: number;
+		created_at: number;
+		updated_at: number;
+	}
+
+	interface CreateResult {
+		id: string;
+		invite_url: string;
+		token: string;
+		expires_at: number;
+		email_sent: boolean;
+	}
+
+	// ==========================================================================
+	// State
+	// ==========================================================================
+
+	const tenantId = $derived($page.params.id);
+
+	let invitations = $state<TenantInvitation[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+	let successMessage = $state('');
+
+	// Create dialog
+	let showCreateDialog = $state(false);
+	let creating = $state(false);
+	let createError = $state('');
+	let newInvitedEmail = $state('');
+	let newRoleId = $state('');
+	let newOrgId = $state('');
+	let newMaxUses = $state(1);
+	let newExpiresInHours = $state(72);
+
+	// Created result dialog
+	let showResultDialog = $state(false);
+	let createResult = $state<CreateResult | null>(null);
+	let copySuccess = $state(false);
+
+	// Cancel confirm
+	let cancellingId = $state('');
+
+	// ==========================================================================
+	// API
+	// ==========================================================================
+
+	async function apiFetch(path: string, options?: Parameters<typeof fetch>[1]) {
+		const response = await fetch(path, {
+			credentials: 'include',
+			...options,
+			headers: {
+				'Content-Type': 'application/json',
+				...((options as Record<string, unknown>)?.headers as Record<string, string> | undefined)
+			}
+		});
+		if (!response.ok) {
+			const data = await response.json().catch(() => ({}));
+			throw new Error(
+				(data as { error?: string; message?: string }).message ||
+					`Request failed: ${response.status}`
+			);
+		}
+		return response.json();
+	}
+
+	async function loadInvitations() {
+		loading = true;
+		error = '';
+		try {
+			const data = await apiFetch(
+				`/api/admin/tenants/${tenantId}/invitations?include_expired=false`
+			);
+			invitations = data.items ?? [];
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to load invitations';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function handleCreate() {
+		creating = true;
+		createError = '';
+		try {
+			const body: Record<string, unknown> = {
+				max_uses: newMaxUses,
+				expires_in_hours: newExpiresInHours
+			};
+			if (newInvitedEmail) body.invited_email = newInvitedEmail;
+			if (newRoleId) body.role_id = newRoleId;
+			if (newOrgId) body.org_id = newOrgId;
+
+			const result = await apiFetch(`/api/admin/tenants/${tenantId}/invitations`, {
+				method: 'POST',
+				body: JSON.stringify(body)
+			});
+
+			createResult = result as CreateResult;
+			showCreateDialog = false;
+			showResultDialog = true;
+			resetCreateForm();
+			await loadInvitations();
+		} catch (err) {
+			createError = err instanceof Error ? err.message : 'Failed to create invitation';
+		} finally {
+			creating = false;
+		}
+	}
+
+	async function handleCancel(inv: TenantInvitation) {
+		if (cancellingId) return;
+		if (!confirm('Cancel this invitation? This cannot be undone.')) return;
+		cancellingId = inv.id;
+		try {
+			await apiFetch(`/api/admin/tenants/${tenantId}/invitations/${inv.id}`, {
+				method: 'DELETE'
+			});
+			successMessage = 'Invitation cancelled.';
+			invitations = invitations.filter((i) => i.id !== inv.id);
+			setTimeout(() => (successMessage = ''), 4000);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to cancel invitation';
+		} finally {
+			cancellingId = '';
+		}
+	}
+
+	async function copyToClipboard(text: string) {
+		try {
+			await navigator.clipboard.writeText(text);
+			copySuccess = true;
+			setTimeout(() => (copySuccess = false), 2000);
+		} catch {
+			// Fallback
+			const el = document.createElement('textarea');
+			el.value = text;
+			document.body.appendChild(el);
+			el.select();
+			document.execCommand('copy');
+			document.body.removeChild(el);
+			copySuccess = true;
+			setTimeout(() => (copySuccess = false), 2000);
+		}
+	}
+
+	function resetCreateForm() {
+		newInvitedEmail = '';
+		newRoleId = '';
+		newOrgId = '';
+		newMaxUses = 1;
+		newExpiresInHours = 72;
+		createError = '';
+	}
+
+	// ==========================================================================
+	// Helpers
+	// ==========================================================================
+
+	function formatDate(ts: number) {
+		return new Date(ts * 1000).toLocaleString();
+	}
+
+	function isExpired(inv: TenantInvitation) {
+		return inv.expires_at < Math.floor(Date.now() / 1000);
+	}
+
+	function isExhausted(inv: TenantInvitation) {
+		return inv.max_uses !== -1 && inv.use_count >= inv.max_uses;
+	}
+
+	// ==========================================================================
+	// Lifecycle
+	// ==========================================================================
+
+	onMount(() => {
+		loadInvitations();
+	});
+</script>
+
+<div class="page-container">
+	<div class="page-header">
+		<div>
+			<a href="/admin/tenants" class="back-link">← Tenants</a>
+			<h1 class="page-title">Invitations</h1>
+			<p class="page-subtitle">Manage invitation links for this tenant.</p>
+		</div>
+		<button class="btn btn-primary" onclick={() => (showCreateDialog = true)}>
+			+ Create Invitation
+		</button>
+	</div>
+
+	{#if successMessage}
+		<div class="alert alert-success">{successMessage}</div>
+	{/if}
+	{#if error}
+		<div class="alert alert-error">{error}</div>
+	{/if}
+
+	<!-- Invitations Table -->
+	<div class="card">
+		{#if loading}
+			<div class="loading-state">Loading invitations...</div>
+		{:else if invitations.length === 0}
+			<div class="empty-state">
+				<p>No active invitations. Create one to invite users to this tenant.</p>
+			</div>
+		{:else}
+			<table class="data-table">
+				<thead>
+					<tr>
+						<th>Email</th>
+						<th>Role</th>
+						<th>Org</th>
+						<th>Uses</th>
+						<th>Expires</th>
+						<th>Status</th>
+						<th>Actions</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each invitations as inv (inv.id)}
+						<tr>
+							<td>
+								{#if inv.invited_email}
+									{inv.invited_email}
+								{:else}
+									<span class="text-muted">Anyone</span>
+								{/if}
+							</td>
+							<td>{inv.role_id ?? '—'}</td>
+							<td>{inv.org_id ?? '—'}</td>
+							<td>{inv.use_count} / {inv.max_uses === -1 ? '∞' : inv.max_uses}</td>
+							<td>{formatDate(inv.expires_at)}</td>
+							<td>
+								{#if isExpired(inv)}
+									<span class="badge badge-expired">Expired</span>
+								{:else if isExhausted(inv)}
+									<span class="badge badge-exhausted">Exhausted</span>
+								{:else}
+									<span class="badge badge-active">Active</span>
+								{/if}
+							</td>
+							<td>
+								<button
+									class="btn-icon btn-icon-danger"
+									disabled={cancellingId === inv.id}
+									onclick={() => handleCancel(inv)}
+									title="Cancel invitation"
+								>
+									✕
+								</button>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		{/if}
+	</div>
+</div>
+
+<!-- Create Invitation Dialog -->
+{#if showCreateDialog}
+	<div class="dialog-overlay" role="dialog" aria-modal="true" aria-label="Create Invitation">
+		<div class="dialog">
+			<div class="dialog-header">
+				<h2>Create Invitation</h2>
+				<button
+					class="dialog-close"
+					onclick={() => {
+						showCreateDialog = false;
+						resetCreateForm();
+					}}>✕</button
+				>
+			</div>
+			<div class="dialog-body">
+				{#if createError}
+					<div class="alert alert-error">{createError}</div>
+				{/if}
+
+				<div class="form-field">
+					<label for="invited-email">Invited Email (optional)</label>
+					<input
+						id="invited-email"
+						type="email"
+						bind:value={newInvitedEmail}
+						placeholder="user@example.com — leave blank for open invitation"
+						class="form-input"
+					/>
+					<p class="form-hint">If set, only this email address can use the invitation.</p>
+				</div>
+
+				<div class="form-field">
+					<label for="role-id">Auto-assign Role ID (optional)</label>
+					<input
+						id="role-id"
+						type="text"
+						bind:value={newRoleId}
+						placeholder="role_id"
+						class="form-input"
+					/>
+				</div>
+
+				<div class="form-field">
+					<label for="org-id">Auto-assign Org ID (optional)</label>
+					<input
+						id="org-id"
+						type="text"
+						bind:value={newOrgId}
+						placeholder="org_id"
+						class="form-input"
+					/>
+				</div>
+
+				<div class="form-row">
+					<div class="form-field">
+						<label for="max-uses">Max Uses</label>
+						<input
+							id="max-uses"
+							type="number"
+							bind:value={newMaxUses}
+							min="-1"
+							max="1000"
+							class="form-input"
+						/>
+						<p class="form-hint">Use -1 for unlimited.</p>
+					</div>
+					<div class="form-field">
+						<label for="expires-hours">Expires In (hours)</label>
+						<input
+							id="expires-hours"
+							type="number"
+							bind:value={newExpiresInHours}
+							min="1"
+							max="720"
+							class="form-input"
+						/>
+					</div>
+				</div>
+			</div>
+			<div class="dialog-footer">
+				<button
+					class="btn btn-secondary"
+					onclick={() => {
+						showCreateDialog = false;
+						resetCreateForm();
+					}}>Cancel</button
+				>
+				<button class="btn btn-primary" onclick={handleCreate} disabled={creating}>
+					{creating ? 'Creating...' : 'Create Invitation'}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- Result Dialog (show invite URL) -->
+{#if showResultDialog && createResult}
+	<div class="dialog-overlay" role="dialog" aria-modal="true" aria-label="Invitation Created">
+		<div class="dialog">
+			<div class="dialog-header">
+				<h2>Invitation Created</h2>
+				<button class="dialog-close" onclick={() => (showResultDialog = false)}>✕</button>
+			</div>
+			<div class="dialog-body">
+				{#if !createResult.email_sent}
+					<div class="alert alert-warning">
+						Email could not be sent (email plugin not configured). Share the URL below manually.
+					</div>
+				{:else}
+					<div class="alert alert-success">Invitation email sent successfully.</div>
+				{/if}
+
+				<div class="form-field">
+					<label for="invite-url-field">Invitation URL</label>
+					<div class="url-copy-row">
+						<input
+							id="invite-url-field"
+							type="text"
+							readonly
+							value={createResult.invite_url}
+							class="form-input url-input"
+						/>
+						<button
+							class="btn btn-secondary"
+							onclick={() => copyToClipboard(createResult!.invite_url)}
+						>
+							{copySuccess ? 'Copied!' : 'Copy'}
+						</button>
+					</div>
+				</div>
+
+				<p class="expires-note">
+					Expires: {formatDate(createResult.expires_at)}
+				</p>
+			</div>
+			<div class="dialog-footer">
+				<button class="btn btn-primary" onclick={() => (showResultDialog = false)}>Done</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.page-container {
+		max-width: 1000px;
+		margin: 0 auto;
+		padding: 1.5rem;
+	}
+
+	.page-header {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		margin-bottom: 1.5rem;
+	}
+
+	.back-link {
+		font-size: 0.85rem;
+		color: var(--text-muted, #6b7280);
+		text-decoration: none;
+		display: block;
+		margin-bottom: 0.25rem;
+	}
+
+	.back-link:hover {
+		color: var(--primary, #4f46e5);
+	}
+
+	.page-title {
+		font-size: 1.5rem;
+		font-weight: 700;
+		margin: 0 0 0.25rem;
+	}
+
+	.page-subtitle {
+		color: var(--text-muted, #6b7280);
+		font-size: 0.875rem;
+		margin: 0;
+	}
+
+	.card {
+		background: var(--card-bg, #fff);
+		border: 1px solid var(--border, #e5e7eb);
+		border-radius: 0.5rem;
+		overflow: hidden;
+	}
+
+	.loading-state,
+	.empty-state {
+		padding: 3rem;
+		text-align: center;
+		color: var(--text-muted, #6b7280);
+	}
+
+	.data-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 0.875rem;
+	}
+
+	.data-table th {
+		padding: 0.75rem 1rem;
+		text-align: left;
+		font-weight: 600;
+		background: var(--table-header-bg, #f9fafb);
+		border-bottom: 1px solid var(--border, #e5e7eb);
+		white-space: nowrap;
+	}
+
+	.data-table td {
+		padding: 0.75rem 1rem;
+		border-bottom: 1px solid var(--border-light, #f3f4f6);
+		vertical-align: middle;
+	}
+
+	.text-muted {
+		color: var(--text-muted, #9ca3af);
+		font-style: italic;
+	}
+
+	.badge {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.2rem 0.6rem;
+		border-radius: 9999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+	}
+
+	.badge-active {
+		background: var(--color-success-bg, #dcfce7);
+		color: var(--color-success, #16a34a);
+	}
+
+	.badge-expired,
+	.badge-exhausted {
+		background: var(--color-warning-bg, #fef3c7);
+		color: var(--color-warning, #d97706);
+	}
+
+	.btn {
+		padding: 0.5rem 1rem;
+		border-radius: 0.375rem;
+		font-size: 0.875rem;
+		font-weight: 500;
+		cursor: pointer;
+		border: none;
+		transition: opacity 0.15s;
+	}
+
+	.btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.btn-primary {
+		background: var(--primary, #4f46e5);
+		color: #fff;
+	}
+
+	.btn-primary:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+
+	.btn-secondary {
+		background: var(--card-bg, #fff);
+		color: var(--text, #111827);
+		border: 1px solid var(--border, #e5e7eb);
+	}
+
+	.btn-secondary:hover:not(:disabled) {
+		background: var(--hover-bg, #f3f4f6);
+	}
+
+	.btn-icon {
+		width: 2rem;
+		height: 2rem;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 0.375rem;
+		border: none;
+		cursor: pointer;
+		font-size: 0.875rem;
+	}
+
+	.btn-icon-danger {
+		background: transparent;
+		color: var(--color-error, #dc2626);
+	}
+
+	.btn-icon-danger:hover:not(:disabled) {
+		background: var(--color-error-bg, #fee2e2);
+	}
+
+	.alert {
+		padding: 0.75rem 1rem;
+		border-radius: 0.375rem;
+		font-size: 0.875rem;
+		margin-bottom: 1rem;
+	}
+
+	.alert-success {
+		background: var(--color-success-bg, #dcfce7);
+		color: var(--color-success, #16a34a);
+	}
+
+	.alert-error {
+		background: var(--color-error-bg, #fee2e2);
+		color: var(--color-error, #dc2626);
+	}
+
+	.alert-warning {
+		background: var(--color-warning-bg, #fef3c7);
+		color: var(--color-warning, #d97706);
+	}
+
+	/* Dialog */
+	.dialog-overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 1000;
+	}
+
+	.dialog {
+		background: var(--card-bg, #fff);
+		border-radius: 0.5rem;
+		width: 100%;
+		max-width: 500px;
+		margin: 1rem;
+		box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+	}
+
+	.dialog-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 1.25rem 1.5rem;
+		border-bottom: 1px solid var(--border, #e5e7eb);
+	}
+
+	.dialog-header h2 {
+		font-size: 1.1rem;
+		font-weight: 600;
+		margin: 0;
+	}
+
+	.dialog-close {
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: var(--text-muted, #6b7280);
+		font-size: 1.1rem;
+		padding: 0.25rem;
+	}
+
+	.dialog-body {
+		padding: 1.5rem;
+	}
+
+	.dialog-footer {
+		display: flex;
+		justify-content: flex-end;
+		gap: 0.75rem;
+		padding: 1rem 1.5rem;
+		border-top: 1px solid var(--border, #e5e7eb);
+	}
+
+	.form-field {
+		margin-bottom: 1rem;
+	}
+
+	.form-field label {
+		display: block;
+		font-size: 0.875rem;
+		font-weight: 500;
+		margin-bottom: 0.375rem;
+	}
+
+	.form-input {
+		width: 100%;
+		padding: 0.5rem 0.75rem;
+		border: 1px solid var(--border, #d1d5db);
+		border-radius: 0.375rem;
+		font-size: 0.875rem;
+		background: var(--input-bg, #fff);
+		color: var(--text, #111827);
+		box-sizing: border-box;
+	}
+
+	.form-hint {
+		font-size: 0.75rem;
+		color: var(--text-muted, #6b7280);
+		margin-top: 0.25rem;
+	}
+
+	.form-row {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 1rem;
+	}
+
+	.url-copy-row {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.url-input {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.expires-note {
+		font-size: 0.8rem;
+		color: var(--text-muted, #6b7280);
+		margin-top: 0.75rem;
+	}
+</style>

--- a/packages/ar-auth/src/direct-auth.ts
+++ b/packages/ar-auth/src/direct-auth.ts
@@ -1558,9 +1558,7 @@ export async function directEmailCodeVerifyHandler(c: Context<{ Bindings: Env }>
       )
         .bind(tenantId)
         .all<{ field_key: string; field_type: string; validation_rules: string | null }>();
-      const schemaMap = new Map(
-        (schemaRows.results ?? []).map((r) => [r.field_key, r])
-      );
+      const schemaMap = new Map((schemaRows.results ?? []).map((r) => [r.field_key, r]));
       const fieldNow = Math.floor(now / 1000);
 
       for (const [key, value] of Object.entries(customFields)) {

--- a/packages/ar-auth/src/direct-auth.ts
+++ b/packages/ar-auth/src/direct-auth.ts
@@ -58,6 +58,8 @@ import {
   buildRefreshTokenRotatorInstanceName,
   createRefreshTokenJti,
   generateRefreshTokenRandomPart,
+  // Tenant domain resolution
+  resolveTenantFromEmailDomain,
 } from '@authrim/ar-lib-core';
 
 import {
@@ -1115,9 +1117,19 @@ export async function directEmailCodeSendHandler(c: Context<{ Bindings: Env }>) 
       code_challenge: string;
       code_challenge_method: CodeChallengeMethod;
       locale?: string;
+      invite_token?: string;
+      custom_fields?: Record<string, unknown>;
     }>();
 
-    const { client_id, email, code_challenge, code_challenge_method, locale } = body;
+    const {
+      client_id,
+      email,
+      code_challenge,
+      code_challenge_method,
+      locale,
+      invite_token,
+      custom_fields,
+    } = body;
 
     if (!client_id || !email || !code_challenge || code_challenge_method !== 'S256') {
       return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_REQUIRED_FIELD, {
@@ -1150,7 +1162,61 @@ export async function directEmailCodeSendHandler(c: Context<{ Bindings: Env }>) 
     }
 
     // Check/create user
-    const tenantId = getTenantIdFromContext(c);
+    let tenantId = getTenantIdFromContext(c);
+
+    // Invitation token routing: overrides all other tenant resolution
+    let inviteData: {
+      invite_id: string;
+      invite_token: string;
+      invite_role_id: string | null;
+      invite_org_id: string | null;
+      invited_email: string | null;
+    } | null = null;
+
+    if (invite_token && c.env.DB) {
+      const nowTs = Math.floor(Date.now() / 1000);
+      const row = await c.env.DB.prepare(
+        `SELECT id, tenant_id, invited_email, role_id, org_id, max_uses, use_count
+         FROM tenant_invitations WHERE token = ? AND expires_at > ?`
+      )
+        .bind(invite_token, nowTs)
+        .first<{
+          id: string;
+          tenant_id: string;
+          invited_email: string | null;
+          role_id: string | null;
+          org_id: string | null;
+          max_uses: number;
+          use_count: number;
+        }>();
+
+      if (!row) {
+        return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
+      }
+      if (row.max_uses !== -1 && row.use_count >= row.max_uses) {
+        return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
+      }
+      // If invitation is restricted to a specific email, enforce it
+      if (row.invited_email && row.invited_email.toLowerCase() !== email.toLowerCase()) {
+        return createErrorResponse(c, AR_ERROR_CODES.AUTH_INVALID_CODE);
+      }
+
+      tenantId = row.tenant_id;
+      inviteData = {
+        invite_id: row.id,
+        invite_token,
+        invite_role_id: row.role_id,
+        invite_org_id: row.org_id,
+        invited_email: row.invited_email,
+      };
+    } else if (tenantId === 'default' && c.env.DB) {
+      // If Host header did not resolve a specific tenant, try email domain routing
+      const resolvedTenantId = await resolveTenantFromEmailDomain(c.env.DB, email, c.env);
+      if (resolvedTenantId) {
+        tenantId = resolvedTenantId;
+      }
+    }
+
     const authCtx = createAuthContextFromHono(c, tenantId);
     let user: { id: string; email: string; name: string | null } | null = null;
 
@@ -1229,6 +1295,18 @@ export async function directEmailCodeSendHandler(c: Context<{ Bindings: Env }>) 
         client_id,
         email_hash: emailHash,
         issued_at: issuedAt,
+        // Invite metadata (present only when signup is via invitation)
+        ...(inviteData
+          ? {
+              invite_id: inviteData.invite_id,
+              invite_token: inviteData.invite_token,
+              invite_role_id: inviteData.invite_role_id,
+              invite_org_id: inviteData.invite_org_id,
+              invite_tenant_id: tenantId,
+            }
+          : {}),
+        // Custom registration fields (validated and saved after email verification)
+        ...(custom_fields ? { custom_fields } : {}),
       },
     });
 
@@ -1355,11 +1433,8 @@ export async function directEmailCodeVerifyHandler(c: Context<{ Bindings: Env }>
       challenge: string;
       userId: string;
       email?: string;
-      metadata?: {
-        code_challenge: string;
-        client_id: string;
-        issued_at: number;
-      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      metadata?: Record<string, any>;
     };
 
     try {
@@ -1412,6 +1487,140 @@ export async function directEmailCodeVerifyHandler(c: Context<{ Bindings: Env }>
     );
 
     const isNewUser = userCore ? now - (userCore.created_at || 0) < 60000 : false;
+
+    // Apply invitation role/org assignment if present
+    const inviteId = challengeData.metadata?.invite_id as string | undefined;
+    const inviteToken = challengeData.metadata?.invite_token as string | undefined;
+    const inviteRoleId = challengeData.metadata?.invite_role_id as string | undefined;
+    const inviteOrgId = challengeData.metadata?.invite_org_id as string | undefined;
+
+    if (inviteId && inviteToken && c.env.DB) {
+      const inviteNow = Math.floor(now / 1000);
+      try {
+        // Increment use_count atomically
+        await c.env.DB.prepare(
+          'UPDATE tenant_invitations SET use_count = use_count + 1, updated_at = ? WHERE id = ?'
+        )
+          .bind(inviteNow, inviteId)
+          .run();
+
+        // Assign role if specified
+        if (inviteRoleId) {
+          await c.env.DB.prepare(
+            `INSERT OR IGNORE INTO role_assignments (id, tenant_id, user_id, role_id, scope_type, scope_target, created_at, updated_at)
+             VALUES (?, ?, ?, ?, 'tenant', ?, ?, ?)`
+          )
+            .bind(
+              crypto.randomUUID(),
+              tenantId,
+              challengeData.userId,
+              inviteRoleId,
+              tenantId,
+              inviteNow,
+              inviteNow
+            )
+            .run();
+        }
+
+        // Assign org if specified
+        if (inviteOrgId) {
+          await c.env.DB.prepare(
+            `INSERT OR IGNORE INTO org_memberships (id, tenant_id, user_id, org_id, membership_type, created_at, updated_at)
+             VALUES (?, ?, ?, ?, 'member', ?, ?)`
+          )
+            .bind(
+              crypto.randomUUID(),
+              tenantId,
+              challengeData.userId,
+              inviteOrgId,
+              inviteNow,
+              inviteNow
+            )
+            .run();
+        }
+      } catch (inviteErr) {
+        log.warn('Failed to apply invitation assignments', {
+          error: String(inviteErr),
+          invite_id: inviteId,
+        });
+      }
+    }
+
+    // Save custom registration fields if present
+    const customFields = challengeData.metadata?.custom_fields as
+      | Record<string, unknown>
+      | undefined;
+    if (customFields && c.env.DB) {
+      const schemaRows = await c.env.DB.prepare(
+        `SELECT field_key, field_type, validation_rules
+         FROM custom_claim_schemas
+         WHERE tenant_id = ? AND show_on_registration = 1 AND is_active = 1`
+      )
+        .bind(tenantId)
+        .all<{ field_key: string; field_type: string; validation_rules: string | null }>();
+      const schemaMap = new Map(
+        (schemaRows.results ?? []).map((r) => [r.field_key, r])
+      );
+      const fieldNow = Math.floor(now / 1000);
+
+      for (const [key, value] of Object.entries(customFields)) {
+        const schema = schemaMap.get(key);
+        if (!schema) continue; // unknown field — reject
+
+        const strVal = String(value);
+
+        // Apply validation_rules if present
+        if (schema.validation_rules) {
+          try {
+            const rules = JSON.parse(schema.validation_rules) as Record<string, unknown>;
+            if (schema.field_type === 'number') {
+              const numVal = Number(strVal);
+              if (isNaN(numVal)) continue;
+              if (rules.min !== undefined && numVal < (rules.min as number)) continue;
+              if (rules.max !== undefined && numVal > (rules.max as number)) continue;
+            } else if (schema.field_type === 'enum') {
+              const enumVals = rules.enum_values as string[] | undefined;
+              if (enumVals && !enumVals.includes(strVal)) continue;
+            } else {
+              // string / date
+              if (rules.min_length !== undefined && strVal.length < (rules.min_length as number))
+                continue;
+              if (rules.max_length !== undefined && strVal.length > (rules.max_length as number))
+                continue;
+              if (rules.pattern) {
+                try {
+                  if (!new RegExp(rules.pattern as string).test(strVal)) continue;
+                } catch {
+                  /* invalid regex — skip pattern check */
+                }
+              }
+            }
+          } catch {
+            /* malformed validation_rules JSON — skip validation */
+          }
+        }
+
+        try {
+          await c.env.DB.prepare(
+            `INSERT INTO user_custom_fields (id, user_id, tenant_id, field_key, field_value, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(user_id, tenant_id, field_key) DO UPDATE SET field_value=excluded.field_value, updated_at=excluded.updated_at`
+          )
+            .bind(
+              crypto.randomUUID(),
+              challengeData.userId,
+              tenantId,
+              key,
+              strVal,
+              fieldNow,
+              fieldNow
+            )
+            .run();
+        } catch {
+          // Non-fatal
+        }
+      }
+    }
 
     // Generate auth_code
     const authCode = await generateAuthCode(

--- a/packages/ar-auth/src/index.ts
+++ b/packages/ar-auth/src/index.ts
@@ -74,6 +74,8 @@ import {
   directSessionHandler,
   directLogoutHandler,
 } from './direct-auth';
+import { validateInvitationHandler, useInvitationHandler } from './invitation-handlers';
+import { registrationFieldsHandler } from './registration-fields';
 
 // Create Hono app with Cloudflare Workers types
 const app = new Hono<{ Bindings: Env }>();
@@ -474,6 +476,16 @@ app.get('/api/v1/auth/direct/session', directSessionHandler);
 
 // Logout endpoint
 app.post('/api/v1/auth/direct/logout', directLogoutHandler);
+
+// Invitation API (public)
+// - GET  /api/v1/invitations/validate?token=xxx  - Validate token
+// - POST /api/v1/invitations/use                 - Mark token used
+app.get('/api/v1/invitations/validate', validateInvitationHandler);
+app.post('/api/v1/invitations/use', useInvitationHandler);
+
+// Registration fields (public)
+// - GET /api/v1/registration-fields  - Fields visible on signup form
+app.get('/api/v1/registration-fields', registrationFieldsHandler);
 
 // Flow Engine API
 // Track C: Flow-based authentication with UIContract

--- a/packages/ar-auth/src/invitation-handlers.ts
+++ b/packages/ar-auth/src/invitation-handlers.ts
@@ -1,0 +1,226 @@
+/**
+ * Public Invitation API Handlers
+ *
+ * Token-based invitation flow for tenant-specific signup routing.
+ * These endpoints are public (no authentication required).
+ *
+ * - GET  /api/v1/invitations/validate?token=xxx  - Validate a token and return tenant info
+ * - POST /api/v1/invitations/use                 - Mark a token as used (called after signup)
+ *
+ * @packageDocumentation
+ */
+
+import type { Context } from 'hono';
+import type { Env } from '@authrim/ar-lib-core';
+import { D1Adapter, createErrorResponse, AR_ERROR_CODES, getLogger } from '@authrim/ar-lib-core';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface TenantInvitationRow {
+  id: string;
+  token: string;
+  tenant_id: string;
+  invited_email: string | null;
+  role_id: string | null;
+  org_id: string | null;
+  max_uses: number;
+  use_count: number;
+  expires_at: number;
+}
+
+interface TenantRow {
+  id: string;
+  name: string;
+}
+
+// =============================================================================
+// Handlers
+// =============================================================================
+
+/**
+ * GET /api/v1/invitations/validate?token=xxx
+ * Validate an invitation token and return tenant/email info.
+ * Called by the /invite landing page to show tenant name before signup.
+ */
+export async function validateInvitationHandler(c: Context<{ Bindings: Env }>) {
+  const log = getLogger(c).module('INVITATIONS');
+  const token = c.req.query('token');
+
+  if (!token || token.length < 32) {
+    return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_REQUIRED_FIELD, {
+      variables: { field: 'token' },
+    });
+  }
+
+  try {
+    const now = Math.floor(Date.now() / 1000);
+    const adapter = new D1Adapter({ db: c.env.DB });
+
+    const invitation = await adapter.queryOne<TenantInvitationRow>(
+      `SELECT id, token, tenant_id, invited_email, role_id, org_id, max_uses, use_count, expires_at
+       FROM tenant_invitations
+       WHERE token = ? AND expires_at > ?`,
+      [token, now]
+    );
+
+    if (!invitation) {
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
+    }
+
+    // Check uses remaining
+    if (invitation.max_uses !== -1 && invitation.use_count >= invitation.max_uses) {
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
+    }
+
+    const tenant = await adapter.queryOne<TenantRow>('SELECT id, name FROM tenants WHERE id = ?', [
+      invitation.tenant_id,
+    ]);
+
+    if (!tenant) {
+      log.warn('Invitation references non-existent tenant', {
+        tenant_id: invitation.tenant_id,
+        invitation_id: invitation.id,
+      });
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
+    }
+
+    return c.json({
+      valid: true,
+      invitation_id: invitation.id,
+      tenant_id: invitation.tenant_id,
+      tenant_name: tenant.name,
+      invited_email: invitation.invited_email,
+      expires_at: invitation.expires_at,
+    });
+  } catch (error) {
+    log.error('Failed to validate invitation', { error: String(error) });
+    return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
+  }
+}
+
+/**
+ * POST /api/v1/invitations/use
+ * Mark an invitation token as used after successful signup.
+ * Also applies role/org assignments to the user.
+ *
+ * Body: { token: string, user_id: string }
+ */
+export async function useInvitationHandler(c: Context<{ Bindings: Env }>) {
+  const log = getLogger(c).module('INVITATIONS');
+
+  try {
+    const body = await c.req.json<{ token: string; user_id: string }>();
+    const { token, user_id } = body;
+
+    if (!token || !user_id) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_REQUIRED_FIELD, {
+        variables: { field: 'token, user_id' },
+      });
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    const adapter = new D1Adapter({ db: c.env.DB });
+
+    const invitation = await adapter.queryOne<TenantInvitationRow>(
+      `SELECT id, tenant_id, invited_email, role_id, org_id, max_uses, use_count, expires_at
+       FROM tenant_invitations
+       WHERE token = ? AND expires_at > ?`,
+      [token, now]
+    );
+
+    if (!invitation) {
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
+    }
+
+    if (invitation.max_uses !== -1 && invitation.use_count >= invitation.max_uses) {
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
+    }
+
+    // Verify the user_id actually exists in the correct tenant
+    const userRow = await adapter.queryOne<{ id: string }>(
+      'SELECT id FROM users_core WHERE id = ? AND tenant_id = ? AND is_active = 1',
+      [user_id, invitation.tenant_id]
+    );
+    if (!userRow) {
+      log.warn('useInvitation: user_id not found in invitation tenant', {
+        user_id,
+        tenant_id: invitation.tenant_id,
+        invitation_id: invitation.id,
+      });
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
+    }
+
+    // If invitation is email-restricted, verify the user's email matches (PII DB)
+    if (invitation.invited_email && c.env.DB_PII) {
+      const piiRow = await c.env.DB_PII.prepare(
+        'SELECT email FROM users_pii WHERE id = ? AND tenant_id = ?'
+      )
+        .bind(user_id, invitation.tenant_id)
+        .first<{ email: string }>();
+
+      // No PII record → cannot verify email; block to prevent misuse
+      if (!piiRow || piiRow.email.toLowerCase() !== invitation.invited_email.toLowerCase()) {
+        log.warn('useInvitation: invited_email verification failed', {
+          invitation_id: invitation.id,
+          user_id,
+          reason: !piiRow ? 'no_pii_record' : 'email_mismatch',
+        });
+        return createErrorResponse(c, AR_ERROR_CODES.AUTH_INVALID_CODE);
+      }
+    }
+
+    // Atomically increment use_count only if still within limit
+    const result = await c.env.DB.prepare(
+      `UPDATE tenant_invitations
+       SET use_count = use_count + 1, updated_at = ?
+       WHERE id = ? AND (max_uses = -1 OR use_count < max_uses)`
+    )
+      .bind(now, invitation.id)
+      .run();
+
+    if (result.meta.changes === 0) {
+      // Another concurrent request consumed the last use
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
+    }
+
+    // Apply role/org assignments
+    if (invitation.role_id) {
+      try {
+        await adapter.execute(
+          `INSERT OR IGNORE INTO role_assignments (id, tenant_id, user_id, role_id, scope_type, scope_target, created_at, updated_at)
+           VALUES (?, ?, ?, ?, 'tenant', ?, ?, ?)`,
+          [
+            crypto.randomUUID(),
+            invitation.tenant_id,
+            user_id,
+            invitation.role_id,
+            invitation.tenant_id,
+            now,
+            now,
+          ]
+        );
+      } catch (assignErr) {
+        log.warn('Failed to assign role from invitation', { error: String(assignErr) });
+      }
+    }
+
+    if (invitation.org_id) {
+      try {
+        await adapter.execute(
+          `INSERT OR IGNORE INTO org_memberships (id, tenant_id, user_id, org_id, membership_type, created_at, updated_at)
+           VALUES (?, ?, ?, ?, 'member', ?, ?)`,
+          [crypto.randomUUID(), invitation.tenant_id, user_id, invitation.org_id, now, now]
+        );
+      } catch (assignErr) {
+        log.warn('Failed to assign org from invitation', { error: String(assignErr) });
+      }
+    }
+
+    return c.json({ success: true });
+  } catch (error) {
+    log.error('Failed to use invitation', { error: String(error) });
+    return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
+  }
+}

--- a/packages/ar-auth/src/registration-fields.ts
+++ b/packages/ar-auth/src/registration-fields.ts
@@ -1,0 +1,75 @@
+/**
+ * Registration Fields API Handler
+ *
+ * Returns custom claim schemas marked as visible on the registration form.
+ * Public endpoint — no authentication required.
+ *
+ * - GET /api/v1/registration-fields
+ *
+ * @packageDocumentation
+ */
+
+import type { Context } from 'hono';
+import type { Env } from '@authrim/ar-lib-core';
+import {
+  D1Adapter,
+  createErrorResponse,
+  AR_ERROR_CODES,
+  getLogger,
+  getTenantIdFromContext,
+} from '@authrim/ar-lib-core';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface RegistrationFieldRow {
+  field_key: string;
+  display_label: string;
+  field_type: string;
+  registration_required: number;
+  registration_order: number;
+  registration_placeholder: string | null;
+  validation_rules: string | null;
+}
+
+// =============================================================================
+// Handler
+// =============================================================================
+
+/**
+ * GET /api/v1/registration-fields
+ * Returns fields with show_on_registration=1 for the current tenant.
+ */
+export async function registrationFieldsHandler(c: Context<{ Bindings: Env }>) {
+  const log = getLogger(c).module('REGISTRATION-FIELDS');
+
+  try {
+    const tenantId = getTenantIdFromContext(c);
+    const adapter = new D1Adapter({ db: c.env.DB });
+
+    const rows = await adapter.query<RegistrationFieldRow>(
+      `SELECT field_key, display_label, field_type, registration_required,
+              registration_order, registration_placeholder, validation_rules
+       FROM custom_claim_schemas
+       WHERE tenant_id = ? AND show_on_registration = 1 AND is_active = 1
+       ORDER BY registration_order ASC, display_order ASC`,
+      [tenantId]
+    );
+
+    const fields = rows.map((row) => ({
+      field_key: row.field_key,
+      display_label: row.display_label,
+      field_type: row.field_type,
+      required: row.registration_required === 1,
+      order: row.registration_order,
+      placeholder: row.registration_placeholder,
+      validation_rules: row.validation_rules ? JSON.parse(row.validation_rules) : null,
+    }));
+
+    return c.json({ fields });
+  } catch (error) {
+    log.error('Failed to fetch registration fields', { error: String(error) });
+    return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
+  }
+}

--- a/packages/ar-lib-core/src/index.ts
+++ b/packages/ar-lib-core/src/index.ts
@@ -224,6 +224,7 @@ export * from './vc/status-list-manager';
 // Services
 export * from './services/rule-evaluator';
 export * from './services/org-domain-resolver';
+export * from './services/tenant-domain-resolver';
 export * from './services/token-claim-evaluator';
 export * from './services/unified-check-service';
 export * from './services/check-audit-service';

--- a/packages/ar-lib-core/src/services/tenant-domain-resolver.ts
+++ b/packages/ar-lib-core/src/services/tenant-domain-resolver.ts
@@ -1,0 +1,83 @@
+/**
+ * Tenant Domain Resolver Service
+ *
+ * Platform-level email domain → tenant routing.
+ * When the Host header cannot determine a specific tenant (resolves to 'default'),
+ * this service checks if the user's email domain maps to a specific tenant.
+ *
+ * Used during signup to automatically route users to their tenant.
+ */
+
+import type { D1Database } from '@cloudflare/workers-types';
+import {
+  generateEmailDomainHashWithVersion,
+  getEmailDomainHashConfig,
+} from '../utils/email-domain-hash';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger().module('TENANT-DOMAIN-RESOLVER');
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface TenantDomainMappingRow {
+  tenant_id: string;
+  priority: number;
+}
+
+// =============================================================================
+// Resolver
+// =============================================================================
+
+/**
+ * Resolve a tenant ID from an email address's domain.
+ *
+ * Looks up the email domain in `tenant_domain_mappings` (verified=1, is_active=1)
+ * and returns the highest-priority matching tenant ID, or null if none found.
+ *
+ * This should only be called when the Host header resolves to 'default',
+ * as Host-header tenant resolution always takes precedence.
+ *
+ * @param db - D1 database binding
+ * @param email - User email address (e.g. "user@company.com")
+ * @param env - Cloudflare Workers environment bindings
+ * @returns Tenant ID string, or null if no mapping found
+ */
+export async function resolveTenantFromEmailDomain(
+  db: D1Database,
+  email: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  env: any
+): Promise<string | null> {
+  try {
+    const hashConfig = await getEmailDomainHashConfig(env);
+    const hashResult = await generateEmailDomainHashWithVersion(email, hashConfig);
+
+    const row = await db
+      .prepare(
+        `SELECT tenant_id, priority
+         FROM tenant_domain_mappings
+         WHERE domain_hash = ? AND verified = 1 AND is_active = 1
+         ORDER BY priority DESC
+         LIMIT 1`
+      )
+      .bind(hashResult.hash)
+      .first<TenantDomainMappingRow>();
+
+    if (!row) {
+      return null;
+    }
+
+    log.debug('Resolved tenant from email domain', {
+      tenant_id: row.tenant_id,
+      priority: row.priority,
+    });
+
+    return row.tenant_id;
+  } catch (error) {
+    // Non-fatal: fall back to default tenant
+    log.warn('Tenant domain resolution failed', { error: (error as Error).message });
+    return null;
+  }
+}

--- a/packages/ar-login-ui/src/routes/invite/+page.svelte
+++ b/packages/ar-login-ui/src/routes/invite/+page.svelte
@@ -1,0 +1,256 @@
+<script lang="ts">
+	import { Input, Card, Alert } from '$lib/components';
+	import { onMount } from 'svelte';
+
+	// ---------------------------------------------------------------------------
+	// State
+	// ---------------------------------------------------------------------------
+	let token = $state('');
+	let tenantName = $state('');
+	let invitedEmail = $state<string | null>(null);
+
+	let email = $state('');
+	let loading = $state(true);
+	let submitting = $state(false);
+	let error = $state('');
+	let sent = $state(false);
+
+	// ---------------------------------------------------------------------------
+	// Lifecycle
+	// ---------------------------------------------------------------------------
+	onMount(async () => {
+		const params = new URLSearchParams(window.location.search);
+		const t = params.get('token');
+
+		if (!t) {
+			error = 'Invalid invitation link. No token provided.';
+			loading = false;
+			return;
+		}
+
+		token = t;
+		await validateToken(t);
+	});
+
+	async function validateToken(t: string) {
+		loading = true;
+		error = '';
+		try {
+			const res = await fetch(`/api/v1/invitations/validate?token=${encodeURIComponent(t)}`);
+			if (!res.ok) {
+				const data = await res.json().catch(() => ({}));
+				error =
+					(data as { error?: string; message?: string }).message ||
+					'This invitation link is invalid or has expired.';
+				loading = false;
+				return;
+			}
+			const data = (await res.json()) as {
+				invitation_id: string;
+				tenant_name: string;
+				invited_email: string | null;
+			};
+			tenantName = data.tenant_name;
+			invitedEmail = data.invited_email;
+			if (invitedEmail) {
+				email = invitedEmail;
+			}
+		} catch {
+			error = 'Failed to validate invitation. Please try again.';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		error = '';
+
+		if (!email) {
+			error = 'Email address is required.';
+			return;
+		}
+		if (invitedEmail && email.toLowerCase() !== invitedEmail.toLowerCase()) {
+			error = 'This invitation is for a different email address.';
+			return;
+		}
+
+		submitting = true;
+		try {
+			// Redirect to signup with invite context
+			const qs = `invite_token=${encodeURIComponent(token)}&email=${encodeURIComponent(email)}&tenant=${encodeURIComponent(tenantName)}`;
+			window.location.href = `/signup?${qs}`;
+		} catch {
+			error = 'An error occurred. Please try again.';
+			submitting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Invitation - {tenantName || 'Authrim'}</title>
+	<meta name="referrer" content="no-referrer" />
+</svelte:head>
+
+<div class="invite-page">
+	<Card>
+		{#if loading}
+			<div class="loading-state">
+				<div class="spinner" aria-label="Loading..."></div>
+				<p>Validating your invitation...</p>
+			</div>
+		{:else if error && !tenantName}
+			<div class="error-state">
+				<div class="error-icon">✕</div>
+				<h2>Invalid Invitation</h2>
+				<p>{error}</p>
+			</div>
+		{:else if sent}
+			<div class="success-state">
+				<div class="success-icon">✓</div>
+				<h2>Check your email</h2>
+				<p>We've sent a verification code to <strong>{email}</strong>.</p>
+			</div>
+		{:else}
+			<div class="invite-content">
+				<div class="invite-header">
+					<h2>You're invited to <strong>{tenantName}</strong></h2>
+					<p>Accept your invitation by signing up with your email address.</p>
+				</div>
+
+				{#if error}
+					<Alert variant="error">{error}</Alert>
+				{/if}
+
+				<form onsubmit={handleSubmit}>
+					<div class="form-field">
+						<Input
+							type="email"
+							label="Email address"
+							bind:value={email}
+							placeholder="you@example.com"
+							disabled={!!invitedEmail}
+							required
+						/>
+						{#if invitedEmail}
+							<p class="field-hint">This invitation is for this specific email address.</p>
+						{/if}
+					</div>
+
+					<button type="submit" class="submit-btn" disabled={submitting}>
+						{submitting ? 'Loading...' : 'Continue'}
+					</button>
+				</form>
+			</div>
+		{/if}
+	</Card>
+</div>
+
+<style>
+	.invite-page {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 100vh;
+		padding: 1rem;
+	}
+
+	.loading-state,
+	.error-state,
+	.success-state {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1rem;
+		padding: 2rem;
+		text-align: center;
+	}
+
+	.spinner {
+		width: 2rem;
+		height: 2rem;
+		border: 3px solid var(--color-border, #e5e7eb);
+		border-top-color: var(--color-primary, #4f46e5);
+		border-radius: 50%;
+		animation: spin 0.8s linear infinite;
+	}
+
+	@keyframes spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	.error-icon,
+	.success-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 3rem;
+		height: 3rem;
+		border-radius: 50%;
+		font-size: 1.25rem;
+		font-weight: bold;
+	}
+
+	.error-icon {
+		background-color: var(--color-error-bg, #fee2e2);
+		color: var(--color-error, #dc2626);
+	}
+
+	.success-icon {
+		background-color: var(--color-success-bg, #dcfce7);
+		color: var(--color-success, #16a34a);
+	}
+
+	.invite-content {
+		padding: 1.5rem;
+	}
+
+	.invite-header {
+		margin-bottom: 1.5rem;
+	}
+
+	.invite-header h2 {
+		font-size: 1.25rem;
+		margin-bottom: 0.5rem;
+	}
+
+	.invite-header p {
+		color: var(--color-text-muted, #6b7280);
+		font-size: 0.9rem;
+	}
+
+	.form-field {
+		margin-bottom: 1rem;
+	}
+
+	.field-hint {
+		font-size: 0.8rem;
+		color: var(--color-text-muted, #6b7280);
+		margin-top: 0.25rem;
+	}
+
+	.submit-btn {
+		width: 100%;
+		padding: 0.625rem 1.25rem;
+		background: var(--primary, #4f46e5);
+		color: #fff;
+		border: none;
+		border-radius: 0.375rem;
+		font-size: 0.875rem;
+		font-weight: 500;
+		cursor: pointer;
+		transition: opacity 0.15s;
+		margin-top: 0.5rem;
+	}
+
+	.submit-btn:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+
+	.submit-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+</style>

--- a/packages/ar-login-ui/src/routes/signup/+page.svelte
+++ b/packages/ar-login-ui/src/routes/signup/+page.svelte
@@ -15,6 +15,20 @@
 	// ---------------------------------------------------------------------------
 	let email = $state('');
 	let name = $state('');
+	let inviteToken = $state('');
+	let inviteTenantName = $state('');
+
+	// Registration fields (custom)
+	interface RegistrationField {
+		field_key: string;
+		display_label: string;
+		field_type: string;
+		required: boolean;
+		placeholder: string | null;
+		validation_rules: Record<string, unknown> | null;
+	}
+	let registrationFields = $state<RegistrationField[]>([]);
+	let customFieldValues = $state<Record<string, string>>({});
 	let error = $state('');
 	let passkeyLoading = $state(false);
 	let emailCodeLoading = $state(false);
@@ -67,7 +81,23 @@
 			isDarkMode = checkDarkMode();
 		});
 
-		await loadLoginMethods();
+		// Read invite context from URL params
+		const params = new URLSearchParams(window.location.search);
+		const token = params.get('invite_token');
+		const prefilledEmail = params.get('email');
+		const tenant = params.get('tenant');
+
+		if (token) {
+			inviteToken = token;
+		}
+		if (prefilledEmail) {
+			email = prefilledEmail;
+		}
+		if (tenant) {
+			inviteTenantName = tenant;
+		}
+
+		await Promise.all([loadLoginMethods(), loadRegistrationFields()]);
 	});
 
 	async function loadLoginMethods() {
@@ -86,6 +116,22 @@
 			emailCodeEnabled = true;
 		} finally {
 			methodsLoading = false;
+		}
+	}
+
+	async function loadRegistrationFields() {
+		try {
+			const res = await fetch('/api/v1/registration-fields');
+			if (res.ok) {
+				const data = (await res.json()) as { fields: RegistrationField[] };
+				registrationFields = data.fields ?? [];
+				// Initialize values
+				for (const f of registrationFields) {
+					customFieldValues[f.field_key] = '';
+				}
+			}
+		} catch {
+			// Non-fatal: proceed without custom fields
 		}
 	}
 
@@ -157,6 +203,22 @@
 				});
 			}
 
+			// Apply invitation if present (passkey flow: server doesn't see invite_token during registration)
+			if (inviteToken && verifyData?.userId) {
+				try {
+					const inviteRes = await fetch('/api/v1/invitations/use', {
+						method: 'POST',
+						headers: { 'Content-Type': 'application/json' },
+						body: JSON.stringify({ token: inviteToken, user_id: verifyData.userId })
+					});
+					if (!inviteRes.ok) {
+						console.warn('[signup] Failed to apply invitation:', inviteRes.status);
+					}
+				} catch (inviteErr) {
+					console.warn('[signup] Failed to apply invitation:', inviteErr);
+				}
+			}
+
 			window.location.href = '/';
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'An error occurred during passkey registration';
@@ -177,7 +239,17 @@
 			if (apiError) {
 				throw new Error(apiError.error_description || 'Failed to send verification code');
 			}
-			window.location.href = `/verify-email-code?email=${encodeURIComponent(email)}`;
+			// Persist custom field values for post-verification saving
+			if (Object.keys(customFieldValues).length > 0) {
+				try {
+					sessionStorage.setItem('signup_custom_fields', JSON.stringify(customFieldValues));
+				} catch {
+					// Non-fatal
+				}
+			}
+			let verifyQs = `email=${encodeURIComponent(email)}`;
+			if (inviteToken) verifyQs += `&invite_token=${encodeURIComponent(inviteToken)}`;
+			window.location.href = `/verify-email-code?${verifyQs}`;
 		} catch (err) {
 			error =
 				err instanceof Error ? err.message : 'An error occurred while sending verification code';
@@ -292,9 +364,15 @@
 					<h2 class="auth-section-title">
 						{$LL.register_title()}
 					</h2>
-					<p class="auth-section-subtitle">
-						{$LL.register_subtitle()}
-					</p>
+					{#if inviteTenantName}
+						<p class="auth-section-subtitle">
+							You've been invited to <strong>{inviteTenantName}</strong>. Create your account to continue.
+						</p>
+					{:else}
+						<p class="auth-section-subtitle">
+							{$LL.register_subtitle()}
+						</p>
+					{/if}
 				</div>
 
 				<!-- Error Alert -->
@@ -330,6 +408,48 @@
 						required
 					/>
 				</div>
+
+				<!-- Custom Registration Fields -->
+				{#if registrationFields.length > 0}
+					{#each registrationFields as field (field.field_key)}
+						<div class="mb-4">
+							{#if field.field_type === 'boolean'}
+								<label class="flex items-center gap-2" style="cursor: pointer;">
+									<input
+										type="checkbox"
+										checked={customFieldValues[field.field_key] === 'true'}
+										onchange={(e) => {
+											customFieldValues[field.field_key] = (
+												e.currentTarget as HTMLInputElement
+											).checked
+												? 'true'
+												: 'false';
+										}}
+									/>
+									<span style="font-size: 0.875rem; color: var(--text);"
+										>{field.display_label}{field.required ? ' *' : ''}</span
+									>
+								</label>
+							{:else if field.field_type === 'number'}
+								<Input
+									label="{field.display_label}{field.required ? ' *' : ''}"
+									type="number"
+									placeholder={field.placeholder ?? ''}
+									bind:value={customFieldValues[field.field_key]}
+									required={field.required}
+								/>
+							{:else}
+								<Input
+									label="{field.display_label}{field.required ? ' *' : ''}"
+									type="text"
+									placeholder={field.placeholder ?? ''}
+									bind:value={customFieldValues[field.field_key]}
+									required={field.required}
+								/>
+							{/if}
+						</div>
+					{/each}
+				{/if}
 
 				<!-- Passkey Button -->
 				{#if showPasskey}

--- a/packages/ar-login-ui/src/routes/verify-email-code/+page.svelte
+++ b/packages/ar-login-ui/src/routes/verify-email-code/+page.svelte
@@ -10,6 +10,7 @@
 	import { page } from '$app/stores';
 
 	let email = $state('');
+	let inviteToken = $state('');
 	let error = $state('');
 	let success = $state('');
 	let loading = $state(false);
@@ -37,8 +38,9 @@
 	});
 
 	onMount(() => {
-		// Get email from URL parameter
+		// Get email and invite_token from URL parameters
 		email = $page.url.searchParams.get('email') || '';
+		inviteToken = $page.url.searchParams.get('invite_token') || '';
 
 		// If no email, redirect to login
 		if (!email) {
@@ -117,6 +119,19 @@
 					email: data.user?.email || email,
 					name: data.user?.name || undefined
 				});
+			}
+
+			// Apply invitation if present
+			if (inviteToken && data?.userId) {
+				try {
+					await fetch('/api/v1/invitations/use', {
+						method: 'POST',
+						headers: { 'Content-Type': 'application/json' },
+						body: JSON.stringify({ token: inviteToken, user_id: data.userId })
+					});
+				} catch {
+					// Non-fatal: proceed regardless
+				}
 			}
 
 			// Redirect to home after delay

--- a/packages/ar-management/src/admin-custom-claims.ts
+++ b/packages/ar-management/src/admin-custom-claims.ts
@@ -545,8 +545,9 @@ export async function adminCustomClaimCreateHandler(c: AdminContext) {
         validation_rules, include_in_id_token, include_in_userinfo, include_in_introspection,
         required_scopes, scope_mode, is_searchable, is_exportable, is_vc_claim,
         claim_namespace, description, display_order, schema_version,
-        operation_status, created_by, created_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 'active', ?, ?, ?)`,
+        operation_status, created_by, created_at, updated_at,
+        show_on_registration, registration_required, registration_order, registration_placeholder
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 'active', ?, ?, ?, ?, ?, ?, ?)`,
       [
         id,
         tenantId,
@@ -570,6 +571,10 @@ export async function adminCustomClaimCreateHandler(c: AdminContext) {
         createdBy,
         now,
         now,
+        body.show_on_registration ? 1 : 0,
+        body.registration_required ? 1 : 0,
+        body.registration_order || 0,
+        body.registration_placeholder || null,
       ]
     );
 
@@ -970,6 +975,11 @@ export async function adminCustomClaimUpdateHandler(c: AdminContext) {
       is_vc_claim: (v) => (v ? 1 : 0),
       description: (v) => v || null,
       display_order: (v) => v,
+      // Registration form fields (migration 060)
+      show_on_registration: (v) => (v ? 1 : 0),
+      registration_required: (v) => (v ? 1 : 0),
+      registration_order: (v) => v,
+      registration_placeholder: (v) => v || null,
     };
 
     for (const [key, transform] of Object.entries(updateableFields)) {

--- a/packages/ar-management/src/admin-settings-meta.ts
+++ b/packages/ar-management/src/admin-settings-meta.ts
@@ -1097,12 +1097,16 @@ export async function adminSettingsValidateHandler(c: Context<{ Bindings: Env }>
  * Schema for tenant clone request
  */
 const TenantCloneRequestSchema = z.object({
-  name: z.string().min(1).max(200),
-  subdomain: z
+  id: z
     .string()
-    .min(3)
+    .min(1)
     .max(63)
-    .regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/, 'Invalid subdomain format'),
+    .regex(
+      /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/,
+      'Invalid id format: must start and end with a lowercase letter or digit'
+    ),
+  name: z.string().min(1).max(200),
+  description: z.string().max(500).optional(),
   include_clients: z.boolean().default(false),
   include_roles: z.boolean().default(true),
   include_webhooks: z.boolean().default(false),
@@ -1113,8 +1117,9 @@ const TenantCloneRequestSchema = z.object({
  * Clone tenant settings to create a new tenant
  *
  * Request body:
- * - name: string - Name for the new tenant
- * - subdomain: string - Subdomain for the new tenant
+ * - id: string - Slug ID for the new tenant (^[a-z0-9]([a-z0-9-]*[a-z0-9])?$, max 63 chars)
+ * - name: string - Display name for the new tenant
+ * - description?: string - Optional description
  * - include_clients: boolean - Whether to clone client configurations
  * - include_roles: boolean - Whether to clone custom roles
  * - include_webhooks: boolean - Whether to clone webhook configurations
@@ -1146,7 +1151,14 @@ export async function adminTenantCloneHandler(c: Context<{ Bindings: Env }>) {
       });
     }
 
-    const { name, subdomain, include_clients, include_roles, include_webhooks } = parseResult.data;
+    const {
+      id: newTenantId,
+      name,
+      description,
+      include_clients,
+      include_roles,
+      include_webhooks,
+    } = parseResult.data;
     const adapter = createAdapter(c);
 
     // Verify source tenant exists and user has access
@@ -1154,8 +1166,7 @@ export async function adminTenantCloneHandler(c: Context<{ Bindings: Env }>) {
     const sourceTenant = await adapter.queryOne<{
       id: string;
       name: string;
-      settings: string;
-    }>('SELECT id, name, settings FROM tenants WHERE id = ?', [sourceTenantId]);
+    }>('SELECT id, name FROM tenants WHERE id = ?', [sourceTenantId]);
 
     if (!sourceTenant) {
       return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND, {
@@ -1163,27 +1174,25 @@ export async function adminTenantCloneHandler(c: Context<{ Bindings: Env }>) {
       });
     }
 
-    // Check subdomain availability
-    const existingSubdomain = await adapter.queryOne<{ id: string }>(
-      'SELECT id FROM tenants WHERE subdomain = ?',
-      [subdomain]
+    // Check id (slug) availability
+    const existingTenant = await adapter.queryOne<{ id: string }>(
+      'SELECT id FROM tenants WHERE id = ?',
+      [newTenantId]
     );
 
-    if (existingSubdomain) {
+    if (existingTenant) {
       return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
-        variables: { field: 'subdomain', reason: 'Subdomain already in use' },
+        variables: { field: 'id', reason: 'Tenant ID already in use' },
       });
     }
 
-    // Generate new tenant ID
-    const newTenantId = crypto.randomUUID();
     const nowTs = Math.floor(Date.now() / 1000);
 
-    // Clone tenant with new name and subdomain
+    // Clone tenant with new id, name, and description
     await adapter.execute(
-      `INSERT INTO tenants (id, name, subdomain, settings, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?)`,
-      [newTenantId, name, subdomain, sourceTenant.settings, nowTs, nowTs]
+      `INSERT INTO tenants (id, name, description, is_active, is_default, created_at, updated_at)
+       VALUES (?, ?, ?, 1, 0, ?, ?)`,
+      [newTenantId, name, description ?? null, nowTs, nowTs]
     );
 
     const clonedItems = {
@@ -1297,16 +1306,16 @@ export async function adminTenantCloneHandler(c: Context<{ Bindings: Env }>) {
     await createAuditLogFromContext(c, 'tenant.cloned', 'tenant', newTenantId, {
       source_tenant_id: sourceTenantId,
       source_tenant_name: sourceTenant.name,
+      new_tenant_id: newTenantId,
       new_tenant_name: name,
-      subdomain,
       cloned_items: clonedItems,
     });
 
     return c.json(
       {
-        tenant_id: newTenantId,
+        id: newTenantId,
         name,
-        subdomain,
+        description: description ?? null,
         source_tenant_id: sourceTenantId,
         source_tenant_name: sourceTenant.name,
         cloned_items: clonedItems,

--- a/packages/ar-management/src/admin-tenant-domain-mappings.ts
+++ b/packages/ar-management/src/admin-tenant-domain-mappings.ts
@@ -1,0 +1,556 @@
+/**
+ * Admin Tenant Domain Mappings API Endpoints
+ *
+ * Platform-level CRUD for tenant domain mappings (system_admin only).
+ * Maps email domains (hashed) to specific tenants for signup auto-routing.
+ *
+ * - GET    /api/admin/platform/tenant-domain-mappings          - List mappings
+ * - POST   /api/admin/platform/tenant-domain-mappings          - Create mapping
+ * - GET    /api/admin/platform/tenant-domain-mappings/:id      - Get mapping
+ * - PUT    /api/admin/platform/tenant-domain-mappings/:id      - Update mapping
+ * - DELETE /api/admin/platform/tenant-domain-mappings/:id      - Delete mapping
+ * - POST   /api/admin/platform/tenant-domain-mappings/verify          - Initiate DNS verification
+ * - POST   /api/admin/platform/tenant-domain-mappings/verify/confirm  - Confirm DNS verification
+ *
+ * @packageDocumentation
+ */
+
+import type { Context } from 'hono';
+import type { Env } from '@authrim/ar-lib-core';
+import {
+  D1Adapter,
+  createErrorResponse,
+  AR_ERROR_CODES,
+  createAuditLogFromContext,
+  getLogger,
+  generateEmailDomainHashWithVersion,
+  getEmailDomainHashConfig,
+  generateVerificationToken,
+  getVerificationRecordName,
+  getExpectedRecordValue,
+  verifyDomainDnsTxt,
+  calculateVerificationExpiry,
+  isVerificationExpired,
+} from '@authrim/ar-lib-core';
+import { z } from 'zod';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Domain format validation regex (RFC 1035 compliant) */
+const DOMAIN_REGEX = /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/;
+const MAX_DOMAIN_LENGTH = 253;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface TenantDomainMappingRow {
+  id: string;
+  domain_hash: string;
+  hash_version: number;
+  tenant_id: string;
+  priority: number;
+  is_active: number;
+  verified: number;
+  verification_token: string | null;
+  verification_expires_at: number | null;
+  created_by: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+// =============================================================================
+// Validation
+// =============================================================================
+
+function validateDomain(domain: string): { valid: boolean; error?: string } {
+  if (!domain?.trim()) return { valid: false, error: 'domain is required' };
+  const normalized = domain.toLowerCase().trim();
+  if (normalized.length > MAX_DOMAIN_LENGTH)
+    return {
+      valid: false,
+      error: `domain exceeds maximum length of ${MAX_DOMAIN_LENGTH} characters`,
+    };
+  if (!DOMAIN_REGEX.test(normalized))
+    return {
+      valid: false,
+      error:
+        'invalid domain format. Must be lowercase letters, numbers, hyphens, and dots. Labels cannot start or end with hyphens.',
+    };
+  return { valid: true };
+}
+
+const CreateSchema = z.object({
+  domain: z.string().min(1).max(MAX_DOMAIN_LENGTH),
+  tenant_id: z.string().min(1).max(63),
+  priority: z.number().int().min(0).max(1000).optional().default(0),
+  is_active: z.boolean().optional().default(true),
+  verified: z.boolean().optional().default(false),
+});
+
+const UpdateSchema = z.object({
+  priority: z.number().int().min(0).max(1000).optional(),
+  is_active: z.boolean().optional(),
+});
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function formatMapping(row: TenantDomainMappingRow) {
+  return {
+    id: row.id,
+    tenant_id: row.tenant_id,
+    hash_version: row.hash_version,
+    priority: row.priority,
+    is_active: row.is_active === 1,
+    verified: row.verified === 1,
+    verification_expires_at: row.verification_expires_at,
+    created_by: row.created_by,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    // domain_hash is intentionally omitted from responses (security)
+  };
+}
+
+// =============================================================================
+// Handlers
+// =============================================================================
+
+/**
+ * GET /api/admin/platform/tenant-domain-mappings
+ * List all tenant domain mappings
+ */
+export async function listTenantDomainMappingsHandler(c: Context<{ Bindings: Env }>) {
+  const tenantIdFilter = c.req.query('tenant_id');
+  const verified = c.req.query('verified');
+  const limit = Math.min(parseInt(c.req.query('limit') || '50', 10), 100);
+  const offset = parseInt(c.req.query('offset') || '0', 10);
+
+  try {
+    const adapter = new D1Adapter({ db: c.env.DB });
+
+    let query = `SELECT * FROM tenant_domain_mappings WHERE 1=1`;
+    const params: unknown[] = [];
+
+    if (tenantIdFilter) {
+      query += ` AND tenant_id = ?`;
+      params.push(tenantIdFilter);
+    }
+    if (verified !== undefined) {
+      query += ` AND verified = ?`;
+      params.push(verified === 'true' ? 1 : 0);
+    }
+
+    const countQuery = query.replace('SELECT *', 'SELECT COUNT(*) as count');
+    const countRow = await adapter.queryOne<{ count: number }>(countQuery, params);
+    const total = countRow?.count ?? 0;
+
+    query += ` ORDER BY priority DESC, created_at ASC LIMIT ? OFFSET ?`;
+    params.push(limit, offset);
+
+    const rows = await adapter.query<TenantDomainMappingRow>(query, params);
+
+    return c.json({
+      mappings: rows.map(formatMapping),
+      total,
+      limit,
+      offset,
+    });
+  } catch (error) {
+    const log = getLogger(c).module('ADMIN-TENANT-DOMAIN-MAPPINGS');
+    log.error('Failed to list tenant domain mappings', {}, error as Error);
+    return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
+  }
+}
+
+/**
+ * POST /api/admin/platform/tenant-domain-mappings
+ * Create a new tenant domain mapping
+ */
+export async function createTenantDomainMappingHandler(c: Context<{ Bindings: Env }>) {
+  const log = getLogger(c).module('ADMIN-TENANT-DOMAIN-MAPPINGS');
+
+  try {
+    const body = await c.req.json<unknown>();
+    const parseResult = CreateSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
+        variables: {
+          field: 'body',
+          reason: parseResult.error.issues.map((i) => i.message).join(', '),
+        },
+      });
+    }
+
+    const { domain, tenant_id, priority, is_active, verified } = parseResult.data;
+
+    const domainValidation = validateDomain(domain);
+    if (!domainValidation.valid) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
+        variables: { field: 'domain', reason: domainValidation.error! },
+      });
+    }
+
+    const adapter = new D1Adapter({ db: c.env.DB });
+
+    // Verify tenant exists
+    const tenant = await adapter.queryOne<{ id: string }>('SELECT id FROM tenants WHERE id = ?', [
+      tenant_id,
+    ]);
+    if (!tenant) {
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND, {
+        variables: { resource: 'tenant' },
+      });
+    }
+
+    // Generate domain hash
+    const hashConfig = await getEmailDomainHashConfig(c.env);
+    const hashResult = await generateEmailDomainHashWithVersion(
+      `user@${domain.toLowerCase()}`,
+      hashConfig
+    );
+
+    // Check for duplicate (active mappings)
+    const existing = await adapter.queryOne<{ id: string }>(
+      'SELECT id FROM tenant_domain_mappings WHERE domain_hash = ? AND is_active = 1',
+      [hashResult.hash]
+    );
+    if (existing) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
+        variables: { field: 'domain', reason: 'An active mapping for this domain already exists' },
+      });
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    const createdBy = (c as any).get('adminAuth')?.adminId as string | undefined;
+    const nowTs = Math.floor(Date.now() / 1000);
+    const id = crypto.randomUUID();
+
+    await adapter.execute(
+      `INSERT INTO tenant_domain_mappings
+        (id, domain_hash, hash_version, tenant_id, priority, is_active, verified,
+         created_by, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        id,
+        hashResult.hash,
+        hashResult.version,
+        tenant_id,
+        priority,
+        is_active ? 1 : 0,
+        verified ? 1 : 0,
+        createdBy ?? null,
+        nowTs,
+        nowTs,
+      ]
+    );
+
+    const created = await adapter.queryOne<TenantDomainMappingRow>(
+      'SELECT * FROM tenant_domain_mappings WHERE id = ?',
+      [id]
+    );
+
+    await createAuditLogFromContext(
+      c,
+      'tenant_domain_mapping.created',
+      'tenant_domain_mapping',
+      id,
+      {
+        tenant_id,
+        priority,
+      }
+    );
+
+    return c.json(formatMapping(created!), 201);
+  } catch (error) {
+    log.error('Failed to create tenant domain mapping', {}, error as Error);
+    return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
+  }
+}
+
+/**
+ * GET /api/admin/platform/tenant-domain-mappings/:id
+ * Get a single tenant domain mapping
+ */
+export async function getTenantDomainMappingHandler(c: Context<{ Bindings: Env }>) {
+  const id = c.req.param('id');
+
+  try {
+    const adapter = new D1Adapter({ db: c.env.DB });
+    const row = await adapter.queryOne<TenantDomainMappingRow>(
+      'SELECT * FROM tenant_domain_mappings WHERE id = ?',
+      [id]
+    );
+
+    if (!row) {
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND, {
+        variables: { resource: 'tenant_domain_mapping' },
+      });
+    }
+
+    return c.json(formatMapping(row));
+  } catch (error) {
+    const log = getLogger(c).module('ADMIN-TENANT-DOMAIN-MAPPINGS');
+    log.error('Failed to get tenant domain mapping', { id }, error as Error);
+    return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
+  }
+}
+
+/**
+ * PUT /api/admin/platform/tenant-domain-mappings/:id
+ * Update a tenant domain mapping (priority and is_active only; domain cannot change)
+ */
+export async function updateTenantDomainMappingHandler(c: Context<{ Bindings: Env }>) {
+  const id = c.req.param('id');
+
+  try {
+    const body = await c.req.json<unknown>();
+    const parseResult = UpdateSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
+        variables: {
+          field: 'body',
+          reason: parseResult.error.issues.map((i) => i.message).join(', '),
+        },
+      });
+    }
+
+    const updates = parseResult.data;
+    const adapter = new D1Adapter({ db: c.env.DB });
+
+    const existing = await adapter.queryOne<TenantDomainMappingRow>(
+      'SELECT * FROM tenant_domain_mappings WHERE id = ?',
+      [id]
+    );
+
+    if (!existing) {
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND, {
+        variables: { resource: 'tenant_domain_mapping' },
+      });
+    }
+
+    const fields: string[] = [];
+    const values: unknown[] = [];
+
+    if (updates.priority !== undefined) {
+      fields.push('priority = ?');
+      values.push(updates.priority);
+    }
+    if (updates.is_active !== undefined) {
+      fields.push('is_active = ?');
+      values.push(updates.is_active ? 1 : 0);
+    }
+
+    if (fields.length === 0) {
+      return c.json(formatMapping(existing));
+    }
+
+    const nowTs = Math.floor(Date.now() / 1000);
+    fields.push('updated_at = ?');
+    values.push(nowTs);
+    values.push(id);
+
+    await adapter.execute(
+      `UPDATE tenant_domain_mappings SET ${fields.join(', ')} WHERE id = ?`,
+      values
+    );
+
+    const updated = await adapter.queryOne<TenantDomainMappingRow>(
+      'SELECT * FROM tenant_domain_mappings WHERE id = ?',
+      [id]
+    );
+
+    await createAuditLogFromContext(
+      c,
+      'tenant_domain_mapping.updated',
+      'tenant_domain_mapping',
+      id,
+      {
+        changes: updates,
+      }
+    );
+
+    return c.json(formatMapping(updated!));
+  } catch (error) {
+    const log = getLogger(c).module('ADMIN-TENANT-DOMAIN-MAPPINGS');
+    log.error('Failed to update tenant domain mapping', { id }, error as Error);
+    return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
+  }
+}
+
+/**
+ * DELETE /api/admin/platform/tenant-domain-mappings/:id
+ * Delete a tenant domain mapping
+ */
+export async function deleteTenantDomainMappingHandler(c: Context<{ Bindings: Env }>) {
+  const id = c.req.param('id');
+
+  try {
+    const adapter = new D1Adapter({ db: c.env.DB });
+
+    const existing = await adapter.queryOne<{ id: string }>(
+      'SELECT id FROM tenant_domain_mappings WHERE id = ?',
+      [id]
+    );
+
+    if (!existing) {
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND, {
+        variables: { resource: 'tenant_domain_mapping' },
+      });
+    }
+
+    await adapter.execute('DELETE FROM tenant_domain_mappings WHERE id = ?', [id]);
+
+    await createAuditLogFromContext(
+      c,
+      'tenant_domain_mapping.deleted',
+      'tenant_domain_mapping',
+      id,
+      {}
+    );
+
+    return c.json({ success: true });
+  } catch (error) {
+    const log = getLogger(c).module('ADMIN-TENANT-DOMAIN-MAPPINGS');
+    log.error('Failed to delete tenant domain mapping', { id }, error as Error);
+    return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
+  }
+}
+
+/**
+ * POST /api/admin/platform/tenant-domain-mappings/verify
+ * Initiate DNS TXT verification for a mapping
+ */
+export async function initiateTenantDomainVerificationHandler(c: Context<{ Bindings: Env }>) {
+  const log = getLogger(c).module('ADMIN-TENANT-DOMAIN-MAPPINGS');
+
+  try {
+    const body = await c.req.json<{ id: string; domain: string }>();
+
+    if (!body.id || !body.domain) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_REQUIRED_FIELD, {
+        variables: { field: 'id, domain' },
+      });
+    }
+
+    const adapter = new D1Adapter({ db: c.env.DB });
+    const existing = await adapter.queryOne<TenantDomainMappingRow>(
+      'SELECT * FROM tenant_domain_mappings WHERE id = ?',
+      [body.id]
+    );
+
+    if (!existing) {
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND, {
+        variables: { resource: 'tenant_domain_mapping' },
+      });
+    }
+
+    const token = await generateVerificationToken();
+    const expiresAt = calculateVerificationExpiry();
+    const nowTs = Math.floor(Date.now() / 1000);
+
+    await adapter.execute(
+      'UPDATE tenant_domain_mappings SET verification_token = ?, verification_expires_at = ?, verified = 0, updated_at = ? WHERE id = ?',
+      [token, expiresAt, nowTs, body.id]
+    );
+
+    const domain = body.domain.toLowerCase().trim();
+
+    return c.json({
+      id: body.id,
+      dns_record_name: getVerificationRecordName(domain),
+      dns_record_value: getExpectedRecordValue(token),
+      dns_record_type: 'TXT',
+      expires_at: expiresAt,
+    });
+  } catch (error) {
+    log.error('Failed to initiate tenant domain verification', {}, error as Error);
+    return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
+  }
+}
+
+/**
+ * POST /api/admin/platform/tenant-domain-mappings/verify/confirm
+ * Confirm DNS TXT verification for a mapping
+ */
+export async function confirmTenantDomainVerificationHandler(c: Context<{ Bindings: Env }>) {
+  const log = getLogger(c).module('ADMIN-TENANT-DOMAIN-MAPPINGS');
+
+  try {
+    const body = await c.req.json<{ id: string; domain: string }>();
+
+    if (!body.id || !body.domain) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_REQUIRED_FIELD, {
+        variables: { field: 'id, domain' },
+      });
+    }
+
+    const adapter = new D1Adapter({ db: c.env.DB });
+    const existing = await adapter.queryOne<TenantDomainMappingRow>(
+      'SELECT * FROM tenant_domain_mappings WHERE id = ?',
+      [body.id]
+    );
+
+    if (!existing) {
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND, {
+        variables: { resource: 'tenant_domain_mapping' },
+      });
+    }
+
+    if (!existing.verification_token) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
+        variables: { field: 'id', reason: 'Verification not initiated. Call /verify first.' },
+      });
+    }
+
+    if (isVerificationExpired(existing.verification_expires_at ?? 0)) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
+        variables: {
+          field: 'id',
+          reason: 'Verification token has expired. Re-initiate verification.',
+        },
+      });
+    }
+
+    const domain = body.domain.toLowerCase().trim();
+    const verified = await verifyDomainDnsTxt(domain, existing.verification_token);
+
+    if (!verified) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
+        variables: {
+          field: 'domain',
+          reason: `DNS TXT record not found or does not match. Add TXT record: ${getVerificationRecordName(domain)} = ${getExpectedRecordValue(existing.verification_token)}`,
+        },
+      });
+    }
+
+    const nowTs = Math.floor(Date.now() / 1000);
+    await adapter.execute(
+      'UPDATE tenant_domain_mappings SET verified = 1, verification_token = NULL, verification_expires_at = NULL, updated_at = ? WHERE id = ?',
+      [nowTs, body.id]
+    );
+
+    const updated = await adapter.queryOne<TenantDomainMappingRow>(
+      'SELECT * FROM tenant_domain_mappings WHERE id = ?',
+      [body.id]
+    );
+
+    await createAuditLogFromContext(
+      c,
+      'tenant_domain_mapping.verified',
+      'tenant_domain_mapping',
+      body.id,
+      { domain }
+    );
+
+    return c.json(formatMapping(updated!));
+  } catch (error) {
+    log.error('Failed to confirm tenant domain verification', {}, error as Error);
+    return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
+  }
+}

--- a/packages/ar-management/src/admin-tenant-invitations.ts
+++ b/packages/ar-management/src/admin-tenant-invitations.ts
@@ -1,0 +1,344 @@
+/**
+ * Admin Tenant Invitations API Endpoints
+ *
+ * Token-based invitation flow for tenant-specific signup routing.
+ *
+ * - POST   /api/admin/tenants/:id/invitations          - Create invitation
+ * - GET    /api/admin/tenants/:id/invitations          - List invitations
+ * - DELETE /api/admin/tenants/:id/invitations/:inv_id  - Cancel invitation
+ *
+ * @packageDocumentation
+ */
+
+import type { Context } from 'hono';
+import type { Env } from '@authrim/ar-lib-core';
+import {
+  D1Adapter,
+  createErrorResponse,
+  AR_ERROR_CODES,
+  createAuditLogFromContext,
+  getLogger,
+  getPluginContext,
+} from '@authrim/ar-lib-core';
+import { z } from 'zod';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Default invitation expiry: 72 hours */
+const DEFAULT_EXPIRES_IN_HOURS = 72;
+const MAX_EXPIRES_IN_HOURS = 720; // 30 days
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface TenantInvitationRow {
+  id: string;
+  token: string;
+  tenant_id: string;
+  invited_email: string | null;
+  invited_by: string;
+  role_id: string | null;
+  org_id: string | null;
+  max_uses: number;
+  use_count: number;
+  expires_at: number;
+  created_at: number;
+  updated_at: number;
+}
+
+// =============================================================================
+// Validation
+// =============================================================================
+
+const CreateInvitationSchema = z.object({
+  invited_email: z.string().email().optional().nullable(),
+  role_id: z.string().min(1).max(63).optional().nullable(),
+  org_id: z.string().min(1).max(63).optional().nullable(),
+  max_uses: z.number().int().min(-1).max(1000).optional().default(1),
+  expires_in_hours: z
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_EXPIRES_IN_HOURS)
+    .optional()
+    .default(DEFAULT_EXPIRES_IN_HOURS),
+});
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Generate a 256-bit entropy token (two UUIDs concatenated, hyphens removed) */
+function generateInvitationToken(): string {
+  return crypto.randomUUID().replace(/-/g, '') + crypto.randomUUID().replace(/-/g, '');
+}
+
+function formatInvitation(row: TenantInvitationRow) {
+  return {
+    id: row.id,
+    tenant_id: row.tenant_id,
+    invited_email: row.invited_email,
+    invited_by: row.invited_by,
+    role_id: row.role_id,
+    org_id: row.org_id,
+    max_uses: row.max_uses,
+    use_count: row.use_count,
+    expires_at: row.expires_at,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    // token is intentionally omitted from list responses
+  };
+}
+
+function getAdminUserId(c: Context<{ Bindings: Env }>): string {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (c as any).get('adminAuth')?.adminId ?? 'unknown';
+}
+
+// =============================================================================
+// Handlers
+// =============================================================================
+
+/**
+ * POST /api/admin/tenants/:id/invitations
+ * Create a new invitation for the tenant
+ */
+export async function createTenantInvitationHandler(c: Context<{ Bindings: Env }>) {
+  const log = getLogger(c).module('ADMIN-TENANT-INVITATIONS');
+  const tenantId = c.req.param('id');
+
+  try {
+    const body = await c.req.json();
+    const parsed = CreateInvitationSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_request', details: parsed.error.flatten() }, 400);
+    }
+
+    const { invited_email, role_id, org_id, max_uses, expires_in_hours } = parsed.data;
+
+    // Verify tenant exists
+    const adapter = new D1Adapter({ db: c.env.DB });
+    const tenant = await adapter.queryOne<{ id: string; name: string }>(
+      'SELECT id, name FROM tenants WHERE id = ?',
+      [tenantId]
+    );
+    if (!tenant) {
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    const expiresAt = now + expires_in_hours * 3600;
+    const invitationId = crypto.randomUUID();
+    const token = generateInvitationToken();
+    const adminId = getAdminUserId(c);
+
+    await adapter.execute(
+      `INSERT INTO tenant_invitations
+        (id, token, tenant_id, invited_email, invited_by, role_id, org_id, max_uses, use_count, expires_at, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?)`,
+      [
+        invitationId,
+        token,
+        tenantId,
+        invited_email ?? null,
+        adminId,
+        role_id ?? null,
+        org_id ?? null,
+        max_uses,
+        expiresAt,
+        now,
+        now,
+      ]
+    );
+
+    const inviteUrl = `${c.env.ISSUER_URL}/invite?token=${token}`;
+
+    // Conditionally send email if invited_email is specified and email plugin is available
+    let emailSent = false;
+    if (invited_email) {
+      const pluginCtx = getPluginContext(c);
+      const emailNotifier = pluginCtx.registry.getNotifier('email');
+
+      if (emailNotifier) {
+        const fromEmail = c.env.EMAIL_FROM || 'noreply@authrim.dev';
+        const emailResult = await emailNotifier.send({
+          channel: 'email',
+          to: invited_email,
+          from: fromEmail,
+          subject: `You've been invited to ${tenant.name}`,
+          body: getInvitationEmailHtml({
+            tenantName: tenant.name,
+            inviteUrl,
+            expiresInHours: expires_in_hours,
+          }),
+          metadata: {
+            textBody: getInvitationEmailText({
+              tenantName: tenant.name,
+              inviteUrl,
+              expiresInHours: expires_in_hours,
+            }),
+          },
+        });
+
+        if (emailResult.success) {
+          emailSent = true;
+        } else {
+          log.warn('Failed to send invitation email', { error: emailResult.error });
+        }
+      } else {
+        log.warn('Email notifier not configured, invitation URL returned without sending email', {
+          tenant_id: tenantId,
+          invited_email,
+        });
+      }
+    }
+
+    await createAuditLogFromContext(
+      c,
+      'tenant_invitation.create',
+      'tenant_invitation',
+      invitationId,
+      { tenant_id: tenantId, invited_email, role_id, org_id, email_sent: emailSent }
+    );
+
+    return c.json(
+      {
+        id: invitationId,
+        invite_url: inviteUrl,
+        token,
+        expires_at: expiresAt,
+        email_sent: emailSent,
+      },
+      201
+    );
+  } catch (error) {
+    log.error('Failed to create tenant invitation', { tenant_id: tenantId, error: String(error) });
+    return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
+  }
+}
+
+/**
+ * GET /api/admin/tenants/:id/invitations
+ * List invitations for the tenant
+ */
+export async function listTenantInvitationsHandler(c: Context<{ Bindings: Env }>) {
+  const log = getLogger(c).module('ADMIN-TENANT-INVITATIONS');
+  const tenantId = c.req.param('id');
+
+  const limit = Math.min(parseInt(c.req.query('limit') || '50', 10), 100);
+  const offset = parseInt(c.req.query('offset') || '0', 10);
+  const includeExpired = c.req.query('include_expired') === 'true';
+
+  try {
+    const adapter = new D1Adapter({ db: c.env.DB });
+
+    // Verify tenant exists
+    const tenant = await adapter.queryOne<{ id: string }>('SELECT id FROM tenants WHERE id = ?', [
+      tenantId,
+    ]);
+    if (!tenant) {
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    const expiryFilter = includeExpired ? '' : ` AND expires_at > ${now}`;
+
+    const total = await adapter.queryOne<{ count: number }>(
+      `SELECT COUNT(*) as count FROM tenant_invitations WHERE tenant_id = ?${expiryFilter}`,
+      [tenantId]
+    );
+
+    const rows = await adapter.query<TenantInvitationRow>(
+      `SELECT * FROM tenant_invitations WHERE tenant_id = ?${expiryFilter}
+       ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+      [tenantId, limit, offset]
+    );
+
+    return c.json({
+      items: rows.map(formatInvitation),
+      total: total?.count ?? 0,
+      limit,
+      offset,
+    });
+  } catch (error) {
+    log.error('Failed to list tenant invitations', { tenant_id: tenantId, error: String(error) });
+    return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
+  }
+}
+
+/**
+ * DELETE /api/admin/tenants/:id/invitations/:inv_id
+ * Cancel (delete) an invitation
+ */
+export async function cancelTenantInvitationHandler(c: Context<{ Bindings: Env }>) {
+  const log = getLogger(c).module('ADMIN-TENANT-INVITATIONS');
+  const tenantId = c.req.param('id');
+  const invId = c.req.param('inv_id');
+
+  try {
+    const adapter = new D1Adapter({ db: c.env.DB });
+
+    const invitation = await adapter.queryOne<{ id: string }>(
+      'SELECT id FROM tenant_invitations WHERE id = ? AND tenant_id = ?',
+      [invId, tenantId]
+    );
+    if (!invitation) {
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
+    }
+
+    await adapter.execute('DELETE FROM tenant_invitations WHERE id = ?', [invId]);
+
+    await createAuditLogFromContext(c, 'tenant_invitation.cancel', 'tenant_invitation', invId, {
+      tenant_id: tenantId,
+    });
+
+    return c.json({ success: true });
+  } catch (error) {
+    log.error('Failed to cancel tenant invitation', {
+      tenant_id: tenantId,
+      inv_id: invId,
+      error: String(error),
+    });
+    return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
+  }
+}
+
+// =============================================================================
+// Email Templates
+// =============================================================================
+
+interface InvitationEmailParams {
+  tenantName: string;
+  inviteUrl: string;
+  expiresInHours: number;
+}
+
+function getInvitationEmailHtml(params: InvitationEmailParams): string {
+  const { tenantName, inviteUrl, expiresInHours } = params;
+  return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="referrer" content="no-referrer"></head>
+<body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <h2>You've been invited to ${tenantName}</h2>
+  <p>Click the link below to accept your invitation and create your account:</p>
+  <p><a href="${inviteUrl}" style="display:inline-block;padding:12px 24px;background:#4f46e5;color:#fff;text-decoration:none;border-radius:6px;">Accept Invitation</a></p>
+  <p style="color:#666;font-size:14px;">This invitation link expires in ${expiresInHours} hours.</p>
+  <p style="color:#999;font-size:12px;">If you did not expect this invitation, you can safely ignore this email.</p>
+</body>
+</html>`;
+}
+
+function getInvitationEmailText(params: InvitationEmailParams): string {
+  const { tenantName, inviteUrl, expiresInHours } = params;
+  return `You've been invited to ${tenantName}
+
+Accept your invitation and create your account:
+${inviteUrl}
+
+This invitation link expires in ${expiresInHours} hours.
+
+If you did not expect this invitation, you can safely ignore this email.`;
+}

--- a/packages/ar-management/src/admin-tenants.ts
+++ b/packages/ar-management/src/admin-tenants.ts
@@ -1,0 +1,541 @@
+/**
+ * Admin Tenants API Endpoints
+ *
+ * CRUD management for tenants:
+ * - GET    /api/admin/tenants          - List all tenants
+ * - POST   /api/admin/tenants          - Create tenant
+ * - GET    /api/admin/tenants/:id      - Get tenant
+ * - PATCH  /api/admin/tenants/:id      - Update tenant (name, description, is_active)
+ * - DELETE /api/admin/tenants/:id      - Delete tenant (default tenant not allowed)
+ * - POST   /api/admin/tenants/:id/set-default - Set as default tenant
+ *
+ * @packageDocumentation
+ */
+
+import type { Context } from 'hono';
+import type { Env } from '@authrim/ar-lib-core';
+import {
+  D1Adapter,
+  type DatabaseAdapter,
+  createErrorResponse,
+  AR_ERROR_CODES,
+  createAuditLogFromContext,
+  getLogger,
+} from '@authrim/ar-lib-core';
+import { z } from 'zod';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/**
+ * Tables to delete when removing a tenant.
+ * Order matters: child tables first, then parent tables.
+ * Exported for reuse in the async delete Cron job.
+ */
+export const TENANT_TABLES_TO_DELETE = [
+  // Tables with explicit FK CASCADE in schema (still delete manually for safety)
+  'idempotency_keys',
+  'operational_logs',
+  'security_alerts',
+  // Access management
+  'access_review_items',
+  'access_reviews',
+  // Jobs
+  'admin_jobs',
+  // AI
+  'ai_grants',
+  // Attributes
+  'attribute_verifications',
+  'verified_attributes',
+  'user_verified_attributes',
+  // Audit
+  'audit_log',
+  // Branding
+  'branding_settings',
+  // API keys
+  'check_api_keys',
+  // Auth flows
+  'ciba_requests',
+  'device_codes',
+  'external_idp_auth_states',
+  'flows',
+  'password_reset_tokens',
+  // Consents
+  'client_consent_overrides',
+  'consent_history',
+  'consent_item_history',
+  'consent_policy_versions',
+  'consent_statement_localizations',
+  'consent_statement_versions',
+  'consent_statements',
+  'oauth_client_consents',
+  'tenant_consent_requirements',
+  'user_consent_records',
+  // Compliance
+  'compliance_reports',
+  'data_export_requests',
+  // Credentials (VC)
+  'credential_configurations',
+  'issued_credentials',
+  'presentation_definitions',
+  'status_lists',
+  'trusted_issuers',
+  'vp_requests',
+  // Identity
+  'identity_providers',
+  'linked_identities',
+  'passkeys',
+  'subject_identifiers',
+  'upstream_providers',
+  // Clients
+  'oauth_clients',
+  // Organizations
+  'org_domain_mappings',
+  'subject_org_membership',
+  'organizations',
+  // Policies
+  'permission_change_audit',
+  'permission_check_audit',
+  'policy_rules',
+  'policy_simulations',
+  'relation_definitions',
+  'relationship_closure',
+  'relationships',
+  'resource_permissions',
+  'role_assignment_rules',
+  // Roles
+  'role_assignments',
+  'user_roles',
+  'roles',
+  // Security
+  'security_threats',
+  'suspicious_activities',
+  // Sessions
+  'sessions',
+  // Settings
+  'settings_history',
+  // Custom claims
+  'custom_claim_schema_history',
+  'custom_claim_schemas',
+  // Token claim rules
+  'token_claim_rules',
+  // Refresh token sharding
+  'refresh_token_shard_configs',
+  // Users (tenant-specific user data, not users_core which is shared)
+  'user_custom_fields',
+  'user_token_families',
+  'users',
+  // Webhooks
+  'webhook_delivery_logs',
+  'webhook_configs',
+] as const;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface TenantRow {
+  id: string;
+  name: string;
+  description: string | null;
+  is_active: number;
+  is_default: number;
+  created_at: number;
+  updated_at: number;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function createAdapter(c: Context<{ Bindings: Env }>): DatabaseAdapter {
+  return new D1Adapter({ db: c.env.DB });
+}
+
+function formatTenant(row: TenantRow) {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    is_active: row.is_active === 1,
+    is_default: row.is_default === 1,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+// =============================================================================
+// Validation Schemas
+// =============================================================================
+
+// DNS label format: starts and ends with alphanumeric, hyphens allowed in the middle
+const TENANT_ID_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+
+const CreateTenantSchema = z.object({
+  id: z
+    .string()
+    .min(1)
+    .max(63)
+    .regex(
+      TENANT_ID_REGEX,
+      'id must start and end with a lowercase letter or digit (hyphens allowed in between)'
+    ),
+  name: z.string().min(1).max(200),
+  description: z.string().max(500).optional(),
+});
+
+const UpdateTenantSchema = z.object({
+  name: z.string().min(1).max(200).optional(),
+  description: z.string().max(500).nullable().optional(),
+  is_active: z.boolean().optional(),
+});
+
+// =============================================================================
+// Handlers
+// =============================================================================
+
+/**
+ * GET /api/admin/tenants
+ * List all tenants
+ */
+export async function adminTenantsListHandler(c: Context<{ Bindings: Env }>) {
+  try {
+    const adapter = createAdapter(c);
+    const rows = await adapter.query<TenantRow>(
+      'SELECT id, name, description, is_active, is_default, created_at, updated_at FROM tenants ORDER BY is_default DESC, name ASC',
+      []
+    );
+
+    return c.json({
+      tenants: rows.map(formatTenant),
+      total: rows.length,
+    });
+  } catch (error) {
+    const log = getLogger(c).module('ADMIN-TENANTS');
+    log.error('Failed to list tenants', {}, error as Error);
+    return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
+  }
+}
+
+/**
+ * POST /api/admin/tenants
+ * Create a new tenant
+ */
+export async function adminTenantCreateHandler(c: Context<{ Bindings: Env }>) {
+  try {
+    const body = await c.req.json<unknown>();
+    const parseResult = CreateTenantSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
+        variables: {
+          field: 'body',
+          reason: parseResult.error.issues.map((i) => i.message).join(', '),
+        },
+      });
+    }
+
+    const { id, name, description } = parseResult.data;
+    const adapter = createAdapter(c);
+
+    // Check id availability
+    const existing = await adapter.queryOne<{ id: string }>('SELECT id FROM tenants WHERE id = ?', [
+      id,
+    ]);
+
+    if (existing) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
+        variables: { field: 'id', reason: 'Tenant ID already exists' },
+      });
+    }
+
+    const nowTs = Math.floor(Date.now() / 1000);
+
+    await adapter.execute(
+      `INSERT INTO tenants (id, name, description, is_active, is_default, created_at, updated_at)
+       VALUES (?, ?, ?, 1, 0, ?, ?)`,
+      [id, name, description ?? null, nowTs, nowTs]
+    );
+
+    const created = await adapter.queryOne<TenantRow>(
+      'SELECT id, name, description, is_active, is_default, created_at, updated_at FROM tenants WHERE id = ?',
+      [id]
+    );
+
+    await createAuditLogFromContext(c, 'tenant.created', 'tenant', id, {
+      name,
+      description: description ?? null,
+    });
+
+    return c.json(formatTenant(created!), 201);
+  } catch (error) {
+    const log = getLogger(c).module('ADMIN-TENANTS');
+    log.error('Failed to create tenant', {}, error as Error);
+    return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
+  }
+}
+
+/**
+ * GET /api/admin/tenants/:id
+ * Get a single tenant
+ */
+export async function adminTenantGetHandler(c: Context<{ Bindings: Env }>) {
+  const id = c.req.param('id');
+
+  try {
+    const adapter = createAdapter(c);
+    const tenant = await adapter.queryOne<TenantRow>(
+      'SELECT id, name, description, is_active, is_default, created_at, updated_at FROM tenants WHERE id = ?',
+      [id]
+    );
+
+    if (!tenant) {
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND, {
+        variables: { resource: 'tenant' },
+      });
+    }
+
+    return c.json(formatTenant(tenant));
+  } catch (error) {
+    const log = getLogger(c).module('ADMIN-TENANTS');
+    log.error('Failed to get tenant', { id }, error as Error);
+    return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
+  }
+}
+
+/**
+ * PATCH /api/admin/tenants/:id
+ * Update tenant (name, description, is_active)
+ * Note: id and is_default cannot be changed via this endpoint
+ */
+export async function adminTenantUpdateHandler(c: Context<{ Bindings: Env }>) {
+  const id = c.req.param('id');
+
+  try {
+    const body = await c.req.json<unknown>();
+    const parseResult = UpdateTenantSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
+        variables: {
+          field: 'body',
+          reason: parseResult.error.issues.map((i) => i.message).join(', '),
+        },
+      });
+    }
+
+    const updates = parseResult.data;
+    const adapter = createAdapter(c);
+
+    // Check tenant exists
+    const existing = await adapter.queryOne<TenantRow>(
+      'SELECT id, name, description, is_active, is_default, created_at, updated_at FROM tenants WHERE id = ?',
+      [id]
+    );
+
+    if (!existing) {
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND, {
+        variables: { resource: 'tenant' },
+      });
+    }
+
+    // The default tenant cannot be deactivated: doing so would lock out the ability
+    // to reassign the default (set-default rejects inactive tenants)
+    if (existing.is_default === 1 && updates.is_active === false) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
+        variables: { field: 'is_active', reason: 'Cannot deactivate the default tenant' },
+      });
+    }
+
+    // Build update fields
+    const fields: string[] = [];
+    const values: unknown[] = [];
+
+    if (updates.name !== undefined) {
+      fields.push('name = ?');
+      values.push(updates.name);
+    }
+    if ('description' in updates) {
+      fields.push('description = ?');
+      values.push(updates.description ?? null);
+    }
+    if (updates.is_active !== undefined) {
+      fields.push('is_active = ?');
+      values.push(updates.is_active ? 1 : 0);
+    }
+
+    if (fields.length === 0) {
+      return c.json(formatTenant(existing));
+    }
+
+    const nowTs = Math.floor(Date.now() / 1000);
+    fields.push('updated_at = ?');
+    values.push(nowTs);
+    values.push(id);
+
+    await adapter.execute(`UPDATE tenants SET ${fields.join(', ')} WHERE id = ?`, values);
+
+    const updated = await adapter.queryOne<TenantRow>(
+      'SELECT id, name, description, is_active, is_default, created_at, updated_at FROM tenants WHERE id = ?',
+      [id]
+    );
+
+    await createAuditLogFromContext(c, 'tenant.updated', 'tenant', id, {
+      changes: updates,
+    });
+
+    return c.json(formatTenant(updated!));
+  } catch (error) {
+    const log = getLogger(c).module('ADMIN-TENANTS');
+    log.error('Failed to update tenant', { id }, error as Error);
+    return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
+  }
+}
+
+/**
+ * DELETE /api/admin/tenants/:id
+ * Schedule a tenant deletion as an async job.
+ * The tenant is immediately deactivated; all data is deleted by the Cron job.
+ * Returns 202 Accepted with the job ID.
+ * The 'default' tenant cannot be deleted.
+ */
+export async function adminTenantDeleteHandler(c: Context<{ Bindings: Env }>) {
+  const id = c.req.param('id');
+
+  if (id === 'default') {
+    return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
+      variables: { field: 'id', reason: 'Cannot delete the default tenant' },
+    });
+  }
+
+  try {
+    const adapter = createAdapter(c);
+
+    const existing = await adapter.queryOne<{ id: string; is_default: number }>(
+      'SELECT id, is_default FROM tenants WHERE id = ?',
+      [id]
+    );
+
+    if (!existing) {
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND, {
+        variables: { resource: 'tenant' },
+      });
+    }
+
+    if (existing.is_default === 1) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
+        variables: { field: 'id', reason: 'Cannot delete the default tenant' },
+      });
+    }
+
+    const nowTs = Math.floor(Date.now() / 1000);
+
+    // Immediately deactivate the tenant to block new requests
+    await adapter.execute('UPDATE tenants SET is_active = 0, updated_at = ? WHERE id = ?', [
+      nowTs,
+      id,
+    ]);
+
+    // Get admin identity for job attribution
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    const adminAuth = (c as any).get('adminAuth') as { adminId?: string } | null;
+    const createdBy = adminAuth?.adminId ?? 'unknown';
+
+    const jobId = crypto.randomUUID();
+    // Estimate completion: max 1 hour (next hourly cron tick)
+    const estimatedCompletion = nowTs + 3600;
+
+    await adapter.execute(
+      `INSERT INTO admin_jobs (
+        id, tenant_id, job_type, status, progress, config,
+        created_by, created_at, updated_at, estimated_completion
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        jobId,
+        'default',
+        'tenants/delete',
+        'pending',
+        JSON.stringify({ stage: 'queued' }),
+        JSON.stringify({ tenant_id: id }),
+        createdBy,
+        nowTs,
+        nowTs,
+        estimatedCompletion,
+      ]
+    );
+
+    await createAuditLogFromContext(c, 'tenant.delete_queued', 'tenant', id, {
+      tenant_id: id,
+      job_id: jobId,
+    });
+
+    return c.json(
+      {
+        job_id: jobId,
+        status: 'pending',
+        estimated_completion: estimatedCompletion,
+      },
+      202
+    );
+  } catch (error) {
+    const log = getLogger(c).module('ADMIN-TENANTS');
+    log.error('Failed to queue tenant deletion', { id }, error as Error);
+    return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
+  }
+}
+
+/**
+ * POST /api/admin/tenants/:id/set-default
+ * Set a tenant as the default tenant (atomically, using D1 batch)
+ */
+export async function adminTenantSetDefaultHandler(c: Context<{ Bindings: Env }>) {
+  const id = c.req.param('id');
+
+  try {
+    const adapter = createAdapter(c);
+
+    const existing = await adapter.queryOne<{ id: string; is_active: number }>(
+      'SELECT id, is_active FROM tenants WHERE id = ?',
+      [id]
+    );
+
+    if (!existing) {
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND, {
+        variables: { resource: 'tenant' },
+      });
+    }
+
+    if (existing.is_active === 0) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
+        variables: { field: 'id', reason: 'Cannot set an inactive tenant as default' },
+      });
+    }
+
+    const nowTs = Math.floor(Date.now() / 1000);
+
+    // Atomic swap using D1 batch
+    await c.env.DB.batch([
+      c.env.DB.prepare(
+        'UPDATE tenants SET is_default = 0, updated_at = ? WHERE is_default = 1'
+      ).bind(nowTs),
+      c.env.DB.prepare('UPDATE tenants SET is_default = 1, updated_at = ? WHERE id = ?').bind(
+        nowTs,
+        id
+      ),
+    ]);
+
+    const updated = await adapter.queryOne<TenantRow>(
+      'SELECT id, name, description, is_active, is_default, created_at, updated_at FROM tenants WHERE id = ?',
+      [id]
+    );
+
+    await createAuditLogFromContext(c, 'tenant.set_default', 'tenant', id, { tenant_id: id });
+
+    return c.json(formatTenant(updated!));
+  } catch (error) {
+    const log = getLogger(c).module('ADMIN-TENANTS');
+    log.error('Failed to set default tenant', { id }, error as Error);
+    return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
+  }
+}

--- a/packages/ar-management/src/external-providers.ts
+++ b/packages/ar-management/src/external-providers.ts
@@ -100,6 +100,10 @@ async function proxyToExternalIdp(
  * GET /api/admin/external-providers - List all external IdP providers
  */
 export async function adminExternalProvidersListHandler(c: Context<{ Bindings: Env }>) {
+  // When bridge is not configured, return an empty list instead of 500
+  if (!c.env.EXTERNAL_IDP) {
+    return c.json({ providers: [] });
+  }
   return proxyToExternalIdp(c, EXTERNAL_IDP_ADMIN_PATH, 'GET');
 }
 
@@ -107,6 +111,15 @@ export async function adminExternalProvidersListHandler(c: Context<{ Bindings: E
  * POST /api/admin/external-providers - Create a new external IdP provider
  */
 export async function adminExternalProvidersCreateHandler(c: Context<{ Bindings: Env }>) {
+  if (!c.env.EXTERNAL_IDP) {
+    return c.json(
+      {
+        error: 'service_unavailable',
+        message: 'External IdP Bridge is not configured. Enable the bridge component in your deployment.',
+      },
+      503
+    );
+  }
   const body = await c.req.text();
   return proxyToExternalIdp(c, EXTERNAL_IDP_ADMIN_PATH, 'POST', body);
 }

--- a/packages/ar-management/src/external-providers.ts
+++ b/packages/ar-management/src/external-providers.ts
@@ -115,7 +115,8 @@ export async function adminExternalProvidersCreateHandler(c: Context<{ Bindings:
     return c.json(
       {
         error: 'service_unavailable',
-        message: 'External IdP Bridge is not configured. Enable the bridge component in your deployment.',
+        message:
+          'External IdP Bridge is not configured. Enable the bridge component in your deployment.',
       },
       503
     );

--- a/packages/ar-management/src/index.ts
+++ b/packages/ar-management/src/index.ts
@@ -263,6 +263,29 @@ import {
   adminSettingsValidateHandler,
   adminTenantCloneHandler,
 } from './admin-settings-meta';
+import {
+  adminTenantsListHandler,
+  adminTenantCreateHandler,
+  adminTenantGetHandler,
+  adminTenantUpdateHandler,
+  adminTenantDeleteHandler,
+  adminTenantSetDefaultHandler,
+  TENANT_TABLES_TO_DELETE,
+} from './admin-tenants';
+import {
+  listTenantDomainMappingsHandler,
+  createTenantDomainMappingHandler,
+  getTenantDomainMappingHandler,
+  updateTenantDomainMappingHandler,
+  deleteTenantDomainMappingHandler,
+  initiateTenantDomainVerificationHandler,
+  confirmTenantDomainVerificationHandler,
+} from './admin-tenant-domain-mappings';
+import {
+  createTenantInvitationHandler,
+  listTenantInvitationsHandler,
+  cancelTenantInvitationHandler,
+} from './admin-tenant-invitations';
 import { userConsentsListHandler, userConsentRevokeHandler } from './user-consents';
 import { getLoginMethodsHandler } from './login-methods';
 import {
@@ -958,30 +981,75 @@ app.get('/api/admin/settings/diff', adminSettingsDiffHandler);
 app.get('/api/admin/settings/schema', adminSettingsSchemaHandler);
 app.post('/api/admin/settings/validate', adminSettingsValidateHandler);
 
-// Tenant List API
-// - GET /api/admin/tenants - List available tenants
-// Currently Authrim is single-tenant, so this returns only the default tenant
-app.get('/api/admin/tenants', async (c) => {
-  // For now, return only the default tenant
-  // Multi-tenant support will be added in future versions
-  return c.json({
-    tenants: [
-      {
-        id: 'default',
-        name: 'Default Tenant',
-        createdAt: new Date().toISOString(),
-        status: 'active',
-      },
-    ],
-    _links: {
-      self: '/api/admin/tenants',
-    },
-  });
-});
-
-// Tenant Clone (Phase 3)
-// - POST /api/admin/tenants/:id/clone - Clone tenant settings to new tenant
+// Tenant Management API
+// - GET    /api/admin/tenants          - List all tenants
+// - POST   /api/admin/tenants          - Create tenant
+// - GET    /api/admin/tenants/:id      - Get tenant
+// - PATCH  /api/admin/tenants/:id      - Update tenant
+// - DELETE /api/admin/tenants/:id      - Delete tenant (default not allowed)
+// - POST   /api/admin/tenants/:id/set-default - Set as default tenant
+// - POST   /api/admin/tenants/:id/clone       - Clone tenant settings
+// Note: /set-default and /clone must be registered BEFORE :id routes to avoid conflicts
+app.get('/api/admin/tenants', adminTenantsListHandler);
+app.post('/api/admin/tenants', adminTenantCreateHandler);
+app.post('/api/admin/tenants/:id/set-default', adminTenantSetDefaultHandler);
 app.post('/api/admin/tenants/:id/clone', adminTenantCloneHandler);
+app.get('/api/admin/tenants/:id', adminTenantGetHandler);
+app.patch('/api/admin/tenants/:id', adminTenantUpdateHandler);
+app.delete('/api/admin/tenants/:id', adminTenantDeleteHandler);
+
+// Tenant Invitations API
+// - POST   /api/admin/tenants/:id/invitations          - Create invitation
+// - GET    /api/admin/tenants/:id/invitations          - List invitations
+// - DELETE /api/admin/tenants/:id/invitations/:inv_id  - Cancel invitation
+app.post('/api/admin/tenants/:id/invitations', createTenantInvitationHandler);
+app.get('/api/admin/tenants/:id/invitations', listTenantInvitationsHandler);
+app.delete('/api/admin/tenants/:id/invitations/:inv_id', cancelTenantInvitationHandler);
+
+// Platform Tenant Domain Mappings API (system_admin only)
+// - GET    /api/admin/platform/tenant-domain-mappings        - List mappings
+// - POST   /api/admin/platform/tenant-domain-mappings        - Create mapping
+// - POST   /api/admin/platform/tenant-domain-mappings/verify          - Initiate DNS verification
+// - POST   /api/admin/platform/tenant-domain-mappings/verify/confirm  - Confirm DNS verification
+// - GET    /api/admin/platform/tenant-domain-mappings/:id    - Get mapping
+// - PUT    /api/admin/platform/tenant-domain-mappings/:id    - Update mapping
+// - DELETE /api/admin/platform/tenant-domain-mappings/:id    - Delete mapping
+// Note: /verify and /verify/confirm must be before /:id to avoid route conflicts
+app.get(
+  '/api/admin/platform/tenant-domain-mappings',
+  requireSystemAdmin,
+  listTenantDomainMappingsHandler
+);
+app.post(
+  '/api/admin/platform/tenant-domain-mappings',
+  requireSystemAdmin,
+  createTenantDomainMappingHandler
+);
+app.post(
+  '/api/admin/platform/tenant-domain-mappings/verify',
+  requireSystemAdmin,
+  initiateTenantDomainVerificationHandler
+);
+app.post(
+  '/api/admin/platform/tenant-domain-mappings/verify/confirm',
+  requireSystemAdmin,
+  confirmTenantDomainVerificationHandler
+);
+app.get(
+  '/api/admin/platform/tenant-domain-mappings/:id',
+  requireSystemAdmin,
+  getTenantDomainMappingHandler
+);
+app.put(
+  '/api/admin/platform/tenant-domain-mappings/:id',
+  requireSystemAdmin,
+  updateTenantDomainMappingHandler
+);
+app.delete(
+  '/api/admin/platform/tenant-domain-mappings/:id',
+  requireSystemAdmin,
+  deleteTenantDomainMappingHandler
+);
 
 // =============================================================================
 // Settings API v2 (Unified Settings Management) - RECOMMENDED
@@ -2331,12 +2399,12 @@ app.onError((err, c) => {
 });
 
 /**
- * Scheduled handler for D1 database cleanup
- * Runs daily at 2:00 AM UTC to clean up expired data
+ * Scheduled handler for D1 database cleanup and async job processing.
+ * Runs hourly to clean up expired data and process pending jobs.
  *
  * Cron configuration in wrangler.toml:
  * [triggers]
- * crons = ["0 2 * * *"]  # Daily at 2:00 AM UTC
+ * crons = ["0 * * * *"]  # Hourly
  */
 async function handleScheduled(event: ScheduledEvent, env: Env): Promise<void> {
   const now = Math.floor(Date.now() / 1000); // Unix timestamp in seconds
@@ -2446,6 +2514,67 @@ async function handleScheduled(event: ScheduledEvent, env: Env): Promise<void> {
     log.error('D1 cleanup job failed', {}, error as Error);
     // Don't throw - we don't want to mark the cron job as failed
     // Errors are logged for monitoring
+  }
+
+  // Process pending tenant deletion jobs (up to 5 per Cron run to stay within CPU limits)
+  try {
+    const pendingJobsResult = await env.DB.prepare(
+      "SELECT id, config FROM admin_jobs WHERE job_type = 'tenants/delete' AND status = 'pending' LIMIT 5"
+    ).all<{ id: string; config: string }>();
+
+    const pendingJobs = pendingJobsResult.results ?? [];
+
+    for (const job of pendingJobs) {
+      const nowTs = Math.floor(Date.now() / 1000);
+      await env.DB.prepare(
+        "UPDATE admin_jobs SET status = 'processing', started_at = ?, updated_at = ? WHERE id = ?"
+      )
+        .bind(nowTs, nowTs, job.id)
+        .run();
+
+      try {
+        const config = JSON.parse(job.config) as { tenant_id: string };
+        const tenantId = config.tenant_id;
+
+        // Delete all tenant data in batches of 100 (D1 batch limit)
+        const deleteStatements = [
+          ...TENANT_TABLES_TO_DELETE.map((table) =>
+            env.DB.prepare(`DELETE FROM ${table} WHERE tenant_id = ?`).bind(tenantId)
+          ),
+          env.DB.prepare('DELETE FROM tenants WHERE id = ?').bind(tenantId),
+        ];
+
+        const BATCH_SIZE = 100;
+        for (let i = 0; i < deleteStatements.length; i += BATCH_SIZE) {
+          await env.DB.batch(deleteStatements.slice(i, i + BATCH_SIZE));
+        }
+
+        const completedTs = Math.floor(Date.now() / 1000);
+        await env.DB.prepare(
+          "UPDATE admin_jobs SET status = 'completed', completed_at = ?, updated_at = ?, progress = ? WHERE id = ?"
+        )
+          .bind(completedTs, completedTs, JSON.stringify({ stage: 'completed' }), job.id)
+          .run();
+
+        log.info('Tenant deletion job completed', { job_id: job.id, tenant_id: tenantId });
+      } catch (jobError) {
+        const failedTs = Math.floor(Date.now() / 1000);
+        await env.DB.prepare(
+          "UPDATE admin_jobs SET status = 'failed', error_message = ?, completed_at = ?, updated_at = ? WHERE id = ?"
+        )
+          .bind(String(jobError), failedTs, failedTs, job.id)
+          .run();
+
+        log.error('Tenant deletion job failed', { job_id: job.id }, jobError as Error);
+      }
+    }
+
+    if (pendingJobs.length > 0) {
+      log.info('Tenant deletion jobs processed', { count: pendingJobs.length });
+    }
+  } catch (jobsError) {
+    log.error('Tenant deletion job processing failed', {}, jobsError as Error);
+    // Don't throw - other cleanup tasks already completed
   }
 }
 

--- a/packages/ar-management/src/login-methods.ts
+++ b/packages/ar-management/src/login-methods.ts
@@ -250,9 +250,9 @@ async function getLoginUISettings(
     customBlocks: [...DEFAULT_UI_CONFIG.appearance.customBlocks],
   };
 
-  // Try settings-v2 (AUTHRIM_CONFIG KV) first
+  // Try settings-v2 (SETTINGS KV) first
   try {
-    const kvJson = await env.AUTHRIM_CONFIG?.get('settings:tenant:default:login-ui');
+    const kvJson = await env.SETTINGS?.get('settings:tenant:default:login-ui');
     if (kvJson) {
       const kvSettings = JSON.parse(kvJson) as LoginUIKVSettings;
       return {
@@ -416,12 +416,12 @@ function buildUIConfig(loginUI: LoginUIResolved): UIConfig {
 
 /**
  * Resolve cache TTL from KV → env → default
- * Priority: KV (AUTHRIM_CONFIG) → env (LOGIN_METHODS_CACHE_TTL) → DEFAULT_CACHE_TTL
+ * Priority: KV (SETTINGS) → env (LOGIN_METHODS_CACHE_TTL) → DEFAULT_CACHE_TTL
  */
 async function resolveCacheTTL(env: Env): Promise<number> {
   // 1. Try KV (settings-v2)
   try {
-    const kvJson = await env.AUTHRIM_CONFIG?.get('settings:tenant:default:login-methods');
+    const kvJson = await env.SETTINGS?.get('settings:tenant:default:login-methods');
     if (kvJson) {
       const kvSettings = JSON.parse(kvJson) as { 'login-methods.cache_ttl'?: number };
       const kvTTL = kvSettings['login-methods.cache_ttl'];

--- a/packages/ar-management/src/login-methods.ts
+++ b/packages/ar-management/src/login-methods.ts
@@ -250,9 +250,9 @@ async function getLoginUISettings(
     customBlocks: [...DEFAULT_UI_CONFIG.appearance.customBlocks],
   };
 
-  // Try settings-v2 (SETTINGS KV) first
+  // Try settings-v2 (AUTHRIM_CONFIG KV) first
   try {
-    const kvJson = await env.SETTINGS?.get('settings:tenant:default:login-ui');
+    const kvJson = await env.AUTHRIM_CONFIG?.get('settings:tenant:default:login-ui');
     if (kvJson) {
       const kvSettings = JSON.parse(kvJson) as LoginUIKVSettings;
       return {
@@ -421,7 +421,7 @@ function buildUIConfig(loginUI: LoginUIResolved): UIConfig {
 async function resolveCacheTTL(env: Env): Promise<number> {
   // 1. Try KV (settings-v2)
   try {
-    const kvJson = await env.SETTINGS?.get('settings:tenant:default:login-methods');
+    const kvJson = await env.AUTHRIM_CONFIG?.get('settings:tenant:default:login-methods');
     if (kvJson) {
       const kvSettings = JSON.parse(kvJson) as { 'login-methods.cache_ttl'?: number };
       const kvTTL = kvSettings['login-methods.cache_ttl'];

--- a/packages/setup/migrations/000_fresh_schema.sql
+++ b/packages/setup/migrations/000_fresh_schema.sql
@@ -2117,3 +2117,69 @@ CREATE INDEX idx_ws_subs_connection
 CREATE INDEX idx_ws_subs_subject
     ON websocket_subscriptions(subject_id, is_active);
 
+
+-- =============================================================================
+-- From 053: Custom Claim Schemas (with registration form fields from 060)
+-- =============================================================================
+
+CREATE TABLE custom_claim_schemas (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  field_key TEXT NOT NULL,
+  display_label TEXT NOT NULL,
+  field_type TEXT NOT NULL DEFAULT 'string',
+  is_pii INTEGER NOT NULL DEFAULT 0,
+  is_required INTEGER NOT NULL DEFAULT 0,
+  is_active INTEGER NOT NULL DEFAULT 1,
+  validation_rules TEXT CHECK(validation_rules IS NULL OR json_valid(validation_rules)),
+  include_in_id_token INTEGER NOT NULL DEFAULT 0,
+  include_in_userinfo INTEGER NOT NULL DEFAULT 0,
+  include_in_introspection INTEGER NOT NULL DEFAULT 0,
+  required_scopes TEXT CHECK(required_scopes IS NULL OR json_valid(required_scopes)),
+  scope_mode TEXT NOT NULL DEFAULT 'any' CHECK(scope_mode IN ('all', 'any')),
+  is_searchable INTEGER NOT NULL DEFAULT 1,
+  is_exportable INTEGER NOT NULL DEFAULT 1,
+  is_vc_claim INTEGER NOT NULL DEFAULT 0,
+  claim_namespace TEXT,
+  description TEXT,
+  display_order INTEGER NOT NULL DEFAULT 0,
+  schema_version INTEGER NOT NULL DEFAULT 1,
+  operation_status TEXT NOT NULL DEFAULT 'active',
+  operation_detail TEXT,
+  is_system INTEGER NOT NULL DEFAULT 0,
+  created_by TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  show_on_registration    INTEGER NOT NULL DEFAULT 0,
+  registration_required   INTEGER NOT NULL DEFAULT 0,
+  registration_order      INTEGER NOT NULL DEFAULT 0,
+  registration_placeholder TEXT
+);
+
+CREATE UNIQUE INDEX uniq_ccs_active_key ON custom_claim_schemas(tenant_id, field_key) WHERE is_active = 1;
+CREATE INDEX idx_ccs_tenant_active ON custom_claim_schemas(tenant_id, is_active, display_order);
+CREATE INDEX idx_ccs_tenant_key ON custom_claim_schemas(tenant_id, field_key);
+CREATE INDEX idx_ccs_operation ON custom_claim_schemas(operation_status) WHERE operation_status != 'active';
+
+-- =============================================================================
+-- From 059: Tenant Invitations
+-- =============================================================================
+
+CREATE TABLE tenant_invitations (
+  id             TEXT PRIMARY KEY,
+  token          TEXT NOT NULL UNIQUE,
+  tenant_id      TEXT NOT NULL DEFAULT 'default',
+  invited_email  TEXT,
+  invited_by     TEXT NOT NULL,
+  role_id        TEXT,
+  org_id         TEXT,
+  max_uses       INTEGER NOT NULL DEFAULT 1,
+  use_count      INTEGER NOT NULL DEFAULT 0,
+  expires_at     INTEGER NOT NULL,
+  created_at     INTEGER NOT NULL,
+  updated_at     INTEGER NOT NULL
+);
+
+CREATE INDEX idx_ti_token  ON tenant_invitations(token)
+  WHERE expires_at > unixepoch();
+CREATE INDEX idx_ti_tenant ON tenant_invitations(tenant_id, created_at DESC);

--- a/packages/setup/src/__tests__/ui-deployment.test.ts
+++ b/packages/setup/src/__tests__/ui-deployment.test.ts
@@ -135,24 +135,22 @@ describe('resolveUiDeploymentSettings', () => {
     expect(login.needsProxy).toBe(true);
     expect(login.serviceBindingName).toBe('AR_ROUTER');
     expect(login.uiEnv.PUBLIC_API_BASE_URL).toBe('');
-    expect(login.uiEnv.PUBLIC_API_PROXY_BACKEND_URL).toBe(
-      'https://test-ar-router.example.workers.dev'
-    );
-    expect(login.uiEnv.API_BACKEND_URL).toBe('https://test-ar-router.example.workers.dev');
+    // When custom domain is set, workers_dev is false so workers.dev is unreachable.
+    // runtimeApiBackendUrl should use the custom domain (apiBaseUrl), not the disabled workers.dev URL.
+    expect(login.uiEnv.PUBLIC_API_PROXY_BACKEND_URL).toBe('https://test.authrim.com');
+    expect(login.uiEnv.API_BACKEND_URL).toBe('https://test.authrim.com');
     expect(login.uiEnv.PUBLIC_AUTHRIM_ISSUER).toBe('https://test.authrim.com');
     expect(login.uiEnv.PUBLIC_LOGIN_UI_CLIENT_ID).toBe('login-ui-client');
-    expect(login.runtimeApiBackendUrl).toBe('https://test-ar-router.example.workers.dev');
+    expect(login.runtimeApiBackendUrl).toBe('https://test.authrim.com');
 
     expect(admin.useRelativeApi).toBe(true);
     expect(admin.needsProxy).toBe(true);
     expect(admin.serviceBindingName).toBe('AR_ROUTER');
     expect(admin.uiEnv.PUBLIC_API_BASE_URL).toBe('');
-    expect(admin.uiEnv.PUBLIC_API_PROXY_BACKEND_URL).toBe(
-      'https://test-ar-router.example.workers.dev'
-    );
-    expect(admin.uiEnv.API_BACKEND_URL).toBe('https://test-ar-router.example.workers.dev');
+    expect(admin.uiEnv.PUBLIC_API_PROXY_BACKEND_URL).toBe('https://test.authrim.com');
+    expect(admin.uiEnv.API_BACKEND_URL).toBe('https://test.authrim.com');
     expect(admin.uiEnv.PUBLIC_AUTHRIM_ISSUER).toBe('https://test.authrim.com');
-    expect(admin.runtimeApiBackendUrl).toBe('https://test-ar-router.example.workers.dev');
+    expect(admin.runtimeApiBackendUrl).toBe('https://test.authrim.com');
   });
 
   it('uses direct cross-origin API calls for same-site custom domains', () => {

--- a/packages/setup/src/core/config.ts
+++ b/packages/setup/src/core/config.ts
@@ -11,11 +11,25 @@ import { z } from 'zod';
 // URL Configuration
 // =============================================================================
 
+/**
+ * Accepts a full URL or a bare hostname and normalizes to a full https:// URL.
+ * e.g. "example.com" → "https://example.com"
+ */
+const urlOrHostname = z
+  .string()
+  .transform((val) => {
+    if (!val.includes('://')) {
+      return `https://${val}`;
+    }
+    return val;
+  })
+  .pipe(z.string().url());
+
 export const UrlConfigSchema = z.object({
   /** Custom domain (null = use auto-generated URL) */
-  custom: z.string().url().nullable().optional(),
+  custom: urlOrHostname.nullable().optional(),
   /** Auto-generated URL (workers.dev or pages.dev) */
-  auto: z.string().url().optional(),
+  auto: urlOrHostname.optional(),
   /** Cloudflare zone ID for custom domain (populated during setup) */
   zoneId: z.string().nullable().optional(),
   /** Whether to configure Workers custom domain binding */
@@ -24,9 +38,9 @@ export const UrlConfigSchema = z.object({
 
 export const UiUrlConfigSchema = z.object({
   /** Custom domain (null = use auto-generated URL) */
-  custom: z.string().url().nullable().optional(),
+  custom: urlOrHostname.nullable().optional(),
   /** Auto-generated URL (workers.dev or pages.dev) */
-  auto: z.string().url().optional(),
+  auto: urlOrHostname.optional(),
   /**
    * Whether to serve this UI from the same domain as the API via proxy
    * - true: UI is proxied through ar-router (e.g., https://api.example.com/admin)
@@ -192,7 +206,7 @@ export const QueueFeatureSchema = z.object({
 });
 
 export const R2FeatureSchema = z.object({
-  enabled: z.boolean().default(false),
+  enabled: z.boolean().default(true),
 });
 
 export const EmailFeatureSchema = z.object({

--- a/packages/setup/src/core/ui-deployment.ts
+++ b/packages/setup/src/core/ui-deployment.ts
@@ -78,7 +78,11 @@ export function resolveUiDeploymentSettings(
     normalizeUrl(config.urls?.api?.custom) ||
     normalizeUrl(config.urls?.api?.auto) ||
     `https://${env}-ar-router.workers.dev`;
-  const runtimeApiBackendUrl = normalizeUrl(config.urls?.api?.auto) || apiBaseUrl;
+  // Use apiBaseUrl (prefers custom domain over workers.dev) as the runtime backend URL.
+  // When a custom domain is set, workers_dev is false (disabled), so the workers.dev
+  // URL is unreachable. apiBaseUrl already resolves to the best available URL:
+  // custom domain → auto (workers.dev) → fallback.
+  const runtimeApiBackendUrl = apiBaseUrl;
 
   const uiConfig = getUiConfig(config, component);
   const uiUrl = uiConfig?.sameAsApi

--- a/packages/setup/src/core/wrangler.ts
+++ b/packages/setup/src/core/wrangler.ts
@@ -320,8 +320,8 @@ export function generateWranglerConfig(
     }
   }
 
-  // R2 Buckets (optional)
-  if (config.features.r2?.enabled && resourceIds.r2) {
+  // R2 Buckets — add bindings whenever provisioned resources are available
+  if (resourceIds.r2 && Object.keys(resourceIds.r2).length > 0) {
     const r2Buckets: Array<{ binding: string; bucket_name: string }> = [];
 
     if (component === 'ar-auth' || component === 'ar-management') {

--- a/packages/setup/src/i18n/locales/de.ts
+++ b/packages/setup/src/i18n/locales/de.ts
@@ -794,6 +794,8 @@ const de: Translations = {
     'Diese URL kann nur <strong>einmal</strong> verwendet werden und läuft am <strong>{{date}}</strong> ab.',
   'web.complete.adminSetupUnavailable':
     'Setup-URL nicht verfügbar. Sie können den Administratorzugang später über die Admin-UI konfigurieren.',
+  'web.complete.customDomainNote':
+    'ℹ️ Benutzerdefinierte Domain: DNS-Weitergabe kann einige Minuten bis Stunden dauern. Falls die obige URL noch nicht erreichbar ist, warten Sie bitte.',
 
   // Web UI Environment Management
   'web.env.title': 'Umgebungen',

--- a/packages/setup/src/i18n/locales/de.ts
+++ b/packages/setup/src/i18n/locales/de.ts
@@ -859,6 +859,7 @@ const de: Translations = {
   'web.form.envName': 'Umgebungsname',
   'web.form.envNamePlaceholder': 'z.B. prod, staging, dev',
   'web.form.envNameHint': 'Nur Kleinbuchstaben, Zahlen und Bindestriche',
+  'web.form.envNameError': 'Nur Kleinbuchstaben, Zahlen und Bindestriche erlaubt (muss mit einem Buchstaben beginnen)',
   'web.form.baseDomain': 'Basis-Domain (API-Domain)',
   'web.form.baseDomainPlaceholder': 'oidc.beispiel.de',
   'web.form.baseDomainHint': 'Benutzerdefinierte Domain für Authrim. Leer lassen für workers.dev',

--- a/packages/setup/src/i18n/locales/de.ts
+++ b/packages/setup/src/i18n/locales/de.ts
@@ -859,7 +859,8 @@ const de: Translations = {
   'web.form.envName': 'Umgebungsname',
   'web.form.envNamePlaceholder': 'z.B. prod, staging, dev',
   'web.form.envNameHint': 'Nur Kleinbuchstaben, Zahlen und Bindestriche',
-  'web.form.envNameError': 'Nur Kleinbuchstaben, Zahlen und Bindestriche erlaubt (muss mit einem Buchstaben beginnen)',
+  'web.form.envNameError':
+    'Nur Kleinbuchstaben, Zahlen und Bindestriche erlaubt (muss mit einem Buchstaben beginnen)',
   'web.form.baseDomain': 'Basis-Domain (API-Domain)',
   'web.form.baseDomainPlaceholder': 'oidc.beispiel.de',
   'web.form.baseDomainHint': 'Benutzerdefinierte Domain für Authrim. Leer lassen für workers.dev',

--- a/packages/setup/src/i18n/locales/en.ts
+++ b/packages/setup/src/i18n/locales/en.ts
@@ -850,6 +850,7 @@ const en: Translations = {
   'web.form.envName': 'Environment Name',
   'web.form.envNamePlaceholder': 'e.g., prod, staging, dev',
   'web.form.envNameHint': 'Lowercase letters, numbers, and hyphens only',
+  'web.form.envNameError': 'Only lowercase letters, numbers, and hyphens are allowed (must start with a letter)',
   'web.form.baseDomain': 'Base Domain (API Domain)',
   'web.form.baseDomainPlaceholder': 'oidc.example.com',
   'web.form.baseDomainHint': 'Custom domain for Authrim. Leave empty to use workers.dev',

--- a/packages/setup/src/i18n/locales/en.ts
+++ b/packages/setup/src/i18n/locales/en.ts
@@ -786,6 +786,8 @@ const en: Translations = {
     'This URL can only be used <strong>once</strong> and expires <strong>{{date}}</strong>.',
   'web.complete.adminSetupUnavailable':
     'Setup URL not available. You can configure admin access from the Admin UI later.',
+  'web.complete.customDomainNote':
+    'ℹ️ Custom domain: DNS propagation may take a few minutes to a few hours. If the URL above is not accessible yet, please wait and try again.',
 
   // Web UI Environment Management
   'web.env.title': 'Environments',

--- a/packages/setup/src/i18n/locales/en.ts
+++ b/packages/setup/src/i18n/locales/en.ts
@@ -850,7 +850,8 @@ const en: Translations = {
   'web.form.envName': 'Environment Name',
   'web.form.envNamePlaceholder': 'e.g., prod, staging, dev',
   'web.form.envNameHint': 'Lowercase letters, numbers, and hyphens only',
-  'web.form.envNameError': 'Only lowercase letters, numbers, and hyphens are allowed (must start with a letter)',
+  'web.form.envNameError':
+    'Only lowercase letters, numbers, and hyphens are allowed (must start with a letter)',
   'web.form.baseDomain': 'Base Domain (API Domain)',
   'web.form.baseDomainPlaceholder': 'oidc.example.com',
   'web.form.baseDomainHint': 'Custom domain for Authrim. Leave empty to use workers.dev',

--- a/packages/setup/src/i18n/locales/es.ts
+++ b/packages/setup/src/i18n/locales/es.ts
@@ -797,6 +797,8 @@ const es: Translations = {
     'Esta URL solo se puede usar <strong>una vez</strong> y expira el <strong>{{date}}</strong>.',
   'web.complete.adminSetupUnavailable':
     'URL de configuración no disponible. Puede configurar el acceso de administrador desde la UI de administración más tarde.',
+  'web.complete.customDomainNote':
+    'ℹ️ Dominio personalizado: la propagación DNS puede tardar de minutos a horas. Si la URL no está accesible todavía, espere e intente de nuevo.',
 
   // Web UI Environment Management
   'web.env.title': 'Entornos',

--- a/packages/setup/src/i18n/locales/es.ts
+++ b/packages/setup/src/i18n/locales/es.ts
@@ -861,6 +861,7 @@ const es: Translations = {
   'web.form.envName': 'Nombre del Entorno',
   'web.form.envNamePlaceholder': 'ej., prod, staging, dev',
   'web.form.envNameHint': 'Solo letras minúsculas, números y guiones',
+  'web.form.envNameError': 'Solo se permiten letras minúsculas, números y guiones (debe comenzar con una letra)',
   'web.form.baseDomain': 'Dominio Base (Dominio API)',
   'web.form.baseDomainPlaceholder': 'oidc.ejemplo.com',
   'web.form.baseDomainHint':

--- a/packages/setup/src/i18n/locales/es.ts
+++ b/packages/setup/src/i18n/locales/es.ts
@@ -861,7 +861,8 @@ const es: Translations = {
   'web.form.envName': 'Nombre del Entorno',
   'web.form.envNamePlaceholder': 'ej., prod, staging, dev',
   'web.form.envNameHint': 'Solo letras minúsculas, números y guiones',
-  'web.form.envNameError': 'Solo se permiten letras minúsculas, números y guiones (debe comenzar con una letra)',
+  'web.form.envNameError':
+    'Solo se permiten letras minúsculas, números y guiones (debe comenzar con una letra)',
   'web.form.baseDomain': 'Dominio Base (Dominio API)',
   'web.form.baseDomainPlaceholder': 'oidc.ejemplo.com',
   'web.form.baseDomainHint':

--- a/packages/setup/src/i18n/locales/fr.ts
+++ b/packages/setup/src/i18n/locales/fr.ts
@@ -872,7 +872,8 @@ const fr: Translations = {
   'web.form.envName': "Nom de l'Environnement",
   'web.form.envNamePlaceholder': 'ex : prod, staging, dev',
   'web.form.envNameHint': 'Lettres minuscules, chiffres et tirets uniquement',
-  'web.form.envNameError': 'Seuls les lettres minuscules, chiffres et tirets sont autorisés (doit commencer par une lettre)',
+  'web.form.envNameError':
+    'Seuls les lettres minuscules, chiffres et tirets sont autorisés (doit commencer par une lettre)',
   'web.form.baseDomain': 'Domaine de Base (Domaine API)',
   'web.form.baseDomainPlaceholder': 'oidc.exemple.com',
   'web.form.baseDomainHint':

--- a/packages/setup/src/i18n/locales/fr.ts
+++ b/packages/setup/src/i18n/locales/fr.ts
@@ -872,6 +872,7 @@ const fr: Translations = {
   'web.form.envName': "Nom de l'Environnement",
   'web.form.envNamePlaceholder': 'ex : prod, staging, dev',
   'web.form.envNameHint': 'Lettres minuscules, chiffres et tirets uniquement',
+  'web.form.envNameError': 'Seuls les lettres minuscules, chiffres et tirets sont autorisés (doit commencer par une lettre)',
   'web.form.baseDomain': 'Domaine de Base (Domaine API)',
   'web.form.baseDomainPlaceholder': 'oidc.exemple.com',
   'web.form.baseDomainHint':

--- a/packages/setup/src/i18n/locales/fr.ts
+++ b/packages/setup/src/i18n/locales/fr.ts
@@ -807,6 +807,8 @@ const fr: Translations = {
     "Cette URL ne peut être utilisée qu'<strong>une seule fois</strong> et expire le <strong>{{date}}</strong>.",
   'web.complete.adminSetupUnavailable':
     "URL de configuration non disponible. Vous pouvez configurer l'accès administrateur depuis l'interface d'administration plus tard.",
+  'web.complete.customDomainNote':
+    "ℹ️ Domaine personnalisé : la propagation DNS peut prendre de quelques minutes à plusieurs heures. Si l'URL ci-dessus n'est pas encore accessible, veuillez patienter.",
 
   // Web UI Environment Management
   'web.env.title': 'Environnements',

--- a/packages/setup/src/i18n/locales/id.ts
+++ b/packages/setup/src/i18n/locales/id.ts
@@ -852,6 +852,7 @@ const id: Translations = {
   'web.form.envName': 'Nama Environment',
   'web.form.envNamePlaceholder': 'contoh: prod, staging, dev',
   'web.form.envNameHint': 'Hanya huruf kecil, angka, dan tanda hubung',
+  'web.form.envNameError': 'Hanya huruf kecil, angka, dan tanda hubung yang diperbolehkan (harus dimulai dengan huruf)',
   'web.form.baseDomain': 'Domain Dasar (Domain API)',
   'web.form.baseDomainPlaceholder': 'oidc.example.com',
   'web.form.baseDomainHint': 'Domain kustom untuk Authrim. Kosongkan untuk menggunakan workers.dev',

--- a/packages/setup/src/i18n/locales/id.ts
+++ b/packages/setup/src/i18n/locales/id.ts
@@ -852,7 +852,8 @@ const id: Translations = {
   'web.form.envName': 'Nama Environment',
   'web.form.envNamePlaceholder': 'contoh: prod, staging, dev',
   'web.form.envNameHint': 'Hanya huruf kecil, angka, dan tanda hubung',
-  'web.form.envNameError': 'Hanya huruf kecil, angka, dan tanda hubung yang diperbolehkan (harus dimulai dengan huruf)',
+  'web.form.envNameError':
+    'Hanya huruf kecil, angka, dan tanda hubung yang diperbolehkan (harus dimulai dengan huruf)',
   'web.form.baseDomain': 'Domain Dasar (Domain API)',
   'web.form.baseDomainPlaceholder': 'oidc.example.com',
   'web.form.baseDomainHint': 'Domain kustom untuk Authrim. Kosongkan untuk menggunakan workers.dev',

--- a/packages/setup/src/i18n/locales/id.ts
+++ b/packages/setup/src/i18n/locales/id.ts
@@ -788,6 +788,8 @@ const id: Translations = {
     'URL ini hanya dapat digunakan <strong>sekali</strong> dan kedaluwarsa pada <strong>{{date}}</strong>.',
   'web.complete.adminSetupUnavailable':
     'URL pengaturan tidak tersedia. Anda dapat mengonfigurasi akses admin dari UI Admin nanti.',
+  'web.complete.customDomainNote':
+    'ℹ️ Domain kustom: propagasi DNS mungkin membutuhkan beberapa menit hingga beberapa jam. Jika URL di atas belum dapat diakses, harap tunggu.',
 
   // Web UI Environment Management
   'web.env.title': 'Environment',

--- a/packages/setup/src/i18n/locales/ja.ts
+++ b/packages/setup/src/i18n/locales/ja.ts
@@ -844,6 +844,7 @@ const ja: Translations = {
   'web.form.envName': '環境名',
   'web.form.envNamePlaceholder': '例: prod, staging, dev',
   'web.form.envNameHint': '小文字英数字とハイフンのみ使用可能',
+  'web.form.envNameError': '環境名は小文字英数字とハイフンのみ使用可能です（先頭は英字）',
   'web.form.baseDomain': 'ベースドメイン（APIドメイン）',
   'web.form.baseDomainPlaceholder': 'oidc.example.com',
   'web.form.baseDomainHint': 'Authrim用のカスタムドメイン。空欄でworkers.devを使用',

--- a/packages/setup/src/i18n/locales/ja.ts
+++ b/packages/setup/src/i18n/locales/ja.ts
@@ -781,6 +781,8 @@ const ja: Translations = {
     'このURLは<strong>1回のみ</strong>使用可能で、<strong>{{date}}</strong>に失効します。',
   'web.complete.adminSetupUnavailable':
     'セットアップURLが利用できません。後で管理UIから管理者アクセスを設定できます。',
+  'web.complete.customDomainNote':
+    'ℹ️ カスタムドメインのDNS反映には数分〜数時間かかることがあります。上記URLにまだアクセスできない場合は、しばらくお待ちください。',
 
   // Web UI Environment Management
   'web.env.title': '環境',

--- a/packages/setup/src/i18n/locales/ko.ts
+++ b/packages/setup/src/i18n/locales/ko.ts
@@ -781,6 +781,8 @@ const ko: Translations = {
     '이 URL은 <strong>한 번만</strong> 사용할 수 있으며 <strong>{{date}}</strong>에 만료됩니다.',
   'web.complete.adminSetupUnavailable':
     '설정 URL을 사용할 수 없습니다. 나중에 관리 UI에서 관리자 액세스를 구성할 수 있습니다.',
+  'web.complete.customDomainNote':
+    'ℹ️ 커스텀 도메인: DNS 전파에 몇 분에서 몇 시간이 걸릴 수 있습니다. 위 URL에 아직 접근할 수 없는 경우 잠시 기다려 주세요.',
 
   // Web UI Environment Management
   'web.env.title': '환경',

--- a/packages/setup/src/i18n/locales/ko.ts
+++ b/packages/setup/src/i18n/locales/ko.ts
@@ -844,6 +844,7 @@ const ko: Translations = {
   'web.form.envName': '환경 이름',
   'web.form.envNamePlaceholder': '예: prod, staging, dev',
   'web.form.envNameHint': '소문자, 숫자 및 하이픈만 허용',
+  'web.form.envNameError': '소문자, 숫자 및 하이픈만 허용됩니다 (첫 글자는 영문자여야 합니다)',
   'web.form.baseDomain': '기본 도메인 (API 도메인)',
   'web.form.baseDomainPlaceholder': 'oidc.example.com',
   'web.form.baseDomainHint': 'Authrim용 사용자 정의 도메인. workers.dev를 사용하려면 비워두세요',

--- a/packages/setup/src/i18n/locales/pt.ts
+++ b/packages/setup/src/i18n/locales/pt.ts
@@ -859,6 +859,7 @@ const pt: Translations = {
   'web.form.envName': 'Nome do Ambiente',
   'web.form.envNamePlaceholder': 'ex: prod, staging, dev',
   'web.form.envNameHint': 'Apenas letras minúsculas, números e hífens',
+  'web.form.envNameError': 'Apenas letras minúsculas, números e hífens são permitidos (deve começar com uma letra)',
   'web.form.baseDomain': 'Domínio Base (Domínio API)',
   'web.form.baseDomainPlaceholder': 'oidc.exemplo.com',
   'web.form.baseDomainHint':

--- a/packages/setup/src/i18n/locales/pt.ts
+++ b/packages/setup/src/i18n/locales/pt.ts
@@ -859,7 +859,8 @@ const pt: Translations = {
   'web.form.envName': 'Nome do Ambiente',
   'web.form.envNamePlaceholder': 'ex: prod, staging, dev',
   'web.form.envNameHint': 'Apenas letras minúsculas, números e hífens',
-  'web.form.envNameError': 'Apenas letras minúsculas, números e hífens são permitidos (deve começar com uma letra)',
+  'web.form.envNameError':
+    'Apenas letras minúsculas, números e hífens são permitidos (deve começar com uma letra)',
   'web.form.baseDomain': 'Domínio Base (Domínio API)',
   'web.form.baseDomainPlaceholder': 'oidc.exemplo.com',
   'web.form.baseDomainHint':

--- a/packages/setup/src/i18n/locales/pt.ts
+++ b/packages/setup/src/i18n/locales/pt.ts
@@ -795,6 +795,8 @@ const pt: Translations = {
     'Este URL só pode ser usado <strong>uma vez</strong> e expira em <strong>{{date}}</strong>.',
   'web.complete.adminSetupUnavailable':
     'URL de configuração não disponível. Você pode configurar o acesso de administrador na UI de Administração mais tarde.',
+  'web.complete.customDomainNote':
+    'ℹ️ Domínio personalizado: a propagação DNS pode levar de minutos a horas. Se a URL acima ainda não estiver acessível, aguarde e tente novamente.',
 
   // Web UI Environment Management
   'web.env.title': 'Ambientes',

--- a/packages/setup/src/i18n/locales/ru.ts
+++ b/packages/setup/src/i18n/locales/ru.ts
@@ -855,6 +855,7 @@ const ru: Translations = {
   'web.form.envName': 'Название окружения',
   'web.form.envNamePlaceholder': 'например, prod, staging, dev',
   'web.form.envNameHint': 'Только строчные буквы, цифры и дефисы',
+  'web.form.envNameError': 'Допустимы только строчные буквы, цифры и дефисы (должно начинаться с буквы)',
   'web.form.baseDomain': 'Базовый домен (домен API)',
   'web.form.baseDomainPlaceholder': 'oidc.example.com',
   'web.form.baseDomainHint': 'Собственный домен для Authrim. Оставьте пустым для workers.dev',

--- a/packages/setup/src/i18n/locales/ru.ts
+++ b/packages/setup/src/i18n/locales/ru.ts
@@ -855,7 +855,8 @@ const ru: Translations = {
   'web.form.envName': 'Название окружения',
   'web.form.envNamePlaceholder': 'например, prod, staging, dev',
   'web.form.envNameHint': 'Только строчные буквы, цифры и дефисы',
-  'web.form.envNameError': 'Допустимы только строчные буквы, цифры и дефисы (должно начинаться с буквы)',
+  'web.form.envNameError':
+    'Допустимы только строчные буквы, цифры и дефисы (должно начинаться с буквы)',
   'web.form.baseDomain': 'Базовый домен (домен API)',
   'web.form.baseDomainPlaceholder': 'oidc.example.com',
   'web.form.baseDomainHint': 'Собственный домен для Authrim. Оставьте пустым для workers.dev',

--- a/packages/setup/src/i18n/locales/ru.ts
+++ b/packages/setup/src/i18n/locales/ru.ts
@@ -790,6 +790,8 @@ const ru: Translations = {
     'Этот URL можно использовать только <strong>один раз</strong>, он истекает <strong>{{date}}</strong>.',
   'web.complete.adminSetupUnavailable':
     'URL настройки недоступен. Вы можете настроить доступ администратора в интерфейсе администрирования позже.',
+  'web.complete.customDomainNote':
+    'ℹ️ Пользовательский домен: распространение DNS может занять от нескольких минут до нескольких часов. Если URL ещё недоступен, подождите.',
 
   // Web UI Environment Management
   'web.env.title': 'Окружения',

--- a/packages/setup/src/i18n/locales/zh-CN.ts
+++ b/packages/setup/src/i18n/locales/zh-CN.ts
@@ -837,6 +837,7 @@ const zhCN: Translations = {
   'web.form.envName': '环境名称',
   'web.form.envNamePlaceholder': '例如：prod、staging、dev',
   'web.form.envNameHint': '仅限小写字母、数字和连字符',
+  'web.form.envNameError': '只允许小写字母、数字和连字符（必须以字母开头）',
   'web.form.baseDomain': '基础域名（API 域名）',
   'web.form.baseDomainPlaceholder': 'oidc.example.com',
   'web.form.baseDomainHint': 'Authrim 的自定义域名。留空使用 workers.dev',

--- a/packages/setup/src/i18n/locales/zh-CN.ts
+++ b/packages/setup/src/i18n/locales/zh-CN.ts
@@ -774,6 +774,8 @@ const zhCN: Translations = {
   'web.complete.urlWarning':
     '此 URL 只能使用<strong>一次</strong>，将于 <strong>{{date}}</strong> 失效。',
   'web.complete.adminSetupUnavailable': '设置 URL 不可用。您可以稍后从管理 UI 配置管理员访问权限。',
+  'web.complete.customDomainNote':
+    'ℹ️ 自定义域名：DNS 传播可能需要几分钟到几小时。如果上面的 URL 暂时无法访问，请稍候再试。',
 
   // Web UI Environment Management
   'web.env.title': '环境',

--- a/packages/setup/src/i18n/locales/zh-TW.ts
+++ b/packages/setup/src/i18n/locales/zh-TW.ts
@@ -837,6 +837,7 @@ const zhTW: Translations = {
   'web.form.envName': '環境名稱',
   'web.form.envNamePlaceholder': '例如：prod、staging、dev',
   'web.form.envNameHint': '僅限小寫字母、數字和連字符',
+  'web.form.envNameError': '只允許小寫字母、數字和連字符（必須以字母開頭）',
   'web.form.baseDomain': '基礎網域（API 網域）',
   'web.form.baseDomainPlaceholder': 'oidc.example.com',
   'web.form.baseDomainHint': 'Authrim 的自訂網域。留空以使用 workers.dev',

--- a/packages/setup/src/i18n/locales/zh-TW.ts
+++ b/packages/setup/src/i18n/locales/zh-TW.ts
@@ -774,6 +774,8 @@ const zhTW: Translations = {
   'web.complete.urlWarning':
     '此 URL 只能使用<strong>一次</strong>，將於 <strong>{{date}}</strong> 失效。',
   'web.complete.adminSetupUnavailable': '設定 URL 不可用。您可以稍後從管理 UI 設定管理員存取權限。',
+  'web.complete.customDomainNote':
+    'ℹ️ 自訂網域：DNS 傳播可能需要幾分鐘到幾小時。如果上方 URL 尚無法存取，請稍等後再試。',
 
   // Web UI Environment Management
   'web.env.title': '環境',

--- a/packages/setup/src/web/api.ts
+++ b/packages/setup/src/web/api.ts
@@ -1177,9 +1177,11 @@ export function createApiRoutes(): Hono {
         // Update lock file with deployed workers information
         if (workersSuccess && !dryRun && summary.successCount > 0) {
           try {
-            const { loadLockFileAuto, saveLockFile: saveLock, AuthrimLockSchema } = await import(
-              '../core/lock.js'
-            );
+            const {
+              loadLockFileAuto,
+              saveLockFile: saveLock,
+              AuthrimLockSchema,
+            } = await import('../core/lock.js');
             const { lock: currentLock, path: lockPath } = await loadLockFileAuto(rootDir, env);
 
             if (lockPath) {

--- a/packages/setup/src/web/api.ts
+++ b/packages/setup/src/web/api.ts
@@ -1177,14 +1177,20 @@ export function createApiRoutes(): Hono {
         // Update lock file with deployed workers information
         if (workersSuccess && !dryRun && summary.successCount > 0) {
           try {
-            const { loadLockFileAuto, saveLockFile: saveLock } = await import('../core/lock.js');
+            const { loadLockFileAuto, saveLockFile: saveLock, AuthrimLockSchema } = await import(
+              '../core/lock.js'
+            );
             const { lock: currentLock, path: lockPath } = await loadLockFileAuto(rootDir, env);
 
-            if (currentLock && lockPath) {
+            if (lockPath) {
+              // Use existing lock or create minimal one (recovery scenario: lock deleted/missing)
+              const now = new Date().toISOString();
+              const baseLock = currentLock ?? AuthrimLockSchema.parse({ env, createdAt: now });
+
               const workers: Record<
                 string,
                 { name: string; deployedAt?: string; version?: string }
-              > = { ...currentLock.workers };
+              > = { ...baseLock.workers };
 
               for (const result of summary.results) {
                 if (result.success && result.deployedAt) {
@@ -1197,9 +1203,9 @@ export function createApiRoutes(): Hono {
               }
 
               const updatedLock = {
-                ...currentLock,
+                ...baseLock,
                 workers,
-                updatedAt: new Date().toISOString(),
+                updatedAt: now,
               };
 
               await saveLock(updatedLock, lockPath);

--- a/packages/setup/src/web/api.ts
+++ b/packages/setup/src/web/api.ts
@@ -70,8 +70,8 @@ import {
 import { completeInitialSetup } from '../core/admin.js';
 import { resolveUiDeploymentSettings } from '../core/ui-deployment.js';
 import { saveUiEnv, buildInitialUiEnvConfig } from '../core/ui-env.js';
-import { writeFile, chmod } from 'node:fs/promises';
-import { join } from 'node:path';
+import { writeFile, chmod, mkdir } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
 
 // =============================================================================
 // Session & Security
@@ -366,7 +366,6 @@ export function createApiRoutes(): Hono {
         const envPaths = getEnvironmentPaths({ baseDir, env });
 
         // Ensure directory exists
-        const { mkdir } = await import('node:fs/promises');
         await mkdir(envPaths.root, { recursive: true });
 
         // Save config
@@ -533,7 +532,6 @@ export function createApiRoutes(): Hono {
         const envPaths = getEnvironmentPaths({ baseDir, env, keysBaseDir });
 
         // Ensure directory exists with restrictive permissions
-        const { mkdir } = await import('node:fs/promises');
         await mkdir(keysDir, { recursive: true, mode: 0o700 });
 
         // Save API key with restrictive permissions
@@ -643,6 +641,8 @@ export function createApiRoutes(): Hono {
         addProgress('Creating lock file...');
         const lock = createLockFile(env, resources);
         const rootDir = findAuthrimBaseDir(process.cwd());
+        const envPaths = getEnvironmentPaths({ baseDir: rootDir, env });
+        addProgress(`Saving lock.json to ${envPaths.lock} ...`);
         await saveLockFile(lock, { env, baseDir: rootDir });
 
         // Save config.json
@@ -687,7 +687,9 @@ export function createApiRoutes(): Hono {
         });
         addProgress(`Configured URLs: API=${apiUrl}`);
 
-        const envPaths = getEnvironmentPaths({ baseDir: rootDir, env });
+        // Explicitly ensure directory exists (defense in depth; saveLockFile also creates it)
+        await mkdir(dirname(envPaths.config), { recursive: true });
+        addProgress(`Saving config.json to ${envPaths.config} ...`);
         await writeFile(envPaths.config, JSON.stringify(config, null, 2), 'utf-8');
         const initialUiEnv = buildInitialUiEnvConfig(config);
         if (initialUiEnv) {
@@ -733,12 +735,19 @@ export function createApiRoutes(): Hono {
 
         state.status = 'configuring';
         addProgress('Provisioning complete!');
+        addProgress(`📁 Config saved: ${envPaths.config}`);
+        addProgress(`📁 Lock saved:   ${envPaths.lock}`);
 
         return c.json({
           success: true,
           resources,
           lock,
           config,
+          savedPaths: {
+            config: envPaths.config,
+            lock: envPaths.lock,
+            root: envPaths.root,
+          },
         });
       } catch (error) {
         state.status = 'error';

--- a/packages/setup/src/web/ui.ts
+++ b/packages/setup/src/web/ui.ts
@@ -2049,6 +2049,7 @@ export function getHtmlTemplate(
         <label for="env"><span data-i18n="web.form.envName">Environment Name</span> <span style="color: var(--error);">*</span></label>
         <input type="text" id="env" placeholder="e.g., prod, staging, dev" data-i18n-placeholder="web.form.envNamePlaceholder" required>
         <small style="color: var(--text-muted)" data-i18n="web.form.envNameHint">Lowercase letters, numbers, and hyphens only</small>
+        <span id="env-error" style="display: none; color: var(--error); font-size: 0.85rem;" data-i18n="web.form.envNameError">Only lowercase letters, numbers, and hyphens are allowed (must start with a letter)</span>
       </div>
 
       <!-- 3. Domain Configuration -->
@@ -3567,6 +3568,32 @@ export function getHtmlTemplate(
       }
     });
 
+    // Validate environment name on blur
+    const envInput = document.getElementById('env');
+    const envError = document.getElementById('env-error');
+    function validateEnvName(value) {
+      return /^[a-z][a-z0-9-]*$/.test(value);
+    }
+    envInput.addEventListener('blur', () => {
+      const value = envInput.value.trim();
+      if (value && !validateEnvName(value)) {
+        envInput.style.borderColor = 'var(--error)';
+        if (envError) envError.style.display = 'block';
+      } else {
+        envInput.style.borderColor = '';
+        if (envError) envError.style.display = 'none';
+      }
+    });
+    envInput.addEventListener('input', () => {
+      if (envInput.style.borderColor) {
+        const value = envInput.value.trim();
+        if (!value || validateEnvName(value)) {
+          envInput.style.borderColor = '';
+          if (envError) envError.style.display = 'none';
+        }
+      }
+    });
+
     // Update UI based on base domain presence
     function updateBaseDomainUI() {
       const baseDomain = document.getElementById('base-domain').value.trim();
@@ -3722,11 +3749,15 @@ export function getHtmlTemplate(
 
     document.getElementById('btn-configure').addEventListener('click', async () => {
       // Get and validate environment name
-      let env = document.getElementById('env').value.toLowerCase().replace(/[^a-z0-9-]/g, '');
-      if (!env) {
-        alert('Please enter a valid environment name');
+      const envRaw = document.getElementById('env').value.trim();
+      if (!envRaw || !validateEnvName(envRaw)) {
+        document.getElementById('env').style.borderColor = 'var(--error)';
+        const errEl = document.getElementById('env-error');
+        if (errEl) errEl.style.display = 'block';
+        document.getElementById('env').focus();
         return;
       }
+      const env = envRaw;
 
       // Check if environment already exists
       const configureBtn = document.getElementById('btn-configure');
@@ -4085,7 +4116,7 @@ export function getHtmlTemplate(
 
         const result = await api('/provision', {
           method: 'POST',
-          body: { env: config.env, databaseConfig: config.database },
+          body: { env: config.env, databaseConfig: config.database, createR2: true },
         });
 
         // Stop polling

--- a/packages/setup/src/web/ui.ts
+++ b/packages/setup/src/web/ui.ts
@@ -4362,6 +4362,16 @@ export function getHtmlTemplate(
       urlsEl.appendChild(createUrlItem('Login UI:', loginUrl));
       urlsEl.appendChild(createUrlItem('Admin UI:', adminUrl));
 
+      // Show custom domain propagation note when any custom domain is set
+      if (config.apiDomain || config.loginUiDomain || config.adminUiDomain) {
+        const domainNoteDiv = document.createElement('div');
+        domainNoteDiv.className = 'hint-box';
+        domainNoteDiv.style.marginTop = '0.75rem';
+        domainNoteDiv.setAttribute('data-i18n', 'web.complete.customDomainNote');
+        domainNoteDiv.textContent = t('web.complete.customDomainNote');
+        urlsEl.appendChild(domainNoteDiv);
+      }
+
       // Create Admin Setup section (separate, prominent box)
       const adminSetupSection = document.createElement('div');
       adminSetupSection.style.cssText = 'margin-top: 1.5rem; padding: 1.25rem; background: linear-gradient(135deg, rgba(37, 99, 235, 0.1) 0%, rgba(59, 130, 246, 0.05) 100%); border: 2px solid var(--primary); border-radius: 12px;';
@@ -4387,9 +4397,11 @@ export function getHtmlTemplate(
         const titleH4 = document.createElement('h4');
         titleH4.style.cssText = 'margin: 0; font-size: 1.1rem; font-weight: 600; color: var(--primary);';
         titleH4.textContent = t('web.complete.adminAccountTitle');
+        titleH4.setAttribute('data-i18n', 'web.complete.adminAccountTitle');
         const importantBadge = document.createElement('span');
         importantBadge.style.cssText = 'background: var(--warning); color: white; font-size: 0.7rem; padding: 0.2rem 0.5rem; border-radius: 4px; font-weight: 600;';
         importantBadge.textContent = t('web.complete.adminAccountImportant');
+        importantBadge.setAttribute('data-i18n', 'web.complete.adminAccountImportant');
         headerDiv.appendChild(iconSpan);
         headerDiv.appendChild(titleH4);
         headerDiv.appendChild(importantBadge);
@@ -4398,6 +4410,7 @@ export function getHtmlTemplate(
         const descP = document.createElement('p');
         descP.style.cssText = 'margin: 0 0 0.75rem; font-size: 0.9rem; color: var(--text-muted);';
         descP.textContent = t('web.complete.adminAccountDesc');
+        descP.setAttribute('data-i18n', 'web.complete.adminAccountDesc');
 
         // URL input + copy button row
         const inputRow = document.createElement('div');
@@ -4411,13 +4424,16 @@ export function getHtmlTemplate(
         copyBtn.className = 'btn-secondary';
         copyBtn.style.whiteSpace = 'nowrap';
         copyBtn.textContent = t('web.complete.copy');
+        copyBtn.setAttribute('data-i18n', 'web.complete.copy');
         const setupUrlForCopy = result.setupUrl;
-        const copyLabel = t('web.complete.copy');
-        const copiedLabel = t('web.complete.copied');
         copyBtn.addEventListener('click', () => {
           navigator.clipboard.writeText(setupUrlForCopy);
-          copyBtn.textContent = copiedLabel;
-          setTimeout(() => { copyBtn.textContent = copyLabel; }, 2000);
+          copyBtn.removeAttribute('data-i18n'); // prevent updateAllTranslations from overwriting "Copied"
+          copyBtn.textContent = t('web.complete.copied');
+          setTimeout(() => {
+            copyBtn.textContent = t('web.complete.copy');
+            copyBtn.setAttribute('data-i18n', 'web.complete.copy');
+          }, 2000);
         });
         inputRow.appendChild(urlInput);
         inputRow.appendChild(copyBtn);
@@ -4430,9 +4446,10 @@ export function getHtmlTemplate(
         openLink.target = '_blank';
         openLink.className = 'btn-primary';
         openLink.textContent = t('web.complete.openSetup');
+        openLink.setAttribute('data-i18n', 'web.complete.openSetup');
         openDiv.appendChild(openLink);
 
-        // Warning hint
+        // Warning hint (uses innerHTML for <strong> tags — not updated on language change)
         const hintDiv = document.createElement('div');
         hintDiv.className = 'hint-box';
         hintDiv.style.marginTop = '0.75rem';
@@ -4459,12 +4476,14 @@ export function getHtmlTemplate(
         const titleH4 = document.createElement('h4');
         titleH4.style.cssText = 'margin: 0; font-size: 1.1rem; font-weight: 600; color: var(--text-muted);';
         titleH4.textContent = t('web.complete.adminAccountTitle');
+        titleH4.setAttribute('data-i18n', 'web.complete.adminAccountTitle');
         headerDiv.appendChild(iconSpan);
         headerDiv.appendChild(titleH4);
 
         const descP = document.createElement('p');
         descP.style.cssText = 'margin: 0; font-size: 0.9rem; color: var(--text-muted);';
         descP.textContent = t('web.complete.adminSetupUnavailable');
+        descP.setAttribute('data-i18n', 'web.complete.adminSetupUnavailable');
 
         adminSetupSection.appendChild(headerDiv);
         adminSetupSection.appendChild(descP);
@@ -4476,6 +4495,7 @@ export function getHtmlTemplate(
           if (debug.alreadyCompleted) {
             debugP.style.color = 'var(--text-muted)';
             debugP.textContent = t('web.complete.adminSetupUnavailable');
+            debugP.setAttribute('data-i18n', 'web.complete.adminSetupUnavailable');
           } else if (debug.error) {
             debugP.style.color = 'var(--error)';
             debugP.textContent = 'Error: ' + debug.error;

--- a/packages/setup/src/web/ui.ts
+++ b/packages/setup/src/web/ui.ts
@@ -5532,7 +5532,7 @@ export function getHtmlTemplate(
         // Try to load config to get custom API domain
         try {
           const configResponse = await api('/config?env=' + encodeURIComponent(selectedEnvForDetail.env));
-          if (configResponse.success && configResponse.config) {
+          if (configResponse.exists && configResponse.config) {
             baseUrl = configResponse.config.urls?.api?.custom || configResponse.config.urls?.api?.auto || '';
           }
         } catch (e) {

--- a/packages/setup/src/web/ui.ts
+++ b/packages/setup/src/web/ui.ts
@@ -4098,6 +4098,10 @@ export function getHtmlTemplate(
           // Final progress update
           updateProgressUI('provision', totalResources, totalResources, '✅ Provisioning complete!');
           output.textContent += '\\n✅ Provisioning complete!\\n';
+          if (result.savedPaths) {
+            output.textContent += '📁 Config: ' + result.savedPaths.config + '\\n';
+            output.textContent += '📁 Lock:   ' + result.savedPaths.lock + '\\n';
+          }
           scrollToBottom(log);
           status.textContent = t('web.status.complete');
           status.className = 'status-badge status-success';


### PR DESCRIPTION
## Summary

- **Item 3: Tenant Invitations** — Token-based invitation flow for tenant-specific signup routing. Admin can create invite links with optional email restriction, role/org auto-assignment, and email delivery via notifier plugin. New `/invite` landing page in Login UI.
- **Item 4: Custom Registration Fields** — Extends `custom_claim_schemas` with registration display columns. Public `GET /api/v1/registration-fields` endpoint. Dynamic field rendering in signup page with server-side `validation_rules` enforcement.
- **Item 2: Tenant Domain Mappings** — Platform-level email domain → tenant routing table and admin UI.
- **Bug fix: `SettingsPatchResult.version`** — `newVersion` field name mismatch caused `ifMatch` to be dropped after first PATCH, resulting in 400 errors on subsequent settings changes.
- **Bug fix: Japanese UI strings** — Replace remaining Japanese text with English in diagnostic-logging and custom-claims pages.
- **Setup tool: R2 provisioning** — R2 buckets (AVATARS, DIAGNOSTIC_LOGS) now provisioned by default.

## Test plan

- [ ] Create invitation link (with/without email restriction) → open `/invite?token=xxx` → sign up → verify tenant/role/org assignment
- [ ] With Resend plugin disabled: confirm `email_sent: false`, invite URL still returned
- [ ] Add custom claim with `show_on_registration=1` → verify field appears on `/signup` → submit → check `user_custom_fields`
- [ ] Toggle "Persist logs to R2" → confirm no 400 error → toggle again → confirm version tracks correctly
- [ ] Confirm all UI text is in English (no Japanese visible)