### PR TITLE
test: add high-priority coverage gaps

### DIFF
--- a/packages/ar-auth/src/__tests__/par.test.ts
+++ b/packages/ar-auth/src/__tests__/par.test.ts
@@ -1,0 +1,288 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '@authrim/ar-lib-core';
+
+const {
+  mockValidateClientId,
+  mockValidateRedirectUri,
+  mockValidateScope,
+  mockIsRedirectUriRegistered,
+  mockCreateOAuthConfigManager,
+  mockValidateClientAssertion,
+  mockValidateDPoPProof,
+  mockVerifyClientSecretHash,
+  mockGetTokenFormat,
+  mockParseToken,
+  mockIsInternalUrl,
+  mockValidateAuthorizationDetails,
+  mockGetClientCached,
+  mockGetPARRequestStoreForNewRequest,
+  mockStoreRequestRpc,
+  mockGetLogger,
+  mockLogger,
+} = vi.hoisted(() => {
+  const logger = {
+    module: vi.fn().mockReturnThis(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+
+  return {
+    mockValidateClientId: vi.fn(),
+    mockValidateRedirectUri: vi.fn(),
+    mockValidateScope: vi.fn(),
+    mockIsRedirectUriRegistered: vi.fn(),
+    mockCreateOAuthConfigManager: vi.fn(),
+    mockValidateClientAssertion: vi.fn(),
+    mockValidateDPoPProof: vi.fn(),
+    mockVerifyClientSecretHash: vi.fn(),
+    mockGetTokenFormat: vi.fn(),
+    mockParseToken: vi.fn(),
+    mockIsInternalUrl: vi.fn(),
+    mockValidateAuthorizationDetails: vi.fn(),
+    mockGetClientCached: vi.fn(),
+    mockGetPARRequestStoreForNewRequest: vi.fn(),
+    mockStoreRequestRpc: vi.fn(),
+    mockGetLogger: vi.fn().mockReturnValue(logger),
+    mockLogger: logger,
+  };
+});
+
+vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@authrim/ar-lib-core')>();
+  return {
+    ...actual,
+    validateClientId: mockValidateClientId,
+    validateRedirectUri: mockValidateRedirectUri,
+    validateScope: mockValidateScope,
+    isRedirectUriRegistered: mockIsRedirectUriRegistered,
+    createOAuthConfigManager: mockCreateOAuthConfigManager,
+    validateClientAssertion: mockValidateClientAssertion,
+    validateDPoPProof: mockValidateDPoPProof,
+    verifyClientSecretHash: mockVerifyClientSecretHash,
+    getTokenFormat: mockGetTokenFormat,
+    parseToken: mockParseToken,
+    isInternalUrl: mockIsInternalUrl,
+    validateAuthorizationDetails: mockValidateAuthorizationDetails,
+    getClientCached: mockGetClientCached,
+    getPARRequestStoreForNewRequest: mockGetPARRequestStoreForNewRequest,
+    getLogger: mockGetLogger,
+  };
+});
+
+vi.mock('../issuer', () => ({
+  getRequestIssuer: vi.fn().mockReturnValue('https://op.example.com'),
+}));
+
+import { parHandler } from '../par';
+
+function createMockContext(options: {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: Record<string, unknown>;
+  env?: Partial<Env>;
+}) {
+  const headers = Object.fromEntries(
+    Object.entries(options.headers ?? {}).map(([key, value]) => [key.toLowerCase(), value])
+  );
+
+  const env = {
+    ISSUER_URL: 'https://op.example.com',
+    SETTINGS: {
+      get: vi.fn().mockResolvedValue(null),
+    } as unknown as KVNamespace,
+    PAR_REQUEST_STORE: {} as Env['PAR_REQUEST_STORE'],
+    DPOP_JTI_STORE: {} as DurableObjectNamespace,
+    ...options.env,
+  } as Env;
+
+  const c = {
+    req: {
+      method: options.method ?? 'POST',
+      header: (name: string) => headers[name.toLowerCase()],
+      parseBody: vi.fn().mockResolvedValue(options.body ?? {}),
+    },
+    env,
+    json: vi.fn((body: unknown, status = 200) =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    ),
+    get: vi.fn().mockImplementation((key: string) => {
+      if (key === 'tenantId') return 'default';
+      return undefined;
+    }),
+  } as any;
+
+  return c;
+}
+
+describe('PAR Handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockValidateClientId.mockReturnValue({ valid: true });
+    mockValidateRedirectUri.mockReturnValue({ valid: true });
+    mockValidateScope.mockReturnValue({ valid: true });
+    mockIsRedirectUriRegistered.mockReturnValue(true);
+    mockCreateOAuthConfigManager.mockReturnValue({});
+    mockValidateClientAssertion.mockResolvedValue({ valid: true });
+    mockValidateDPoPProof.mockResolvedValue({ valid: true, jkt: 'thumbprint' });
+    mockVerifyClientSecretHash.mockResolvedValue(true);
+    mockGetTokenFormat.mockReturnValue('jwt');
+    mockParseToken.mockReturnValue(null);
+    mockIsInternalUrl.mockReturnValue(false);
+    mockValidateAuthorizationDetails.mockReturnValue({
+      valid: true,
+      sanitized: [{ type: 'payment_initiation' }],
+    });
+    mockGetClientCached.mockResolvedValue({
+      client_id: 'client-123',
+      redirect_uris: ['https://client.example.com/callback'],
+    });
+    mockStoreRequestRpc.mockResolvedValue(undefined);
+    mockGetPARRequestStoreForNewRequest.mockResolvedValue({
+      requestUri: 'urn:ietf:params:oauth:request_uri:par_test',
+      stub: {
+        storeRequestRpc: mockStoreRequestRpc,
+      },
+    });
+    mockGetLogger.mockReturnValue(mockLogger);
+  });
+
+  it('rejects non form-encoded requests before processing the payload', async () => {
+    const c = createMockContext({
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: {
+        client_id: 'client-123',
+      },
+    });
+
+    const response = await parHandler(c);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'invalid_request',
+      error_description: 'Content-Type must be application/x-www-form-urlencoded',
+    });
+    expect(mockGetClientCached).not.toHaveBeenCalled();
+  });
+
+  it('enforces private_key_jwt for FAPI PAR requests', async () => {
+    mockGetClientCached.mockResolvedValue({
+      client_id: 'client-123',
+      client_secret_hash: 'hash_secret',
+      redirect_uris: ['https://client.example.com/callback'],
+    });
+
+    const c = createMockContext({
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: {
+        client_id: 'client-123',
+        client_secret: 'secret',
+        response_type: 'code',
+        redirect_uri: 'https://client.example.com/callback',
+        scope: 'openid profile',
+        code_challenge: 'a'.repeat(43),
+        code_challenge_method: 'S256',
+      },
+      env: {
+        SETTINGS: {
+          get: vi.fn().mockResolvedValue(
+            JSON.stringify({
+              fapi: {
+                enabled: true,
+              },
+            })
+          ),
+        } as unknown as KVNamespace,
+      },
+    });
+
+    const response = await parHandler(c);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'invalid_client',
+      error_description: 'FAPI 2.0 requires private_key_jwt authentication for PAR',
+    });
+    expect(mockStoreRequestRpc).not.toHaveBeenCalled();
+  });
+
+  it('caps FAPI request_uri expiry at 60 seconds on successful requests', async () => {
+    const c = createMockContext({
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: {
+        client_id: 'client-123',
+        response_type: 'code',
+        redirect_uri: 'https://client.example.com/callback',
+        scope: 'openid profile',
+        code_challenge: 'a'.repeat(43),
+        code_challenge_method: 'S256',
+        state: 'state-123',
+      },
+      env: {
+        SETTINGS: {
+          get: vi.fn().mockResolvedValue(
+            JSON.stringify({
+              fapi: {
+                enabled: true,
+                requirePrivateKeyJwt: false,
+                maxRequestUriExpiry: 120,
+              },
+            })
+          ),
+        } as unknown as KVNamespace,
+      },
+    });
+
+    const response = await parHandler(c);
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      request_uri: 'urn:ietf:params:oauth:request_uri:par_test',
+      expires_in: 60,
+    });
+    expect(mockStoreRequestRpc).toHaveBeenCalledWith({
+      requestUri: 'urn:ietf:params:oauth:request_uri:par_test',
+      data: expect.objectContaining({
+        client_id: 'client-123',
+        state: 'state-123',
+      }),
+      ttl: 60,
+    });
+  });
+
+  it('rejects authorization_details when RAR is not enabled', async () => {
+    const c = createMockContext({
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: {
+        client_id: 'client-123',
+        response_type: 'code',
+        redirect_uri: 'https://client.example.com/callback',
+        scope: 'openid profile',
+        authorization_details: JSON.stringify([{ type: 'payment_initiation' }]),
+      },
+    });
+
+    const response = await parHandler(c);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'invalid_request',
+      error_description:
+        'authorization_details parameter is not supported. Enable RAR feature to use Rich Authorization Requests.',
+    });
+    expect(mockStoreRequestRpc).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ar-lib-core/src/repositories/__tests__/session-client.test.ts
+++ b/packages/ar-lib-core/src/repositories/__tests__/session-client.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DatabaseAdapter } from '../../db/adapter';
+import { SessionClientRepository } from '../core/session-client';
+
+describe('SessionClientRepository logout lookups', () => {
+  let adapter: DatabaseAdapter;
+  let repository: SessionClientRepository;
+  let queryMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    queryMock = vi.fn();
+    adapter = {
+      query: queryMock,
+      queryOne: vi.fn(),
+      execute: vi.fn(),
+      transaction: vi.fn(),
+    } as unknown as DatabaseAdapter;
+    repository = new SessionClientRepository(adapter);
+  });
+
+  it('maps backchannel logout rows into typed client records', async () => {
+    queryMock.mockResolvedValue([
+      {
+        id: 'row-1',
+        session_id: 'session-123',
+        client_id: 'client-123',
+        first_token_at: 100,
+        last_token_at: 200,
+        last_seen_at: null,
+        client_name: 'Backchannel Client',
+        backchannel_logout_uri: 'https://client.example.com/backchannel',
+        backchannel_logout_session_required: 1,
+        frontchannel_logout_uri: 'https://client.example.com/frontchannel',
+        frontchannel_logout_session_required: 0,
+      },
+    ]);
+
+    const result = await repository.findBackchannelLogoutClients('session-123');
+
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('c.backchannel_logout_uri IS NOT NULL'),
+      ['session-123']
+    );
+    expect(result).toEqual([
+      {
+        id: 'row-1',
+        session_id: 'session-123',
+        client_id: 'client-123',
+        first_token_at: 100,
+        last_token_at: 200,
+        last_seen_at: null,
+        client_name: 'Backchannel Client',
+        backchannel_logout_uri: 'https://client.example.com/backchannel',
+        backchannel_logout_session_required: true,
+        frontchannel_logout_uri: 'https://client.example.com/frontchannel',
+        frontchannel_logout_session_required: false,
+      },
+    ]);
+  });
+
+  it('maps frontchannel logout rows into typed client records', async () => {
+    queryMock.mockResolvedValue([
+      {
+        id: 'row-2',
+        session_id: 'session-123',
+        client_id: 'client-456',
+        first_token_at: 300,
+        last_token_at: 400,
+        last_seen_at: 450,
+        client_name: 'Frontchannel Client',
+        backchannel_logout_uri: null,
+        backchannel_logout_session_required: 0,
+        frontchannel_logout_uri: 'https://client.example.com/logout',
+        frontchannel_logout_session_required: 1,
+      },
+    ]);
+
+    const result = await repository.findFrontchannelLogoutClients('session-123');
+
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('c.frontchannel_logout_uri IS NOT NULL'),
+      ['session-123']
+    );
+    expect(result).toEqual([
+      {
+        id: 'row-2',
+        session_id: 'session-123',
+        client_id: 'client-456',
+        first_token_at: 300,
+        last_token_at: 400,
+        last_seen_at: 450,
+        client_name: 'Frontchannel Client',
+        backchannel_logout_uri: null,
+        backchannel_logout_session_required: false,
+        frontchannel_logout_uri: 'https://client.example.com/logout',
+        frontchannel_logout_session_required: true,
+      },
+    ]);
+  });
+
+  it('returns webhook clients with the exact payload used by webhook dispatch', async () => {
+    queryMock.mockResolvedValue([
+      {
+        id: 'row-3',
+        session_id: 'session-123',
+        client_id: 'client-789',
+        client_name: 'Webhook Client',
+        logout_webhook_uri: 'https://client.example.com/hooks/logout',
+        logout_webhook_secret_encrypted: 'encrypted-secret',
+      },
+    ]);
+
+    const result = await repository.findWebhookClients('session-123');
+
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('c.logout_webhook_uri IS NOT NULL'),
+      ['session-123']
+    );
+    expect(result).toEqual([
+      {
+        id: 'row-3',
+        session_id: 'session-123',
+        client_id: 'client-789',
+        client_name: 'Webhook Client',
+        logout_webhook_uri: 'https://client.example.com/hooks/logout',
+        logout_webhook_secret_encrypted: 'encrypted-secret',
+      },
+    ]);
+  });
+});

--- a/packages/ar-management/src/__tests__/admin-session.test.ts
+++ b/packages/ar-management/src/__tests__/admin-session.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '@authrim/ar-lib-core';
+
+const {
+  mockGetCookie,
+  mockSetCookie,
+  mockBuildIssuerUrl,
+  mockGetTenantIdFromContext,
+  mockParseAllowedOrigins,
+  mockIsAllowedOrigin,
+  mockPublishEvent,
+  mockGetAdminCookieSameSite,
+  mockGetLogger,
+  mockLogger,
+  mockAdminAdapter,
+  mockAdminSessionRepo,
+  MockD1Adapter,
+  MockAdminSessionRepository,
+} = vi.hoisted(() => {
+  const logger = {
+    module: vi.fn().mockReturnThis(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+
+  const adminAdapter = {
+    query: vi.fn(),
+    queryOne: vi.fn(),
+  };
+
+  const adminSessionRepo = {
+    getSession: vi.fn(),
+    getSessionIncludingExpired: vi.fn(),
+    deleteSession: vi.fn(),
+  };
+
+  const MockD1Adapter = vi.fn(function MockD1Adapter() {
+    return adminAdapter;
+  });
+
+  const MockAdminSessionRepository = vi.fn(function MockAdminSessionRepository() {
+    return adminSessionRepo;
+  });
+
+  return {
+    mockGetCookie: vi.fn(),
+    mockSetCookie: vi.fn(),
+    mockBuildIssuerUrl: vi.fn().mockReturnValue('https://admin.example.com'),
+    mockGetTenantIdFromContext: vi.fn().mockReturnValue('default'),
+    mockParseAllowedOrigins: vi.fn().mockReturnValue(['https://admin.example.com']),
+    mockIsAllowedOrigin: vi.fn().mockReturnValue(true),
+    mockPublishEvent: vi.fn().mockResolvedValue(undefined),
+    mockGetAdminCookieSameSite: vi.fn().mockReturnValue('Lax'),
+    mockGetLogger: vi.fn().mockReturnValue(logger),
+    mockLogger: logger,
+    mockAdminAdapter: adminAdapter,
+    mockAdminSessionRepo: adminSessionRepo,
+    MockD1Adapter,
+    MockAdminSessionRepository,
+  };
+});
+
+vi.mock('hono/cookie', () => ({
+  getCookie: mockGetCookie,
+  setCookie: mockSetCookie,
+}));
+
+vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@authrim/ar-lib-core')>();
+  return {
+    ...actual,
+    buildIssuerUrl: mockBuildIssuerUrl,
+    getTenantIdFromContext: mockGetTenantIdFromContext,
+    parseAllowedOrigins: mockParseAllowedOrigins,
+    isAllowedOrigin: mockIsAllowedOrigin,
+    getLogger: mockGetLogger,
+    D1Adapter: MockD1Adapter,
+    AdminSessionRepository: MockAdminSessionRepository,
+    publishEvent: mockPublishEvent,
+    getAdminCookieSameSite: mockGetAdminCookieSameSite,
+  };
+});
+
+import { adminLogoutHandler, adminSessionStatusHandler } from '../admin-session';
+
+function createMockContext(options: {
+  headers?: Record<string, string>;
+  env?: Partial<Env>;
+}) {
+  const headers = Object.fromEntries(
+    Object.entries(options.headers ?? {}).map(([key, value]) => [key.toLowerCase(), value])
+  );
+
+  return {
+    req: {
+      header: (name: string) => headers[name.toLowerCase()],
+    },
+    env: {
+      ISSUER_URL: 'https://admin.example.com',
+      DB_ADMIN: {} as D1Database,
+      ...options.env,
+    } as Env,
+    json: vi.fn((body: unknown, status = 200) =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    ),
+  } as any;
+}
+
+describe('Admin Session Handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBuildIssuerUrl.mockReturnValue('https://admin.example.com');
+    mockGetTenantIdFromContext.mockReturnValue('default');
+    mockParseAllowedOrigins.mockReturnValue(['https://admin.example.com']);
+    mockIsAllowedOrigin.mockReturnValue(true);
+    mockPublishEvent.mockResolvedValue(undefined);
+    mockGetAdminCookieSameSite.mockReturnValue('Lax');
+    mockGetLogger.mockReturnValue(mockLogger);
+  });
+
+  it('returns session details when the admin user has an allowed role', async () => {
+    mockGetCookie.mockReturnValue('admin-session-123');
+    mockAdminSessionRepo.getSession.mockResolvedValue({
+      id: 'admin-session-123',
+      admin_user_id: 'admin-user-1',
+      created_at: 100,
+      expires_at: 200,
+    });
+    mockAdminAdapter.query.mockResolvedValue([{ name: 'viewer' }]);
+    mockAdminAdapter.queryOne.mockResolvedValue({
+      email: 'admin@example.com',
+      name: 'Admin User',
+      last_login_at: 1700000000,
+    });
+
+    const response = await adminSessionStatusHandler(createMockContext({}));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      active: true,
+      session_id: 'admin-session-123',
+      user_id: 'admin-user-1',
+      email: 'admin@example.com',
+      name: 'Admin User',
+      roles: ['viewer'],
+      last_login_at: 1700000000,
+    });
+  });
+
+  it('rejects session status requests when the user lacks an admin role', async () => {
+    mockGetCookie.mockReturnValue('admin-session-123');
+    mockAdminSessionRepo.getSession.mockResolvedValue({
+      id: 'admin-session-123',
+      admin_user_id: 'admin-user-1',
+      created_at: 100,
+      expires_at: 200,
+    });
+    mockAdminAdapter.query.mockResolvedValue([{ name: 'auditor' }]);
+
+    const response = await adminSessionStatusHandler(createMockContext({}));
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'forbidden',
+      error_description: 'You do not have admin permissions',
+    });
+  });
+
+  it('rejects admin logout when both Origin and Referer are missing', async () => {
+    mockGetCookie.mockReturnValue('admin-session-123');
+
+    const response = await adminLogoutHandler(createMockContext({}));
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'forbidden',
+      error_description: 'Origin or Referer header is required',
+    });
+    expect(mockSetCookie).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid Referer fallback and clears the admin session cookie', async () => {
+    mockGetCookie.mockReturnValue('admin-session-123');
+    mockAdminSessionRepo.getSessionIncludingExpired.mockResolvedValue({
+      admin_user_id: 'admin-user-1',
+    });
+    mockAdminSessionRepo.deleteSession.mockResolvedValue(true);
+
+    const response = await adminLogoutHandler(
+      createMockContext({
+        headers: {
+          Referer: 'https://admin.example.com/settings',
+        },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      message: 'Logged out successfully',
+    });
+    expect(mockIsAllowedOrigin).toHaveBeenCalledWith('https://admin.example.com', [
+      'https://admin.example.com',
+    ]);
+    expect(mockSetCookie).toHaveBeenCalledWith(
+      expect.anything(),
+      'authrim_admin_session',
+      '',
+      expect.objectContaining({
+        path: '/',
+        httpOnly: true,
+        secure: true,
+        sameSite: 'Lax',
+        maxAge: 0,
+      })
+    );
+    expect(mockPublishEvent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/setup/src/__tests__/deploy.test.ts
+++ b/packages/setup/src/__tests__/deploy.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildPagesUiBuildEnv, deployWorker } from '../core/deploy.js';
+
+const tempDirs: string[] = [];
+
+function createTempRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'authrim-deploy-test-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe('buildPagesUiBuildEnv', () => {
+  it('strips leaked PUBLIC_* values and injects the runtime API base URL', () => {
+    const result = buildPagesUiBuildEnv(
+      {
+        KEEP_ME: '1',
+        PUBLIC_API_BASE_URL: 'https://stale.example.com',
+        PUBLIC_AUTHRIM_ISSUER: 'https://stale-issuer.example.com',
+      },
+      {
+        apiBaseUrl: 'https://api.example.com',
+        preferPackageEnv: false,
+      }
+    );
+
+    expect(result.KEEP_ME).toBe('1');
+    expect(result.PUBLIC_API_BASE_URL).toBe('https://api.example.com');
+    expect(result.PUBLIC_AUTHRIM_ISSUER).toBeUndefined();
+  });
+
+  it('prefers package-local env files over shell PUBLIC_* variables', () => {
+    const result = buildPagesUiBuildEnv(
+      {
+        PUBLIC_API_BASE_URL: 'https://shell.example.com',
+        PUBLIC_LOGIN_UI_CLIENT_ID: 'client-from-shell',
+      },
+      {
+        apiBaseUrl: 'https://api.example.com',
+        preferPackageEnv: true,
+      }
+    );
+
+    expect(result.PUBLIC_API_BASE_URL).toBeUndefined();
+    expect(result.PUBLIC_LOGIN_UI_CLIENT_ID).toBeUndefined();
+  });
+});
+
+describe('deployWorker', () => {
+  it('rejects invalid environment names before attempting deployment', async () => {
+    const result = await deployWorker('ar-auth', {
+      env: 'Prod!',
+      rootDir: '/tmp/does-not-matter',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Invalid environment name');
+  });
+
+  it('supports dry runs when the package and wrangler config are present', async () => {
+    const rootDir = createTempRoot();
+    const packageDir = join(rootDir, 'packages', 'ar-auth');
+    mkdirSync(packageDir, { recursive: true });
+    writeFileSync(join(packageDir, 'wrangler.toml'), 'name = "test-ar-auth"\n');
+    writeFileSync(
+      join(packageDir, 'package.json'),
+      JSON.stringify({
+        name: '@authrim/ar-auth',
+        version: '9.9.9',
+      })
+    );
+
+    const progressMessages: string[] = [];
+    const result = await deployWorker('ar-auth', {
+      env: 'test',
+      rootDir,
+      dryRun: true,
+      onProgress: (message) => progressMessages.push(message),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.version).toBe('9.9.9');
+    expect(progressMessages).toContain('[1/3] Deploying test-ar-auth...');
+    expect(progressMessages).toContain('  [DRY RUN] Would deploy ar-auth with --env test');
+  });
+});


### PR DESCRIPTION
## Summary
- add PAR endpoint regression coverage for content-type, FAPI auth, TTL capping, and RAR gating
- add admin session/logout coverage for role checks and CSRF origin/referer validation
- add repository coverage for session-client logout lookup shapes and setup deploy guardrails

## Validation
- pnpm --filter @authrim/ar-lib-core typecheck
- pnpm --filter @authrim/ar-management typecheck
- pnpm --filter @authrim/ar-auth typecheck
- pnpm --filter @authrim/setup typecheck
- pnpm --filter @authrim/ar-lib-core build
- pnpm --filter @authrim/ar-lib-core test
- pnpm --filter @authrim/ar-management test
- pnpm --filter @authrim/ar-auth test
- pnpm --filter @authrim/setup test