### PR TITLE
Add tenant lifecycle state

### DIFF
--- a/migrations/007_tenant_lifecycle_state.sql
+++ b/migrations/007_tenant_lifecycle_state.sql
@@ -1,0 +1,24 @@
+-- =============================================================================
+-- Tenant lifecycle state
+-- Replace tenants.is_active with tenants.lifecycle_state as the canonical lifecycle gate.
+-- =============================================================================
+
+ALTER TABLE tenants
+  ADD COLUMN lifecycle_state TEXT NOT NULL DEFAULT 'active'
+  CHECK (lifecycle_state IN (
+    'provisioning',
+    'active',
+    'suspended',
+    'frozen',
+    'migration_read_only',
+    'deleting',
+    'deleted',
+    'restore_pending',
+    'restore_validating'
+  ));
+
+UPDATE tenants
+SET lifecycle_state = CASE WHEN is_active = 1 THEN 'active' ELSE 'suspended' END
+WHERE lifecycle_state IS NULL OR lifecycle_state = 'active';
+
+ALTER TABLE tenants DROP COLUMN is_active;

--- a/packages/ar-admin-ui/src/lib/admin/__tests__/tenant-d1-ui-state.test.ts
+++ b/packages/ar-admin-ui/src/lib/admin/__tests__/tenant-d1-ui-state.test.ts
@@ -38,7 +38,7 @@ describe('tenant D1 UI state', () => {
 			tenant_code: 'draft-tenant',
 			name: 'Draft Tenant',
 			description: null,
-			is_active: false,
+			lifecycle_state: 'suspended',
 			is_default: false,
 			created_at: 1,
 			updated_at: 1,

--- a/packages/ar-admin-ui/src/lib/api/admin-tenants.ts
+++ b/packages/ar-admin-ui/src/lib/api/admin-tenants.ts
@@ -19,7 +19,16 @@ export interface Tenant {
 	tenant_code: string;
 	name: string;
 	description: string | null;
-	is_active: boolean;
+	lifecycle_state:
+		| 'provisioning'
+		| 'active'
+		| 'suspended'
+		| 'frozen'
+		| 'migration_read_only'
+		| 'deleting'
+		| 'deleted'
+		| 'restore_pending'
+		| 'restore_validating';
 	is_default: boolean;
 	created_at: number;
 	updated_at: number;
@@ -28,6 +37,12 @@ export interface Tenant {
 	provisioning_slot_id?: string | null;
 	provisioning_updated_at?: number | null;
 }
+
+export type OperatorMutableTenantLifecycleState =
+	| 'active'
+	| 'suspended'
+	| 'frozen'
+	| 'migration_read_only';
 
 export interface TenantListResponse {
 	tenants: Tenant[];
@@ -78,7 +93,7 @@ export interface UpdateTenantRequest {
 	name?: string;
 	tenant_code?: string;
 	description?: string | null;
-	is_active?: boolean;
+	lifecycle_state?: OperatorMutableTenantLifecycleState;
 }
 
 // =============================================================================

--- a/packages/ar-admin-ui/src/lib/stores/tenants.svelte.ts
+++ b/packages/ar-admin-ui/src/lib/stores/tenants.svelte.ts
@@ -34,7 +34,9 @@ function createTenantStore() {
 
 		/** Active tenants suitable for the header selector */
 		get activeTenants(): { id: string; name: string }[] {
-			return tenants.filter((t) => t.is_active).map((t) => ({ id: t.id, name: t.name }));
+			return tenants
+				.filter((t) => t.lifecycle_state === 'active')
+				.map((t) => ({ id: t.id, name: t.name }));
 		},
 
 		/** The current default tenant id */

--- a/packages/ar-admin-ui/src/routes/admin/tenants/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/tenants/+page.svelte
@@ -134,10 +134,10 @@
 							<td class="tenant-name">{tenant.name}</td>
 							<td class="tenant-description">{tenant.description ?? '—'}</td>
 							<td>
-								{#if tenant.is_active}
+								{#if tenant.lifecycle_state === 'active'}
 									<span class="badge badge-active">Active</span>
 								{:else}
-									<span class="badge badge-inactive">Disabled</span>
+									<span class="badge badge-inactive">{tenant.lifecycle_state}</span>
 								{/if}
 							</td>
 							<td>

--- a/packages/ar-admin-ui/src/routes/admin/tenants/[id]/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/tenants/[id]/+page.svelte
@@ -2,7 +2,12 @@
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
-	import { adminTenantsAPI, type Tenant } from '$lib/api/admin-tenants';
+	import {
+		adminTenantsAPI,
+		type OperatorMutableTenantLifecycleState,
+		type Tenant,
+		type UpdateTenantRequest
+	} from '$lib/api/admin-tenants';
 	import {
 		tenantVanityDomainsAPI,
 		type TenantVanityDomain
@@ -33,7 +38,7 @@
 	let editName = $state('');
 	let editTenantCode = $state('');
 	let editDescription = $state('');
-	let editIsActive = $state(true);
+	let editLifecycleState = $state<OperatorMutableTenantLifecycleState>('active');
 
 	// Delete confirmation
 	let showDeleteConfirm = $state(false);
@@ -72,7 +77,13 @@
 	const singleTenantMode = $derived(tenantStore.singleTenantMode);
 	const provisioningFailed = $derived(tenant?.provisioning_status === 'provisioning_failed');
 	const provisioningDraftState = $derived(getTenantProvisioningDraftUiState(tenant));
-	const tenantOperational = $derived(!!tenant?.is_active && !provisioningFailed);
+	const tenantOperational = $derived(tenant?.lifecycle_state === 'active' && !provisioningFailed);
+	const lifecycleEditable = $derived(
+		tenant?.lifecycle_state === 'active' ||
+			tenant?.lifecycle_state === 'suspended' ||
+			tenant?.lifecycle_state === 'frozen' ||
+			tenant?.lifecycle_state === 'migration_read_only'
+	);
 
 	// ==========================================================================
 	// Validation
@@ -155,7 +166,12 @@
 		editName = tenant.name;
 		editTenantCode = tenant.tenant_code;
 		editDescription = tenant.description ?? '';
-		editIsActive = tenant.is_active;
+		editLifecycleState =
+			tenant.lifecycle_state === 'suspended' ||
+			tenant.lifecycle_state === 'frozen' ||
+			tenant.lifecycle_state === 'migration_read_only'
+				? tenant.lifecycle_state
+				: 'active';
 		saveError = '';
 		isEditing = true;
 	}
@@ -176,7 +192,7 @@
 			saveError = 'Name is required';
 			return;
 		}
-		if (singleTenantMode && editIsActive !== tenant.is_active) {
+		if (singleTenantMode && lifecycleEditable && editLifecycleState !== tenant.lifecycle_state) {
 			saveError = 'The initial tenant must remain active in single-tenant mode.';
 			return;
 		}
@@ -184,12 +200,15 @@
 		saving = true;
 		saveError = '';
 		try {
-			const updated = await adminTenantsAPI.update(tenant.id, {
+			const payload: UpdateTenantRequest = {
 				name: editName.trim(),
 				tenant_code: editTenantCode.trim(),
-				description: editDescription.trim() || null,
-				is_active: editIsActive
-			});
+				description: editDescription.trim() || null
+			};
+			if (lifecycleEditable && editLifecycleState !== tenant.lifecycle_state) {
+				payload.lifecycle_state = editLifecycleState;
+			}
+			const updated = await adminTenantsAPI.update(tenant.id, payload);
 			tenantStore.update(updated);
 			tenant = updated;
 			isEditing = false;
@@ -224,7 +243,7 @@
 		deleteError = '';
 		try {
 			await adminTenantsAPI.delete(tenant.id);
-			tenantStore.update({ ...tenant, is_active: false });
+			tenantStore.update({ ...tenant, lifecycle_state: 'deleting' });
 			goto('/admin/tenants');
 		} catch (err) {
 			deleteError = err instanceof Error ? err.message : 'Failed to delete tenant';
@@ -449,10 +468,10 @@
 			<div class="status-row">
 				{#if provisioningFailed}
 					<span class="badge badge-error">Provisioning Failed</span>
-				{:else if tenant.is_active}
+				{:else if tenant.lifecycle_state === 'active'}
 					<span class="badge badge-active">Active</span>
 				{:else}
-					<span class="badge badge-inactive">Inactive</span>
+					<span class="badge badge-inactive">{tenant.lifecycle_state}</span>
 				{/if}
 				{#if tenant.description}
 					<p class="description">{tenant.description}</p>
@@ -467,7 +486,7 @@
 			</div>
 		{/if}
 
-		{#if provisioningFailed || !tenant.is_active}
+		{#if provisioningFailed || tenant.lifecycle_state !== 'active'}
 			<section class="card status-card">
 				<div class="status-card-header">
 					<i class={provisioningFailed ? 'i-ph-warning-circle' : 'i-ph-pause-circle'}></i>
@@ -578,30 +597,24 @@
 						></textarea>
 					</div>
 					<div class="form-group">
-						<label
-							class="form-label toggle-label"
-							class:disabled={singleTenantMode || tenant.is_default}
+						<label for="edit-lifecycle-state" class="form-label">Lifecycle State</label>
+						<select
+							id="edit-lifecycle-state"
+							class="form-input"
+							bind:value={editLifecycleState}
+							disabled={singleTenantMode || tenant.is_default || !lifecycleEditable}
 						>
-							<span>Active</span>
-							<div
-								class="toggle-switch"
-								class:checked={editIsActive}
-								class:disabled={singleTenantMode || tenant.is_default}
-							>
-								<input
-									type="checkbox"
-									bind:checked={editIsActive}
-									class="toggle-input"
-									id="edit-active"
-									disabled={singleTenantMode || tenant.is_default}
-								/>
-								<label for="edit-active" class="toggle-slider"></label>
-							</div>
-						</label>
+							<option value="active">Active</option>
+							<option value="suspended">Suspended</option>
+							<option value="frozen">Frozen</option>
+							<option value="migration_read_only">Migration read-only</option>
+						</select>
 						{#if singleTenantMode}
 							<p class="field-hint">Cannot be changed in single-tenant mode.</p>
 						{:else if tenant.is_default}
 							<p class="field-hint">The default tenant must remain active.</p>
+						{:else if !lifecycleEditable}
+							<p class="field-hint">This lifecycle state requires a dedicated operation.</p>
 						{/if}
 					</div>
 				</div>
@@ -635,10 +648,10 @@
 					<div class="detail-row">
 						<dt>Status</dt>
 						<dd>
-							{#if tenant.is_active}
+							{#if tenant.lifecycle_state === 'active'}
 								<span class="badge badge-active">Active</span>
 							{:else}
-								<span class="badge badge-inactive">Inactive</span>
+								<span class="badge badge-inactive">{tenant.lifecycle_state}</span>
 							{/if}
 						</dd>
 					</div>
@@ -1204,66 +1217,6 @@
 		margin-top: 20px;
 		padding-top: 16px;
 		border-top: 1px solid var(--border);
-	}
-
-	/* Toggle switch */
-	.toggle-label {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		cursor: pointer;
-	}
-
-	.toggle-label.disabled {
-		cursor: not-allowed;
-		opacity: 0.6;
-	}
-
-	.toggle-switch {
-		position: relative;
-	}
-
-	.toggle-input {
-		position: absolute;
-		opacity: 0;
-		width: 0;
-		height: 0;
-	}
-
-	.toggle-slider {
-		display: block;
-		width: 40px;
-		height: 22px;
-		background: var(--bg-tertiary);
-		border-radius: var(--radius-full);
-		position: relative;
-		cursor: pointer;
-		transition: background var(--transition-fast);
-	}
-
-	.toggle-switch.disabled .toggle-slider {
-		cursor: not-allowed;
-	}
-
-	.toggle-slider::after {
-		content: '';
-		position: absolute;
-		top: 3px;
-		left: 3px;
-		width: 16px;
-		height: 16px;
-		background: white;
-		border-radius: var(--radius-full);
-		transition: transform var(--transition-fast);
-		box-shadow: var(--shadow-sm);
-	}
-
-	.toggle-switch.checked .toggle-slider {
-		background: var(--primary);
-	}
-
-	.toggle-switch.checked .toggle-slider::after {
-		transform: translateX(18px);
 	}
 
 	/* Settings */

--- a/packages/ar-bridge/src/__tests__/token-refresh.test.ts
+++ b/packages/ar-bridge/src/__tests__/token-refresh.test.ts
@@ -110,7 +110,7 @@ describe('scheduled bridge token refresh', () => {
     const result = await refreshExpiringTokensForScheduledTenants(createEnv(settings));
 
     expect(mockCoreAdapter.query).toHaveBeenCalledWith(
-      'SELECT id FROM tenants WHERE is_active = 1 AND id > ? ORDER BY id ASC LIMIT ?',
+      "SELECT id FROM tenants WHERE lifecycle_state = 'active' AND id > ? ORDER BY id ASC LIMIT ?",
       ['tenant-a', 2]
     );
     expect(mockResolveUserStoreRuntimeSourcesFromEnv).toHaveBeenCalledWith(
@@ -154,12 +154,12 @@ describe('scheduled bridge token refresh', () => {
 
     expect(mockCoreAdapter.query).toHaveBeenNthCalledWith(
       1,
-      'SELECT id FROM tenants WHERE is_active = 1 AND id > ? ORDER BY id ASC LIMIT ?',
+      "SELECT id FROM tenants WHERE lifecycle_state = 'active' AND id > ? ORDER BY id ASC LIMIT ?",
       ['tenant-z', 2]
     );
     expect(mockCoreAdapter.query).toHaveBeenNthCalledWith(
       2,
-      'SELECT id FROM tenants WHERE is_active = 1 ORDER BY id ASC LIMIT ?',
+      "SELECT id FROM tenants WHERE lifecycle_state = 'active' ORDER BY id ASC LIMIT ?",
       [2]
     );
     expect(settings.put).toHaveBeenCalledWith(TOKEN_REFRESH_TENANT_CURSOR_KEY, 'tenant-a');
@@ -195,7 +195,7 @@ describe('scheduled bridge token refresh', () => {
     await refreshExpiringTokensForScheduledTenants(createEnv(settings));
 
     expect(mockCoreAdapter.query).toHaveBeenCalledWith(
-      'SELECT id FROM tenants WHERE is_active = 1 ORDER BY id ASC LIMIT ?',
+      "SELECT id FROM tenants WHERE lifecycle_state = 'active' ORDER BY id ASC LIMIT ?",
       [100]
     );
     expect(mockIdentityAdapter.query).toHaveBeenCalledWith(expect.any(String), [
@@ -251,7 +251,7 @@ describe('scheduled bridge token refresh', () => {
     await refreshExpiringTokensForScheduledTenants(createEnv(settings));
 
     expect(mockCoreAdapter.query).toHaveBeenCalledWith(
-      'SELECT id FROM tenants WHERE is_active = 1 ORDER BY id ASC LIMIT ?',
+      "SELECT id FROM tenants WHERE lifecycle_state = 'active' ORDER BY id ASC LIMIT ?",
       [100]
     );
     expect(mockIdentityAdapter.query).toHaveBeenCalledWith(expect.any(String), [

--- a/packages/ar-bridge/src/services/token-refresh.ts
+++ b/packages/ar-bridge/src/services/token-refresh.ts
@@ -365,7 +365,7 @@ async function listNextTokenRefreshTenantIds(env: Env, batchSize: number): Promi
 
   if (cursor) {
     const rows = await adapter.query<{ id: string }>(
-      'SELECT id FROM tenants WHERE is_active = 1 AND id > ? ORDER BY id ASC LIMIT ?',
+      "SELECT id FROM tenants WHERE lifecycle_state = 'active' AND id > ? ORDER BY id ASC LIMIT ?",
       [cursor, batchSize]
     );
     if (rows.length > 0) {
@@ -374,7 +374,7 @@ async function listNextTokenRefreshTenantIds(env: Env, batchSize: number): Promi
   }
 
   const rows = await adapter.query<{ id: string }>(
-    'SELECT id FROM tenants WHERE is_active = 1 ORDER BY id ASC LIMIT ?',
+    "SELECT id FROM tenants WHERE lifecycle_state = 'active' ORDER BY id ASC LIMIT ?",
     [batchSize]
   );
   return rows.map((row) => row.id);

--- a/packages/ar-lib-core/src/middleware/__tests__/request-context.test.ts
+++ b/packages/ar-lib-core/src/middleware/__tests__/request-context.test.ts
@@ -167,8 +167,8 @@ describe('requestContextMiddleware – tenant existence check', () => {
       expect(body.error).toBe('not_found');
     });
 
-    it('returns 404 for an inactive tenant (no row returned)', async () => {
-      // is_active = 0 → query returns nothing (WHERE is_active = 1)
+    it('returns 404 for a non-active tenant (no row returned)', async () => {
+      // lifecycle_state != 'active' -> query returns nothing.
       const db = createMockDB({ tenantRow: null });
       const kv = createMockKV({ cachedValue: null });
       const env: TestEnv = { BASE_DOMAIN, DB: db, AUTHRIM_CONFIG: kv };
@@ -185,7 +185,7 @@ describe('requestContextMiddleware – tenant existence check', () => {
       const res = await app.request(makeRequest(`sample.${BASE_DOMAIN}`), undefined, env as Env);
       expect(res.status).toBe(200);
       expect(db.prepare).not.toHaveBeenCalledWith(
-        'SELECT id FROM tenants WHERE id = ? AND is_active = 1'
+        "SELECT id FROM tenants WHERE id = ? AND lifecycle_state = 'active'"
       );
     });
 

--- a/packages/ar-lib-core/src/services/__tests__/tenant-domain-resolver.test.ts
+++ b/packages/ar-lib-core/src/services/__tests__/tenant-domain-resolver.test.ts
@@ -45,7 +45,10 @@ describe('tenant-domain-resolver', () => {
       { tenant_id: 'acme', priority: 20 },
       { tenant_id: 'beta', priority: 10 },
     ]);
-    expect(adapter.query).toHaveBeenCalledOnce();
+    expect(adapter.query).toHaveBeenCalledWith(
+      expect.stringContaining("tenants.lifecycle_state = 'active'"),
+      ['hashed-domain']
+    );
   });
 
   it('returns the highest-priority tenant for the single-result helper', async () => {

--- a/packages/ar-lib-core/src/services/__tests__/tenant-vanity-domain-resolver.test.ts
+++ b/packages/ar-lib-core/src/services/__tests__/tenant-vanity-domain-resolver.test.ts
@@ -46,7 +46,10 @@ describe('tenant-vanity-domain-resolver', () => {
     const result = await resolveTenantFromVanityHost(adapter, kv, 'Login.Example.com');
 
     expect(result).toBe('tenant-123');
-    expect(adapter.queryOne).toHaveBeenCalledOnce();
+    expect(adapter.queryOne).toHaveBeenCalledWith(
+      expect.stringContaining("tenants.lifecycle_state = 'active'"),
+      ['login.example.com']
+    );
     expect(kv.put).toHaveBeenCalledOnce();
   });
 

--- a/packages/ar-lib-core/src/services/tenant-domain-resolver.ts
+++ b/packages/ar-lib-core/src/services/tenant-domain-resolver.ts
@@ -39,8 +39,9 @@ export interface TenantDomainCandidate {
 /**
  * Resolve a tenant ID from an email address's domain.
  *
- * Looks up the email domain in `tenant_domain_mappings` (verified=1, is_active=1)
- * and returns the highest-priority matching tenant ID, or null if none found.
+ * Looks up the email domain in `tenant_domain_mappings` (verified=1, is_active=1),
+ * filters to tenants with `lifecycle_state='active'`, and returns the
+ * highest-priority matching tenant ID, or null if none found.
  *
  * This should only be called when the Host header resolves to 'default',
  * as Host-header tenant resolution always takes precedence.
@@ -68,7 +69,7 @@ export async function resolveTenantCandidatesFromEmailDomain(
        WHERE tenant_domain_mappings.active_domain_hash = ?
          AND tenant_domain_mappings.verified = 1
          AND tenant_domain_mappings.is_active = 1
-         AND tenants.is_active = 1
+         AND tenants.lifecycle_state = 'active'
        ORDER BY priority DESC, tenant_domain_mappings.tenant_id ASC`,
       [hashResult.hash]
     );

--- a/packages/ar-lib-core/src/services/tenant-vanity-domain-resolver.ts
+++ b/packages/ar-lib-core/src/services/tenant-vanity-domain-resolver.ts
@@ -146,7 +146,7 @@ export async function resolveTenantFromVanityHost(
        WHERE tenant_vanity_domains.active_hostname = ?
          AND tenant_vanity_domains.is_active = 1
          AND tenant_vanity_domains.status = 'active'
-         AND tenants.is_active = 1
+         AND tenants.lifecycle_state = 'active'
        LIMIT 1`,
       [hostname]
     );

--- a/packages/ar-lib-core/src/utils/issuer.ts
+++ b/packages/ar-lib-core/src/utils/issuer.ts
@@ -35,7 +35,7 @@ export interface IssuerEnvLike {
 }
 
 /**
- * Validate that a tenant exists and is active using D1 + KV positive cache.
+ * Validate that a tenant exists and is runtime-active using D1 + KV positive cache.
  *
  * - Positive cache TTL: 300s (negative results are NOT cached to allow immediate
  *   recognition after tenant creation)
@@ -44,7 +44,7 @@ export interface IssuerEnvLike {
  * @param db - D1 database binding (undefined = fail-open)
  * @param kv - KV namespace for caching (undefined = skip cache)
  * @param tenantId - Tenant ID to validate
- * @returns true if tenant exists and is active, false if not found or inactive
+ * @returns true if tenant exists and is active, false if not found or not runtime-active
  */
 export async function validateTenantExistsAsync(
   db: DatabaseSource | undefined,
@@ -69,7 +69,7 @@ export async function validateTenantExistsAsync(
   try {
     const adapter = ensureDatabaseAdapter(db, 'tenant-exists');
     const row = await adapter.queryOne<{ id: string }>(
-      'SELECT id FROM tenants WHERE id = ? AND is_active = 1',
+      "SELECT id FROM tenants WHERE id = ? AND lifecycle_state = 'active'",
       [tenantId]
     );
 

--- a/packages/ar-management/src/__tests__/admin-compatibility.test.ts
+++ b/packages/ar-management/src/__tests__/admin-compatibility.test.ts
@@ -1,0 +1,48 @@
+import type { Env } from '@authrim/ar-lib-core';
+import { describe, expect, it } from 'vitest';
+import worker from '../index';
+
+function createMockKV(): KVNamespace {
+  return {
+    get: async () => null,
+    put: async () => undefined,
+    delete: async () => undefined,
+    list: async () => ({ keys: [] }),
+  } as unknown as KVNamespace;
+}
+
+describe('Admin API compatibility surface', () => {
+  it('returns the removed admin session endpoint error before admin authentication', async () => {
+    const response = await worker.fetch(
+      new Request('https://example.com/api/admin/sessions/me', {
+        headers: {
+          'X-Tenant-Id': 'tenant-a',
+        },
+      }),
+      {
+        DEFAULT_TENANT_ID: 'tenant-a',
+        AUTHRIM_CONFIG: createMockKV(),
+      } as unknown as Env
+    );
+    const payload = (await response.json()) as {
+      error?: string;
+      error_uri?: string;
+      error_details?: {
+        code?: string;
+        severity?: string;
+        retryable?: boolean;
+      };
+    };
+
+    expect(response.status).toBe(404);
+    expect(payload.error).toBe('legacy_endpoint_not_supported');
+    expect(payload.error_uri).toBe(
+      'https://docs.authrim.com/errors/error-codes#legacy-endpoint-not-supported'
+    );
+    expect(payload.error_details).toMatchObject({
+      code: 'legacy_endpoint_not_supported',
+      severity: 'fatal',
+      retryable: false,
+    });
+  });
+});

--- a/packages/ar-management/src/__tests__/admin-tenants-tenant-d1-pool.test.ts
+++ b/packages/ar-management/src/__tests__/admin-tenants-tenant-d1-pool.test.ts
@@ -2,9 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Env } from '@authrim/ar-lib-core';
 import {
   adminTenantCreateHandler,
+  adminTenantDeleteHandler,
   adminTenantGetHandler,
   adminTenantProvisioningCleanupHandler,
   adminTenantProvisioningRetryHandler,
+  adminTenantUpdateHandler,
   adminTenantsListHandler,
 } from '../admin-tenants';
 
@@ -27,7 +29,7 @@ interface TenantRow {
   tenant_code: string;
   name: string;
   description: string | null;
-  is_active: number;
+  lifecycle_state: string;
   is_default: number;
   created_at: number;
   updated_at: number;
@@ -189,7 +191,7 @@ function createTenantRow(id: string, overrides: Partial<TenantRow> = {}): Tenant
     tenant_code: id,
     name: id,
     description: null,
-    is_active: 1,
+    lifecycle_state: 'active',
     is_default: 0,
     created_at: 1,
     updated_at: 1,
@@ -202,7 +204,7 @@ function createTenantRowFromInsertParams(params: unknown[]): TenantRow {
     tenant_code: String(params[1]),
     name: String(params[3]),
     description: params[4] as string | null,
-    is_active: Number(params[5]),
+    lifecycle_state: String(params[5]),
     created_at: Number(params[7]),
     updated_at: Number(params[8]),
   });
@@ -464,16 +466,16 @@ describe('tenant D1 pool tenant management', () => {
         controlTenant = createTenantRowFromInsertParams(params);
         return { rowsAffected: 1 };
       }
-      if (op === 'execute' && sql.includes('UPDATE tenants SET is_active = 1')) {
+      if (op === 'execute' && sql.includes("UPDATE tenants SET lifecycle_state = 'active'")) {
         if (controlTenant) {
-          controlTenant = { ...controlTenant, is_active: 1, updated_at: Number(params[0]) };
+          controlTenant = { ...controlTenant, lifecycle_state: 'active', updated_at: Number(params[0]) };
         }
         return { rowsAffected: 1 };
       }
       if (
         op === 'queryOne' &&
         sql.includes(
-          'SELECT id, tenant_code, name, description, is_active, is_default, created_at, updated_at FROM tenants WHERE id = ?'
+          'SELECT id, tenant_code, name, description, lifecycle_state, is_default, created_at, updated_at FROM tenants WHERE id = ?'
         )
       ) {
         return controlTenant;
@@ -525,21 +527,21 @@ describe('tenant D1 pool tenant management', () => {
     );
     const body = (await response.json()) as {
       id: string;
-      is_active: boolean;
+      lifecycle_state: string;
       provisioning: { mode: string; slot_id: string; smoke_test: string };
     };
 
     expect(response.status).toBe(201);
     expect(body).toMatchObject({
       id: 'second',
-      is_active: true,
+      lifecycle_state: 'active',
       provisioning: {
         mode: 'tenant-d1-preallocated-pool',
         slot_id: 'slot-0001',
         smoke_test: 'passed',
       },
     });
-    expect(tenantDbRow).toMatchObject({ id: 'second', is_active: 1 });
+    expect(tenantDbRow).toMatchObject({ id: 'second', lifecycle_state: 'active' });
     expect(slotState).toBe('assigned');
     expect(assignedTenantId).toBe('second');
   });
@@ -562,18 +564,20 @@ describe('tenant D1 pool tenant management', () => {
         controlTenant = createTenantRowFromInsertParams(params);
         return { rowsAffected: 1 };
       }
-      if (op === 'execute' && sql.includes('UPDATE tenants SET is_active = 0')) {
+      if (op === 'execute' && sql.includes("UPDATE tenants SET lifecycle_state = 'suspended'")) {
         if (controlTenant) {
           controlTenant = {
             ...controlTenant,
-            is_active: 0,
+            lifecycle_state: 'suspended',
             updated_at: Number(params[0]),
           };
         }
         return { rowsAffected: 1 };
       }
-      if (op === 'execute' && sql.includes('DELETE FROM tenants')) {
-        controlTenant = null;
+      if (op === 'execute' && sql.includes("UPDATE tenants SET lifecycle_state = 'deleted'")) {
+        controlTenant = controlTenant
+          ? { ...controlTenant, lifecycle_state: 'deleted', updated_at: Number(params[0]) }
+          : null;
         return { rowsAffected: 1 };
       }
       throw new Error(`unexpected default adapter SQL: ${sql}`);
@@ -647,7 +651,7 @@ describe('tenant D1 pool tenant management', () => {
 
     expect(response.status).toBe(500);
     expect(slotState).toBe('reset_required');
-    expect(controlTenant).toMatchObject({ id: 'second', is_active: 0 });
+    expect(controlTenant).toMatchObject({ id: 'second', lifecycle_state: 'suspended' });
   });
 
   it('cleans up a failed provisioning draft without releasing the reset-required slot', async () => {
@@ -655,15 +659,19 @@ describe('tenant D1 pool tenant management', () => {
       state: 'reset_required',
       assigned_tenant_id: 'second',
     });
-    let controlTenant: TenantRow | null = createTenantRow('second', { is_active: 0 });
+    let controlTenant: TenantRow | null = createTenantRow('second', {
+      lifecycle_state: 'suspended',
+    });
     let cleanupAuditWritten = false;
 
     adapters.defaultAdapter = createAdapter((sql, _params, op) => {
       if (op === 'queryOne' && sql.includes('FROM tenants WHERE id = ?')) {
         return controlTenant;
       }
-      if (op === 'execute' && sql.includes('DELETE FROM tenants')) {
-        controlTenant = null;
+      if (op === 'execute' && sql.includes("UPDATE tenants SET lifecycle_state = 'deleted'")) {
+        controlTenant = controlTenant
+          ? { ...controlTenant, lifecycle_state: 'deleted', updated_at: Number(_params[0]) }
+          : null;
         return { rowsAffected: 1 };
       }
       throw new Error(`unexpected default adapter SQL: ${sql}`);
@@ -718,7 +726,7 @@ describe('tenant D1 pool tenant management', () => {
 
     expect(response.status).toBe(200);
     expect(body).toMatchObject({ status: 'cleaned', slot_id: 'slot-0001' });
-    expect(controlTenant).toBeNull();
+    expect(controlTenant).toMatchObject({ id: 'second', lifecycle_state: 'deleted' });
     expect(cleanupAuditWritten).toBe(true);
   });
 
@@ -730,7 +738,7 @@ describe('tenant D1 pool tenant management', () => {
 
     adapters.defaultAdapter = createAdapter((sql, _params, op) => {
       if (op === 'queryOne' && sql.includes('FROM tenants WHERE id = ?')) {
-        return createTenantRow('second', { is_active: 0 });
+        return createTenantRow('second', { lifecycle_state: 'suspended' });
       }
       throw new Error(`unexpected default adapter SQL: ${sql}`);
     });
@@ -790,7 +798,9 @@ describe('tenant D1 pool tenant management', () => {
     const slot = createSlot({ state: 'available', assigned_tenant_id: null });
     let slotState = 'available';
     let assignedTenantId: string | null = null;
-    let controlTenant: TenantRow | null = createTenantRow('second', { is_active: 0 });
+    let controlTenant: TenantRow | null = createTenantRow('second', {
+      lifecycle_state: 'suspended',
+    });
     let tenantDbRow: TenantRow | null = null;
 
     adapters.defaultAdapter = createAdapter((sql, params, op) => {
@@ -801,11 +811,11 @@ describe('tenant D1 pool tenant management', () => {
         controlTenant = createTenantRowFromInsertParams(params);
         return { rowsAffected: 1 };
       }
-      if (op === 'execute' && sql.includes('UPDATE tenants SET is_active = 1')) {
+      if (op === 'execute' && sql.includes("UPDATE tenants SET lifecycle_state = 'active'")) {
         if (controlTenant) {
           controlTenant = {
             ...controlTenant,
-            is_active: 1,
+            lifecycle_state: 'active',
             updated_at: Number(params[0]),
           };
         }
@@ -886,19 +896,19 @@ describe('tenant D1 pool tenant management', () => {
     );
     const body = (await response.json()) as {
       id: string;
-      is_active: boolean;
+      lifecycle_state: string;
       provisioning: { retry: string; slot_id: string };
     };
 
     expect(response.status).toBe(200);
     expect(body).toMatchObject({
       id: 'second',
-      is_active: true,
+      lifecycle_state: 'active',
       provisioning: { retry: 'succeeded', slot_id: 'slot-0001' },
     });
     expect(slotState).toBe('assigned');
-    expect(controlTenant).toMatchObject({ id: 'second', is_active: 1 });
-    expect(tenantDbRow).toMatchObject({ id: 'second', is_active: 1 });
+    expect(controlTenant).toMatchObject({ id: 'second', lifecycle_state: 'active' });
+    expect(tenantDbRow).toMatchObject({ id: 'second', lifecycle_state: 'active' });
   });
 
   it('rejects provisioning retry when the failed slot has already been reused', async () => {
@@ -910,7 +920,7 @@ describe('tenant D1 pool tenant management', () => {
 
     adapters.defaultAdapter = createAdapter((sql, _params, op) => {
       if (op === 'queryOne' && sql.includes('FROM tenants WHERE id = ?')) {
-        return createTenantRow('second', { is_active: 0 });
+        return createTenantRow('second', { lifecycle_state: 'suspended' });
       }
       throw new Error(`unexpected default adapter SQL: ${sql}`);
     });
@@ -981,14 +991,18 @@ describe('tenant D1 pool tenant management', () => {
       state: 'assigned',
       assigned_tenant_id: 'third',
     });
-    let controlTenant: TenantRow | null = createTenantRow('second', { is_active: 0 });
+    let controlTenant: TenantRow | null = createTenantRow('second', {
+      lifecycle_state: 'suspended',
+    });
 
     adapters.defaultAdapter = createAdapter((sql, _params, op) => {
       if (op === 'queryOne' && sql.includes('FROM tenants WHERE id = ?')) {
         return controlTenant;
       }
-      if (op === 'execute' && sql.includes('DELETE FROM tenants')) {
-        controlTenant = null;
+      if (op === 'execute' && sql.includes("UPDATE tenants SET lifecycle_state = 'deleted'")) {
+        controlTenant = controlTenant
+          ? { ...controlTenant, lifecycle_state: 'deleted', updated_at: Number(_params[0]) }
+          : null;
         return { rowsAffected: 1 };
       }
       throw new Error(`unexpected default adapter SQL: ${sql}`);
@@ -1045,6 +1059,170 @@ describe('tenant D1 pool tenant management', () => {
 
     expect(response.status).toBe(200);
     expect(body).toMatchObject({ status: 'cleaned', slot_id: 'slot-0001' });
-    expect(controlTenant).toBeNull();
+    expect(controlTenant).toMatchObject({ id: 'second', lifecycle_state: 'deleted' });
+  });
+
+  it('allows operator lifecycle updates only for mutable lifecycle states', async () => {
+    let tenantRow = createTenantRow('second', { lifecycle_state: 'active' });
+    adapters.defaultAdapter = createAdapter((sql, params, op) => {
+      if (op === 'queryOne' && sql.includes('FROM tenants WHERE id = ?')) {
+        return tenantRow;
+      }
+      if (op === 'execute' && sql.includes('UPDATE tenants SET lifecycle_state = ?')) {
+        tenantRow = { ...tenantRow, lifecycle_state: String(params[0]), updated_at: Number(params[1]) };
+        return { rowsAffected: 1 };
+      }
+      throw new Error(`unexpected default adapter SQL: ${sql}`);
+    });
+
+    const response = await adminTenantUpdateHandler(
+      createContext({ lifecycle_state: 'suspended' }, {}, { id: 'second' })
+    );
+    const body = (await response.json()) as TenantRow;
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ id: 'second', lifecycle_state: 'suspended' });
+  });
+
+  it('rejects direct PATCH requests to internal lifecycle states', async () => {
+    adapters.defaultAdapter = createAdapter();
+
+    const response = await adminTenantUpdateHandler(
+      createContext({ lifecycle_state: 'deleted' }, {}, { id: 'second' })
+    );
+
+    expect(response.status).toBe(400);
+    expect(adapters.defaultAdapter.execute).not.toHaveBeenCalled();
+    expect(adapters.defaultAdapter.queryOne).not.toHaveBeenCalled();
+  });
+
+  it('rejects direct lifecycle changes from terminal/internal states', async () => {
+    const tenantRow = createTenantRow('second', { lifecycle_state: 'deleted' });
+    adapters.defaultAdapter = createAdapter((sql, _params, op) => {
+      if (op === 'queryOne' && sql.includes('FROM tenants WHERE id = ?')) {
+        return tenantRow;
+      }
+      throw new Error(`unexpected default adapter SQL: ${sql}`);
+    });
+
+    const response = await adminTenantUpdateHandler(
+      createContext({ lifecycle_state: 'active' }, {}, { id: 'second' })
+    );
+    const body = (await response.json()) as { details?: { variables?: { reason?: string } } };
+
+    expect(response.status).toBe(400);
+    expect(body.details?.variables?.reason).toBe('Lifecycle state requires a dedicated operation');
+    expect(adapters.defaultAdapter.execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects deactivating the current default tenant by row flag', async () => {
+    adapters.defaultAdapter = createAdapter((sql, _params, op) => {
+      if (op === 'queryOne' && sql.includes('FROM tenants WHERE id = ?')) {
+        return createTenantRow('second', { is_default: 1 });
+      }
+      throw new Error(`unexpected default adapter SQL: ${sql}`);
+    });
+
+    const response = await adminTenantUpdateHandler(
+      createContext({ lifecycle_state: 'suspended' }, {}, { id: 'second' })
+    );
+    const body = (await response.json()) as { details?: { variables?: { reason?: string } } };
+
+    expect(response.status).toBe(400);
+    expect(body.details?.variables?.reason).toBe('Cannot deactivate the default tenant');
+    expect(adapters.defaultAdapter.execute).not.toHaveBeenCalled();
+  });
+
+  it('queues tenant deletion and lifecycle update in one transaction', async () => {
+    adapters.defaultAdapter = createAdapter((sql, _params, op) => {
+      if (
+        op === 'queryOne' &&
+        sql === 'SELECT id, is_default, lifecycle_state FROM tenants WHERE id = ?'
+      ) {
+        return { id: 'second', is_default: 0, lifecycle_state: 'active' };
+      }
+      if (
+        op === 'execute' &&
+        (sql.includes("UPDATE tenants SET lifecycle_state = 'deleting'") ||
+          sql.includes('INSERT INTO admin_jobs'))
+      ) {
+        return { rowsAffected: 1 };
+      }
+      throw new Error(`unexpected default adapter SQL: ${sql}`);
+    });
+
+    const response = await adminTenantDeleteHandler(createContext({}, {}, { id: 'second' }));
+    const body = (await response.json()) as { job_id: string; status: string };
+
+    expect(response.status).toBe(202);
+    expect(body.status).toBe('pending');
+    expect(adapters.defaultAdapter.transaction).toHaveBeenCalledOnce();
+    expect(adapters.defaultAdapter.execute).toHaveBeenCalledWith(
+      "UPDATE tenants SET lifecycle_state = 'deleting', updated_at = ? WHERE id = ?",
+      [expect.any(Number), 'second']
+    );
+    expect(adapters.defaultAdapter.execute).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO admin_jobs'),
+      expect.arrayContaining(['tenants/delete', 'pending', JSON.stringify({ tenant_id: 'second' })])
+    );
+  });
+
+  it('rejects deleting the current default tenant by row flag', async () => {
+    adapters.defaultAdapter = createAdapter((sql, _params, op) => {
+      if (
+        op === 'queryOne' &&
+        sql === 'SELECT id, is_default, lifecycle_state FROM tenants WHERE id = ?'
+      ) {
+        return { id: 'second', is_default: 1, lifecycle_state: 'active' };
+      }
+      throw new Error(`unexpected default adapter SQL: ${sql}`);
+    });
+
+    const response = await adminTenantDeleteHandler(createContext({}, {}, { id: 'second' }));
+    const body = (await response.json()) as { details?: { variables?: { reason?: string } } };
+
+    expect(response.status).toBe(400);
+    expect(body.details?.variables?.reason).toBe('Cannot delete the default tenant');
+    expect(adapters.defaultAdapter.transaction).not.toHaveBeenCalled();
+  });
+
+  it('rejects deleting tenants already in internal lifecycle states', async () => {
+    adapters.defaultAdapter = createAdapter((sql, _params, op) => {
+      if (
+        op === 'queryOne' &&
+        sql === 'SELECT id, is_default, lifecycle_state FROM tenants WHERE id = ?'
+      ) {
+        return { id: 'second', is_default: 0, lifecycle_state: 'deleting' };
+      }
+      throw new Error(`unexpected default adapter SQL: ${sql}`);
+    });
+
+    const response = await adminTenantDeleteHandler(createContext({}, {}, { id: 'second' }));
+    const body = (await response.json()) as { details?: { variables?: { reason?: string } } };
+
+    expect(response.status).toBe(400);
+    expect(body.details?.variables?.reason).toBe('Lifecycle state requires a dedicated operation');
+    expect(adapters.defaultAdapter.transaction).not.toHaveBeenCalled();
+  });
+
+  it('does not invalidate tenant cache when deletion transaction fails', async () => {
+    const kv = createKVNamespace();
+    adapters.defaultAdapter = createAdapter((sql, _params, op) => {
+      if (
+        op === 'queryOne' &&
+        sql === 'SELECT id, is_default, lifecycle_state FROM tenants WHERE id = ?'
+      ) {
+        return { id: 'second', is_default: 0, lifecycle_state: 'active' };
+      }
+      throw new Error(`unexpected default adapter SQL: ${sql}`);
+    });
+    adapters.defaultAdapter.transaction.mockRejectedValueOnce(new Error('job insert failed'));
+
+    const response = await adminTenantDeleteHandler(
+      createContext({}, { AUTHRIM_CONFIG: kv }, { id: 'second' })
+    );
+
+    expect(response.status).toBe(500);
+    expect(kv.delete).not.toHaveBeenCalled();
   });
 });

--- a/packages/ar-management/src/__tests__/admin-tenants-tenant-d1-pool.test.ts
+++ b/packages/ar-management/src/__tests__/admin-tenants-tenant-d1-pool.test.ts
@@ -468,7 +468,11 @@ describe('tenant D1 pool tenant management', () => {
       }
       if (op === 'execute' && sql.includes("UPDATE tenants SET lifecycle_state = 'active'")) {
         if (controlTenant) {
-          controlTenant = { ...controlTenant, lifecycle_state: 'active', updated_at: Number(params[0]) };
+          controlTenant = {
+            ...controlTenant,
+            lifecycle_state: 'active',
+            updated_at: Number(params[0]),
+          };
         }
         return { rowsAffected: 1 };
       }
@@ -1069,7 +1073,11 @@ describe('tenant D1 pool tenant management', () => {
         return tenantRow;
       }
       if (op === 'execute' && sql.includes('UPDATE tenants SET lifecycle_state = ?')) {
-        tenantRow = { ...tenantRow, lifecycle_state: String(params[0]), updated_at: Number(params[1]) };
+        tenantRow = {
+          ...tenantRow,
+          lifecycle_state: String(params[0]),
+          updated_at: Number(params[1]),
+        };
         return { rowsAffected: 1 };
       }
       throw new Error(`unexpected default adapter SQL: ${sql}`);

--- a/packages/ar-management/src/__tests__/discovery-isolation.test.ts
+++ b/packages/ar-management/src/__tests__/discovery-isolation.test.ts
@@ -15,9 +15,9 @@ import type { Env } from '@authrim/ar-lib-core';
  * - Request validation
  *
  * Design notes:
- * - resolveTenantCandidatesFromEmailDomain uses `INNER JOIN tenants … AND tenants.is_active = 1`
+ * - resolveTenantCandidatesFromEmailDomain uses `INNER JOIN tenants … AND tenants.lifecycle_state = 'active'`
  *   so the email mock must never return inactive tenants (mirrors real DB behaviour).
- * - FakeD1Adapter applies is_active = 1 on tenant_code lookups, fixing a gap in
+ * - FakeD1Adapter applies lifecycle_state = 'active' on tenant_code lookups, fixing a gap in
  *   the existing discovery.test.ts fixture.
  */
 
@@ -28,10 +28,15 @@ const mocked = vi.hoisted(() => {
 
   const state = {
     tenants: [
-      { id: 'default', tenant_code: 'default', name: 'Default Tenant', is_active: 1 },
-      { id: 'acme', tenant_code: 'acme-code', name: 'Acme Corp', is_active: 1 },
-      { id: 'beta', tenant_code: 'beta-code', name: 'Beta Inc', is_active: 1 },
-      { id: 'inactive', tenant_code: 'inactive-code', name: 'Gone Co', is_active: 0 },
+      { id: 'default', tenant_code: 'default', name: 'Default Tenant', lifecycle_state: 'active' },
+      { id: 'acme', tenant_code: 'acme-code', name: 'Acme Corp', lifecycle_state: 'active' },
+      { id: 'beta', tenant_code: 'beta-code', name: 'Beta Inc', lifecycle_state: 'active' },
+      {
+        id: 'inactive',
+        tenant_code: 'inactive-code',
+        name: 'Gone Co',
+        lifecycle_state: 'suspended',
+      },
     ],
     users: [
       { id: 'user-1', tenant_id: 'acme', email: 'user@gmail.com', is_active: 1 },
@@ -88,8 +93,8 @@ const mocked = vi.hoisted(() => {
    * FakeD1Adapter accurately mirrors the SQL filters used in discovery.ts.
    *
    * Key difference from the existing discovery.test.ts fixture:
-   * - tenant_code lookups apply AND is_active = 1, matching the real SQL:
-   *   `WHERE tenant_code = ? AND is_active = 1`
+   * - tenant_code lookups apply AND lifecycle_state = 'active', matching the real SQL:
+   *   `WHERE tenant_code = ? AND lifecycle_state = 'active'`
    */
   class FakeD1Adapter {
     constructor(_options: { db: unknown }) {}
@@ -102,8 +107,8 @@ const mocked = vi.hoisted(() => {
           .map((user) => ({ id: user.id, tenant_id: user.tenant_id })) as T[];
       }
 
-      if (query.includes('FROM tenants') && query.includes('WHERE is_active = 1')) {
-        return state.tenants.filter((tenant) => tenant.is_active === 1) as T[];
+      if (query.includes('FROM tenants') && query.includes("WHERE lifecycle_state = 'active'")) {
+        return state.tenants.filter((tenant) => tenant.lifecycle_state === 'active') as T[];
       }
       if (query.includes('FROM oauth_clients WHERE client_id = ?')) {
         return state.clients.filter((client) => client.client_id === params[0]) as T[];
@@ -118,16 +123,18 @@ const mocked = vi.hoisted(() => {
           (user) => user.id === params[0] && user.tenant_id === params[1] && user.is_active === 1
         ) ?? null) as T | null;
       }
-      // Tenant lookup by tenant_code — is_active = 1 filter applied
-      if (query.includes('FROM tenants WHERE tenant_code = ? AND is_active = 1')) {
-        return (state.tenants.find((t) => t.tenant_code === params[0] && t.is_active === 1) ??
-          null) as T | null;
+      // Tenant lookup by tenant_code — lifecycle_state = 'active' filter applied
+      if (query.includes("FROM tenants WHERE tenant_code = ? AND lifecycle_state = 'active'")) {
+        return (state.tenants.find(
+          (t) => t.tenant_code === params[0] && t.lifecycle_state === 'active'
+        ) ?? null) as T | null;
       }
 
-      // Tenant lookup by id — is_active = 1 filter applied
-      if (query.includes('FROM tenants WHERE id = ? AND is_active = 1')) {
-        return (state.tenants.find((t) => t.id === params[0] && t.is_active === 1) ??
-          null) as T | null;
+      // Tenant lookup by id — lifecycle_state = 'active' filter applied
+      if (query.includes("FROM tenants WHERE id = ? AND lifecycle_state = 'active'")) {
+        return (state.tenants.find(
+          (t) => t.id === params[0] && t.lifecycle_state === 'active'
+        ) ?? null) as T | null;
       }
 
       // Invitation lookup — expires_at > now filter applied
@@ -560,7 +567,7 @@ describe('Discovery API: tenant_slug resolution', () => {
     expect(body.code).toBe('tenant_slug_not_found');
   });
 
-  it('returns not_found for an inactive tenant slug (is_active = 0)', async () => {
+  it('returns not_found for a suspended tenant slug', async () => {
     const { app, env } = createDiscoveryApp();
 
     const res = await postDiscovery(app, env, { mode: 'tenant_slug', value: 'inactive' });
@@ -729,7 +736,7 @@ describe('Discovery API: data isolation', () => {
       expect(body.candidate.tenant_id).toBe('beta');
     });
 
-    it('returns not_found for inactive-code (tenant is_active = 0)', async () => {
+    it('returns not_found for inactive-code (tenant lifecycle_state is suspended)', async () => {
       const { app, env } = createDiscoveryApp();
 
       const res = await postDiscovery(app, env, { mode: 'tenant_code', value: 'inactive-code' });
@@ -797,7 +804,7 @@ describe('Discovery API: data isolation', () => {
       const res = await postDiscovery(app, env, { mode: 'app_hint', value: 'inactive-app' });
       const body = (await res.json()) as { result: string; code: string };
 
-      // Client row is found, but getTenantRowById('inactive') returns null (is_active = 0)
+      // Client row is found, but getTenantRowById('inactive') returns null (not active).
       expect(body.result).toBe('not_found');
       expect(body.code).toBe('app_hint_not_found');
     });

--- a/packages/ar-management/src/__tests__/discovery-isolation.test.ts
+++ b/packages/ar-management/src/__tests__/discovery-isolation.test.ts
@@ -132,9 +132,8 @@ const mocked = vi.hoisted(() => {
 
       // Tenant lookup by id — lifecycle_state = 'active' filter applied
       if (query.includes("FROM tenants WHERE id = ? AND lifecycle_state = 'active'")) {
-        return (state.tenants.find(
-          (t) => t.id === params[0] && t.lifecycle_state === 'active'
-        ) ?? null) as T | null;
+        return (state.tenants.find((t) => t.id === params[0] && t.lifecycle_state === 'active') ??
+          null) as T | null;
       }
 
       // Invitation lookup — expires_at > now filter applied

--- a/packages/ar-management/src/__tests__/discovery.test.ts
+++ b/packages/ar-management/src/__tests__/discovery.test.ts
@@ -5,10 +5,15 @@ import type { Env } from '@authrim/ar-lib-core';
 const mocked = vi.hoisted(() => {
   const state = {
     tenants: [
-      { id: 'default', tenant_code: 'default', name: 'Default Tenant', is_active: 1 },
-      { id: 'acme', tenant_code: 'acme', name: 'Acme Tenant', is_active: 1 },
-      { id: 'beta', tenant_code: 'beta', name: 'Beta Tenant', is_active: 1 },
-      { id: 'inactive', tenant_code: 'inactive', name: 'Inactive Tenant', is_active: 0 },
+      { id: 'default', tenant_code: 'default', name: 'Default Tenant', lifecycle_state: 'active' },
+      { id: 'acme', tenant_code: 'acme', name: 'Acme Tenant', lifecycle_state: 'active' },
+      { id: 'beta', tenant_code: 'beta', name: 'Beta Tenant', lifecycle_state: 'active' },
+      {
+        id: 'inactive',
+        tenant_code: 'inactive',
+        name: 'Inactive Tenant',
+        lifecycle_state: 'suspended',
+      },
     ],
     users: [
       { id: 'user-1', tenant_id: 'acme', email: 'user@gmail.com', is_active: 1 },
@@ -42,13 +47,15 @@ const mocked = vi.hoisted(() => {
           .filter((user) => user.email === email && user.is_active === 1)
           .map((user) => ({ id: user.id, tenant_id: user.tenant_id })) as T[];
       }
-      if (query.includes('FROM tenants') && query.includes('WHERE is_active = 1')) {
+      if (query.includes('FROM tenants') && query.includes("WHERE lifecycle_state = 'active'")) {
         if (!query.includes('LIMIT 2')) {
           return state.tenants
-            .filter((tenant) => tenant.is_active === 1)
+            .filter((tenant) => tenant.lifecycle_state === 'active')
             .sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id)) as T[];
         }
-        return state.tenants.filter((tenant) => tenant.is_active === 1).slice(0, 2) as T[];
+        return state.tenants
+          .filter((tenant) => tenant.lifecycle_state === 'active')
+          .slice(0, 2) as T[];
       }
       if (query.includes('FROM oauth_clients WHERE client_id = ?')) {
         return state.clients.filter((client) => client.client_id === params[0]) as T[];
@@ -67,9 +74,10 @@ const mocked = vi.hoisted(() => {
         return (state.tenants.find((tenant) => tenant.tenant_code === params[0]) ??
           null) as T | null;
       }
-      if (query.includes('FROM tenants WHERE id = ? AND is_active = 1')) {
-        return (state.tenants.find((tenant) => tenant.id === params[0] && tenant.is_active === 1) ??
-          null) as T | null;
+      if (query.includes("FROM tenants WHERE id = ? AND lifecycle_state = 'active'")) {
+        return (state.tenants.find(
+          (tenant) => tenant.id === params[0] && tenant.lifecycle_state === 'active'
+        ) ?? null) as T | null;
       }
       if (query.includes('FROM tenant_invitations')) {
         const token = params[0];

--- a/packages/ar-management/src/__tests__/settings-v2.test.ts
+++ b/packages/ar-management/src/__tests__/settings-v2.test.ts
@@ -1094,6 +1094,27 @@ describe('Settings API v2', () => {
   });
 
   describe('Authorization Boundaries', () => {
+    it('should allow org_admin access to tenant settings for their own tenant via adminAuth', async () => {
+      const { app, mockEnv } = createTestApp({
+        adminAuth: {
+          userId: 'org_admin_1',
+          authMethod: 'bearer',
+          roles: ['org_admin'],
+          org_id: 'tenant_123',
+        },
+      });
+
+      const res = await app.request(
+        '/api/admin/tenants/tenant_123/settings/oauth',
+        { method: 'GET' },
+        mockEnv
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SettingsGetResult;
+      expect(body.scope).toEqual({ type: 'tenant', id: 'tenant_123' });
+    });
+
     it('should reject tenant settings access across tenant boundaries', async () => {
       const { app, mockEnv } = createTestApp({
         adminAuth: {

--- a/packages/ar-management/src/__tests__/tenant-deletion-jobs.test.ts
+++ b/packages/ar-management/src/__tests__/tenant-deletion-jobs.test.ts
@@ -77,7 +77,7 @@ describe('tenant deletion jobs', () => {
     mockControlTx.execute.mockReset();
   });
 
-  it('updates job rows with id and tenant_id while deleting the target tenant', async () => {
+  it('updates job rows with id and tenant_id while tombstoning the target tenant', async () => {
     mockAdapter.query.mockResolvedValue([
       {
         id: 'job-1',
@@ -135,9 +135,10 @@ describe('tenant deletion jobs', () => {
       'DELETE FROM tenant_discovery_indexes WHERE tenant_id = ?',
       expect.any(Array)
     );
-    expect(mockTx.execute).toHaveBeenCalledWith('DELETE FROM tenants WHERE id = ?', [
-      'target-tenant',
-    ]);
+    expect(mockTx.execute).toHaveBeenCalledWith(
+      "UPDATE tenants SET lifecycle_state = 'deleted', updated_at = ? WHERE id = ?",
+      [expect.any(Number), 'target-tenant']
+    );
     expect(mockAdapter.execute).toHaveBeenCalledWith(
       "UPDATE admin_jobs SET status = 'completed', completed_at = ?, updated_at = ?, progress = ? WHERE id = ? AND tenant_id = ?",
       [
@@ -199,7 +200,7 @@ describe('tenant deletion jobs', () => {
     expect(mockAdapter.execute).toHaveBeenCalledTimes(1);
   });
 
-  it('marks the scoped job failed when tenant row deletion fails', async () => {
+  it('marks the scoped job failed without reactivating lifecycle after purge starts', async () => {
     const failure = new Error('delete failed');
     mockAdapter.query.mockResolvedValue([
       {
@@ -212,6 +213,10 @@ describe('tenant deletion jobs', () => {
 
     await processPendingTenantDeletionJobs({} as never, logger);
 
+    expect(mockAdapter.execute).not.toHaveBeenCalledWith(
+      "UPDATE tenants SET lifecycle_state = 'suspended', updated_at = ? WHERE id = ?",
+      expect.any(Array)
+    );
     expect(mockAdapter.execute).toHaveBeenCalledWith(
       "UPDATE admin_jobs SET status = 'failed', error_message = ?, completed_at = ?, updated_at = ? WHERE id = ? AND tenant_id = ?",
       [
@@ -231,6 +236,75 @@ describe('tenant deletion jobs', () => {
       { job_id: 'job-3' },
       failure
     );
+  });
+
+  it('keeps the tenant deleted when control cleanup fails after core purge', async () => {
+    const failure = new Error('control cleanup failed');
+    mockAdapter.query.mockResolvedValue([
+      {
+        id: 'job-control-failed',
+        tenant_id: 'operator-tenant',
+        config: JSON.stringify({ tenant_id: 'target-tenant', skip_backup: true }),
+      },
+    ]);
+    mockControlAdapter.transaction.mockRejectedValueOnce(failure);
+
+    await processPendingTenantDeletionJobs({ DB_ADMIN: 'control-db' } as never, logger);
+
+    expect(mockTx.execute).toHaveBeenCalledWith(
+      "UPDATE tenants SET lifecycle_state = 'deleted', updated_at = ? WHERE id = ?",
+      [expect.any(Number), 'target-tenant']
+    );
+    expect(mockAdapter.execute).not.toHaveBeenCalledWith(
+      "UPDATE tenants SET lifecycle_state = 'suspended', updated_at = ? WHERE id = ?",
+      expect.any(Array)
+    );
+    expect(mockAdapter.execute).toHaveBeenCalledWith(
+      "UPDATE admin_jobs SET status = 'failed', error_message = ?, completed_at = ?, updated_at = ? WHERE id = ? AND tenant_id = ?",
+      [
+        expect.stringContaining('control cleanup failed'),
+        expect.any(Number),
+        expect.any(Number),
+        'job-control-failed',
+        'operator-tenant',
+      ]
+    );
+  });
+
+  it('marks the scoped job failed and suspends the tenant when the pre-purge backup job failed', async () => {
+    mockAdapter.query.mockResolvedValue([
+      {
+        id: 'job-backup-failed',
+        tenant_id: 'operator-tenant',
+        config: JSON.stringify({
+          tenant_id: 'target-tenant',
+          backup_job_id: 'backup-job-1',
+        }),
+      },
+    ]);
+    mockAdapter.queryOne.mockResolvedValueOnce({ status: 'failed' });
+
+    await processPendingTenantDeletionJobs({} as never, logger);
+
+    expect(mockAdapter.queryOne).toHaveBeenCalledWith(
+      'SELECT status FROM admin_jobs WHERE id = ? AND tenant_id = ?',
+      ['backup-job-1', 'target-tenant']
+    );
+    expect(mockAdapter.execute).toHaveBeenCalledWith(
+      "UPDATE tenants SET lifecycle_state = 'suspended', updated_at = ? WHERE id = ?",
+      [expect.any(Number), 'target-tenant']
+    );
+    expect(mockAdapter.execute).toHaveBeenCalledWith(
+      "UPDATE admin_jobs SET status = 'failed', error_message = ?, completed_at = ?, updated_at = ? WHERE id = ? AND tenant_id = ?",
+      [
+        expect.stringContaining('tenant_deletion_backup_job_failed:backup-job-1'),
+        expect.any(Number),
+        expect.any(Number),
+        'job-backup-failed',
+        'operator-tenant',
+      ]
+    );
+    expect(mockAdapter.transaction).not.toHaveBeenCalled();
   });
 
   it('creates and waits for a deletion-before-purge backup job by default', async () => {

--- a/packages/ar-management/src/admin-settings-meta.ts
+++ b/packages/ar-management/src/admin-settings-meta.ts
@@ -1298,10 +1298,10 @@ export async function adminTenantCloneHandler(c: Context<{ Bindings: Env }>) {
     const tenantKey = createOpaqueTenantKey();
     await adapter.execute(
       `INSERT INTO tenants (
-         id, tenant_code, tenant_key, name, description, is_active, is_default,
+         id, tenant_code, tenant_key, name, description, lifecycle_state, is_default,
          default_tenant_guard, created_at, updated_at
        )
-       VALUES (?, ?, ?, ?, ?, 1, 0, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, 'active', 0, ?, ?, ?)`,
       [newTenantId, newTenantId, tenantKey, name, description ?? null, null, nowTs, nowTs]
     );
 

--- a/packages/ar-management/src/admin-tenant-vanity-domains.ts
+++ b/packages/ar-management/src/admin-tenant-vanity-domains.ts
@@ -293,7 +293,7 @@ async function createDomain(
 ) {
   const adapter = ensureDatabaseAdapter(db, 'tenant-vanity-domains');
   const tenant = await adapter.queryOne<{ id: string }>(
-    'SELECT id FROM tenants WHERE id = ? AND is_active = 1',
+    "SELECT id FROM tenants WHERE id = ? AND lifecycle_state = 'active'",
     [tenantId]
   );
   if (!tenant) {

--- a/packages/ar-management/src/admin-tenants.ts
+++ b/packages/ar-management/src/admin-tenants.ts
@@ -233,7 +233,9 @@ function isInternalLifecycleState(state: TenantLifecycleState): boolean {
 }
 
 function isOperatorMutableLifecycleState(state: TenantLifecycleState): boolean {
-  return (TENANT_OPERATOR_MUTABLE_LIFECYCLE_STATES as readonly TenantLifecycleState[]).includes(state);
+  return (TENANT_OPERATOR_MUTABLE_LIFECYCLE_STATES as readonly TenantLifecycleState[]).includes(
+    state
+  );
 }
 
 interface TenantDatabaseSlotRow {
@@ -304,7 +306,9 @@ function formatTenantWithProvisioning(row: TenantRow, metadata: TenantProvisioni
   return {
     ...formatTenant(row),
     ...(metadata ?? {
-      provisioning_status: isRuntimeActiveLifecycleState(row.lifecycle_state) ? 'active' : 'inactive',
+      provisioning_status: isRuntimeActiveLifecycleState(row.lifecycle_state)
+        ? 'active'
+        : 'inactive',
       provisioning_error: null,
       provisioning_slot_id: null,
       provisioning_updated_at: null,
@@ -2022,10 +2026,7 @@ export async function adminTenantDeleteHandler(c: Context<{ Bindings: Env }>) {
       id: string;
       is_default: number;
       lifecycle_state: TenantLifecycleState;
-    }>(
-      'SELECT id, is_default, lifecycle_state FROM tenants WHERE id = ?',
-      [id]
-    );
+    }>('SELECT id, is_default, lifecycle_state FROM tenants WHERE id = ?', [id]);
 
     if (!existing) {
       return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND, {

--- a/packages/ar-management/src/admin-tenants.ts
+++ b/packages/ar-management/src/admin-tenants.ts
@@ -5,7 +5,7 @@
  * - GET    /api/admin/tenants          - List all tenants
  * - POST   /api/admin/tenants          - Create tenant
  * - GET    /api/admin/tenants/:id      - Get tenant
- * - PATCH  /api/admin/tenants/:id      - Update tenant (name, description, is_active)
+ * - PATCH  /api/admin/tenants/:id      - Update tenant (name, description, lifecycle_state)
  * - DELETE /api/admin/tenants/:id      - Delete tenant (primary tenant not allowed)
  * - POST   /api/admin/tenants/:id/set-default - Set as default tenant
  *
@@ -41,7 +41,7 @@ import { createOpaqueTenantKey } from './logging-tenant-key';
 
 /**
  * Invalidate the tenant existence KV cache for a given tenant.
- * Called after create, is_active change, and deactivate to ensure
+ * Called after create, lifecycle_state change, and deactivate to ensure
  * request-context middleware picks up the new state promptly.
  */
 async function invalidateTenantExistsCache(
@@ -180,10 +180,60 @@ interface TenantRow {
   tenant_code: string;
   name: string;
   description: string | null;
-  is_active: number;
+  lifecycle_state: TenantLifecycleState;
   is_default: number;
   created_at: number;
   updated_at: number;
+}
+
+type TenantLifecycleState =
+  | 'provisioning'
+  | 'active'
+  | 'suspended'
+  | 'frozen'
+  | 'migration_read_only'
+  | 'deleting'
+  | 'deleted'
+  | 'restore_pending'
+  | 'restore_validating';
+
+const TENANT_LIFECYCLE_STATES = [
+  'provisioning',
+  'active',
+  'suspended',
+  'frozen',
+  'migration_read_only',
+  'deleting',
+  'deleted',
+  'restore_pending',
+  'restore_validating',
+] as const satisfies readonly TenantLifecycleState[];
+
+const TENANT_OPERATOR_MUTABLE_LIFECYCLE_STATES = [
+  'active',
+  'suspended',
+  'frozen',
+  'migration_read_only',
+] as const satisfies readonly TenantLifecycleState[];
+
+const TENANT_INTERNAL_LIFECYCLE_STATES = [
+  'provisioning',
+  'deleting',
+  'deleted',
+  'restore_pending',
+  'restore_validating',
+] as const satisfies readonly TenantLifecycleState[];
+
+function isRuntimeActiveLifecycleState(state: TenantLifecycleState): boolean {
+  return state === 'active';
+}
+
+function isInternalLifecycleState(state: TenantLifecycleState): boolean {
+  return (TENANT_INTERNAL_LIFECYCLE_STATES as readonly TenantLifecycleState[]).includes(state);
+}
+
+function isOperatorMutableLifecycleState(state: TenantLifecycleState): boolean {
+  return (TENANT_OPERATOR_MUTABLE_LIFECYCLE_STATES as readonly TenantLifecycleState[]).includes(state);
 }
 
 interface TenantDatabaseSlotRow {
@@ -243,7 +293,7 @@ function formatTenant(row: TenantRow) {
     tenant_code: row.tenant_code,
     name: row.name,
     description: row.description,
-    is_active: row.is_active === 1,
+    lifecycle_state: row.lifecycle_state,
     is_default: row.is_default === 1,
     created_at: row.created_at,
     updated_at: row.updated_at,
@@ -254,7 +304,7 @@ function formatTenantWithProvisioning(row: TenantRow, metadata: TenantProvisioni
   return {
     ...formatTenant(row),
     ...(metadata ?? {
-      provisioning_status: row.is_active === 1 ? 'active' : 'inactive',
+      provisioning_status: isRuntimeActiveLifecycleState(row.lifecycle_state) ? 'active' : 'inactive',
       provisioning_error: null,
       provisioning_slot_id: null,
       provisioning_updated_at: null,
@@ -294,7 +344,7 @@ async function getTenantProvisioningMetadata(
       result?: string;
     } | null = null;
 
-    if (row.is_active !== 1) {
+    if (!isRuntimeActiveLifecycleState(row.lifecycle_state)) {
       const latestTerminalEvent = await adminAdapter.queryOne<{
         slot_id: string;
         error_code: string | null;
@@ -323,7 +373,7 @@ async function getTenantProvisioningMetadata(
       ]);
     }
 
-    if (failure && row.is_active !== 1) {
+    if (failure && !isRuntimeActiveLifecycleState(row.lifecycle_state)) {
       return {
         provisioning_status: 'provisioning_failed',
         provisioning_error: failure.error_code ?? null,
@@ -335,7 +385,9 @@ async function getTenantProvisioningMetadata(
 
     if (!failure && !provisioningSlot) {
       return {
-        provisioning_status: row.is_active === 1 ? 'active' : 'inactive',
+        provisioning_status: isRuntimeActiveLifecycleState(row.lifecycle_state)
+          ? 'active'
+          : 'inactive',
         provisioning_error: null,
         provisioning_slot_id: null,
         provisioning_updated_at: null,
@@ -344,7 +396,9 @@ async function getTenantProvisioningMetadata(
 
     if (!provisioningSlot || !['reset_required', 'unavailable'].includes(provisioningSlot.state)) {
       return {
-        provisioning_status: row.is_active === 1 ? 'active' : 'inactive',
+        provisioning_status: isRuntimeActiveLifecycleState(row.lifecycle_state)
+          ? 'active'
+          : 'inactive',
         provisioning_error: null,
         provisioning_slot_id: null,
         provisioning_updated_at: null,
@@ -423,7 +477,7 @@ const UpdateTenantSchema = z.object({
     )
     .optional(),
   description: z.string().max(500).nullable().optional(),
-  is_active: z.boolean().optional(),
+  lifecycle_state: z.enum(TENANT_OPERATOR_MUTABLE_LIFECYCLE_STATES).optional(),
 });
 
 // =============================================================================
@@ -1057,14 +1111,14 @@ async function upsertTenantRow(
     tenantCode: string;
     name: string;
     description: string | null;
-    isActive: boolean;
+    lifecycleState: TenantLifecycleState;
     nowTs: number;
   }
 ): Promise<void> {
   const tenantKey = createOpaqueTenantKey();
   await adapter.execute(
     `INSERT INTO tenants (
-       id, tenant_code, tenant_key, name, description, is_active, is_default,
+       id, tenant_code, tenant_key, name, description, lifecycle_state, is_default,
        default_tenant_guard, created_at, updated_at
      )
      VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, ?)
@@ -1072,7 +1126,7 @@ async function upsertTenantRow(
        tenant_code = excluded.tenant_code,
        name = excluded.name,
        description = excluded.description,
-       is_active = excluded.is_active,
+       lifecycle_state = excluded.lifecycle_state,
        updated_at = excluded.updated_at`,
     [
       input.id,
@@ -1080,7 +1134,7 @@ async function upsertTenantRow(
       tenantKey,
       input.name,
       input.description,
-      input.isActive ? 1 : 0,
+      input.lifecycleState,
       getDefaultTenantGuard(false),
       input.nowTs,
       input.nowTs,
@@ -1118,7 +1172,7 @@ async function runTenantD1PoolProvisioning(
       tenantCode: input.tenantCode,
       name: input.name,
       description: input.description,
-      isActive: false,
+      lifecycleState: 'provisioning',
       nowTs,
     });
 
@@ -1144,7 +1198,7 @@ async function runTenantD1PoolProvisioning(
       tenantCode: input.tenantCode,
       name: input.name,
       description: input.description,
-      isActive: true,
+      lifecycleState: 'active',
       nowTs,
     });
     tenantDbWritten = true;
@@ -1187,10 +1241,10 @@ async function runTenantD1PoolProvisioning(
       result: 'succeeded',
     });
 
-    await adapter.execute('UPDATE tenants SET is_active = 1, updated_at = ? WHERE id = ?', [
-      nowTs,
-      input.id,
-    ]);
+    await adapter.execute(
+      "UPDATE tenants SET lifecycle_state = 'active', updated_at = ? WHERE id = ?",
+      [nowTs, input.id]
+    );
     await activateTenantDatabaseSlot(adminAdapter, slot.slot_id, input.id);
     await invalidateTenantExistsCache(c.env.AUTHRIM_CONFIG, input.id);
     await recordTenantSlotAudit(adminAdapter, {
@@ -1218,10 +1272,10 @@ async function runTenantD1PoolProvisioning(
       tenantDbWritten ? 'reset_required' : 'available'
     );
     if (tenantDbWritten || !options.deleteTenantRowBeforeTenantDbWrite) {
-      await adapter.execute('UPDATE tenants SET is_active = 0, updated_at = ? WHERE id = ?', [
-        Math.floor(Date.now() / 1000),
-        input.id,
-      ]);
+      await adapter.execute(
+        "UPDATE tenants SET lifecycle_state = 'suspended', updated_at = ? WHERE id = ?",
+        [Math.floor(Date.now() / 1000), input.id]
+      );
     }
     await cleanupTenantD1ProvisioningArtifacts(c, adminAdapter, input.id);
     const cleanupTasks: Promise<unknown>[] = [
@@ -1249,7 +1303,7 @@ async function runTenantD1PoolProvisioning(
   }
 
   const tenant = await adapter.queryOne<TenantRow>(
-    'SELECT id, tenant_code, name, description, is_active, is_default, created_at, updated_at FROM tenants WHERE id = ?',
+    'SELECT id, tenant_code, name, description, lifecycle_state, is_default, created_at, updated_at FROM tenants WHERE id = ?',
     [input.id]
   );
   return { ok: true, tenant: tenant! };
@@ -1291,7 +1345,7 @@ export async function adminTenantsListHandler(c: Context<{ Bindings: Env }>) {
     }
 
     const query = [
-      'SELECT id, tenant_code, name, description, is_active, is_default, created_at, updated_at FROM tenants',
+      'SELECT id, tenant_code, name, description, lifecycle_state, is_default, created_at, updated_at FROM tenants',
       tenantFilters.length > 0 ? `WHERE ${tenantFilters.join(' AND ')}` : '',
       'ORDER BY is_default DESC, name ASC',
     ]
@@ -1461,10 +1515,10 @@ export async function adminTenantCreateHandler(c: Context<{ Bindings: Env }>) {
     const tenantKey = createOpaqueTenantKey();
     await adapter.execute(
       `INSERT INTO tenants (
-         id, tenant_code, tenant_key, name, description, is_active, is_default,
+         id, tenant_code, tenant_key, name, description, lifecycle_state, is_default,
          default_tenant_guard, created_at, updated_at
        )
-       VALUES (?, ?, ?, ?, ?, 1, 0, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, 'active', 0, ?, ?, ?)`,
       [
         id,
         tenantCode,
@@ -1478,7 +1532,7 @@ export async function adminTenantCreateHandler(c: Context<{ Bindings: Env }>) {
     );
 
     const created = await adapter.queryOne<TenantRow>(
-      'SELECT id, tenant_code, name, description, is_active, is_default, created_at, updated_at FROM tenants WHERE id = ?',
+      'SELECT id, tenant_code, name, description, lifecycle_state, is_default, created_at, updated_at FROM tenants WHERE id = ?',
       [id]
     );
 
@@ -1548,7 +1602,7 @@ export async function adminTenantGetHandler(c: Context<{ Bindings: Env }>) {
   try {
     const adapter = createAdapter(c);
     const tenant = await adapter.queryOne<TenantRow>(
-      'SELECT id, tenant_code, name, description, is_active, is_default, created_at, updated_at FROM tenants WHERE id = ?',
+      'SELECT id, tenant_code, name, description, lifecycle_state, is_default, created_at, updated_at FROM tenants WHERE id = ?',
       [id]
     );
 
@@ -1570,7 +1624,7 @@ export async function adminTenantGetHandler(c: Context<{ Bindings: Env }>) {
 
 /**
  * PATCH /api/admin/tenants/:id
- * Update tenant (name, description, is_active)
+ * Update tenant (name, description, lifecycle_state)
  * Note: id and is_default cannot be changed via this endpoint
  */
 export async function adminTenantUpdateHandler(c: Context<{ Bindings: Env }>) {
@@ -1603,7 +1657,7 @@ export async function adminTenantUpdateHandler(c: Context<{ Bindings: Env }>) {
 
     // Check tenant exists
     const existing = await adapter.queryOne<TenantRow>(
-      'SELECT id, tenant_code, name, description, is_active, is_default, created_at, updated_at FROM tenants WHERE id = ?',
+      'SELECT id, tenant_code, name, description, lifecycle_state, is_default, created_at, updated_at FROM tenants WHERE id = ?',
       [id]
     );
 
@@ -1617,12 +1671,32 @@ export async function adminTenantUpdateHandler(c: Context<{ Bindings: Env }>) {
       ? getDefaultTenantId(c.env)
       : getPrimaryTenantId(c.env);
 
-    if (id === protectedTenantId && updates.is_active === false) {
-      const reason = isSingleTenantMode(c.env)
-        ? 'The initial tenant must remain active in single-tenant mode'
-        : 'Cannot deactivate the primary tenant';
+    if (
+      (id === protectedTenantId || existing.is_default === 1) &&
+      updates.lifecycle_state &&
+      updates.lifecycle_state !== 'active'
+    ) {
+      const reason =
+        existing.is_default === 1
+          ? 'Cannot deactivate the default tenant'
+          : isSingleTenantMode(c.env)
+            ? 'The initial tenant must remain active in single-tenant mode'
+            : 'Cannot deactivate the primary tenant';
       return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
-        variables: { field: 'is_active', reason },
+        variables: { field: 'lifecycle_state', reason },
+      });
+    }
+
+    if (
+      updates.lifecycle_state !== undefined &&
+      updates.lifecycle_state !== existing.lifecycle_state &&
+      isInternalLifecycleState(existing.lifecycle_state)
+    ) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
+        variables: {
+          field: 'lifecycle_state',
+          reason: 'Lifecycle state requires a dedicated operation',
+        },
       });
     }
 
@@ -1653,9 +1727,9 @@ export async function adminTenantUpdateHandler(c: Context<{ Bindings: Env }>) {
       fields.push('description = ?');
       values.push(updates.description ?? null);
     }
-    if (updates.is_active !== undefined) {
-      fields.push('is_active = ?');
-      values.push(updates.is_active ? 1 : 0);
+    if (updates.lifecycle_state !== undefined) {
+      fields.push('lifecycle_state = ?');
+      values.push(updates.lifecycle_state);
     }
 
     if (fields.length === 0) {
@@ -1669,13 +1743,13 @@ export async function adminTenantUpdateHandler(c: Context<{ Bindings: Env }>) {
 
     await adapter.execute(`UPDATE tenants SET ${fields.join(', ')} WHERE id = ?`, values);
 
-    // Invalidate cache if is_active changed (tenant may have been activated or deactivated)
-    if (updates.is_active !== undefined) {
+    // Invalidate cache if lifecycle_state changed (tenant may have been activated or deactivated)
+    if (updates.lifecycle_state !== undefined) {
       await invalidateTenantExistsCache(c.env.AUTHRIM_CONFIG, id);
     }
 
     const updated = await adapter.queryOne<TenantRow>(
-      'SELECT id, tenant_code, name, description, is_active, is_default, created_at, updated_at FROM tenants WHERE id = ?',
+      'SELECT id, tenant_code, name, description, lifecycle_state, is_default, created_at, updated_at FROM tenants WHERE id = ?',
       [id]
     );
 
@@ -1719,7 +1793,7 @@ export async function adminTenantProvisioningRetryHandler(c: Context<{ Bindings:
   try {
     const adapter = createAdapter(c);
     const tenant = await adapter.queryOne<TenantRow>(
-      'SELECT id, tenant_code, name, description, is_active, is_default, created_at, updated_at FROM tenants WHERE id = ?',
+      'SELECT id, tenant_code, name, description, lifecycle_state, is_default, created_at, updated_at FROM tenants WHERE id = ?',
       [id]
     );
 
@@ -1858,7 +1932,7 @@ export async function adminTenantProvisioningCleanupHandler(c: Context<{ Binding
   try {
     const adapter = createAdapter(c);
     const tenant = await adapter.queryOne<TenantRow>(
-      'SELECT id, tenant_code, name, description, is_active, is_default, created_at, updated_at FROM tenants WHERE id = ?',
+      'SELECT id, tenant_code, name, description, lifecycle_state, is_default, created_at, updated_at FROM tenants WHERE id = ?',
       [id]
     );
 
@@ -1882,7 +1956,10 @@ export async function adminTenantProvisioningCleanupHandler(c: Context<{ Binding
     const adminAdapter = requireAdminDatabaseAdapter(c.env, 'tenant-d1-provisioning-cleanup');
     await cleanupTenantD1ProvisioningArtifacts(c, adminAdapter, id);
     await Promise.allSettled([
-      adapter.execute('DELETE FROM tenants WHERE id = ?', [id]),
+      adapter.execute(
+        "UPDATE tenants SET lifecycle_state = 'deleted', updated_at = ? WHERE id = ?",
+        [Math.floor(Date.now() / 1000), id]
+      ),
       c.env.AUTHRIM_CONFIG?.delete(buildContractKey(c.env, 'tenant', id)),
       c.env.AUTHRIM_CONFIG?.delete(`settings:tenant:${id}:tenant`),
       c.env.AUTHRIM_CONFIG?.delete(`v1:tenant-exists:${id}`),
@@ -1941,8 +2018,12 @@ export async function adminTenantDeleteHandler(c: Context<{ Bindings: Env }>) {
   try {
     const adapter = createAdapter(c);
 
-    const existing = await adapter.queryOne<{ id: string; is_default: number }>(
-      'SELECT id, is_default FROM tenants WHERE id = ?',
+    const existing = await adapter.queryOne<{
+      id: string;
+      is_default: number;
+      lifecycle_state: TenantLifecycleState;
+    }>(
+      'SELECT id, is_default, lifecycle_state FROM tenants WHERE id = ?',
       [id]
     );
 
@@ -1958,44 +2039,60 @@ export async function adminTenantDeleteHandler(c: Context<{ Bindings: Env }>) {
       });
     }
 
-    const nowTs = Math.floor(Date.now() / 1000);
+    if (existing.is_default === 1) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
+        variables: { field: 'id', reason: 'Cannot delete the default tenant' },
+      });
+    }
 
-    // Immediately deactivate the tenant to block new requests
-    await adapter.execute('UPDATE tenants SET is_active = 0, updated_at = ? WHERE id = ?', [
-      nowTs,
-      id,
-    ]);
-
-    // Invalidate cache so subsequent requests to this tenant return 404 immediately
-    await invalidateTenantExistsCache(c.env.AUTHRIM_CONFIG, id);
+    if (!isOperatorMutableLifecycleState(existing.lifecycle_state)) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
+        variables: {
+          field: 'lifecycle_state',
+          reason: 'Lifecycle state requires a dedicated operation',
+        },
+      });
+    }
 
     // Get admin identity for job attribution
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     const adminAuth = (c as any).get('adminAuth') as { adminId?: string } | null;
     const createdBy = adminAuth?.adminId ?? 'unknown';
 
+    const nowTs = Math.floor(Date.now() / 1000);
     const jobId = crypto.randomUUID();
     // Estimate completion: max 1 hour (next hourly cron tick)
     const estimatedCompletion = nowTs + 3600;
 
-    await adapter.execute(
-      `INSERT INTO admin_jobs (
-        id, tenant_id, job_type, status, progress, config,
-        created_by, created_at, updated_at, estimated_completion
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      [
-        jobId,
-        getTenantIdFromContext(c),
-        'tenants/delete',
-        'pending',
-        JSON.stringify({ stage: 'queued' }),
-        JSON.stringify({ tenant_id: id }),
-        createdBy,
-        nowTs,
-        nowTs,
-        estimatedCompletion,
-      ]
-    );
+    await adapter.transaction(async (tx) => {
+      // Immediately move the tenant out of the runtime-active lifecycle to block new requests.
+      await tx.execute(
+        "UPDATE tenants SET lifecycle_state = 'deleting', updated_at = ? WHERE id = ?",
+        [nowTs, id]
+      );
+
+      await tx.execute(
+        `INSERT INTO admin_jobs (
+          id, tenant_id, job_type, status, progress, config,
+          created_by, created_at, updated_at, estimated_completion
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          jobId,
+          getTenantIdFromContext(c),
+          'tenants/delete',
+          'pending',
+          JSON.stringify({ stage: 'queued' }),
+          JSON.stringify({ tenant_id: id }),
+          createdBy,
+          nowTs,
+          nowTs,
+          estimatedCompletion,
+        ]
+      );
+    });
+
+    // Invalidate cache so subsequent requests to this tenant return 404 immediately.
+    await invalidateTenantExistsCache(c.env.AUTHRIM_CONFIG, id);
 
     await createAuditLogFromContext(c, 'tenant.delete_queued', 'tenant', id, {
       tenant_id: id,
@@ -2040,8 +2137,8 @@ export async function adminTenantSetDefaultHandler(c: Context<{ Bindings: Env }>
   try {
     const adapter = createAdapter(c);
 
-    const existing = await adapter.queryOne<{ id: string; is_active: number }>(
-      'SELECT id, is_active FROM tenants WHERE id = ?',
+    const existing = await adapter.queryOne<{ id: string; lifecycle_state: TenantLifecycleState }>(
+      'SELECT id, lifecycle_state FROM tenants WHERE id = ?',
       [id]
     );
 
@@ -2051,9 +2148,9 @@ export async function adminTenantSetDefaultHandler(c: Context<{ Bindings: Env }>
       });
     }
 
-    if (existing.is_active === 0) {
+    if (!isRuntimeActiveLifecycleState(existing.lifecycle_state)) {
       return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
-        variables: { field: 'id', reason: 'Cannot set an inactive tenant as default' },
+        variables: { field: 'id', reason: 'Cannot set a non-active tenant as default' },
       });
     }
 
@@ -2071,7 +2168,7 @@ export async function adminTenantSetDefaultHandler(c: Context<{ Bindings: Env }>
     });
 
     const updated = await adapter.queryOne<TenantRow>(
-      'SELECT id, tenant_code, name, description, is_active, is_default, created_at, updated_at FROM tenants WHERE id = ?',
+      'SELECT id, tenant_code, name, description, lifecycle_state, is_default, created_at, updated_at FROM tenants WHERE id = ?',
       [id]
     );
 

--- a/packages/ar-management/src/discovery.ts
+++ b/packages/ar-management/src/discovery.ts
@@ -57,7 +57,7 @@ interface TenantLookupRow {
   id: string;
   tenant_code: string;
   name: string;
-  is_active: number;
+  lifecycle_state: string;
 }
 
 interface InvitationLookupRow {
@@ -373,9 +373,9 @@ function appendLoginHint(url: string, loginHint?: string): string {
 async function getSingleActiveTenantCandidate(env: Env): Promise<DiscoveryCandidate | null> {
   const adapter = await getDiscoveryCoreAdapter(env);
   const tenants = await adapter.query<TenantLookupRow>(
-    `SELECT id, tenant_code, name, is_active
+    `SELECT id, tenant_code, name, lifecycle_state
      FROM tenants
-     WHERE is_active = 1
+     WHERE lifecycle_state = 'active'
      ORDER BY id ASC
      LIMIT 2`,
     []
@@ -391,9 +391,9 @@ async function getSingleActiveTenantCandidate(env: Env): Promise<DiscoveryCandid
 async function getActiveTenantWayfCandidates(env: Env): Promise<DiscoveryCandidate[]> {
   const adapter = await getDiscoveryCoreAdapter(env);
   const tenants = await adapter.query<TenantLookupRow>(
-    `SELECT id, tenant_code, name, is_active
+    `SELECT id, tenant_code, name, lifecycle_state
      FROM tenants
-     WHERE is_active = 1
+     WHERE lifecycle_state = 'active'
      ORDER BY name ASC, id ASC`,
     []
   );
@@ -576,7 +576,7 @@ async function getDiscoveryUiConfig(
 async function getTenantRowById(env: Env, tenantId: string): Promise<TenantLookupRow | null> {
   const adapter = await getDiscoveryCoreAdapter(env);
   return adapter.queryOne<TenantLookupRow>(
-    'SELECT id, tenant_code, name, is_active FROM tenants WHERE id = ? AND is_active = 1',
+    "SELECT id, tenant_code, name, lifecycle_state FROM tenants WHERE id = ? AND lifecycle_state = 'active'",
     [tenantId]
   );
 }
@@ -587,7 +587,7 @@ async function getTenantRowByTenantCode(
 ): Promise<TenantLookupRow | null> {
   const adapter = await getDiscoveryCoreAdapter(env);
   return adapter.queryOne<TenantLookupRow>(
-    'SELECT id, tenant_code, name, is_active FROM tenants WHERE tenant_code = ? AND is_active = 1',
+    "SELECT id, tenant_code, name, lifecycle_state FROM tenants WHERE tenant_code = ? AND lifecycle_state = 'active'",
     [tenantCode]
   );
 }
@@ -597,7 +597,7 @@ async function getTenantRowsByExactEmail(env: Env, email: string): Promise<Tenan
 
   try {
     const activeTenants = await coreAdapter.query<TenantLookupRow>(
-      'SELECT id, tenant_code, name, is_active FROM tenants WHERE is_active = 1 ORDER BY id ASC',
+      "SELECT id, tenant_code, name, lifecycle_state FROM tenants WHERE lifecycle_state = 'active' ORDER BY id ASC",
       []
     );
     const matchedTenants = await Promise.all(

--- a/packages/ar-management/src/index.ts
+++ b/packages/ar-management/src/index.ts
@@ -2798,7 +2798,7 @@ async function listMaintenanceTenantIds(
 ): Promise<string[]> {
   try {
     const rows = await adapter.query<{ id: string }>(
-      'SELECT id FROM tenants WHERE is_active = 1 ORDER BY id'
+      "SELECT id FROM tenants WHERE lifecycle_state = 'active' ORDER BY id"
     );
     const tenantIds = rows.map((row) => row.id).filter((id) => id.length > 0);
     if (tenantIds.length > 0) {

--- a/packages/ar-management/src/routes/admin-management/database-connections.ts
+++ b/packages/ar-management/src/routes/admin-management/database-connections.ts
@@ -68,7 +68,7 @@ interface DatabaseConnectionTenantAssignment {
 interface TenantLabelRow {
   id: string;
   name: string;
-  is_active?: boolean | number;
+  lifecycle_state?: string;
 }
 
 interface AssignableDatabaseConnection {
@@ -175,7 +175,7 @@ async function listTenantLabels(c: AdminContext): Promise<DatabaseConnectionTena
       return [];
     }
     const rows = await getCoreAdapter(c).query<TenantLabelRow>(
-      `SELECT id, name, is_active FROM tenants WHERE is_active = 1 ORDER BY name ASC`
+      `SELECT id, name, lifecycle_state FROM tenants WHERE lifecycle_state = 'active' ORDER BY name ASC`
     );
     return rows.map((row) => ({
       id: row.id,

--- a/packages/ar-management/src/tenant-deletion-jobs.ts
+++ b/packages/ar-management/src/tenant-deletion-jobs.ts
@@ -195,7 +195,22 @@ async function deleteTenantRows(
     }
     await tx.execute(`DELETE FROM ${table} WHERE tenant_id = ?`, [targetTenantId]);
   }
-  await tx.execute('DELETE FROM tenants WHERE id = ?', [targetTenantId]);
+  await tx.execute("UPDATE tenants SET lifecycle_state = 'deleted', updated_at = ? WHERE id = ?", [
+    Math.floor(Date.now() / 1000),
+    targetTenantId,
+  ]);
+}
+
+async function suspendTenantAfterDeletionFailure(
+  adapter: Pick<DatabaseAdapter, 'execute'>,
+  targetTenantId: string | null
+): Promise<void> {
+  if (!targetTenantId) return;
+
+  await adapter.execute(
+    "UPDATE tenants SET lifecycle_state = 'suspended', updated_at = ? WHERE id = ?",
+    [Math.floor(Date.now() / 1000), targetTenantId]
+  );
 }
 
 export async function processPendingTenantDeletionJobs(
@@ -224,37 +239,52 @@ export async function processPendingTenantDeletionJobs(
     if (claim.rowsAffected === 0) continue;
     claimedCount += 1;
 
+    let targetTenantId: string | null = null;
+    let shouldSuspendOnFailure = false;
     try {
       const config = parseTenantDeletionJobConfig(job.config);
-      const { tenant_id: targetTenantId } = config;
+      targetTenantId = config.tenant_id;
+      const deletionTargetTenantId = config.tenant_id;
+      shouldSuspendOnFailure = true;
 
       const backup = await ensureDeletionBackupCompleted(coreAdapter, job, config);
       if (!backup.completed) {
         log.info('Tenant deletion job waiting for pre-purge backup', {
           job_id: job.id,
-          tenant_id: targetTenantId,
+          tenant_id: deletionTargetTenantId,
           backup_job_id: backup.backupJobId,
         });
         continue;
       }
 
-      await updateTenantDatabaseLifecycleState(controlAdapter, targetTenantId, job.id, 'deleting');
+      await updateTenantDatabaseLifecycleState(
+        controlAdapter,
+        deletionTargetTenantId,
+        job.id,
+        'deleting'
+      );
 
+      shouldSuspendOnFailure = false;
       await coreAdapter.transaction(async (tx) => {
         await deleteTenantRows(
           tx,
-          targetTenantId,
+          deletionTargetTenantId,
           job.id,
           backup.backupJobId ? [backup.backupJobId] : []
         );
       });
       if (controlAdapter) {
         await controlAdapter.transaction(async (tx) => {
-          await deleteTenantControlRows(tx, targetTenantId);
+          await deleteTenantControlRows(tx, deletionTargetTenantId);
         });
       }
 
-      await updateTenantDatabaseLifecycleState(controlAdapter, targetTenantId, job.id, 'deleted');
+      await updateTenantDatabaseLifecycleState(
+        controlAdapter,
+        deletionTargetTenantId,
+        job.id,
+        'deleted'
+      );
 
       const completedTs = Math.floor(Date.now() / 1000);
       await coreAdapter.execute(
@@ -262,9 +292,15 @@ export async function processPendingTenantDeletionJobs(
         [completedTs, completedTs, JSON.stringify({ stage: 'completed' }), job.id, jobTenantId]
       );
 
-      log.info('Tenant deletion job completed', { job_id: job.id, tenant_id: targetTenantId });
+      log.info('Tenant deletion job completed', {
+        job_id: job.id,
+        tenant_id: deletionTargetTenantId,
+      });
     } catch (jobError) {
       const failedTs = Math.floor(Date.now() / 1000);
+      if (shouldSuspendOnFailure) {
+        await suspendTenantAfterDeletionFailure(coreAdapter, targetTenantId);
+      }
       await coreAdapter.execute(
         "UPDATE admin_jobs SET status = 'failed', error_message = ?, completed_at = ?, updated_at = ? WHERE id = ? AND tenant_id = ?",
         [String(jobError), failedTs, failedTs, job.id, jobTenantId]

--- a/packages/ar-userinfo/src/__tests__/protected-customer-profile.test.ts
+++ b/packages/ar-userinfo/src/__tests__/protected-customer-profile.test.ts
@@ -596,6 +596,47 @@ describe('protected customer profile route', () => {
     });
   });
 
+  it('rejects delegated writes with unknown audit fields before Step-Up', async () => {
+    const { env } = createDelegatedWriteEnv();
+    const response = await createApp().request(
+      'http://localhost/api/protected/customer-profiles/users/user-1',
+      {
+        method: 'PATCH',
+        headers: {
+          Authorization: 'Bearer actor-token',
+          'Content-Type': 'application/json',
+          'Idempotency-Key': 'delegated-key-unknown-audit',
+        },
+        body: JSON.stringify({
+          input: { name: 'Alice Updated' },
+          audit: {
+            reason_code: 'admin_repair',
+            unexpected: 'not-supported',
+          },
+        }),
+      },
+      env
+    );
+    const payload = (await response.json()) as {
+      error?: string;
+      error_details?: {
+        code?: string;
+        field?: string;
+        severity?: string;
+        retryable?: boolean;
+      };
+    };
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe('unknown_audit_field');
+    expect(payload.error_details).toMatchObject({
+      code: 'unknown_audit_field',
+      field: 'audit.unexpected',
+      severity: 'error',
+      retryable: false,
+    });
+  });
+
   it('returns a Step-Up requirement when delegated write receipt is missing', async () => {
     const { env } = createDelegatedWriteEnv();
     const response = await createApp().request(

--- a/packages/setup/src/__tests__/cloudflare-migrations.test.ts
+++ b/packages/setup/src/__tests__/cloudflare-migrations.test.ts
@@ -474,11 +474,7 @@ INSERT INTO tenants (
       runMigrationFiles(sqlite3Path, dbPath, ['007_tenant_lifecycle_state.sql']);
 
       expect(
-        readSqlite(
-          sqlite3Path,
-          dbPath,
-          "SELECT lifecycle_state FROM tenants WHERE id = 'default';"
-        )
+        readSqlite(sqlite3Path, dbPath, "SELECT lifecycle_state FROM tenants WHERE id = 'default';")
       ).toBe('active');
       expect(
         readSqlite(

--- a/packages/setup/src/__tests__/cloudflare-migrations.test.ts
+++ b/packages/setup/src/__tests__/cloudflare-migrations.test.ts
@@ -435,6 +435,69 @@ INSERT INTO oauth_clients (
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it('backfills tenant lifecycle state from is_active and drops the legacy column', () => {
+    const sqlite3Path = findSqlite3();
+    if (!sqlite3Path) {
+      return;
+    }
+
+    const tempDir = mkdtempSync(join(tmpdir(), 'authrim-tenant-lifecycle-migration-'));
+    const dbPath = join(tempDir, 'test.db');
+
+    try {
+      runMigrationFiles(sqlite3Path, dbPath, ['001_core_foundation.sql']);
+      runSqlite(
+        sqlite3Path,
+        dbPath,
+        `
+INSERT INTO tenants (
+  id,
+  tenant_code,
+  tenant_key,
+  name,
+  is_active,
+  created_at,
+  updated_at
+) VALUES (
+  'inactive-tenant',
+  'inactive-tenant',
+  'tenant-key-inactive',
+  'Inactive Tenant',
+  0,
+  1,
+  1
+);
+`
+      );
+
+      runMigrationFiles(sqlite3Path, dbPath, ['007_tenant_lifecycle_state.sql']);
+
+      expect(
+        readSqlite(
+          sqlite3Path,
+          dbPath,
+          "SELECT lifecycle_state FROM tenants WHERE id = 'default';"
+        )
+      ).toBe('active');
+      expect(
+        readSqlite(
+          sqlite3Path,
+          dbPath,
+          "SELECT lifecycle_state FROM tenants WHERE id = 'inactive-tenant';"
+        )
+      ).toBe('suspended');
+      expect(
+        readSqlite(
+          sqlite3Path,
+          dbPath,
+          "SELECT COUNT(*) FROM pragma_table_info('tenants') WHERE name = 'is_active';"
+        )
+      ).toBe('0');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('renderPortableMigrationSql', () => {

--- a/packages/setup/src/core/cloudflare.ts
+++ b/packages/setup/src/core/cloudflare.ts
@@ -2174,7 +2174,7 @@ SET id = ${tenantIdSql},
     tenant_code = ${tenantCodeSql},
     name = ${displayNameSql},
     tenant_key = COALESCE(tenant_key, 't_' || lower(hex(randomblob(18)))),
-    is_active = 1,
+    lifecycle_state = 'active',
     updated_at = ${sqlExpr.nowEpochSeconds}
 WHERE id = 'default'
   AND ${tenantIdSql} <> 'default'
@@ -2182,10 +2182,10 @@ WHERE id = 'default'
   AND (SELECT COUNT(*) FROM tenants) = 1;
 
 INSERT INTO tenants (
-  id, tenant_code, tenant_key, name, description, is_active, is_default,
+  id, tenant_code, tenant_key, name, description, lifecycle_state, is_default,
   default_tenant_guard, created_at, updated_at
 )
-SELECT ${tenantIdSql}, ${tenantCodeSql}, 't_' || lower(hex(randomblob(18))), ${displayNameSql}, NULL, 1,
+SELECT ${tenantIdSql}, ${tenantCodeSql}, 't_' || lower(hex(randomblob(18))), ${displayNameSql}, NULL, 'active',
        CASE WHEN EXISTS (SELECT 1 FROM tenants WHERE is_default = 1) THEN 0 ELSE 1 END,
        CASE WHEN EXISTS (SELECT 1 FROM tenants WHERE is_default = 1) THEN NULL ELSE 'default' END,
        ${sqlExpr.nowEpochSeconds}, ${sqlExpr.nowEpochSeconds}
@@ -2195,7 +2195,7 @@ UPDATE tenants
 SET tenant_code = ${tenantCodeSql},
     name = ${displayNameSql},
     tenant_key = COALESCE(tenant_key, 't_' || lower(hex(randomblob(18)))),
-    is_active = 1,
+    lifecycle_state = 'active',
     updated_at = ${sqlExpr.nowEpochSeconds}
 WHERE id = ${tenantIdSql};
 `.trim();

--- a/packages/setup/src/core/tenant-d1-bootstrap.ts
+++ b/packages/setup/src/core/tenant-d1-bootstrap.ts
@@ -530,9 +530,9 @@ async function verifyInitialTenantD1Bootstrap(input: {
   const [tenantRow] = await queryD1Rows<CountRow>(
     input.coreDatabaseName,
     `SELECT COUNT(*) AS count
-       FROM tenants
+      FROM tenants
       WHERE id = ${tenantIdSql}
-        AND is_active = 1;`
+        AND lifecycle_state = 'active';`
   );
   if (countValue(tenantRow) !== 1) {
     throw new Error('initial_tenant_d1_core_tenant_verification_failed');


### PR DESCRIPTION
## Summary
- Replace the tenant runtime gate from `is_active` to canonical `lifecycle_state` across migrations, Admin API, runtime discovery, domain resolution, tenant deletion jobs, setup bootstrap, and Admin UI.
- Add lifecycle-aware server-side guards for default/primary tenant deactivation and deletion, internal lifecycle states, deletion transactions, cache invalidation, and deletion failure handling.
- Add focused coverage for lifecycle migration backfill/drop behavior, Admin API lifecycle transitions, deletion job failure paths, domain resolver filtering, compatibility endpoints, org admin settings access, and delegated write audit validation.

## Validation
- `pnpm typecheck` passed.
- Focused lifecycle Vitest suite passed: 167 tests across Admin tenant APIs, deletion jobs, discovery, request context, domain resolvers, bridge token refresh, Admin UI state, and setup migrations.
- `pnpm --filter @authrim/setup test` passed: 57 files, 722 tests, 3 skipped.
- `git diff --check` passed.
- `pnpm test` was run twice. Both full monorepo runs reached broad package success but failed in `@authrim/setup` due to timeout-only failures in unrelated long-running crypto/file tests; the timed-out tests passed when rerun directly, and the full `@authrim/setup` package test passed afterward.