### PR TITLE
fix(setup): improve zone check diagnostics

### DIFF
--- a/packages/ar-admin-ui/src/lib/api/admin-info.ts
+++ b/packages/ar-admin-ui/src/lib/api/admin-info.ts
@@ -6,6 +6,10 @@
 
 const API_BASE_URL = import.meta.env.PUBLIC_API_BASE_URL || '';
 
+function resolveTenantId(tenantId?: string): string {
+	return tenantId?.trim() || 'default';
+}
+
 export interface TenantEndpoints {
 	well_known: {
 		openid_configuration: string;
@@ -80,10 +84,13 @@ export interface TenantInfo extends TenantEndpoints {
 	api_url: string;
 }
 
-export async function getTenantInfo(tenantId: string): Promise<TenantInfo> {
-	const response = await fetch(`${API_BASE_URL}/api/admin/tenants/${tenantId}/info`, {
-		credentials: 'include'
-	});
+export async function getTenantInfo(tenantId?: string): Promise<TenantInfo> {
+	const response = await fetch(
+		`${API_BASE_URL}/api/admin/tenants/${encodeURIComponent(resolveTenantId(tenantId))}/info`,
+		{
+			credentials: 'include'
+		}
+	);
 
 	if (!response.ok) {
 		const err = await response.json().catch(() => ({ error: 'unknown_error' }));

--- a/packages/ar-admin-ui/src/lib/api/admin-settings.ts
+++ b/packages/ar-admin-ui/src/lib/api/admin-settings.ts
@@ -13,7 +13,10 @@ import { settingsContext } from '$lib/stores/settings-context.svelte';
 
 function resolveTenantId(tenantId?: string): string {
 	const resolved =
-		tenantId?.trim() || settingsContext.tenantId || settingsContext.availableTenants[0]?.id || '';
+		tenantId?.trim() ||
+		settingsContext.tenantId ||
+		settingsContext.availableTenants[0]?.id ||
+		'default';
 
 	if (!resolved) {
 		throw new Error('Tenant ID is required');

--- a/packages/ar-admin-ui/src/lib/stores/settings-context.svelte.ts
+++ b/packages/ar-admin-ui/src/lib/stores/settings-context.svelte.ts
@@ -50,6 +50,7 @@ export type PermissionLevel = 'view' | 'edit' | 'none';
  * API base URL
  */
 const API_BASE_URL = import.meta.env.PUBLIC_API_BASE_URL || '';
+const FALLBACK_TENANT_ID = 'default';
 
 /**
  * Create settings context store
@@ -121,6 +122,17 @@ function createSettingsContextStore() {
 
 	return {
 		/**
+		 * Resolve the effective tenant ID for API calls.
+		 * In single-tenant mode we may temporarily have no loaded tenant list yet,
+		 * so fall back to 'default' instead of emitting empty tenant paths.
+		 */
+		resolveTenantId(candidate?: string | null): string {
+			return (
+				candidate?.trim() || state.tenantId || state.availableTenants[0]?.id || FALLBACK_TENANT_ID
+			);
+		},
+
+		/**
 		 * Get current state (readonly)
 		 */
 		get current(): SettingsContextState {
@@ -138,7 +150,7 @@ function createSettingsContextStore() {
 		 * Get current tenant ID
 		 */
 		get tenantId(): string {
-			return state.tenantId;
+			return this.resolveTenantId(state.tenantId);
 		},
 
 		/**
@@ -180,9 +192,10 @@ function createSettingsContextStore() {
 		 * Get scope context for API calls
 		 */
 		get scopeContext(): { level: SettingScopeLevel; tenantId?: string; clientId?: string } {
+			const resolvedTenantId = this.resolveTenantId(state.tenantId);
 			return {
 				level: state.currentLevel,
-				tenantId: state.currentLevel !== 'platform' ? state.tenantId : undefined,
+				tenantId: state.currentLevel !== 'platform' ? resolvedTenantId : undefined,
 				clientId: state.currentLevel === 'client' ? (state.clientId ?? undefined) : undefined
 			};
 		},
@@ -240,16 +253,18 @@ function createSettingsContextStore() {
 		 * Set tenant ID
 		 */
 		async setTenantId(tenantId: string): Promise<void> {
+			const resolvedTenantId = this.resolveTenantId(tenantId);
+
 			// Clear client selection and available clients immediately to prevent stale data
 			state.clientId = null;
 			state.availableClients = [];
 
-			state.tenantId = tenantId;
+			state.tenantId = resolvedTenantId;
 			state.error = null;
 
 			// Save to session storage
 			if (browser) {
-				sessionStorage.setItem('settings_tenant_id', tenantId);
+				sessionStorage.setItem('settings_tenant_id', resolvedTenantId);
 				sessionStorage.removeItem('settings_client_id');
 			}
 
@@ -296,18 +311,19 @@ function createSettingsContextStore() {
 						id: t.id,
 						name: t.name || t.id
 					}));
-					if (
-						!state.tenantId ||
-						!state.availableTenants.some((tenant) => tenant.id === state.tenantId)
-					) {
-						state.tenantId = state.availableTenants[0]?.id ?? '';
-					}
+					state.tenantId = this.resolveTenantId(
+						state.availableTenants.some((tenant) => tenant.id === state.tenantId)
+							? state.tenantId
+							: state.availableTenants[0]?.id
+					);
 				} else {
 					state.availableTenants = [];
+					state.tenantId = this.resolveTenantId(state.tenantId);
 				}
 			} catch (err) {
 				console.warn('Failed to load tenants:', err);
 				state.availableTenants = [];
+				state.tenantId = this.resolveTenantId(state.tenantId);
 			} finally {
 				state.isLoading = false;
 			}
@@ -317,18 +333,16 @@ function createSettingsContextStore() {
 		 * Load available clients for current tenant
 		 */
 		async loadClients(): Promise<void> {
-			if (!browser || !state.tenantId) return;
+			const tenantId = this.resolveTenantId(state.tenantId);
+			if (!browser || !tenantId) return;
 
 			state.isLoading = true;
 			state.error = null;
 
 			try {
-				const response = await fetch(
-					`${API_BASE_URL}/api/admin/tenants/${state.tenantId}/clients`,
-					{
-						credentials: 'include'
-					}
-				);
+				const response = await fetch(`${API_BASE_URL}/api/admin/tenants/${tenantId}/clients`, {
+					credentials: 'include'
+				});
 
 				if (response.ok) {
 					const data = await response.json();
@@ -385,7 +399,7 @@ function createSettingsContextStore() {
 		 */
 		reset(): void {
 			state.currentLevel = 'tenant';
-			state.tenantId = state.availableTenants[0]?.id ?? '';
+			state.tenantId = this.resolveTenantId(state.availableTenants[0]?.id);
 			state.clientId = null;
 			state.error = null;
 

--- a/packages/ar-admin-ui/src/routes/admin/info/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/info/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { settingsContext } from '$lib/stores/settings-context.svelte';
 	import { getTenantInfo, type TenantInfo } from '$lib/api/admin-info';
 
@@ -7,6 +8,10 @@
 	let loading = $state(true);
 	let error = $state('');
 	let copiedKey = $state('');
+
+	onMount(async () => {
+		await settingsContext.initialize();
+	});
 
 	// React to tenant switching
 	$effect(() => {
@@ -137,10 +142,30 @@
 				Well-Known / Discovery
 			</h2>
 			<div class="url-grid">
-				{@render urlRow('OpenID Configuration', info.well_known.openid_configuration, 'wk_oidc', info.well_known.openid_configuration)}
-				{@render urlRow('OAuth Authorization Server', info.well_known.oauth_authorization_server, 'wk_oauth', info.well_known.oauth_authorization_server)}
-				{@render urlRow('JWKS (JSON Web Key Set)', info.well_known.jwks, 'wk_jwks', info.well_known.jwks)}
-				{@render urlRow('WebFinger', info.well_known.webfinger, 'wk_webfinger', info.well_known.webfinger)}
+				{@render urlRow(
+					'OpenID Configuration',
+					info.well_known.openid_configuration,
+					'wk_oidc',
+					info.well_known.openid_configuration
+				)}
+				{@render urlRow(
+					'OAuth Authorization Server',
+					info.well_known.oauth_authorization_server,
+					'wk_oauth',
+					info.well_known.oauth_authorization_server
+				)}
+				{@render urlRow(
+					'JWKS (JSON Web Key Set)',
+					info.well_known.jwks,
+					'wk_jwks',
+					info.well_known.jwks
+				)}
+				{@render urlRow(
+					'WebFinger',
+					info.well_known.webfinger,
+					'wk_webfinger',
+					info.well_known.webfinger
+				)}
 			</div>
 		</section>
 
@@ -162,12 +187,24 @@
 			<h3 class="subsection-title">OAuth 2.0 Extensions</h3>
 			<div class="url-grid">
 				{#if info.components.async}
-					{@render urlRow('Device Authorization (RFC 8628)', info.oauth_extensions.device_authorization, 'oauth_device')}
+					{@render urlRow(
+						'Device Authorization (RFC 8628)',
+						info.oauth_extensions.device_authorization,
+						'oauth_device'
+					)}
 				{:else}
 					{@render urlRow('Device Authorization (RFC 8628)', 'Not deployed', 'oauth_device_status')}
 				{/if}
-				{@render urlRow('Pushed Authorization Request (RFC 9126)', info.oauth_extensions.pushed_authorization_request, 'oauth_par')}
-				{@render urlRow('Dynamic Client Registration (RFC 7591)', info.oauth_extensions.dynamic_client_registration, 'oauth_dcr')}
+				{@render urlRow(
+					'Pushed Authorization Request (RFC 9126)',
+					info.oauth_extensions.pushed_authorization_request,
+					'oauth_par'
+				)}
+				{@render urlRow(
+					'Dynamic Client Registration (RFC 7591)',
+					info.oauth_extensions.dynamic_client_registration,
+					'oauth_dcr'
+				)}
 			</div>
 		</section>
 
@@ -179,7 +216,11 @@
 			</h2>
 			<div class="url-grid">
 				{#if info.components.async}
-					{@render urlRow('Backchannel Authentication (RFC 9449)', info.ciba.backchannel_authentication, 'ciba_auth')}
+					{@render urlRow(
+						'Backchannel Authentication (RFC 9449)',
+						info.ciba.backchannel_authentication,
+						'ciba_auth'
+					)}
 				{:else}
 					{@render urlRow('Status', 'Not deployed', 'ciba_status')}
 				{/if}
@@ -212,7 +253,12 @@
 			</h2>
 			<div class="url-grid">
 				{#if info.components.vc}
-					{@render urlRow('Credential Issuer Metadata', info.vc.credential_issuer_metadata, 'vc_meta', info.vc.credential_issuer_metadata)}
+					{@render urlRow(
+						'Credential Issuer Metadata',
+						info.vc.credential_issuer_metadata,
+						'vc_meta',
+						info.vc.credential_issuer_metadata
+					)}
 					{@render urlRow('Credential Endpoint', info.vc.credential, 'vc_credential')}
 					{@render urlRow('Batch Credential', info.vc.batch_credential, 'vc_batch')}
 					{@render urlRow('Deferred Credential', info.vc.deferred_credential, 'vc_deferred')}
@@ -233,7 +279,12 @@
 				{@render urlRow('Base URL', info.scim.base, 'scim_base')}
 				{@render urlRow('Users', info.scim.users, 'scim_users')}
 				{@render urlRow('Groups', info.scim.groups, 'scim_groups')}
-				{@render urlRow('Service Provider Config', info.scim.service_provider_config, 'scim_spc', info.scim.service_provider_config)}
+				{@render urlRow(
+					'Service Provider Config',
+					info.scim.service_provider_config,
+					'scim_spc',
+					info.scim.service_provider_config
+				)}
 			</div>
 		</section>
 

--- a/packages/setup/src/__tests__/cloudflare-wildcard-dns.test.ts
+++ b/packages/setup/src/__tests__/cloudflare-wildcard-dns.test.ts
@@ -196,6 +196,24 @@ describe('ensureWildcardDnsRecord', () => {
       verificationLimited: true,
     });
   });
+
+  it('continues with limited verification when zone lookup is blocked by missing zone:read', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: false }, 403));
+
+    const result = await cloudflare.ensureWildcardDnsRecord('test.example.com');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'https://api.cloudflare.com/client/v4/zones?name=example.com'
+    );
+    expect(result).toEqual({
+      created: false,
+      updated: false,
+      name: '*.test.example.com',
+      target: 'test.example.com',
+      verificationLimited: true,
+    });
+  });
 });
 
 describe('ensureWildcardDnsForMultiTenant', () => {

--- a/packages/setup/src/__tests__/cloudflare-zone-check.test.ts
+++ b/packages/setup/src/__tests__/cloudflare-zone-check.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execa } from 'execa';
+import {
+  checkZoneExists,
+  type ZoneCheckDiagnosticCode,
+  type ZoneCheckResult,
+} from '../core/cloudflare.js';
+
+vi.mock('execa', () => ({
+  execa: vi.fn(),
+}));
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof import('node:os')>('node:os');
+  return {
+    ...actual,
+    homedir: () => '/tmp/authrim-zone-check-tests',
+    platform: () => 'linux',
+  };
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function expectDiagnostic(
+  result: ZoneCheckResult,
+  code: ZoneCheckDiagnosticCode,
+  allowBinding: boolean
+): void {
+  expect(result.found).toBe(code === 'zone_found');
+  expect(result.zoneName).toBe('example.com');
+  expect(result.diagnostic?.code).toBe(code);
+  expect(result.diagnostic?.allowBinding).toBe(allowBinding);
+}
+
+describe('checkZoneExists', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+  const execaMock = vi.mocked(execa);
+  const originalApiToken = process.env.CLOUDFLARE_API_TOKEN;
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    execaMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+    delete process.env.CLOUDFLARE_API_TOKEN;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (originalApiToken === undefined) {
+      delete process.env.CLOUDFLARE_API_TOKEN;
+    } else {
+      process.env.CLOUDFLARE_API_TOKEN = originalApiToken;
+    }
+  });
+
+  it('returns a success diagnostic when the zone exists', async () => {
+    process.env.CLOUDFLARE_API_TOKEN = 'test-token';
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        success: true,
+        result: [{ id: 'zone-1', name: 'example.com', status: 'active' }],
+      })
+    );
+
+    const result = await checkZoneExists('auth.example.com');
+
+    expectDiagnostic(result, 'zone_found', true);
+    expect(result.zone).toEqual({ id: 'zone-1', name: 'example.com', status: 'active' });
+  });
+
+  it('returns zone_not_found when the API succeeds but no zone is visible', async () => {
+    process.env.CLOUDFLARE_API_TOKEN = 'test-token';
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true, result: [] }));
+
+    const result = await checkZoneExists('auth.example.com');
+
+    expectDiagnostic(result, 'zone_not_found', false);
+  });
+
+  it('returns zone_read_forbidden when zone listing is forbidden', async () => {
+    process.env.CLOUDFLARE_API_TOKEN = 'test-token';
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: false }, 403));
+
+    const result = await checkZoneExists('auth.example.com');
+
+    expectDiagnostic(result, 'zone_read_forbidden', true);
+    expect(result.error).toContain('zone:read');
+  });
+
+  it('returns api_error when the Cloudflare API responds with a server error', async () => {
+    process.env.CLOUDFLARE_API_TOKEN = 'test-token';
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: false }, 500));
+
+    const result = await checkZoneExists('auth.example.com');
+
+    expectDiagnostic(result, 'api_error', false);
+  });
+
+  it('returns network_error when fetch rejects', async () => {
+    process.env.CLOUDFLARE_API_TOKEN = 'test-token';
+    fetchMock.mockRejectedValueOnce(new Error('socket hang up'));
+
+    const result = await checkZoneExists('auth.example.com');
+
+    expectDiagnostic(result, 'network_error', false);
+    expect(result.error).toContain('socket hang up');
+  });
+
+  it('returns not_logged_in when Cloudflare auth is missing', async () => {
+    execaMock.mockResolvedValueOnce({
+      stdout: 'Not logged in. Run `wrangler login`.',
+      stderr: '',
+    } as Awaited<ReturnType<typeof execa>>);
+
+    const result = await checkZoneExists('auth.example.com');
+
+    expectDiagnostic(result, 'not_logged_in', false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns token_unavailable when login exists but no API token can be read', async () => {
+    execaMock.mockResolvedValueOnce({
+      stdout: 'You are logged in with an OAuth token, associated with the email test@example.com.',
+      stderr: '',
+    } as Awaited<ReturnType<typeof execa>>);
+
+    const result = await checkZoneExists('auth.example.com');
+
+    expectDiagnostic(result, 'token_unavailable', false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/setup/src/__tests__/web-ui-template.test.ts
+++ b/packages/setup/src/__tests__/web-ui-template.test.ts
@@ -57,6 +57,25 @@ describe('getHtmlTemplate', () => {
     expect(html).toContain('PREREQ_CAPABILITY_COPY');
     expect(html).toContain('"review":"Review"');
     expect(html).toContain('"review":"需确认"');
+    expect(html).toContain('createPrereqCustomDomainReviewAlert');
+    expect(html).toContain('domain.prereq.reviewTitle');
+    expect(html).toContain('domain.action.reloadPage');
+  });
+
+  it('renders structured zone diagnostics with action buttons', () => {
+    const html = getHtmlTemplate(
+      'session-token',
+      false,
+      'en',
+      en as Record<string, string>,
+      SUPPORTED_LOCALES
+    );
+
+    expect(html).toContain('class="domain-check-status"');
+    expect(html).toContain('createZoneDiagnosticAlert');
+    expect(html).toContain('createZoneActionButton');
+    expect(html).toContain('Open Cloudflare Dashboard');
+    expect(html).toContain('Custom-domain checks need a quick review');
   });
 
   it('embeds manual wildcard DNS guidance for deploy warnings', () => {

--- a/packages/setup/src/cli/commands/init.ts
+++ b/packages/setup/src/cli/commands/init.ts
@@ -38,6 +38,7 @@ import {
   getWorkersSubdomain,
   checkZoneExists,
   extractZoneName,
+  isZoneReadPermissionError,
 } from '../../core/cloudflare.js';
 import { createLockFile, saveLockFile, loadLockFile } from '../../core/lock.js';
 import {
@@ -111,6 +112,17 @@ async function checkAndPromptZone(domain: string, domainConfig: ZoneDomainConfig
 
     if (result.error) {
       console.log(chalk.yellow(`  ⚠ ${t('domain.zoneCheckFailed')}: ${result.error}`));
+      if (isZoneReadPermissionError(result.error)) {
+        console.log(
+          chalk.gray(
+            '    Existing zones can still work. Automatic zone verification and DNS assistance will be limited.'
+          )
+        );
+        console.log('');
+        const bind = await confirm({ message: t('domain.configureBinding'), default: true });
+        domainConfig.customDomainBinding = bind;
+        return;
+      }
       console.log(chalk.gray(`    ${t('domain.zoneCheckSkipped')}`));
       return;
     }

--- a/packages/setup/src/cli/commands/init.ts
+++ b/packages/setup/src/cli/commands/init.ts
@@ -38,7 +38,7 @@ import {
   getWorkersSubdomain,
   checkZoneExists,
   extractZoneName,
-  isZoneReadPermissionError,
+  type ZoneCheckResult,
 } from '../../core/cloudflare.js';
 import { createLockFile, saveLockFile, loadLockFile } from '../../core/lock.js';
 import {
@@ -109,28 +109,33 @@ async function checkAndPromptZone(domain: string, domainConfig: ZoneDomainConfig
   try {
     const result = await checkZoneExists(domain);
     spinner.stop();
+    const diagnosticCode = result.diagnostic?.code;
+    const zoneName = extractZoneName(domain);
 
-    if (result.error) {
-      console.log(chalk.yellow(`  ⚠ ${t('domain.zoneCheckFailed')}: ${result.error}`));
-      if (isZoneReadPermissionError(result.error)) {
-        console.log(
-          chalk.gray(
-            '    Existing zones can still work. Automatic zone verification and DNS assistance will be limited.'
-          )
-        );
-        console.log('');
-        const bind = await confirm({ message: t('domain.configureBinding'), default: true });
-        domainConfig.customDomainBinding = bind;
-        return;
-      }
-      console.log(chalk.gray(`    ${t('domain.zoneCheckSkipped')}`));
+    if (result.found && result.zone) {
+      console.log(
+        chalk.green(
+          `  ✓ ${t('domain.zoneFound', { zone: result.zone.name, status: result.zone.status })}`
+        )
+      );
+      domainConfig.zoneId = result.zone.id;
+      console.log('');
+
+      const bind = await confirm({ message: t('domain.configureBinding'), default: true });
+      domainConfig.customDomainBinding = bind;
       return;
     }
 
-    if (!result.found) {
-      const zoneName = extractZoneName(domain);
-      console.log(chalk.yellow(`  ⚠ ${t('domain.zoneNotFound', { zone: zoneName })}`));
-      console.log(chalk.gray(`    ${t('domain.zoneNotFoundHint')}`));
+    printCliZoneDiagnostic(result, { domain, zoneName });
+
+    if (result.diagnostic?.allowBinding) {
+      console.log('');
+      const bind = await confirm({ message: t('domain.configureBinding'), default: true });
+      domainConfig.customDomainBinding = bind;
+      return;
+    }
+
+    if (diagnosticCode === 'zone_not_found') {
       console.log('');
       const ok = await confirm({ message: t('domain.continueWithoutZone'), default: true });
       if (!ok) {
@@ -139,17 +144,7 @@ async function checkAndPromptZone(domain: string, domainConfig: ZoneDomainConfig
       return;
     }
 
-    // Zone found
-    console.log(
-      chalk.green(
-        `  ✓ ${t('domain.zoneFound', { zone: result.zone!.name, status: result.zone!.status })}`
-      )
-    );
-    domainConfig.zoneId = result.zone!.id;
-    console.log('');
-
-    const bind = await confirm({ message: t('domain.configureBinding'), default: true });
-    domainConfig.customDomainBinding = bind;
+    console.log(chalk.gray(`    ${t('domain.zoneCheckSkipped')}`));
   } catch (error) {
     spinner.stop();
     if (error instanceof Error && error.message === 'USER_CANCELLED_DOMAIN') {
@@ -158,6 +153,28 @@ async function checkAndPromptZone(domain: string, domainConfig: ZoneDomainConfig
     // Unexpected error - don't block setup
     console.log(chalk.yellow(`  ⚠ ${t('domain.zoneCheckFailed')}`));
     console.log(chalk.gray(`    ${t('domain.zoneCheckSkipped')}`));
+  }
+}
+
+function printCliZoneDiagnostic(
+  result: ZoneCheckResult,
+  params: { domain: string; zoneName: string }
+): void {
+  const code = result.diagnostic?.code || 'api_error';
+  const translatedParams = {
+    domain: params.domain,
+    zone: params.zoneName,
+  };
+  const title = t(`domain.diagnostic.${code}.title`, translatedParams);
+  const body = t(`domain.diagnostic.${code}.body`, translatedParams);
+  const next = t(`domain.diagnostic.${code}.next`, translatedParams);
+  const icon = result.diagnostic?.severity === 'error' ? '✖' : '⚠';
+  const color = result.diagnostic?.severity === 'error' ? chalk.red : chalk.yellow;
+
+  console.log(color(`  ${icon} ${title}`));
+  console.log(chalk.gray(`    ${body}`));
+  if (next && next !== `domain.diagnostic.${code}.next`) {
+    console.log(chalk.gray(`    ${next}`));
   }
 }
 

--- a/packages/setup/src/core/cloudflare.ts
+++ b/packages/setup/src/core/cloudflare.ts
@@ -492,6 +492,10 @@ export interface ZoneCheckResult {
   error?: string;
 }
 
+export function isZoneReadPermissionError(error?: string): boolean {
+  return (error ?? '').includes('zone:read');
+}
+
 /**
  * Extract zone name (registrable domain) from a hostname.
  * e.g., "auth.example.com" → "example.com"
@@ -1047,17 +1051,26 @@ export async function ensureWildcardDnsRecord(
     throw new Error('Not logged in to Cloudflare (run: wrangler login)');
   }
 
+  const recordName = `*.${baseDomain}`;
+  const recordTarget = baseDomain;
+
   let resolvedZoneId = zoneId || undefined;
   if (!resolvedZoneId) {
     const zoneResult = await checkZoneExists(baseDomain);
     if (!zoneResult.found || !zoneResult.zone?.id) {
+      if (isZoneReadPermissionError(zoneResult.error)) {
+        return {
+          created: false,
+          updated: false,
+          name: recordName,
+          target: recordTarget,
+          verificationLimited: true,
+        };
+      }
       throw new Error(`Cloudflare zone not found for ${baseDomain}`);
     }
     resolvedZoneId = zoneResult.zone.id;
   }
-
-  const recordName = `*.${baseDomain}`;
-  const recordTarget = baseDomain;
 
   const recordResponse = await fetch(
     `https://api.cloudflare.com/client/v4/zones/${resolvedZoneId}/dns_records?name=${encodeURIComponent(recordName)}`,

--- a/packages/setup/src/core/cloudflare.ts
+++ b/packages/setup/src/core/cloudflare.ts
@@ -486,14 +486,129 @@ export interface ZoneInfo {
   status: string;
 }
 
+export type ZoneCheckDiagnosticCode =
+  | 'zone_found'
+  | 'not_logged_in'
+  | 'token_unavailable'
+  | 'zone_read_forbidden'
+  | 'zone_not_found'
+  | 'api_error'
+  | 'network_error';
+
+export type ZoneCheckDiagnosticSeverity = 'success' | 'warning' | 'error';
+
+export type ZoneCheckAction =
+  | 'retry_check'
+  | 'reload_page'
+  | 'run_wrangler_login'
+  | 'check_cloudflare_permissions'
+  | 'open_cloudflare_dashboard';
+
+export interface ZoneCheckDiagnostic {
+  code: ZoneCheckDiagnosticCode;
+  severity: ZoneCheckDiagnosticSeverity;
+  allowBinding: boolean;
+  actions: ZoneCheckAction[];
+}
+
 export interface ZoneCheckResult {
   found: boolean;
   zone?: ZoneInfo;
+  zoneName?: string;
   error?: string;
+  diagnostic?: ZoneCheckDiagnostic;
 }
 
-export function isZoneReadPermissionError(error?: string): boolean {
-  return (error ?? '').includes('zone:read');
+function createZoneDiagnostic(
+  code: ZoneCheckDiagnosticCode,
+  overrides: Partial<ZoneCheckDiagnostic> = {}
+): ZoneCheckDiagnostic {
+  const defaults: Record<ZoneCheckDiagnosticCode, ZoneCheckDiagnostic> = {
+    zone_found: {
+      code: 'zone_found',
+      severity: 'success',
+      allowBinding: true,
+      actions: [],
+    },
+    not_logged_in: {
+      code: 'not_logged_in',
+      severity: 'error',
+      allowBinding: false,
+      actions: ['retry_check', 'reload_page', 'run_wrangler_login'],
+    },
+    token_unavailable: {
+      code: 'token_unavailable',
+      severity: 'error',
+      allowBinding: false,
+      actions: ['retry_check', 'reload_page', 'run_wrangler_login'],
+    },
+    zone_read_forbidden: {
+      code: 'zone_read_forbidden',
+      severity: 'warning',
+      allowBinding: true,
+      actions: ['retry_check', 'reload_page', 'run_wrangler_login', 'check_cloudflare_permissions'],
+    },
+    zone_not_found: {
+      code: 'zone_not_found',
+      severity: 'warning',
+      allowBinding: false,
+      actions: ['retry_check', 'open_cloudflare_dashboard'],
+    },
+    api_error: {
+      code: 'api_error',
+      severity: 'error',
+      allowBinding: false,
+      actions: ['retry_check', 'reload_page'],
+    },
+    network_error: {
+      code: 'network_error',
+      severity: 'error',
+      allowBinding: false,
+      actions: ['retry_check', 'reload_page'],
+    },
+  };
+
+  return {
+    ...defaults[code],
+    ...overrides,
+    actions: overrides.actions ?? defaults[code].actions,
+  };
+}
+
+function createZoneCheckResult(
+  code: ZoneCheckDiagnosticCode,
+  options: {
+    found?: boolean;
+    zone?: ZoneInfo;
+    zoneName?: string;
+    error?: string;
+  } = {}
+): ZoneCheckResult {
+  return {
+    found: options.found ?? code === 'zone_found',
+    zone: options.zone,
+    zoneName: options.zoneName,
+    error: options.error,
+    diagnostic: createZoneDiagnostic(code),
+  };
+}
+
+export function isZoneReadPermissionError(
+  errorOrResult?: string | ZoneCheckResult | ZoneCheckDiagnostic | null
+): boolean {
+  if (!errorOrResult) {
+    return false;
+  }
+  if (typeof errorOrResult === 'string') {
+    return errorOrResult.includes('zone:read');
+  }
+  if ('diagnostic' in errorOrResult) {
+    return (
+      errorOrResult.diagnostic?.code === 'zone_read_forbidden' ||
+      (errorOrResult.error ?? '').includes('zone:read')
+    );
+  }
+  return errorOrResult.code === 'zone_read_forbidden';
 }
 
 /**
@@ -946,12 +1061,21 @@ export function extractZoneName(hostname: string): string {
  */
 export async function checkZoneExists(domain: string): Promise<ZoneCheckResult> {
   try {
+    const zoneName = extractZoneName(domain);
     const tokenInfo = await getCloudflareApiToken();
     if (!tokenInfo) {
-      return { found: false, error: 'Not logged in to Cloudflare (run: wrangler login)' };
+      const auth = await checkAuth();
+      if (!auth.isLoggedIn) {
+        return createZoneCheckResult('not_logged_in', {
+          zoneName,
+          error: 'Not logged in to Cloudflare (run: wrangler login)',
+        });
+      }
+      return createZoneCheckResult('token_unavailable', {
+        zoneName,
+        error: 'Cloudflare API token is unavailable',
+      });
     }
-
-    const zoneName = extractZoneName(domain);
 
     const response = await fetch(
       `https://api.cloudflare.com/client/v4/zones?name=${encodeURIComponent(zoneName)}`,
@@ -964,30 +1088,46 @@ export async function checkZoneExists(domain: string): Promise<ZoneCheckResult> 
 
     if (!response.ok) {
       if (response.status === 403) {
-        return { found: false, error: 'Token lacks zone:read permission' };
+        return createZoneCheckResult('zone_read_forbidden', {
+          zoneName,
+          error: 'Token lacks zone:read permission',
+        });
       }
-      return { found: false, error: `Cloudflare API returned ${response.status}` };
+      return createZoneCheckResult('api_error', {
+        zoneName,
+        error: `Cloudflare API returned ${response.status}`,
+      });
     }
 
     const data = (await response.json()) as {
       success: boolean;
       result: Array<{ id: string; name: string; status: string }>;
+      errors?: CloudflareApiMessage[];
     };
 
-    if (!data.success || !data.result || data.result.length === 0) {
-      return { found: false };
+    if (!data.success) {
+      const apiMessage = data.errors?.find((item) => item.message)?.message;
+      return createZoneCheckResult('api_error', {
+        zoneName,
+        error: apiMessage || 'Cloudflare API returned an unsuccessful response',
+      });
+    }
+
+    if (!data.result || data.result.length === 0) {
+      return createZoneCheckResult('zone_not_found', { zoneName });
     }
 
     const zone = data.result[0];
-    return {
+    return createZoneCheckResult('zone_found', {
       found: true,
       zone: { id: zone.id, name: zone.name, status: zone.status },
-    };
+      zoneName,
+    });
   } catch (error) {
-    return {
-      found: false,
+    return createZoneCheckResult('network_error', {
+      zoneName: extractZoneName(domain),
       error: error instanceof Error ? error.message : 'Unknown error',
-    };
+    });
   }
 }
 
@@ -1058,7 +1198,7 @@ export async function ensureWildcardDnsRecord(
   if (!resolvedZoneId) {
     const zoneResult = await checkZoneExists(baseDomain);
     if (!zoneResult.found || !zoneResult.zone?.id) {
-      if (isZoneReadPermissionError(zoneResult.error)) {
+      if (zoneResult.diagnostic?.code === 'zone_read_forbidden') {
         return {
           created: false,
           updated: false,

--- a/packages/setup/src/core/cloudflare.ts
+++ b/packages/setup/src/core/cloudflare.ts
@@ -608,7 +608,10 @@ export function isZoneReadPermissionError(
       (errorOrResult.error ?? '').includes('zone:read')
     );
   }
-  return errorOrResult.code === 'zone_read_forbidden';
+  if ('code' in errorOrResult) {
+    return errorOrResult.code === 'zone_read_forbidden';
+  }
+  return false;
 }
 
 /**

--- a/packages/setup/src/i18n/locales/de.ts
+++ b/packages/setup/src/i18n/locales/de.ts
@@ -183,6 +183,47 @@ const de: Translations = {
   'domain.zoneCheckSkipped': 'Zone-Überprüfung übersprungen, Einrichtung wird fortgesetzt...',
   'domain.continueWithoutZone': 'Ohne Zone-Verifizierung fortfahren?',
   'domain.configureBinding': 'Custom-Domain-Binding für Workers konfigurieren',
+  'domain.action.retryCheck': 'Erneut prüfen',
+  'domain.action.reloadPage': 'Seite neu laden',
+  'domain.action.openCloudflareDashboard': 'Cloudflare-Dashboard öffnen',
+  'domain.prereq.reviewTitle': 'Die Prüfung der Custom Domain braucht eine Nachkontrolle',
+  'domain.prereq.reviewBody':
+    'Wenn Sie eine Custom Domain verwenden möchten, prüfen Sie nach dem Neuladen der Seite oder einer erneuten Cloudflare-Anmeldung noch einmal.',
+  'domain.diagnostic.zone_found.title': 'Die Cloudflare-Zone ist bereit',
+  'domain.diagnostic.zone_found.body':
+    'Die Zone "{{zone}}" ist in Ihrem Cloudflare-Konto verfügbar.',
+  'domain.diagnostic.zone_found.next':
+    'Sie können mit der Einrichtung des Custom-Domain-Bindings fortfahren.',
+  'domain.diagnostic.not_logged_in.title': 'Eine Cloudflare-Anmeldung ist erforderlich',
+  'domain.diagnostic.not_logged_in.body':
+    'Authrim konnte für diese Zonenprüfung keine Cloudflare-Anmeldung bestätigen.',
+  'domain.diagnostic.not_logged_in.next':
+    '1. Führen Sie `wrangler login` im Terminal aus.\n2. Laden Sie diese Seite neu.\n3. Prüfen Sie die Zone erneut.',
+  'domain.diagnostic.token_unavailable.title': 'Das Cloudflare-Token konnte nicht geladen werden',
+  'domain.diagnostic.token_unavailable.body':
+    'Die Wrangler-Anmeldung scheint vorhanden zu sein, aber das für den Zonenzugriff benötigte API-Token ist noch nicht verfügbar.',
+  'domain.diagnostic.token_unavailable.next':
+    '1. Laden Sie diese Seite neu und prüfen Sie erneut.\n2. Wenn es weiter fehlschlägt, führen Sie `wrangler login` erneut aus.\n3. Starten Sie danach die Zonenprüfung noch einmal.',
+  'domain.diagnostic.zone_read_forbidden.title': 'Der Zugriff auf die Zonenliste ist eingeschränkt',
+  'domain.diagnostic.zone_read_forbidden.body':
+    'Das aktuelle Cloudflare-Token kann die Zonenliste nicht lesen. Vorhandene Zonen können trotzdem funktionieren, aber automatische Verifizierung und DNS-Hilfe sind eingeschränkt.',
+  'domain.diagnostic.zone_read_forbidden.next':
+    '1. Prüfen Sie zuerst erneut.\n2. Wenn es weiter fehlschlägt, führen Sie `wrangler login` erneut aus.\n3. Prüfen Sie, ob das Token die Berechtigung Zone:Read hat.\n4. Wenn die Zone bereits existiert, können Sie manuell fortfahren.',
+  'domain.diagnostic.zone_not_found.title': 'Die Zone wurde in diesem Konto nicht gefunden',
+  'domain.diagnostic.zone_not_found.body':
+    'Cloudflare hat geantwortet, aber die Zone "{{zone}}" ist im aktuellen Konto nicht sichtbar.',
+  'domain.diagnostic.zone_not_found.next':
+    '1. Bestätigen Sie, dass die Zone im verwendeten Cloudflare-Konto existiert.\n2. Wechseln Sie bei Bedarf das Konto oder öffnen Sie das Cloudflare-Dashboard.\n3. Prüfen Sie die Zone danach erneut.',
+  'domain.diagnostic.api_error.title': 'Die Cloudflare-API-Prüfung ist fehlgeschlagen',
+  'domain.diagnostic.api_error.body':
+    'Cloudflare hat bei der Prüfung dieser Zone unerwartet geantwortet.',
+  'domain.diagnostic.api_error.next':
+    'Prüfen Sie zuerst erneut. Wenn es weiter fehlschlägt, laden Sie diese Seite neu und versuchen Sie es noch einmal.',
+  'domain.diagnostic.network_error.title': 'Die Netzwerkprüfung zu Cloudflare ist fehlgeschlagen',
+  'domain.diagnostic.network_error.body':
+    'Die Zonenprüfung konnte nicht abgeschlossen werden, weil Cloudflare oder das Netzwerk nicht wie erwartet geantwortet hat.',
+  'domain.diagnostic.network_error.next':
+    'Prüfen Sie zuerst erneut. Wenn es weiter fehlschlägt, laden Sie diese Seite neu und versuchen Sie es noch einmal.',
   'domain.issuerUrl': 'Aussteller-URL: {{url}}',
   'domain.apiDomain': 'API-/Aussteller-Domain (z.B. auth.beispiel.de)',
   'domain.loginUiDomain': 'Login-UI-Domain (Enter zum Überspringen)',

--- a/packages/setup/src/i18n/locales/en.ts
+++ b/packages/setup/src/i18n/locales/en.ts
@@ -182,6 +182,46 @@ const en: Translations = {
   'domain.zoneCheckSkipped': 'Zone check skipped, continuing with setup...',
   'domain.continueWithoutZone': 'Continue without zone verification?',
   'domain.configureBinding': 'Configure custom domain binding for Workers',
+  'domain.action.retryCheck': 'Recheck',
+  'domain.action.reloadPage': 'Reload Page',
+  'domain.action.openCloudflareDashboard': 'Open Cloudflare Dashboard',
+  'domain.prereq.reviewTitle': 'Custom-domain checks need a quick review',
+  'domain.prereq.reviewBody':
+    'If you plan to use a custom domain, retry the check after reloading the page or refreshing your Cloudflare login.',
+  'domain.diagnostic.zone_found.title': 'Cloudflare zone is ready',
+  'domain.diagnostic.zone_found.body':
+    'The zone "{{zone}}" is available in your Cloudflare account.',
+  'domain.diagnostic.zone_found.next': 'You can continue with custom-domain binding.',
+  'domain.diagnostic.not_logged_in.title': 'Cloudflare login is required',
+  'domain.diagnostic.not_logged_in.body':
+    'Authrim could not confirm a Cloudflare login for this zone check.',
+  'domain.diagnostic.not_logged_in.next':
+    '1. Run `wrangler login` in your terminal.\n2. Reload this page.\n3. Recheck the zone.',
+  'domain.diagnostic.token_unavailable.title': 'Cloudflare token could not be loaded',
+  'domain.diagnostic.token_unavailable.body':
+    'Wrangler login looks present, but the API token needed for zone access is not available yet.',
+  'domain.diagnostic.token_unavailable.next':
+    '1. Reload this page and recheck.\n2. If it still fails, run `wrangler login` again.\n3. Then retry the zone check.',
+  'domain.diagnostic.zone_read_forbidden.title': 'Zone list access is limited',
+  'domain.diagnostic.zone_read_forbidden.body':
+    'The current Cloudflare token cannot read zone listings. Existing zones may still work, but automatic verification and DNS assistance are limited.',
+  'domain.diagnostic.zone_read_forbidden.next':
+    '1. Recheck first.\n2. If it still fails, run `wrangler login` again.\n3. Verify that the token has Zone:Read permission.\n4. If the zone already exists, you can continue manually.',
+  'domain.diagnostic.zone_not_found.title': 'Zone was not found in this account',
+  'domain.diagnostic.zone_not_found.body':
+    'Cloudflare responded, but the zone "{{zone}}" was not visible in the current account.',
+  'domain.diagnostic.zone_not_found.next':
+    '1. Confirm that the zone exists in the Cloudflare account you are using.\n2. If needed, switch accounts or open the Cloudflare dashboard.\n3. Then recheck the zone.',
+  'domain.diagnostic.api_error.title': 'Cloudflare API check failed',
+  'domain.diagnostic.api_error.body':
+    'Cloudflare returned an unexpected response while checking this zone.',
+  'domain.diagnostic.api_error.next':
+    'Retry the check first. If it still fails, reload this page and try again.',
+  'domain.diagnostic.network_error.title': 'Cloudflare network check failed',
+  'domain.diagnostic.network_error.body':
+    'The zone check could not complete because Cloudflare or the network did not respond as expected.',
+  'domain.diagnostic.network_error.next':
+    'Retry the check first. If it still fails, reload this page and try again.',
   'domain.apiDomain': 'API / Issuer domain (e.g., auth.example.com)',
   'domain.loginUiDomain': 'Login UI domain (Enter to skip)',
   'domain.adminUiDomain': 'Admin UI domain (Enter to skip)',

--- a/packages/setup/src/i18n/locales/es.ts
+++ b/packages/setup/src/i18n/locales/es.ts
@@ -183,6 +183,47 @@ const es: Translations = {
   'domain.zoneCheckSkipped': 'Verificación de zona omitida, continuando con la configuración...',
   'domain.continueWithoutZone': '¿Continuar sin verificación de zona?',
   'domain.configureBinding': 'Configurar enlace de dominio personalizado para Workers',
+  'domain.action.retryCheck': 'Volver a comprobar',
+  'domain.action.reloadPage': 'Recargar página',
+  'domain.action.openCloudflareDashboard': 'Abrir panel de Cloudflare',
+  'domain.prereq.reviewTitle': 'La comprobación de dominio personalizado necesita revisión',
+  'domain.prereq.reviewBody':
+    'Si piensa usar un dominio personalizado, vuelva a comprobarlo después de recargar la página o renovar el inicio de sesión de Cloudflare.',
+  'domain.diagnostic.zone_found.title': 'La zona de Cloudflare está lista',
+  'domain.diagnostic.zone_found.body':
+    'La zona "{{zone}}" está disponible en su cuenta de Cloudflare.',
+  'domain.diagnostic.zone_found.next':
+    'Puede continuar con la configuración del binding de dominio personalizado.',
+  'domain.diagnostic.not_logged_in.title': 'Se requiere iniciar sesión en Cloudflare',
+  'domain.diagnostic.not_logged_in.body':
+    'Authrim no pudo confirmar una sesión de Cloudflare para esta verificación de zona.',
+  'domain.diagnostic.not_logged_in.next':
+    '1. Ejecute `wrangler login` en su terminal.\n2. Recargue esta página.\n3. Vuelva a comprobar la zona.',
+  'domain.diagnostic.token_unavailable.title': 'No se pudo cargar el token de Cloudflare',
+  'domain.diagnostic.token_unavailable.body':
+    'Parece que existe una sesión de Wrangler, pero el token de API necesario para acceder a la zona aún no está disponible.',
+  'domain.diagnostic.token_unavailable.next':
+    '1. Recargue esta página y vuelva a comprobar.\n2. Si sigue fallando, ejecute `wrangler login` otra vez.\n3. Luego repita la verificación de zona.',
+  'domain.diagnostic.zone_read_forbidden.title': 'El acceso a la lista de zonas está limitado',
+  'domain.diagnostic.zone_read_forbidden.body':
+    'El token actual de Cloudflare no puede leer la lista de zonas. Las zonas existentes pueden seguir funcionando, pero la verificación automática y la ayuda de DNS estarán limitadas.',
+  'domain.diagnostic.zone_read_forbidden.next':
+    '1. Vuelva a comprobar primero.\n2. Si sigue fallando, ejecute `wrangler login` otra vez.\n3. Verifique que el token tenga permiso Zone:Read.\n4. Si la zona ya existe, puede continuar manualmente.',
+  'domain.diagnostic.zone_not_found.title': 'No se encontró la zona en esta cuenta',
+  'domain.diagnostic.zone_not_found.body':
+    'Cloudflare respondió, pero la zona "{{zone}}" no es visible en la cuenta actual.',
+  'domain.diagnostic.zone_not_found.next':
+    '1. Confirme que la zona exista en la cuenta de Cloudflare que está usando.\n2. Si hace falta, cambie de cuenta o abra el panel de Cloudflare.\n3. Luego vuelva a comprobar la zona.',
+  'domain.diagnostic.api_error.title': 'Falló la comprobación de la API de Cloudflare',
+  'domain.diagnostic.api_error.body':
+    'Cloudflare devolvió una respuesta inesperada al comprobar esta zona.',
+  'domain.diagnostic.api_error.next':
+    'Primero vuelva a comprobar. Si sigue fallando, recargue esta página y pruebe de nuevo.',
+  'domain.diagnostic.network_error.title': 'Falló la comprobación de red hacia Cloudflare',
+  'domain.diagnostic.network_error.body':
+    'La verificación de zona no pudo completarse porque Cloudflare o la red no respondieron como se esperaba.',
+  'domain.diagnostic.network_error.next':
+    'Primero vuelva a comprobar. Si sigue fallando, recargue esta página y pruebe de nuevo.',
   'domain.issuerUrl': 'URL del emisor: {{url}}',
   'domain.apiDomain': 'Dominio API / Emisor (ej: auth.ejemplo.com)',
   'domain.loginUiDomain': 'Dominio UI de inicio de sesión (Enter para omitir)',

--- a/packages/setup/src/i18n/locales/fr.ts
+++ b/packages/setup/src/i18n/locales/fr.ts
@@ -184,6 +184,47 @@ const fr: Translations = {
   'domain.zoneCheckSkipped': 'Vérification de zone ignorée, poursuite de la configuration...',
   'domain.continueWithoutZone': 'Continuer sans vérification de zone ?',
   'domain.configureBinding': 'Configurer la liaison de domaine personnalisé pour Workers',
+  'domain.action.retryCheck': 'Vérifier à nouveau',
+  'domain.action.reloadPage': 'Recharger la page',
+  'domain.action.openCloudflareDashboard': 'Ouvrir le tableau de bord Cloudflare',
+  'domain.prereq.reviewTitle': 'La vérification du domaine personnalisé demande une revue',
+  'domain.prereq.reviewBody':
+    'Si vous comptez utiliser un domaine personnalisé, relancez la vérification après avoir rechargé la page ou rafraîchi la connexion Cloudflare.',
+  'domain.diagnostic.zone_found.title': 'La zone Cloudflare est prête',
+  'domain.diagnostic.zone_found.body':
+    'La zone "{{zone}}" est disponible dans votre compte Cloudflare.',
+  'domain.diagnostic.zone_found.next':
+    'Vous pouvez continuer avec la configuration du binding de domaine personnalisé.',
+  'domain.diagnostic.not_logged_in.title': 'Une connexion Cloudflare est nécessaire',
+  'domain.diagnostic.not_logged_in.body':
+    'Authrim n’a pas pu confirmer une connexion Cloudflare pour cette vérification de zone.',
+  'domain.diagnostic.not_logged_in.next':
+    '1. Exécutez `wrangler login` dans votre terminal.\n2. Rechargez cette page.\n3. Vérifiez à nouveau la zone.',
+  'domain.diagnostic.token_unavailable.title': 'Le jeton Cloudflare n’a pas pu être chargé',
+  'domain.diagnostic.token_unavailable.body':
+    'La connexion Wrangler semble présente, mais le jeton API nécessaire pour lire la zone n’est pas encore disponible.',
+  'domain.diagnostic.token_unavailable.next':
+    '1. Rechargez cette page puis vérifiez à nouveau.\n2. Si cela échoue encore, relancez `wrangler login`.\n3. Essayez ensuite de vérifier la zone de nouveau.',
+  'domain.diagnostic.zone_read_forbidden.title': 'L’accès à la liste des zones est limité',
+  'domain.diagnostic.zone_read_forbidden.body':
+    'Le jeton Cloudflare actuel ne peut pas lire la liste des zones. Les zones existantes peuvent encore fonctionner, mais la vérification automatique et l’assistance DNS seront limitées.',
+  'domain.diagnostic.zone_read_forbidden.next':
+    '1. Vérifiez de nouveau une première fois.\n2. Si cela échoue encore, relancez `wrangler login`.\n3. Vérifiez que le jeton possède la permission Zone:Read.\n4. Si la zone existe déjà, vous pouvez continuer manuellement.',
+  'domain.diagnostic.zone_not_found.title': 'La zone est introuvable dans ce compte',
+  'domain.diagnostic.zone_not_found.body':
+    'Cloudflare a répondu, mais la zone "{{zone}}" n’est pas visible dans le compte actuel.',
+  'domain.diagnostic.zone_not_found.next':
+    '1. Vérifiez que la zone existe dans le compte Cloudflare utilisé.\n2. Si nécessaire, changez de compte ou ouvrez le tableau de bord Cloudflare.\n3. Vérifiez ensuite la zone de nouveau.',
+  'domain.diagnostic.api_error.title': 'La vérification de l’API Cloudflare a échoué',
+  'domain.diagnostic.api_error.body':
+    'Cloudflare a renvoyé une réponse inattendue pendant la vérification de cette zone.',
+  'domain.diagnostic.api_error.next':
+    'Relancez la vérification. Si cela échoue encore, rechargez cette page puis réessayez.',
+  'domain.diagnostic.network_error.title': 'La vérification réseau vers Cloudflare a échoué',
+  'domain.diagnostic.network_error.body':
+    'La vérification de zone n’a pas pu se terminer, car Cloudflare ou le réseau n’a pas répondu comme prévu.',
+  'domain.diagnostic.network_error.next':
+    'Relancez la vérification. Si cela échoue encore, rechargez cette page puis réessayez.',
   'domain.issuerUrl': "URL de l'émetteur : {{url}}",
   'domain.apiDomain': 'Domaine API / Émetteur (ex : auth.exemple.com)',
   'domain.loginUiDomain': 'Domaine UI de connexion (Entrée pour ignorer)',

--- a/packages/setup/src/i18n/locales/id.ts
+++ b/packages/setup/src/i18n/locales/id.ts
@@ -182,6 +182,46 @@ const id: Translations = {
   'domain.zoneCheckSkipped': 'Pemeriksaan zona dilewati, melanjutkan pengaturan...',
   'domain.continueWithoutZone': 'Lanjutkan tanpa verifikasi zona?',
   'domain.configureBinding': 'Konfigurasi binding domain kustom untuk Workers',
+  'domain.action.retryCheck': 'Periksa lagi',
+  'domain.action.reloadPage': 'Muat ulang halaman',
+  'domain.action.openCloudflareDashboard': 'Buka dashboard Cloudflare',
+  'domain.prereq.reviewTitle': 'Pemeriksaan domain kustom perlu ditinjau',
+  'domain.prereq.reviewBody':
+    'Jika Anda akan memakai domain kustom, coba lagi setelah memuat ulang halaman atau memperbarui login Cloudflare.',
+  'domain.diagnostic.zone_found.title': 'Zona Cloudflare siap digunakan',
+  'domain.diagnostic.zone_found.body': 'Zona "{{zone}}" tersedia di akun Cloudflare Anda.',
+  'domain.diagnostic.zone_found.next':
+    'Anda dapat melanjutkan ke konfigurasi binding domain kustom.',
+  'domain.diagnostic.not_logged_in.title': 'Login Cloudflare diperlukan',
+  'domain.diagnostic.not_logged_in.body':
+    'Authrim tidak dapat memastikan status login Cloudflare untuk pemeriksaan zona ini.',
+  'domain.diagnostic.not_logged_in.next':
+    '1. Jalankan `wrangler login` di terminal.\n2. Muat ulang halaman ini.\n3. Periksa zona lagi.',
+  'domain.diagnostic.token_unavailable.title': 'Token Cloudflare tidak dapat dimuat',
+  'domain.diagnostic.token_unavailable.body':
+    'Login Wrangler tampak ada, tetapi token API yang dibutuhkan untuk mengakses zona belum tersedia.',
+  'domain.diagnostic.token_unavailable.next':
+    '1. Muat ulang halaman ini lalu periksa lagi.\n2. Jika masih gagal, jalankan `wrangler login` lagi.\n3. Setelah itu ulangi pemeriksaan zona.',
+  'domain.diagnostic.zone_read_forbidden.title': 'Akses ke daftar zona dibatasi',
+  'domain.diagnostic.zone_read_forbidden.body':
+    'Token Cloudflare saat ini tidak dapat membaca daftar zona. Zona yang sudah ada mungkin tetap berfungsi, tetapi verifikasi otomatis dan bantuan DNS akan terbatas.',
+  'domain.diagnostic.zone_read_forbidden.next':
+    '1. Periksa lagi terlebih dahulu.\n2. Jika masih gagal, jalankan `wrangler login` lagi.\n3. Pastikan token memiliki izin Zone:Read.\n4. Jika zona sudah ada, Anda dapat melanjutkan secara manual.',
+  'domain.diagnostic.zone_not_found.title': 'Zona tidak ditemukan pada akun ini',
+  'domain.diagnostic.zone_not_found.body':
+    'Cloudflare merespons, tetapi zona "{{zone}}" tidak terlihat pada akun saat ini.',
+  'domain.diagnostic.zone_not_found.next':
+    '1. Pastikan zona tersebut ada pada akun Cloudflare yang sedang Anda gunakan.\n2. Jika perlu, ganti akun atau buka dashboard Cloudflare.\n3. Setelah itu periksa zonanya lagi.',
+  'domain.diagnostic.api_error.title': 'Pemeriksaan API Cloudflare gagal',
+  'domain.diagnostic.api_error.body':
+    'Cloudflare mengembalikan respons yang tidak terduga saat memeriksa zona ini.',
+  'domain.diagnostic.api_error.next':
+    'Coba periksa lagi terlebih dahulu. Jika masih gagal, muat ulang halaman ini lalu coba lagi.',
+  'domain.diagnostic.network_error.title': 'Pemeriksaan jaringan ke Cloudflare gagal',
+  'domain.diagnostic.network_error.body':
+    'Pemeriksaan zona tidak dapat diselesaikan karena Cloudflare atau jaringan tidak merespons seperti yang diharapkan.',
+  'domain.diagnostic.network_error.next':
+    'Coba periksa lagi terlebih dahulu. Jika masih gagal, muat ulang halaman ini lalu coba lagi.',
   'domain.issuerUrl': 'URL Issuer: {{url}}',
   'domain.apiDomain': 'Domain API / Issuer (contoh: auth.example.com)',
   'domain.loginUiDomain': 'Domain UI Login (Enter untuk lewati)',

--- a/packages/setup/src/i18n/locales/ja.ts
+++ b/packages/setup/src/i18n/locales/ja.ts
@@ -180,6 +180,46 @@ const ja: Translations = {
   'domain.zoneCheckSkipped': 'ゾーン確認をスキップしてセットアップを続行します...',
   'domain.continueWithoutZone': 'ゾーン確認なしで続行しますか？',
   'domain.configureBinding': 'Workersのカスタムドメインバインディングを設定する',
+  'domain.action.retryCheck': '再確認',
+  'domain.action.reloadPage': 'ページを再読み込み',
+  'domain.action.openCloudflareDashboard': 'Cloudflare ダッシュボードを開く',
+  'domain.prereq.reviewTitle': 'カスタムドメインの確認に追加チェックが必要です',
+  'domain.prereq.reviewBody':
+    'カスタムドメインを使う予定なら、ページを再読み込みするか Cloudflare のログイン状態を更新してから再確認してください。',
+  'domain.diagnostic.zone_found.title': 'Cloudflare ゾーンを確認できました',
+  'domain.diagnostic.zone_found.body':
+    'ゾーン「{{zone}}」は現在の Cloudflare アカウントで利用できます。',
+  'domain.diagnostic.zone_found.next': 'このままカスタムドメインバインディングの設定へ進めます。',
+  'domain.diagnostic.not_logged_in.title': 'Cloudflare へのログインが必要です',
+  'domain.diagnostic.not_logged_in.body':
+    'このゾーン確認では Cloudflare のログイン状態を確認できませんでした。',
+  'domain.diagnostic.not_logged_in.next':
+    '1. ターミナルで `wrangler login` を実行します。\n2. このページを再読み込みします。\n3. ゾーンを再確認します。',
+  'domain.diagnostic.token_unavailable.title': 'Cloudflare の token を読み込めませんでした',
+  'domain.diagnostic.token_unavailable.body':
+    'wrangler のログイン状態はありそうですが、ゾーン確認に必要な API token をまだ取得できていません。',
+  'domain.diagnostic.token_unavailable.next':
+    '1. まずこのページを再読み込みして再確認します。\n2. 改善しなければ `wrangler login` をやり直します。\n3. その後でもう一度ゾーン確認を実行します。',
+  'domain.diagnostic.zone_read_forbidden.title': 'ゾーン一覧の参照権限が不足しています',
+  'domain.diagnostic.zone_read_forbidden.body':
+    '現在の Cloudflare token ではゾーン一覧を読めません。既存ゾーンは利用できる可能性がありますが、自動確認と DNS 補助は制限されます。',
+  'domain.diagnostic.zone_read_forbidden.next':
+    '1. まず再確認します。\n2. 改善しなければ `wrangler login` をやり直します。\n3. token に Zone:Read 権限があるか確認します。\n4. 既存ゾーンなら手動で続行できます。',
+  'domain.diagnostic.zone_not_found.title': 'このアカウントではゾーンが見つかりません',
+  'domain.diagnostic.zone_not_found.body':
+    'Cloudflare から応答はありましたが、ゾーン「{{zone}}」は現在のアカウント配下で確認できませんでした。',
+  'domain.diagnostic.zone_not_found.next':
+    '1. 利用中の Cloudflare アカウントに対象ゾーンが存在するか確認します。\n2. 必要ならアカウントを切り替えるか Cloudflare ダッシュボードを開きます。\n3. その後でゾーンを再確認します。',
+  'domain.diagnostic.api_error.title': 'Cloudflare API の確認に失敗しました',
+  'domain.diagnostic.api_error.body':
+    'このゾーン確認中に Cloudflare API から想定外の応答が返されました。',
+  'domain.diagnostic.api_error.next':
+    'まず再確認し、改善しなければこのページを再読み込みしてからもう一度試してください。',
+  'domain.diagnostic.network_error.title': 'Cloudflare との通信確認に失敗しました',
+  'domain.diagnostic.network_error.body':
+    'Cloudflare またはネットワークの応答が不安定で、ゾーン確認を完了できませんでした。',
+  'domain.diagnostic.network_error.next':
+    'まず再確認し、改善しなければこのページを再読み込みしてからもう一度試してください。',
   'domain.apiDomain': 'API / Issuerドメイン（例: auth.example.com）',
   'domain.loginUiDomain': 'ログインUIドメイン（Enterでスキップ）',
   'domain.adminUiDomain': '管理UIドメイン（Enterでスキップ）',

--- a/packages/setup/src/i18n/locales/ko.ts
+++ b/packages/setup/src/i18n/locales/ko.ts
@@ -179,6 +179,47 @@ const ko: Translations = {
   'domain.zoneCheckSkipped': '영역 확인을 건너뛰고 설정을 계속합니다...',
   'domain.continueWithoutZone': '영역 확인 없이 계속하시겠습니까?',
   'domain.configureBinding': 'Workers에 대한 사용자 정의 도메인 바인딩 구성',
+  'domain.action.retryCheck': '다시 확인',
+  'domain.action.reloadPage': '페이지 새로고침',
+  'domain.action.openCloudflareDashboard': 'Cloudflare 대시보드 열기',
+  'domain.prereq.reviewTitle': '사용자 정의 도메인 확인에 추가 검토가 필요합니다',
+  'domain.prereq.reviewBody':
+    '사용자 정의 도메인을 사용할 예정이라면 페이지를 새로고침하거나 Cloudflare 로그인 상태를 다시 맞춘 뒤 다시 확인하세요.',
+  'domain.diagnostic.zone_found.title': 'Cloudflare 영역을 확인했습니다',
+  'domain.diagnostic.zone_found.body':
+    '"{{zone}}" 영역을 현재 Cloudflare 계정에서 사용할 수 있습니다.',
+  'domain.diagnostic.zone_found.next':
+    '이제 사용자 정의 도메인 바인딩 설정으로 계속할 수 있습니다.',
+  'domain.diagnostic.not_logged_in.title': 'Cloudflare 로그인이 필요합니다',
+  'domain.diagnostic.not_logged_in.body':
+    '이 영역 확인에서 Cloudflare 로그인 상태를 확인할 수 없었습니다.',
+  'domain.diagnostic.not_logged_in.next':
+    '1. 터미널에서 `wrangler login`을 실행합니다.\n2. 이 페이지를 새로고침합니다.\n3. 영역을 다시 확인합니다.',
+  'domain.diagnostic.token_unavailable.title': 'Cloudflare 토큰을 불러올 수 없습니다',
+  'domain.diagnostic.token_unavailable.body':
+    'Wrangler 로그인 상태는 있는 것 같지만, 영역 확인에 필요한 API 토큰을 아직 사용할 수 없습니다.',
+  'domain.diagnostic.token_unavailable.next':
+    '1. 먼저 이 페이지를 새로고침하고 다시 확인합니다.\n2. 계속 실패하면 `wrangler login`을 다시 실행합니다.\n3. 그다음 영역 확인을 다시 시도합니다.',
+  'domain.diagnostic.zone_read_forbidden.title': '영역 목록 조회 권한이 부족합니다',
+  'domain.diagnostic.zone_read_forbidden.body':
+    '현재 Cloudflare 토큰으로는 영역 목록을 읽을 수 없습니다. 기존 영역은 계속 사용할 수 있을 수 있지만 자동 확인과 DNS 보조는 제한됩니다.',
+  'domain.diagnostic.zone_read_forbidden.next':
+    '1. 먼저 다시 확인합니다.\n2. 계속 실패하면 `wrangler login`을 다시 실행합니다.\n3. 토큰에 Zone:Read 권한이 있는지 확인합니다.\n4. 이미 있는 영역이라면 수동으로 계속할 수 있습니다.',
+  'domain.diagnostic.zone_not_found.title': '현재 계정에서 영역을 찾지 못했습니다',
+  'domain.diagnostic.zone_not_found.body':
+    'Cloudflare 응답은 있었지만 "{{zone}}" 영역은 현재 계정에서 보이지 않았습니다.',
+  'domain.diagnostic.zone_not_found.next':
+    '1. 사용 중인 Cloudflare 계정에 해당 영역이 있는지 확인합니다.\n2. 필요하면 계정을 전환하거나 Cloudflare 대시보드를 엽니다.\n3. 그 후 영역을 다시 확인합니다.',
+  'domain.diagnostic.api_error.title': 'Cloudflare API 확인에 실패했습니다',
+  'domain.diagnostic.api_error.body':
+    '이 영역을 확인하는 동안 Cloudflare API가 예상하지 못한 응답을 반환했습니다.',
+  'domain.diagnostic.api_error.next':
+    '먼저 다시 확인하고, 계속 실패하면 이 페이지를 새로고침한 뒤 다시 시도하세요.',
+  'domain.diagnostic.network_error.title': 'Cloudflare 네트워크 확인에 실패했습니다',
+  'domain.diagnostic.network_error.body':
+    'Cloudflare 또는 네트워크 응답이 불안정하여 영역 확인을 완료할 수 없었습니다.',
+  'domain.diagnostic.network_error.next':
+    '먼저 다시 확인하고, 계속 실패하면 이 페이지를 새로고침한 뒤 다시 시도하세요.',
   'domain.issuerUrl': '발급자 URL: {{url}}',
   'domain.apiDomain': 'API / 발급자 도메인 (예: auth.example.com)',
   'domain.loginUiDomain': '로그인 UI 도메인 (건너뛰려면 Enter)',

--- a/packages/setup/src/i18n/locales/pt.ts
+++ b/packages/setup/src/i18n/locales/pt.ts
@@ -182,6 +182,47 @@ const pt: Translations = {
   'domain.zoneCheckSkipped': 'Verificação de zona ignorada, continuando com a configuração...',
   'domain.continueWithoutZone': 'Continuar sem verificação de zona?',
   'domain.configureBinding': 'Configurar vinculação de domínio personalizado para Workers',
+  'domain.action.retryCheck': 'Verificar novamente',
+  'domain.action.reloadPage': 'Recarregar página',
+  'domain.action.openCloudflareDashboard': 'Abrir painel do Cloudflare',
+  'domain.prereq.reviewTitle': 'A verificação de domínio personalizado precisa de revisão',
+  'domain.prereq.reviewBody':
+    'Se você pretende usar um domínio personalizado, tente novamente após recarregar a página ou atualizar o login do Cloudflare.',
+  'domain.diagnostic.zone_found.title': 'A zona do Cloudflare está pronta',
+  'domain.diagnostic.zone_found.body':
+    'A zona "{{zone}}" está disponível na sua conta do Cloudflare.',
+  'domain.diagnostic.zone_found.next':
+    'Você pode continuar com a configuração do binding de domínio personalizado.',
+  'domain.diagnostic.not_logged_in.title': 'É necessário fazer login no Cloudflare',
+  'domain.diagnostic.not_logged_in.body':
+    'O Authrim não conseguiu confirmar um login no Cloudflare para esta verificação de zona.',
+  'domain.diagnostic.not_logged_in.next':
+    '1. Execute `wrangler login` no terminal.\n2. Recarregue esta página.\n3. Verifique a zona novamente.',
+  'domain.diagnostic.token_unavailable.title': 'Não foi possível carregar o token do Cloudflare',
+  'domain.diagnostic.token_unavailable.body':
+    'O login do Wrangler parece existir, mas o token da API necessário para acessar a zona ainda não está disponível.',
+  'domain.diagnostic.token_unavailable.next':
+    '1. Recarregue esta página e verifique novamente.\n2. Se continuar falhando, execute `wrangler login` outra vez.\n3. Depois, repita a verificação da zona.',
+  'domain.diagnostic.zone_read_forbidden.title': 'O acesso à lista de zonas está limitado',
+  'domain.diagnostic.zone_read_forbidden.body':
+    'O token atual do Cloudflare não consegue ler a lista de zonas. Zonas existentes ainda podem funcionar, mas a verificação automática e a ajuda de DNS ficarão limitadas.',
+  'domain.diagnostic.zone_read_forbidden.next':
+    '1. Verifique novamente primeiro.\n2. Se continuar falhando, execute `wrangler login` outra vez.\n3. Confirme que o token possui permissão Zone:Read.\n4. Se a zona já existir, você pode continuar manualmente.',
+  'domain.diagnostic.zone_not_found.title': 'A zona não foi encontrada nesta conta',
+  'domain.diagnostic.zone_not_found.body':
+    'O Cloudflare respondeu, mas a zona "{{zone}}" não está visível na conta atual.',
+  'domain.diagnostic.zone_not_found.next':
+    '1. Confirme que a zona exista na conta do Cloudflare em uso.\n2. Se necessário, troque de conta ou abra o painel do Cloudflare.\n3. Depois, verifique a zona novamente.',
+  'domain.diagnostic.api_error.title': 'A verificação da API do Cloudflare falhou',
+  'domain.diagnostic.api_error.body':
+    'O Cloudflare retornou uma resposta inesperada ao verificar esta zona.',
+  'domain.diagnostic.api_error.next':
+    'Tente verificar novamente primeiro. Se continuar falhando, recarregue esta página e tente outra vez.',
+  'domain.diagnostic.network_error.title': 'A verificação de rede com o Cloudflare falhou',
+  'domain.diagnostic.network_error.body':
+    'A verificação da zona não pôde ser concluída porque o Cloudflare ou a rede não responderam como esperado.',
+  'domain.diagnostic.network_error.next':
+    'Tente verificar novamente primeiro. Se continuar falhando, recarregue esta página e tente outra vez.',
   'domain.issuerUrl': 'URL do Emissor: {{url}}',
   'domain.apiDomain': 'Domínio API / Emissor (ex: auth.exemplo.com)',
   'domain.loginUiDomain': 'Domínio UI de Login (Enter para pular)',

--- a/packages/setup/src/i18n/locales/ru.ts
+++ b/packages/setup/src/i18n/locales/ru.ts
@@ -182,6 +182,45 @@ const ru: Translations = {
   'domain.zoneCheckSkipped': 'Проверка зоны пропущена, продолжение настройки...',
   'domain.continueWithoutZone': 'Продолжить без проверки зоны?',
   'domain.configureBinding': 'Настроить привязку пользовательского домена для Workers',
+  'domain.action.retryCheck': 'Проверить снова',
+  'domain.action.reloadPage': 'Перезагрузить страницу',
+  'domain.action.openCloudflareDashboard': 'Открыть панель Cloudflare',
+  'domain.prereq.reviewTitle': 'Проверка пользовательского домена требует уточнения',
+  'domain.prereq.reviewBody':
+    'Если вы планируете использовать пользовательский домен, повторите проверку после перезагрузки страницы или обновления входа в Cloudflare.',
+  'domain.diagnostic.zone_found.title': 'Зона Cloudflare готова',
+  'domain.diagnostic.zone_found.body': 'Зона "{{zone}}" доступна в вашем аккаунте Cloudflare.',
+  'domain.diagnostic.zone_found.next':
+    'Можно продолжать настройку привязки пользовательского домена.',
+  'domain.diagnostic.not_logged_in.title': 'Требуется вход в Cloudflare',
+  'domain.diagnostic.not_logged_in.body':
+    'Authrim не смог подтвердить вход в Cloudflare для этой проверки зоны.',
+  'domain.diagnostic.not_logged_in.next':
+    '1. Выполните `wrangler login` в терминале.\n2. Перезагрузите эту страницу.\n3. Повторно проверьте зону.',
+  'domain.diagnostic.token_unavailable.title': 'Не удалось загрузить токен Cloudflare',
+  'domain.diagnostic.token_unavailable.body':
+    'Похоже, вход Wrangler есть, но API-токен, нужный для доступа к зоне, пока недоступен.',
+  'domain.diagnostic.token_unavailable.next':
+    '1. Перезагрузите эту страницу и проверьте снова.\n2. Если ошибка останется, заново выполните `wrangler login`.\n3. После этого повторите проверку зоны.',
+  'domain.diagnostic.zone_read_forbidden.title': 'Доступ к списку зон ограничен',
+  'domain.diagnostic.zone_read_forbidden.body':
+    'Текущий токен Cloudflare не может читать список зон. Существующие зоны могут продолжить работать, но автоматическая проверка и помощь с DNS будут ограничены.',
+  'domain.diagnostic.zone_read_forbidden.next':
+    '1. Сначала проверьте снова.\n2. Если ошибка останется, заново выполните `wrangler login`.\n3. Убедитесь, что у токена есть разрешение Zone:Read.\n4. Если зона уже существует, можно продолжить вручную.',
+  'domain.diagnostic.zone_not_found.title': 'Зона не найдена в этом аккаунте',
+  'domain.diagnostic.zone_not_found.body':
+    'Cloudflare ответил, но зона "{{zone}}" не видна в текущем аккаунте.',
+  'domain.diagnostic.zone_not_found.next':
+    '1. Убедитесь, что зона существует в используемом аккаунте Cloudflare.\n2. При необходимости переключите аккаунт или откройте панель Cloudflare.\n3. Затем повторно проверьте зону.',
+  'domain.diagnostic.api_error.title': 'Проверка Cloudflare API завершилась ошибкой',
+  'domain.diagnostic.api_error.body': 'Cloudflare вернул неожиданный ответ при проверке этой зоны.',
+  'domain.diagnostic.api_error.next':
+    'Сначала повторите проверку. Если ошибка останется, перезагрузите страницу и попробуйте снова.',
+  'domain.diagnostic.network_error.title': 'Ошибка сетевой проверки Cloudflare',
+  'domain.diagnostic.network_error.body':
+    'Проверку зоны не удалось завершить, потому что Cloudflare или сеть ответили не так, как ожидалось.',
+  'domain.diagnostic.network_error.next':
+    'Сначала повторите проверку. Если ошибка останется, перезагрузите страницу и попробуйте снова.',
   'domain.issuerUrl': 'URL издателя: {{url}}',
   'domain.apiDomain': 'Домен API / издателя (например, auth.example.com)',
   'domain.loginUiDomain': 'Домен UI для входа (Enter для пропуска)',

--- a/packages/setup/src/i18n/locales/zh-CN.ts
+++ b/packages/setup/src/i18n/locales/zh-CN.ts
@@ -178,6 +178,42 @@ const zhCN: Translations = {
   'domain.zoneCheckSkipped': '已跳过区域检查，继续设置...',
   'domain.continueWithoutZone': '不验证区域继续？',
   'domain.configureBinding': '为 Workers 配置自定义域名绑定',
+  'domain.action.retryCheck': '重新检查',
+  'domain.action.reloadPage': '重新加载页面',
+  'domain.action.openCloudflareDashboard': '打开 Cloudflare 控制台',
+  'domain.prereq.reviewTitle': '自定义域名检查需要额外确认',
+  'domain.prereq.reviewBody':
+    '如果您计划使用自定义域名，请在重新加载页面或刷新 Cloudflare 登录状态后再次检查。',
+  'domain.diagnostic.zone_found.title': 'Cloudflare 区域已就绪',
+  'domain.diagnostic.zone_found.body': '区域 "{{zone}}" 已可在当前 Cloudflare 账户中使用。',
+  'domain.diagnostic.zone_found.next': '您可以继续配置自定义域名绑定。',
+  'domain.diagnostic.not_logged_in.title': '需要登录 Cloudflare',
+  'domain.diagnostic.not_logged_in.body': 'Authrim 无法为这次区域检查确认 Cloudflare 登录状态。',
+  'domain.diagnostic.not_logged_in.next':
+    '1. 在终端运行 `wrangler login`。\n2. 重新加载此页面。\n3. 再次检查区域。',
+  'domain.diagnostic.token_unavailable.title': '无法加载 Cloudflare token',
+  'domain.diagnostic.token_unavailable.body':
+    '看起来 Wrangler 已登录，但当前还拿不到访问区域所需的 API token。',
+  'domain.diagnostic.token_unavailable.next':
+    '1. 先重新加载此页面再检查一次。\n2. 如果仍然失败，请重新执行 `wrangler login`。\n3. 然后再次检查区域。',
+  'domain.diagnostic.zone_read_forbidden.title': '缺少区域列表读取权限',
+  'domain.diagnostic.zone_read_forbidden.body':
+    '当前 Cloudflare token 无法读取区域列表。已有区域可能仍可使用，但自动验证和 DNS 辅助会受到限制。',
+  'domain.diagnostic.zone_read_forbidden.next':
+    '1. 先重新检查一次。\n2. 如果仍然失败，请重新执行 `wrangler login`。\n3. 确认 token 具备 Zone:Read 权限。\n4. 如果区域已经存在，可以手动继续。',
+  'domain.diagnostic.zone_not_found.title': '当前账户中未找到该区域',
+  'domain.diagnostic.zone_not_found.body':
+    'Cloudflare 已返回响应，但当前账户下看不到区域 "{{zone}}"。',
+  'domain.diagnostic.zone_not_found.next':
+    '1. 确认该区域存在于您正在使用的 Cloudflare 账户中。\n2. 如有需要，请切换账户或打开 Cloudflare 控制台。\n3. 然后再次检查区域。',
+  'domain.diagnostic.api_error.title': 'Cloudflare API 检查失败',
+  'domain.diagnostic.api_error.body': '检查此区域时，Cloudflare API 返回了非预期响应。',
+  'domain.diagnostic.api_error.next': '请先重新检查；如果仍然失败，请重新加载此页面后再试一次。',
+  'domain.diagnostic.network_error.title': 'Cloudflare 网络检查失败',
+  'domain.diagnostic.network_error.body':
+    '由于 Cloudflare 或网络没有按预期响应，区域检查未能完成。',
+  'domain.diagnostic.network_error.next':
+    '请先重新检查；如果仍然失败，请重新加载此页面后再试一次。',
   'domain.issuerUrl': '发行者 URL：{{url}}',
   'domain.apiDomain': 'API / 发行者域名（例如：auth.example.com）',
   'domain.loginUiDomain': '登录 UI 域名（按回车跳过）',

--- a/packages/setup/src/i18n/locales/zh-TW.ts
+++ b/packages/setup/src/i18n/locales/zh-TW.ts
@@ -178,6 +178,41 @@ const zhTW: Translations = {
   'domain.zoneCheckSkipped': '已跳過區域檢查，繼續設定...',
   'domain.continueWithoutZone': '不驗證區域繼續？',
   'domain.configureBinding': '為 Workers 設定自訂網域綁定',
+  'domain.action.retryCheck': '重新檢查',
+  'domain.action.reloadPage': '重新載入頁面',
+  'domain.action.openCloudflareDashboard': '開啟 Cloudflare 控制台',
+  'domain.prereq.reviewTitle': '自訂網域檢查需要額外確認',
+  'domain.prereq.reviewBody':
+    '如果您打算使用自訂網域，請在重新載入頁面或更新 Cloudflare 登入狀態後再次檢查。',
+  'domain.diagnostic.zone_found.title': 'Cloudflare 區域已準備完成',
+  'domain.diagnostic.zone_found.body': '區域 "{{zone}}" 已可在目前的 Cloudflare 帳戶中使用。',
+  'domain.diagnostic.zone_found.next': '您可以繼續設定自訂網域綁定。',
+  'domain.diagnostic.not_logged_in.title': '需要登入 Cloudflare',
+  'domain.diagnostic.not_logged_in.body': 'Authrim 無法為這次區域檢查確認 Cloudflare 的登入狀態。',
+  'domain.diagnostic.not_logged_in.next':
+    '1. 在終端機執行 `wrangler login`。\n2. 重新載入此頁面。\n3. 再次檢查區域。',
+  'domain.diagnostic.token_unavailable.title': '無法載入 Cloudflare token',
+  'domain.diagnostic.token_unavailable.body':
+    '看起來 Wrangler 已登入，但目前仍無法取得存取區域所需的 API token。',
+  'domain.diagnostic.token_unavailable.next':
+    '1. 先重新載入此頁面再檢查一次。\n2. 如果仍然失敗，請重新執行 `wrangler login`。\n3. 然後再次檢查區域。',
+  'domain.diagnostic.zone_read_forbidden.title': '缺少區域清單讀取權限',
+  'domain.diagnostic.zone_read_forbidden.body':
+    '目前的 Cloudflare token 無法讀取區域清單。既有區域可能仍可使用，但自動驗證與 DNS 輔助會受到限制。',
+  'domain.diagnostic.zone_read_forbidden.next':
+    '1. 先重新檢查一次。\n2. 如果仍然失敗，請重新執行 `wrangler login`。\n3. 確認 token 具備 Zone:Read 權限。\n4. 如果區域已存在，可以手動繼續。',
+  'domain.diagnostic.zone_not_found.title': '目前帳戶中找不到該區域',
+  'domain.diagnostic.zone_not_found.body': 'Cloudflare 已回應，但目前帳戶下看不到區域 "{{zone}}"。',
+  'domain.diagnostic.zone_not_found.next':
+    '1. 確認該區域存在於您正在使用的 Cloudflare 帳戶中。\n2. 如有需要，請切換帳戶或開啟 Cloudflare 控制台。\n3. 然後再次檢查區域。',
+  'domain.diagnostic.api_error.title': 'Cloudflare API 檢查失敗',
+  'domain.diagnostic.api_error.body': '檢查此區域時，Cloudflare API 回傳了非預期的回應。',
+  'domain.diagnostic.api_error.next': '請先重新檢查；如果仍然失敗，請重新載入此頁面後再試一次。',
+  'domain.diagnostic.network_error.title': 'Cloudflare 網路檢查失敗',
+  'domain.diagnostic.network_error.body':
+    '由於 Cloudflare 或網路沒有如預期回應，區域檢查未能完成。',
+  'domain.diagnostic.network_error.next':
+    '請先重新檢查；如果仍然失敗，請重新載入此頁面後再試一次。',
   'domain.issuerUrl': '發行者 URL：{{url}}',
   'domain.apiDomain': 'API / 發行者網域（例如：auth.example.com）',
   'domain.loginUiDomain': '登入 UI 網域（按 Enter 跳過）',

--- a/packages/setup/src/web/api.ts
+++ b/packages/setup/src/web/api.ts
@@ -241,7 +241,19 @@ export function createApiRoutes(): Hono {
       return c.json(result);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
-      return c.json({ found: false, error: message }, 500);
+      return c.json(
+        {
+          found: false,
+          error: message,
+          diagnostic: {
+            code: 'api_error',
+            severity: 'error',
+            allowBinding: false,
+            actions: ['retry_check', 'reload_page'],
+          },
+        },
+        500
+      );
     }
   });
 

--- a/packages/setup/src/web/ui.ts
+++ b/packages/setup/src/web/ui.ts
@@ -4960,6 +4960,8 @@ export function getHtmlTemplate(
           method: 'POST',
           body: { domain },
         });
+        const permissionLimited =
+          typeof result.error === 'string' && result.error.includes('zone:read');
 
         if (result.found) {
           statusEl.textContent = '✓ ' + t('domain.zoneFound', { zone: result.zone.name, status: result.zone.status });
@@ -4968,11 +4970,13 @@ export function getHtmlTemplate(
           domainZoneId = result.zone.id;
         } else {
           const errorMsg = result.error
-            ? '⚠ ' + t('domain.zoneCheckFailed') + ': ' + result.error
+            ? permissionLimited
+              ? '⚠ ' + t('domain.zoneCheckFailed') + ': ' + result.error + ' — Existing zones can still be used; automatic verification is limited.'
+              : '⚠ ' + t('domain.zoneCheckFailed') + ': ' + result.error
             : '⚠ ' + t('domain.zoneNotFound', { zone: domain });
           statusEl.textContent = errorMsg;
           statusEl.style.color = 'var(--warning, #d97706)';
-          bindingRow.style.display = 'none';
+          bindingRow.style.display = permissionLimited ? 'flex' : 'none';
           domainZoneId = null;
         }
       } catch (e) {

--- a/packages/setup/src/web/ui.ts
+++ b/packages/setup/src/web/ui.ts
@@ -1336,6 +1336,43 @@ export function getHtmlTemplate(
       border-color: rgba(248, 113, 113, 0.24);
     }
 
+    .zone-diagnostic {
+      margin-top: 0.9rem;
+      margin-bottom: 0;
+    }
+
+    .zone-diagnostic-title {
+      font-weight: 700;
+      margin-bottom: 0.35rem;
+      color: inherit;
+    }
+
+    .zone-diagnostic-body,
+    .zone-diagnostic-next {
+      color: inherit;
+      opacity: 0.92;
+    }
+
+    .zone-diagnostic-next {
+      margin-top: 0.45rem;
+      white-space: pre-line;
+    }
+
+    .zone-diagnostic-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.6rem;
+      margin-top: 0.8rem;
+    }
+
+    .zone-diagnostic-actions .btn-secondary {
+      min-width: 0;
+    }
+
+    .domain-check-status {
+      margin-top: 0.75rem;
+    }
+
     .keys-saved-box {
       margin-top: 1rem;
       padding: 1rem 1.125rem;
@@ -2323,6 +2360,7 @@ export function getHtmlTemplate(
 
     const PREREQ_CAPABILITY_COPY = ${JSON.stringify(SETUP_CAPABILITY_COPY)};
     const CLOUDFLARE_DNS_RECORDS_DOCS = ${JSON.stringify(CLOUDFLARE_DNS_RECORDS_DOCS_URL)};
+    const CLOUDFLARE_DASHBOARD_URL = 'https://dash.cloudflare.com/';
 
     function getPrereqCapabilityCopy() {
       const locale = String(_currentLocale || 'en');
@@ -2428,7 +2466,118 @@ export function getHtmlTemplate(
       });
 
       wrapper.appendChild(list);
+
+      if (statuses.customDomain === 'review') {
+        wrapper.appendChild(createPrereqCustomDomainReviewAlert());
+      }
+
       container.appendChild(wrapper);
+    }
+
+    function createZoneActionButton(action, onRetry) {
+      if (action === 'run_wrangler_login' || action === 'check_cloudflare_permissions') {
+        return null;
+      }
+
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'btn-secondary';
+
+      if (action === 'retry_check') {
+        button.textContent = t('domain.action.retryCheck');
+        button.addEventListener('click', () => onRetry?.());
+        return button;
+      }
+
+      if (action === 'reload_page') {
+        button.textContent = t('domain.action.reloadPage');
+        button.addEventListener('click', () => window.location.reload());
+        return button;
+      }
+
+      if (action === 'open_cloudflare_dashboard') {
+        button.textContent = t('domain.action.openCloudflareDashboard');
+        button.addEventListener('click', () =>
+          window.open(CLOUDFLARE_DASHBOARD_URL, '_blank', 'noopener,noreferrer')
+        );
+        return button;
+      }
+
+      return null;
+    }
+
+    function createZoneDiagnosticAlert(result, params) {
+      const diagnostic = result?.diagnostic;
+      if (!diagnostic) {
+        return null;
+      }
+
+      const code = diagnostic.code;
+      const alertType =
+        diagnostic.severity === 'success'
+          ? 'success'
+          : diagnostic.severity === 'error'
+            ? 'error'
+            : 'warning';
+      const alert = document.createElement('div');
+      alert.className = 'alert alert-' + alertType + ' zone-diagnostic';
+
+      const title = document.createElement('div');
+      title.className = 'zone-diagnostic-title';
+      title.textContent = t('domain.diagnostic.' + code + '.title', params);
+      alert.appendChild(title);
+
+      const body = document.createElement('div');
+      body.className = 'zone-diagnostic-body';
+      body.textContent = t('domain.diagnostic.' + code + '.body', params);
+      alert.appendChild(body);
+
+      const nextText = t('domain.diagnostic.' + code + '.next', params);
+      if (nextText && nextText !== 'domain.diagnostic.' + code + '.next') {
+        const next = document.createElement('div');
+        next.className = 'zone-diagnostic-next';
+        next.textContent = nextText;
+        alert.appendChild(next);
+      }
+
+      const actionButtons = (diagnostic.actions || [])
+        .map((action) => createZoneActionButton(action, params.onRetry))
+        .filter(Boolean);
+
+      if (actionButtons.length > 0) {
+        const actions = document.createElement('div');
+        actions.className = 'zone-diagnostic-actions';
+        actionButtons.forEach((button) => actions.appendChild(button));
+        alert.appendChild(actions);
+      }
+
+      return alert;
+    }
+
+    function createPrereqCustomDomainReviewAlert() {
+      const alert = document.createElement('div');
+      alert.className = 'alert alert-warning zone-diagnostic';
+
+      const title = document.createElement('div');
+      title.className = 'zone-diagnostic-title';
+      title.textContent = t('domain.prereq.reviewTitle');
+      alert.appendChild(title);
+
+      const body = document.createElement('div');
+      body.className = 'zone-diagnostic-body';
+      body.textContent = t('domain.prereq.reviewBody');
+      alert.appendChild(body);
+
+      const actions = document.createElement('div');
+      actions.className = 'zone-diagnostic-actions';
+      const retryButton = createZoneActionButton('retry_check', checkPrerequisites);
+      const reloadButton = createZoneActionButton('reload_page');
+
+      if (retryButton) actions.appendChild(retryButton);
+      if (reloadButton) actions.appendChild(reloadButton);
+      alert.appendChild(actions);
+
+      return alert;
     }
 
     /**
@@ -2769,11 +2918,11 @@ export function getHtmlTemplate(
           <small id="multi-tenant-hint" style="color: var(--text-muted); margin-left: 1.5rem;" data-i18n="web.form.multiTenantHint">
             Create tenant subdomains under your custom domain
           </small>
-          <div id="domain-check-row" style="display: none; margin-top: 0.5rem; align-items: center; gap: 0.5rem;">
+          <div id="domain-check-row" style="display: none; margin-top: 0.5rem;">
             <button type="button" id="check-domain-btn" class="btn btn-secondary" style="padding: 0.3rem 0.75rem; font-size: 0.85rem;" data-i18n="domain.checkZoneButton">
               Check Zone
             </button>
-            <span id="domain-check-status" style="font-size: 0.85rem;"></span>
+            <div id="domain-check-status" class="domain-check-status" aria-live="polite"></div>
           </div>
           <label class="checkbox-item" id="custom-domain-binding-row" style="display: none; align-items: center; gap: 0.5rem; margin-top: 0.5rem;">
             <input type="checkbox" id="custom-domain-binding" checked>
@@ -4186,7 +4335,7 @@ export function getHtmlTemplate(
       document.getElementById('comp-vc').checked = false;
 
       document.getElementById('domain-check-row').style.display = 'none';
-      document.getElementById('domain-check-status').textContent = '';
+      document.getElementById('domain-check-status').replaceChildren();
       document.getElementById('custom-domain-binding-row').style.display = 'none';
       document.getElementById('custom-domain-binding').checked = true;
 
@@ -4618,7 +4767,7 @@ export function getHtmlTemplate(
       // Restore domain check UI if custom domain is set
       const loadedBaseDomain = document.getElementById('base-domain').value.trim();
       if (loadedBaseDomain && /^[a-z0-9][a-z0-9.-]*\\.[a-z]{2,}$/i.test(loadedBaseDomain)) {
-        document.getElementById('domain-check-row').style.display = 'flex';
+        document.getElementById('domain-check-row').style.display = 'block';
         // Auto-trigger zone check for loaded domain
         setTimeout(() => document.getElementById('check-domain-btn').click(), 300);
       }
@@ -4930,10 +5079,10 @@ export function getHtmlTemplate(
       const domainCheckRow = document.getElementById('domain-check-row');
       const baseDomain = document.getElementById('base-domain').value.trim();
       if (baseDomain && isValidCustomDomain(baseDomain)) {
-        domainCheckRow.style.display = 'flex';
+        domainCheckRow.style.display = 'block';
       } else {
         domainCheckRow.style.display = 'none';
-        document.getElementById('domain-check-status').textContent = '';
+        document.getElementById('domain-check-status').replaceChildren();
         document.getElementById('custom-domain-binding-row').style.display = 'none';
       }
     });
@@ -4951,8 +5100,7 @@ export function getHtmlTemplate(
 
       const statusEl = document.getElementById('domain-check-status');
       const bindingRow = document.getElementById('custom-domain-binding-row');
-      statusEl.textContent = t('domain.checkingZone', { domain });
-      statusEl.style.color = 'var(--text-muted)';
+      statusEl.replaceChildren(createAlert('info', t('domain.checkingZone', { domain })));
       domainZoneId = null;
 
       try {
@@ -4960,28 +5108,43 @@ export function getHtmlTemplate(
           method: 'POST',
           body: { domain },
         });
-        const permissionLimited =
-          typeof result.error === 'string' && result.error.includes('zone:read');
+        const zoneName = result.zone?.name || result.zoneName || domain;
+        const diagnosticAlert = createZoneDiagnosticAlert(result, {
+          domain,
+          zone: zoneName,
+          onRetry: () => document.getElementById('check-domain-btn').click(),
+        });
 
-        if (result.found) {
-          statusEl.textContent = '✓ ' + t('domain.zoneFound', { zone: result.zone.name, status: result.zone.status });
-          statusEl.style.color = 'var(--success, #22c55e)';
-          bindingRow.style.display = 'flex';
-          domainZoneId = result.zone.id;
-        } else {
-          const errorMsg = result.error
-            ? permissionLimited
-              ? '⚠ ' + t('domain.zoneCheckFailed') + ': ' + result.error + ' — Existing zones can still be used; automatic verification is limited.'
-              : '⚠ ' + t('domain.zoneCheckFailed') + ': ' + result.error
-            : '⚠ ' + t('domain.zoneNotFound', { zone: domain });
-          statusEl.textContent = errorMsg;
-          statusEl.style.color = 'var(--warning, #d97706)';
-          bindingRow.style.display = permissionLimited ? 'flex' : 'none';
-          domainZoneId = null;
+        statusEl.replaceChildren();
+        if (diagnosticAlert) {
+          statusEl.appendChild(diagnosticAlert);
         }
+
+        bindingRow.style.display = result.diagnostic?.allowBinding ? 'flex' : 'none';
+        domainZoneId = result.found && result.zone ? result.zone.id : null;
       } catch (e) {
-        statusEl.textContent = '⚠ ' + t('domain.zoneCheckFailed');
-        statusEl.style.color = 'var(--warning, #d97706)';
+        const diagnosticAlert = createZoneDiagnosticAlert(
+          {
+            found: false,
+            zoneName: domain,
+            diagnostic: {
+              code: 'api_error',
+              severity: 'error',
+              allowBinding: false,
+              actions: ['retry_check', 'reload_page'],
+            },
+          },
+          {
+            domain,
+            zone: domain,
+            onRetry: () => document.getElementById('check-domain-btn').click(),
+          }
+        );
+
+        statusEl.replaceChildren();
+        if (diagnosticAlert) {
+          statusEl.appendChild(diagnosticAlert);
+        }
         bindingRow.style.display = 'none';
         domainZoneId = null;
       }


### PR DESCRIPTION
## Summary
- tolerate missing `zone:read` permission during setup zone checks and wildcard DNS verification
- add structured zone diagnostics with remediation guidance across Web UI and CLI
- add setup tests covering zone diagnostic codes and updated UI rendering

## Verification
- pnpm run format:check
- pnpm --filter @authrim/setup test