### PR TITLE
feat: add DiagnosticLogger support to Login UI for OIDC RP conformance

### DIFF
--- a/packages/ar-login-ui/src/lib/api/client.ts
+++ b/packages/ar-login-ui/src/lib/api/client.ts
@@ -6,6 +6,7 @@
 import { browser } from '$app/environment';
 import { getAuthConfig } from '$lib/auth';
 import { generatePKCE } from '$lib/utils/pkce';
+import { getDiagnosticSessionId as getLoggerSessionId } from '$lib/stores/diagnostic';
 
 // Type definitions
 interface User {
@@ -119,21 +120,30 @@ export function resolveApiBaseUrl(): string {
 export const API_BASE_URL = resolveApiBaseUrl();
 
 const DEFAULT_API_TIMEOUT = 30000; // 30 seconds
-const DIAGNOSTIC_SESSION_KEY = 'authrim_diagnostic_session_id';
 
+/**
+ * Get the current diagnostic session ID.
+ * Uses DiagnosticLogger if enabled, otherwise falls back to sessionStorage.
+ */
 export function getDiagnosticSessionId(): string | undefined {
 	if (!browser) return undefined;
-	let sessionId = sessionStorage.getItem(DIAGNOSTIC_SESSION_KEY);
+
+	// Prefer the DiagnosticLogger's session ID for consistency with ingest logs
+	const fromLogger = getLoggerSessionId();
+	if (fromLogger) return fromLogger;
+
+	// Fallback: generate/persist via sessionStorage when logger is disabled
+	const FALLBACK_KEY = 'authrim_diagnostic_session_id';
+	let sessionId = sessionStorage.getItem(FALLBACK_KEY);
 	if (!sessionId) {
 		try {
 			sessionId = crypto.randomUUID();
 		} catch {
-			// Fallback using cryptographically secure random values
 			const randomBytes = crypto.getRandomValues(new Uint8Array(8));
 			const randomStr = Array.from(randomBytes, (b) => b.toString(16).padStart(2, '0')).join('');
 			sessionId = `diag_${Date.now()}_${randomStr}`;
 		}
-		sessionStorage.setItem(DIAGNOSTIC_SESSION_KEY, sessionId);
+		sessionStorage.setItem(FALLBACK_KEY, sessionId);
 	}
 	return sessionId;
 }

--- a/packages/ar-login-ui/src/lib/diagnostic/diagnostic-logger.ts
+++ b/packages/ar-login-ui/src/lib/diagnostic/diagnostic-logger.ts
@@ -1,0 +1,380 @@
+/**
+ * DiagnosticLogger for Login UI
+ *
+ * Compatible interface with @authrim/web's DiagnosticLogger.
+ * Collects token validation and auth decision logs, persists to localStorage,
+ * and sends batches to the server's diagnostic log ingest endpoint.
+ *
+ * The Login UI is registered as a public OAuth client (token_endpoint_auth_method=none),
+ * so only client_id is required for ingest authentication (no client_secret).
+ */
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type DiagnosticLogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export type TokenValidationStep =
+	| 'issuer-check'
+	| 'audience-check'
+	| 'expiry-check'
+	| 'nonce-check'
+	| 'signature-check'
+	| 'hash-check';
+
+export interface BaseDiagnosticLogEntry {
+	id: string;
+	diagnosticSessionId: string;
+	category: string;
+	level: DiagnosticLogLevel;
+	timestamp: number;
+	metadata?: Record<string, unknown>;
+}
+
+export interface TokenValidationLogEntry extends BaseDiagnosticLogEntry {
+	category: 'token-validation';
+	step: TokenValidationStep;
+	tokenType: string;
+	result: 'pass' | 'fail';
+	expected?: unknown;
+	actual?: unknown;
+	errorMessage?: string;
+	details?: Record<string, unknown>;
+}
+
+export interface AuthDecisionLogEntry extends BaseDiagnosticLogEntry {
+	category: 'auth-decision';
+	decision: 'allow' | 'deny';
+	reason: string;
+	flow?: string;
+	context?: Record<string, unknown>;
+}
+
+export type DiagnosticLogEntry = TokenValidationLogEntry | AuthDecisionLogEntry;
+
+export interface DiagnosticLoggerOptions {
+	enabled: boolean;
+	persistToStorage?: boolean;
+	storageKeyPrefix?: string;
+	maxLogs?: number;
+	sessionId?: string;
+	sendToServer?: boolean;
+	serverUrl?: string;
+	clientId?: string;
+	/** For confidential clients only. Login UI uses public client so this is not needed. */
+	clientSecret?: string;
+	batchSize?: number;
+	flushIntervalMs?: number;
+}
+
+// =============================================================================
+// DiagnosticLogger
+// =============================================================================
+
+export class DiagnosticLogger {
+	private diagnosticSessionId: string;
+	private enabled: boolean;
+	private persistToStorage: boolean;
+	private storageKeyPrefix: string;
+	private maxLogs: number;
+	private logs: DiagnosticLogEntry[] = [];
+
+	private sendToServer: boolean;
+	private serverUrl?: string;
+	private clientId?: string;
+	private clientSecret?: string;
+	private batchSize: number;
+	private flushIntervalMs: number;
+
+	private sendBuffer: DiagnosticLogEntry[] = [];
+	private flushTimer?: ReturnType<typeof setInterval>;
+	private isFlushing = false;
+
+	constructor(options: DiagnosticLoggerOptions) {
+		this.enabled = options.enabled;
+		this.persistToStorage = options.persistToStorage ?? false;
+		this.storageKeyPrefix = options.storageKeyPrefix ?? 'authrim:diagnostic';
+		this.maxLogs = options.maxLogs ?? 1000;
+		this.sendToServer = options.sendToServer ?? false;
+		this.serverUrl = options.serverUrl;
+		this.clientId = options.clientId;
+		this.clientSecret = options.clientSecret;
+		this.batchSize = options.batchSize ?? 50;
+		this.flushIntervalMs = options.flushIntervalMs ?? 5000;
+
+		if (this.sendToServer && (!this.serverUrl || !this.clientId)) {
+			console.warn(
+				'[DiagnosticLogger] sendToServer is enabled but serverUrl or clientId is missing. Server sending disabled.'
+			);
+			this.sendToServer = false;
+		}
+
+		if (options.sessionId) {
+			this.diagnosticSessionId = options.sessionId;
+		} else {
+			this.diagnosticSessionId = this.loadOrGenerateSessionId();
+		}
+
+		if (this.persistToStorage) {
+			this.loadLogsFromStorage();
+		}
+
+		if (this.sendToServer) {
+			this.startFlushTimer();
+			this.registerUnloadHandlers();
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+	// Public API (compatible with @authrim/web DiagnosticLogger)
+	// ---------------------------------------------------------------------------
+
+	getDiagnosticSessionId(): string {
+		return this.diagnosticSessionId;
+	}
+
+	isEnabled(): boolean {
+		return this.enabled;
+	}
+
+	logTokenValidation(options: {
+		step: TokenValidationStep;
+		tokenType: string;
+		result: 'pass' | 'fail';
+		expected?: unknown;
+		actual?: unknown;
+		errorMessage?: string;
+		details?: Record<string, unknown>;
+	}): void {
+		if (!this.enabled) return;
+
+		const entry: TokenValidationLogEntry = {
+			id: this.generateId(),
+			diagnosticSessionId: this.diagnosticSessionId,
+			category: 'token-validation',
+			level: options.result === 'fail' ? 'warn' : 'debug',
+			timestamp: Date.now(),
+			step: options.step,
+			tokenType: options.tokenType,
+			result: options.result,
+			expected: options.expected,
+			actual: options.actual,
+			errorMessage: options.errorMessage,
+			details: options.details
+		};
+
+		this.addEntry(entry);
+	}
+
+	logAuthDecision(options: {
+		decision: 'allow' | 'deny';
+		reason: string;
+		flow?: string;
+		context?: Record<string, unknown>;
+	}): void {
+		if (!this.enabled) return;
+
+		const entry: AuthDecisionLogEntry = {
+			id: this.generateId(),
+			diagnosticSessionId: this.diagnosticSessionId,
+			category: 'auth-decision',
+			level: options.decision === 'deny' ? 'warn' : 'info',
+			timestamp: Date.now(),
+			decision: options.decision,
+			reason: options.reason,
+			flow: options.flow,
+			context: options.context
+		};
+
+		this.addEntry(entry);
+	}
+
+	getLogs(): DiagnosticLogEntry[] {
+		return [...this.logs];
+	}
+
+	exportLogs(): string {
+		return JSON.stringify(this.logs, null, 2);
+	}
+
+	downloadLogs(): void {
+		const content = this.exportLogs();
+		const blob = new Blob([content], { type: 'application/json' });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = `diagnostic-${this.diagnosticSessionId}-${Date.now()}.json`;
+		a.click();
+		URL.revokeObjectURL(url);
+	}
+
+	clearLogs(): void {
+		this.logs = [];
+		this.sendBuffer = [];
+		if (this.persistToStorage) {
+			this.clearStorage();
+		}
+	}
+
+	async flush(): Promise<void> {
+		if (!this.sendToServer || this.sendBuffer.length === 0 || this.isFlushing) return;
+		this.isFlushing = true;
+
+		const batch = this.sendBuffer.splice(0, this.batchSize);
+		try {
+			await this.sendBatch(batch);
+		} catch {
+			// Re-queue failed batch at the front
+			this.sendBuffer.unshift(...batch);
+		} finally {
+			this.isFlushing = false;
+		}
+	}
+
+	flushBeacon(): void {
+		if (!this.sendToServer || !this.serverUrl || !this.clientId || this.sendBuffer.length === 0) {
+			return;
+		}
+
+		const batch = this.sendBuffer.splice(0, this.batchSize);
+		const payload = JSON.stringify({
+			client_id: this.clientId,
+			...(this.clientSecret ? { client_secret: this.clientSecret } : {}),
+			logs: batch
+		});
+
+		navigator.sendBeacon(this.serverUrl, new Blob([payload], { type: 'application/json' }));
+	}
+
+	destroy(): void {
+		if (this.flushTimer) {
+			clearInterval(this.flushTimer);
+			this.flushTimer = undefined;
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+	// Private helpers
+	// ---------------------------------------------------------------------------
+
+	private addEntry(entry: DiagnosticLogEntry): void {
+		if (this.logs.length >= this.maxLogs) {
+			this.logs.shift();
+		}
+		this.logs.push(entry);
+
+		if (this.persistToStorage) {
+			this.saveLogsToStorage();
+		}
+
+		if (this.sendToServer) {
+			this.sendBuffer.push(entry);
+			if (this.sendBuffer.length >= this.batchSize) {
+				this.flush();
+			}
+		}
+	}
+
+	private async sendBatch(batch: DiagnosticLogEntry[]): Promise<void> {
+		if (!this.serverUrl || !this.clientId) return;
+
+		const body: Record<string, unknown> = {
+			client_id: this.clientId,
+			logs: batch
+		};
+		if (this.clientSecret) {
+			body.client_secret = this.clientSecret;
+		}
+
+		const response = await fetch(this.serverUrl, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-Diagnostic-Session-Id': this.diagnosticSessionId
+			},
+			body: JSON.stringify(body),
+			keepalive: true
+		});
+
+		if (!response.ok) {
+			throw new Error(`Ingest failed: ${response.status}`);
+		}
+	}
+
+	private startFlushTimer(): void {
+		this.flushTimer = setInterval(() => {
+			this.flush();
+		}, this.flushIntervalMs);
+	}
+
+	private registerUnloadHandlers(): void {
+		document.addEventListener('visibilitychange', () => {
+			if (document.visibilityState === 'hidden') {
+				this.flushBeacon();
+			}
+		});
+		window.addEventListener('beforeunload', () => {
+			this.flushBeacon();
+		});
+	}
+
+	private loadOrGenerateSessionId(): string {
+		if (this.persistToStorage) {
+			const stored = localStorage.getItem(`${this.storageKeyPrefix}:session-id`);
+			if (stored) return stored;
+		}
+		const id = this.generateSessionId();
+		if (this.persistToStorage) {
+			localStorage.setItem(`${this.storageKeyPrefix}:session-id`, id);
+		}
+		return id;
+	}
+
+	private generateSessionId(): string {
+		try {
+			return crypto.randomUUID();
+		} catch {
+			const bytes = crypto.getRandomValues(new Uint8Array(16));
+			return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+		}
+	}
+
+	private generateId(): string {
+		try {
+			return crypto.randomUUID();
+		} catch {
+			return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+		}
+	}
+
+	private saveLogsToStorage(): void {
+		try {
+			localStorage.setItem(`${this.storageKeyPrefix}:logs`, JSON.stringify(this.logs));
+		} catch {
+			// Quota exceeded - ignore
+		}
+	}
+
+	private loadLogsFromStorage(): void {
+		try {
+			const stored = localStorage.getItem(`${this.storageKeyPrefix}:logs`);
+			if (stored) {
+				const parsed = JSON.parse(stored) as DiagnosticLogEntry[];
+				// Only load logs for the current session
+				this.logs = parsed.filter((e) => e.diagnosticSessionId === this.diagnosticSessionId);
+			}
+		} catch {
+			// Corrupted storage - ignore
+		}
+	}
+
+	private clearStorage(): void {
+		try {
+			localStorage.removeItem(`${this.storageKeyPrefix}:logs`);
+			localStorage.removeItem(`${this.storageKeyPrefix}:session-id`);
+		} catch {
+			// Ignore
+		}
+	}
+}

--- a/packages/ar-login-ui/src/lib/stores/diagnostic.ts
+++ b/packages/ar-login-ui/src/lib/stores/diagnostic.ts
@@ -1,0 +1,47 @@
+/**
+ * Diagnostic Logger Store
+ *
+ * Singleton DiagnosticLogger instance initialized from environment variables.
+ * Enabled only when PUBLIC_DIAGNOSTIC_LOGGING_ENABLED=true.
+ */
+
+import { browser } from '$app/environment';
+import { DiagnosticLogger } from '$lib/diagnostic/diagnostic-logger';
+
+let _logger: DiagnosticLogger | null = null;
+
+/**
+ * Get the singleton DiagnosticLogger instance.
+ * Returns null if diagnostic logging is disabled or running server-side.
+ */
+export function getDiagnosticLogger(): DiagnosticLogger | null {
+	if (!browser) return null;
+	if (_logger) return _logger;
+
+	const enabled = import.meta.env.PUBLIC_DIAGNOSTIC_LOGGING_ENABLED === 'true';
+	if (!enabled) return null;
+
+	const clientId = import.meta.env.PUBLIC_LOGIN_UI_CLIENT_ID as string | undefined;
+	const issuer =
+		(import.meta.env.PUBLIC_AUTHRIM_ISSUER as string | undefined) || window.location.origin;
+
+	_logger = new DiagnosticLogger({
+		enabled: true,
+		persistToStorage: true,
+		sendToServer: !!clientId,
+		serverUrl: `${issuer}/api/v1/diagnostic-logs/ingest`,
+		clientId,
+		batchSize: 50,
+		flushIntervalMs: 5000
+	});
+
+	return _logger;
+}
+
+/**
+ * Get the current diagnostic session ID.
+ * Returns null if diagnostic logging is disabled.
+ */
+export function getDiagnosticSessionId(): string | null {
+	return getDiagnosticLogger()?.getDiagnosticSessionId() ?? null;
+}

--- a/packages/ar-login-ui/src/routes/callback/+page.svelte
+++ b/packages/ar-login-ui/src/routes/callback/+page.svelte
@@ -8,6 +8,7 @@
 	import { getAuthConfig } from '$lib/auth';
 	import { auth } from '$lib/stores/auth';
 	import { API_BASE_URL } from '$lib/api/client';
+	import { getDiagnosticLogger } from '$lib/stores/diagnostic';
 
 	let status = $state<'processing' | 'success' | 'error'>('processing');
 	let errorMessage = $state('');
@@ -53,6 +54,12 @@
 				errorCode = data.error || 'handoff_verification_failed';
 				errorMessage = data.error_description || 'Handoff token verification failed';
 				status = 'error';
+				getDiagnosticLogger()?.logAuthDecision({
+					decision: 'deny',
+					reason: errorCode,
+					flow: 'smart-handoff',
+					context: { status: response.status }
+				});
 				return;
 			}
 
@@ -73,6 +80,12 @@
 
 			console.log('[Authrim] Handoff login successful');
 
+			getDiagnosticLogger()?.logAuthDecision({
+				decision: 'allow',
+				reason: 'handoff_verification_success',
+				flow: 'smart-handoff'
+			});
+
 			status = 'success';
 
 			// Redirect to stored return URL or home
@@ -89,6 +102,11 @@
 			errorCode = 'network_error';
 			errorMessage = 'An error occurred during handoff authentication';
 			status = 'error';
+			getDiagnosticLogger()?.logAuthDecision({
+				decision: 'deny',
+				reason: 'network_error',
+				flow: 'smart-handoff'
+			});
 		}
 	}
 
@@ -198,6 +216,12 @@
 				errorCode = data.error || 'callback_failed';
 				errorMessage = data.error_description || $LL.callback_errorExchangeFailed();
 				status = 'error';
+				getDiagnosticLogger()?.logAuthDecision({
+					decision: 'deny',
+					reason: errorCode,
+					flow: 'authorization_code',
+					context: { status: response.status, provider_id: providerId ?? undefined }
+				});
 				return;
 			}
 
@@ -211,6 +235,13 @@
 					name: tokenData.user.name
 				});
 			}
+
+			getDiagnosticLogger()?.logAuthDecision({
+				decision: 'allow',
+				reason: 'token_exchange_success',
+				flow: 'authorization_code',
+				context: { provider_id: providerId ?? undefined }
+			});
 
 			status = 'success';
 
@@ -229,6 +260,11 @@
 			errorCode = 'network_error';
 			errorMessage = $LL.callback_errorNetwork();
 			status = 'error';
+			getDiagnosticLogger()?.logAuthDecision({
+				decision: 'deny',
+				reason: 'network_error',
+				flow: 'authorization_code'
+			});
 		}
 	});
 

--- a/packages/setup/src/core/login-ui-client.ts
+++ b/packages/setup/src/core/login-ui-client.ts
@@ -50,6 +50,8 @@ interface AdminClientListResponse {
     grant_types: string[];
     is_trusted?: boolean;
     skip_consent?: boolean;
+    token_endpoint_auth_method?: string;
+    require_pkce?: boolean;
   }>;
   pagination: {
     total: number;
@@ -101,10 +103,19 @@ async function readAdminApiSecret(secretPath: string): Promise<string> {
   return secret.trim();
 }
 
+interface ExistingClientInfo {
+  clientId: string;
+  needsMigration: boolean;
+}
+
 /**
- * Check if a Login UI client already exists
+ * Check if a Login UI client already exists.
+ * Returns client_id and whether migration to public client is needed.
  */
-async function findExistingClient(apiBaseUrl: string, adminSecret: string): Promise<string | null> {
+async function findExistingClient(
+  apiBaseUrl: string,
+  adminSecret: string
+): Promise<ExistingClientInfo | null> {
   const response = await fetch(
     `${apiBaseUrl}/api/admin/clients?search=${encodeURIComponent(LOGIN_UI_CLIENT_NAME)}&limit=10`,
     {
@@ -125,7 +136,43 @@ async function findExistingClient(apiBaseUrl: string, adminSecret: string): Prom
     (c) => c.client_name === LOGIN_UI_CLIENT_NAME && c.is_trusted === true
   );
 
-  return existing?.client_id ?? null;
+  if (!existing) return null;
+
+  return {
+    clientId: existing.client_id,
+    needsMigration:
+      existing.token_endpoint_auth_method !== 'none' || existing.require_pkce !== true,
+  };
+}
+
+/**
+ * Update an existing Login UI client to use public client configuration.
+ * Migrates from client_secret_basic to none + require_pkce.
+ */
+async function updateClientToPublic(
+  apiBaseUrl: string,
+  adminSecret: string,
+  clientId: string
+): Promise<void> {
+  const response = await fetch(`${apiBaseUrl}/api/admin/clients/${clientId}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${adminSecret}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({
+      token_endpoint_auth_method: 'none',
+      require_pkce: true,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => 'Unknown error');
+    throw new Error(
+      `Failed to update Login UI client to public client (${response.status}): ${errorBody}`
+    );
+  }
 }
 
 /**
@@ -153,7 +200,8 @@ async function createClient(
       scope: 'openid profile email',
       is_trusted: true,
       skip_consent: true,
-      token_endpoint_auth_method: 'client_secret_basic',
+      token_endpoint_auth_method: 'none',
+      require_pkce: true,
     }),
   });
 
@@ -184,13 +232,21 @@ export async function ensureLoginUiClient(
 
     // Check for existing client
     onProgress?.('Checking for existing Login UI client...');
-    const existingClientId = await findExistingClient(apiBaseUrl, adminSecret);
+    const existingClient = await findExistingClient(apiBaseUrl, adminSecret);
 
-    if (existingClientId) {
-      onProgress?.(`Login UI client already exists: ${existingClientId}`);
+    if (existingClient) {
+      if (existingClient.needsMigration) {
+        onProgress?.(`Migrating Login UI client to public client: ${existingClient.clientId}`);
+        await updateClientToPublic(apiBaseUrl, adminSecret, existingClient.clientId);
+        onProgress?.(
+          'Login UI client migrated to public client (token_endpoint_auth_method=none, require_pkce=true)'
+        );
+      } else {
+        onProgress?.(`Login UI client already exists: ${existingClient.clientId}`);
+      }
       return {
         success: true,
-        clientId: existingClientId,
+        clientId: existingClient.clientId,
         alreadyExists: true,
       };
     }

--- a/packages/setup/src/core/ui-env.ts
+++ b/packages/setup/src/core/ui-env.ts
@@ -46,6 +46,12 @@ export interface UiEnvConfig {
    * Auto-created during deployment via ensureLoginUiClient()
    */
   PUBLIC_LOGIN_UI_CLIENT_ID?: string;
+  /**
+   * Enable Diagnostic Logging in the Login UI.
+   * When 'true', DiagnosticLogger is initialized and logs are sent to the ingest endpoint.
+   * Defaults to 'false' to avoid affecting OIDC conformance test results.
+   */
+  PUBLIC_DIAGNOSTIC_LOGGING_ENABLED?: string;
 }
 
 // =============================================================================
@@ -98,6 +104,8 @@ export function buildInitialUiEnvConfig(config: AuthrimConfig): UiEnvConfig | nu
 
   return {
     PUBLIC_API_BASE_URL: apiUrl,
+    PUBLIC_AUTHRIM_ISSUER: apiUrl,
+    PUBLIC_DIAGNOSTIC_LOGGING_ENABLED: 'false',
   };
 }
 


### PR DESCRIPTION
## Summary

- **Register Login UI as a public OAuth client**: Change to `token_endpoint_auth_method=none` + `require_pkce=true` (appropriate for browser SPAs)
- **Auto-migrate existing clients**: Add `updateClientToPublic()` to automatically migrate clients using `client_secret_basic` to public client configuration
- **Implement DiagnosticLogger**: Add DiagnosticLogger to `ar-login-ui` with session ID tracking, batch log ingest via fetch/sendBeacon, and localStorage persistence
- **Add env var**: `PUBLIC_DIAGNOSTIC_LOGGING_ENABLED` (default: `false`)
- **Integrate diagnostic logging in callback page**: Log auth decisions for both smart-handoff and authorization_code flows

## Background

OIDC RP conformance tests use DiagnosticLogging via the `@authrim/web` SDK. Since the Login UI also acts as an OIDC RP, the diagnostic logging infrastructure needed to be in place. The Login UI itself is not a conformance test target (it does not call the `/token` endpoint directly), but this change lays the groundwork for future coverage.

## Changes

### `packages/setup/src/core/login-ui-client.ts`
- Change `findExistingClient()` return type to `ExistingClientInfo | null` (adds `needsMigration` flag)
- Add `updateClientToPublic()` function (PUT `/api/admin/clients/:id`)
- New client creation: `client_secret_basic` → `none` + `require_pkce: true`
- `ensureLoginUiClient()` now auto-migrates existing clients

### `packages/setup/src/core/ui-env.ts`
- Add `PUBLIC_DIAGNOSTIC_LOGGING_ENABLED` env var (default: `'false'`)
- Include `PUBLIC_AUTHRIM_ISSUER` and `PUBLIC_DIAGNOSTIC_LOGGING_ENABLED` in `buildInitialUiEnvConfig()`

### `packages/ar-login-ui/src/lib/diagnostic/diagnostic-logger.ts` (new)
- `IDiagnosticLogger`-compatible DiagnosticLogger implementation
- Session ID management, batch send (fetch + keepalive), sendBeacon on page unload

### `packages/ar-login-ui/src/lib/stores/diagnostic.ts` (new)
- Singleton store that initializes DiagnosticLogger from env vars
- Exports `getDiagnosticLogger()` and `getDiagnosticSessionId()`

### `packages/ar-login-ui/src/lib/api/client.ts`
- Use DiagnosticLogger session ID as primary source; fall back to sessionStorage

### `packages/ar-login-ui/src/routes/callback/+page.svelte`
- Add diagnostic log calls for smart-handoff flow (success/failure/network error)
- Add diagnostic log calls for authorization_code flow (success/failure/network error)

## Test plan

- [ ] `pnpm run typecheck` passes (ar-login-ui)
- [ ] Auto-migration runs correctly on deploy when an existing client with `client_secret_basic` is present
- [ ] With `PUBLIC_DIAGNOSTIC_LOGGING_ENABLED=true`, logs are sent to the ingest endpoint
- [ ] Default (`false`) returns null from `getDiagnosticLogger()` with no impact on existing flows