### PR TITLE
feat(saml): implement federated identity JIT linking policy

### DIFF
--- a/docs/saml-production-readiness.md
+++ b/docs/saml-production-readiness.md
@@ -91,6 +91,8 @@ The Admin UI preview resolves the first visible page using the current tenant di
 Inbound SAML ACS resolution stores a stable provider subject in `linked_identities` using the
 IdP entityID, NameIDFormat, and NameID. Provider policy controls whether a first login may link
 to an existing verified local email, create a new JIT user, or require a pre-existing link.
+Resolution failures are audited with sanitized policy metadata only, avoiding raw NameID and
+assertion email values.
 
 The Admin UI exposes these controls on SAML IdP providers:
 

--- a/docs/saml-production-readiness.md
+++ b/docs/saml-production-readiness.md
@@ -36,6 +36,8 @@ Authrim includes SAML 2.0 IdP and SP support for tenant-scoped deployments. The 
 - Response/assertion signing policy, AuthnRequest signature policy, SLO signature policy, and algorithm allow-list behavior.
 - Optional encrypted assertion and encrypted NameID support with modern defaults and legacy algorithm opt-in.
 - Persistent NameID registry behavior for strict `AllowCreate=false` handling.
+- Federated identity registry and JIT linking policy for inbound SAML ACS:
+  existing link, verified-email linking, JIT create, or existing-link-only modes.
 - Tenant-scoped request correlation for SAML requests, LogoutRequests, ACS, SLO, artifact state, and IdP-initiated multi-SP SLO fanout.
 - Audit events for SAML policy failures, metadata refresh changes, and logout fanout timeouts.
 
@@ -77,12 +79,27 @@ Local Authrim IdP/SP signing keys are managed through the SAML Entity Info page.
 
 When a SAML flow needs interactive login, Authrim can send the browser to either the tenant host or the shared Login UI base URL.
 
-| Policy | Behavior |
-| --- | --- |
-| Tenant host | Uses the tenant's `/login` URL. This is the default SAML behavior and lets the Login UI resolve the tenant from the request host. |
+| Policy      | Behavior                                                                                                                                                                  |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Tenant host | Uses the tenant's `/login` URL. This is the default SAML behavior and lets the Login UI resolve the tenant from the request host.                                         |
 | UI base URL | Uses the global Login UI `/login` with a tenant hint. This is useful when a deployment wants a common login entry before returning to tenant-specific login or discovery. |
 
 The Admin UI preview resolves the first visible page using the current tenant discovery configuration. If the common entry is configured as WAYF-only, the preview indicates that the tenant chooser is the first page and that only the tenant dropdown is shown.
+
+## Federated Identity Registry
+
+Inbound SAML ACS resolution stores a stable provider subject in `linked_identities` using the
+IdP entityID, NameIDFormat, and NameID. Provider policy controls whether a first login may link
+to an existing verified local email, create a new JIT user, or require a pre-existing link.
+
+The Admin UI exposes these controls on SAML IdP providers:
+
+| Setting                       | Default         | Behavior                                                                                                   |
+| ----------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------- |
+| `jitEmailLinkingPolicy`       | `email_linking` | Existing link, verified email link, then JIT create. Can be restricted to `jit_create_only` or `disabled`. |
+| `allowSyntheticEmailFallback` | `false`         | Allows a non-PII synthetic local email only for legacy IdPs that cannot release email.                     |
+
+See the private runbook for rollout, backfill, validation, and rollback steps.
 
 ## IdP-Initiated Multi-SP SLO
 

--- a/packages/ar-admin-ui/src/lib/api/admin-saml.ts
+++ b/packages/ar-admin-ui/src/lib/api/admin-saml.ts
@@ -94,6 +94,8 @@ export interface SAMLAttributeReleaseRule {
 	required?: boolean;
 }
 
+export type SAMLJitEmailLinkingPolicy = 'email_linking' | 'jit_create_only' | 'disabled';
+
 export interface SAMLProviderConfig {
 	description?: string;
 	providerName?: string;
@@ -115,6 +117,8 @@ export interface SAMLProviderConfig {
 		mode: 'observe' | 'require_any';
 		allowedClassRefs?: string[];
 	};
+	jitEmailLinkingPolicy?: SAMLJitEmailLinkingPolicy;
+	allowSyntheticEmailFallback?: boolean;
 	authnContextClassRefMode?: 'legacy_static' | 'session';
 	defaultAuthnContextClassRef?: string;
 	passkeyAuthnContextClassRef?: string;

--- a/packages/ar-admin-ui/src/routes/admin/saml/[id]/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/saml/[id]/+page.svelte
@@ -6,6 +6,7 @@
 	import {
 		adminSAMLAPI,
 		type SAMLAttributePreset,
+		type SAMLJitEmailLinkingPolicy,
 		type SAMLProvider,
 		type SAMLProviderConfig,
 		type SAMLTrustCertificatePreview
@@ -65,6 +66,8 @@
 	let authnRequestSignaturePolicy = $state<'required' | 'optional' | 'disabled'>('optional');
 	let logoutRequestSignaturePolicy = $state<'required' | 'optional' | 'disabled'>('required');
 	let authnContextPolicyMode = $state<'observe' | 'require_any'>('observe');
+	let jitEmailLinkingPolicy = $state<SAMLJitEmailLinkingPolicy>('email_linking');
+	let allowSyntheticEmailFallback = $state(false);
 	let allowedAuthnContextClassRefs = $state(
 		'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'
 	);
@@ -125,6 +128,8 @@
 		authnRequestSignaturePolicy = data.config.authnRequestSignaturePolicy || 'optional';
 		logoutRequestSignaturePolicy = data.config.logoutRequestSignaturePolicy || 'required';
 		authnContextPolicyMode = data.config.authnContextPolicy?.mode || 'observe';
+		jitEmailLinkingPolicy = data.config.jitEmailLinkingPolicy || 'email_linking';
+		allowSyntheticEmailFallback = data.config.allowSyntheticEmailFallback === true;
 		allowedAuthnContextClassRefs = (
 			data.config.authnContextPolicy?.allowedClassRefs?.length
 				? data.config.authnContextPolicy.allowedClassRefs
@@ -253,10 +258,12 @@
 		if (provider?.providerType === 'saml_idp') {
 			return {
 				...config,
-					providerName: providerName.trim() || undefined,
-					ssoUrl: ssoUrl.trim(),
-					logoutRequestSignaturePolicy,
-					authnContextPolicy: {
+				providerName: providerName.trim() || undefined,
+				ssoUrl: ssoUrl.trim(),
+				logoutRequestSignaturePolicy,
+				jitEmailLinkingPolicy,
+				allowSyntheticEmailFallback,
+				authnContextPolicy: {
 					mode: authnContextPolicyMode,
 					allowedClassRefs: allowedAuthnContextClassRefs
 						.split('\n')
@@ -271,10 +278,10 @@
 			acsUrl: acsUrl.trim(),
 			signAssertions,
 			signResponses,
-				samlProfile,
-				authnRequestSignaturePolicy,
-				logoutRequestSignaturePolicy,
-				authnContextClassRefMode,
+			samlProfile,
+			authnRequestSignaturePolicy,
+			logoutRequestSignaturePolicy,
+			authnContextClassRefMode,
 			defaultAuthnContextClassRef: defaultAuthnContextClassRef.trim() || undefined,
 			passkeyAuthnContextClassRef: passkeyAuthnContextClassRef.trim() || undefined,
 			...selectedPresetConfig()
@@ -435,7 +442,7 @@
 		</div>
 		{#if preview.warnings.length > 0}
 			<div class="certificate-warnings">
-					{#each preview.warnings as warning (warning)}
+				{#each preview.warnings as warning (warning)}
 					<div><i class="i-ph-warning-circle"></i>{warning}</div>
 				{/each}
 			</div>
@@ -662,27 +669,57 @@
 							<input id="providerName" type="text" bind:value={providerName} class="form-input" />
 						</div>
 
-							<div class="form-group">
-								<label for="logoutRequestSignaturePolicy" class="form-label">
-									IdP LogoutRequest Signature
-								</label>
-								<select
-									id="logoutRequestSignaturePolicy"
-									bind:value={logoutRequestSignaturePolicy}
-									class="form-select"
-								>
-									<option value="required">Required</option>
-									<option value="optional">Optional</option>
-									<option value="disabled">Disabled</option>
-								</select>
-								<p class="field-hint">
-									Required by default. Use Optional or Disabled only for explicit legacy IdP
-									compatibility.
-								</p>
-							</div>
+						<div class="form-group">
+							<label for="jitEmailLinkingPolicy" class="form-label">JIT Linking Policy</label>
+							<select
+								id="jitEmailLinkingPolicy"
+								bind:value={jitEmailLinkingPolicy}
+								class="form-select"
+							>
+								<option value="email_linking">Existing verified email or JIT create</option>
+								<option value="jit_create_only">JIT create only</option>
+								<option value="disabled">Existing links only</option>
+							</select>
+							<p class="field-hint">
+								Controls whether first login can link by verified local email or create a user.
+							</p>
+						</div>
 
-							<div class="form-group">
-								<label for="authnContextPolicyMode" class="form-label">AuthnContext Policy</label>
+						<div class="form-group form-group-full">
+							<label class="form-checkbox-label">
+								<input
+									type="checkbox"
+									bind:checked={allowSyntheticEmailFallback}
+									class="checkbox"
+								/>
+								Allow synthetic email fallback
+							</label>
+							<p class="field-hint">
+								Use only for legacy IdPs that cannot release an email attribute.
+							</p>
+						</div>
+
+						<div class="form-group">
+							<label for="logoutRequestSignaturePolicy" class="form-label">
+								IdP LogoutRequest Signature
+							</label>
+							<select
+								id="logoutRequestSignaturePolicy"
+								bind:value={logoutRequestSignaturePolicy}
+								class="form-select"
+							>
+								<option value="required">Required</option>
+								<option value="optional">Optional</option>
+								<option value="disabled">Disabled</option>
+							</select>
+							<p class="field-hint">
+								Required by default. Use Optional or Disabled only for explicit legacy IdP
+								compatibility.
+							</p>
+						</div>
+
+						<div class="form-group">
+							<label for="authnContextPolicyMode" class="form-label">AuthnContext Policy</label>
 							<select
 								id="authnContextPolicyMode"
 								bind:value={authnContextPolicyMode}
@@ -733,9 +770,9 @@
 							</select>
 						</div>
 
-							<div class="form-group">
-								<label for="authnRequestSignaturePolicy" class="form-label">
-									AuthnRequest Signature
+						<div class="form-group">
+							<label for="authnRequestSignaturePolicy" class="form-label">
+								AuthnRequest Signature
 							</label>
 							<select
 								id="authnRequestSignaturePolicy"
@@ -746,25 +783,25 @@
 								<option value="required">Required</option>
 								<option value="disabled">Disabled</option>
 							</select>
-							</div>
+						</div>
 
-							<div class="form-group">
-								<label for="spLogoutRequestSignaturePolicy" class="form-label">
-									LogoutRequest Signature
-								</label>
-								<select
-									id="spLogoutRequestSignaturePolicy"
-									bind:value={logoutRequestSignaturePolicy}
-									class="form-select"
-								>
-									<option value="required">Required</option>
-									<option value="optional">Optional</option>
-									<option value="disabled">Disabled</option>
-								</select>
-								<p class="field-hint">
-									Required by default. Relax only for an explicit legacy SP exception.
-								</p>
-							</div>
+						<div class="form-group">
+							<label for="spLogoutRequestSignaturePolicy" class="form-label">
+								LogoutRequest Signature
+							</label>
+							<select
+								id="spLogoutRequestSignaturePolicy"
+								bind:value={logoutRequestSignaturePolicy}
+								class="form-select"
+							>
+								<option value="required">Required</option>
+								<option value="optional">Optional</option>
+								<option value="disabled">Disabled</option>
+							</select>
+							<p class="field-hint">
+								Required by default. Relax only for an explicit legacy SP exception.
+							</p>
+						</div>
 
 						<div class="form-group">
 							<label for="authnContextClassRefMode" class="form-label">AuthnContext Mode</label>

--- a/packages/ar-admin-ui/src/routes/admin/saml/new/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/saml/new/+page.svelte
@@ -11,6 +11,7 @@
 		type SAMLMetadataBatchStatus,
 		type SAMLMetadataEntitySummary,
 		type SAMLMetadataKeywordFacet,
+		type SAMLJitEmailLinkingPolicy,
 		type SAMLProvider,
 		type SAMLProviderConfig,
 		type SAMLTrustCertificatePreview
@@ -71,6 +72,8 @@
 	let authnRequestSignaturePolicy = $state<'required' | 'optional' | 'disabled'>('optional');
 	let logoutRequestSignaturePolicy = $state<'required' | 'optional' | 'disabled'>('required');
 	let authnContextPolicyMode = $state<'observe' | 'require_any'>('observe');
+	let jitEmailLinkingPolicy = $state<SAMLJitEmailLinkingPolicy>('email_linking');
+	let allowSyntheticEmailFallback = $state(false);
 	let allowedAuthnContextClassRefs = $state(
 		'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'
 	);
@@ -222,11 +225,13 @@
 		if (providerType === 'saml_idp') {
 			return {
 				...config,
-					providerName: providerName.trim() || undefined,
-					ssoUrl: ssoUrl.trim(),
-					certificate: certificate.trim(),
-					logoutRequestSignaturePolicy,
-					authnContextPolicy: {
+				providerName: providerName.trim() || undefined,
+				ssoUrl: ssoUrl.trim(),
+				certificate: certificate.trim(),
+				logoutRequestSignaturePolicy,
+				jitEmailLinkingPolicy,
+				allowSyntheticEmailFallback,
+				authnContextPolicy: {
 					mode: authnContextPolicyMode,
 					allowedClassRefs: allowedAuthnContextClassRefs
 						.split('\n')
@@ -242,10 +247,10 @@
 			certificate: certificate.trim() || undefined,
 			signAssertions,
 			signResponses,
-				samlProfile,
-				authnRequestSignaturePolicy,
-				logoutRequestSignaturePolicy,
-				authnContextClassRefMode,
+			samlProfile,
+			authnRequestSignaturePolicy,
+			logoutRequestSignaturePolicy,
+			authnContextClassRefMode,
 			defaultAuthnContextClassRef: defaultAuthnContextClassRef.trim() || undefined,
 			passkeyAuthnContextClassRef: passkeyAuthnContextClassRef.trim() || undefined,
 			...selectedPresetConfig()
@@ -261,10 +266,12 @@
 		};
 		if (providerType !== 'saml_sp') {
 			return {
-					...config,
-					providerName: providerName.trim() || undefined,
-					logoutRequestSignaturePolicy,
-					authnContextPolicy: {
+				...config,
+				providerName: providerName.trim() || undefined,
+				logoutRequestSignaturePolicy,
+				jitEmailLinkingPolicy,
+				allowSyntheticEmailFallback,
+				authnContextPolicy: {
 					mode: authnContextPolicyMode,
 					allowedClassRefs: allowedAuthnContextClassRefs
 						.split('\n')
@@ -274,10 +281,10 @@
 			};
 		}
 		return {
-				...config,
-				authnRequestSignaturePolicy,
-				logoutRequestSignaturePolicy,
-				authnContextClassRefMode,
+			...config,
+			authnRequestSignaturePolicy,
+			logoutRequestSignaturePolicy,
+			authnContextClassRefMode,
 			defaultAuthnContextClassRef: defaultAuthnContextClassRef.trim() || undefined,
 			passkeyAuthnContextClassRef: passkeyAuthnContextClassRef.trim() || undefined
 		};
@@ -301,6 +308,11 @@
 		authnRequestSignaturePolicy = config.authnRequestSignaturePolicy || 'optional';
 		logoutRequestSignaturePolicy = config.logoutRequestSignaturePolicy || 'required';
 		authnContextPolicyMode = config.authnContextPolicy?.mode || 'observe';
+		jitEmailLinkingPolicy = config.jitEmailLinkingPolicy || jitEmailLinkingPolicy;
+		allowSyntheticEmailFallback =
+			config.allowSyntheticEmailFallback === undefined
+				? allowSyntheticEmailFallback
+				: config.allowSyntheticEmailFallback === true;
 		allowedAuthnContextClassRefs = (
 			config.authnContextPolicy?.allowedClassRefs?.length
 				? config.authnContextPolicy.allowedClassRefs
@@ -931,7 +943,7 @@
 		</div>
 		{#if preview.warnings.length > 0}
 			<div class="certificate-warnings">
-					{#each preview.warnings as warning (warning)}
+				{#each preview.warnings as warning (warning)}
 					<div><i class="i-ph-warning-circle"></i>{warning}</div>
 				{/each}
 			</div>
@@ -1744,27 +1756,57 @@
 								/>
 							</div>
 
-								<div class="form-group">
-									<label for="logoutRequestSignaturePolicy" class="form-label">
-										IdP LogoutRequest Signature
-									</label>
-									<select
-										id="logoutRequestSignaturePolicy"
-										bind:value={logoutRequestSignaturePolicy}
-										class="form-select"
-									>
-										<option value="required">Required</option>
-										<option value="optional">Optional</option>
-										<option value="disabled">Disabled</option>
-									</select>
-									<p class="field-hint">
-										Required by default. Use Optional or Disabled only for explicit legacy IdP
-										compatibility.
-									</p>
-								</div>
+							<div class="form-group">
+								<label for="jitEmailLinkingPolicy" class="form-label">JIT Linking Policy</label>
+								<select
+									id="jitEmailLinkingPolicy"
+									bind:value={jitEmailLinkingPolicy}
+									class="form-select"
+								>
+									<option value="email_linking">Existing verified email or JIT create</option>
+									<option value="jit_create_only">JIT create only</option>
+									<option value="disabled">Existing links only</option>
+								</select>
+								<p class="field-hint">
+									Controls whether first login can link by verified local email or create a user.
+								</p>
+							</div>
 
-								<div class="form-group">
-									<label for="authnContextPolicyMode" class="form-label">AuthnContext Policy</label>
+							<div class="form-group form-group-full">
+								<label class="form-checkbox-label">
+									<input
+										type="checkbox"
+										bind:checked={allowSyntheticEmailFallback}
+										class="checkbox"
+									/>
+									Allow synthetic email fallback
+								</label>
+								<p class="field-hint">
+									Use only for legacy IdPs that cannot release an email attribute.
+								</p>
+							</div>
+
+							<div class="form-group">
+								<label for="logoutRequestSignaturePolicy" class="form-label">
+									IdP LogoutRequest Signature
+								</label>
+								<select
+									id="logoutRequestSignaturePolicy"
+									bind:value={logoutRequestSignaturePolicy}
+									class="form-select"
+								>
+									<option value="required">Required</option>
+									<option value="optional">Optional</option>
+									<option value="disabled">Disabled</option>
+								</select>
+								<p class="field-hint">
+									Required by default. Use Optional or Disabled only for explicit legacy IdP
+									compatibility.
+								</p>
+							</div>
+
+							<div class="form-group">
+								<label for="authnContextPolicyMode" class="form-label">AuthnContext Policy</label>
 								<select
 									id="authnContextPolicyMode"
 									bind:value={authnContextPolicyMode}
@@ -1820,9 +1862,9 @@
 								</select>
 							</div>
 
-								<div class="form-group">
-									<label for="authnRequestSignaturePolicy" class="form-label">
-										AuthnRequest Signature
+							<div class="form-group">
+								<label for="authnRequestSignaturePolicy" class="form-label">
+									AuthnRequest Signature
 								</label>
 								<select
 									id="authnRequestSignaturePolicy"
@@ -1832,26 +1874,26 @@
 									<option value="optional">Optional</option>
 									<option value="required">Required</option>
 									<option value="disabled">Disabled</option>
-									</select>
-								</div>
+								</select>
+							</div>
 
-								<div class="form-group">
-									<label for="spLogoutRequestSignaturePolicy" class="form-label">
-										LogoutRequest Signature
-									</label>
-									<select
-										id="spLogoutRequestSignaturePolicy"
-										bind:value={logoutRequestSignaturePolicy}
-										class="form-select"
-									>
-										<option value="required">Required</option>
-										<option value="optional">Optional</option>
-										<option value="disabled">Disabled</option>
-									</select>
-									<p class="field-hint">
-										Required by default. Relax only for an explicit legacy SP exception.
-									</p>
-								</div>
+							<div class="form-group">
+								<label for="spLogoutRequestSignaturePolicy" class="form-label">
+									LogoutRequest Signature
+								</label>
+								<select
+									id="spLogoutRequestSignaturePolicy"
+									bind:value={logoutRequestSignaturePolicy}
+									class="form-select"
+								>
+									<option value="required">Required</option>
+									<option value="optional">Optional</option>
+									<option value="disabled">Disabled</option>
+								</select>
+								<p class="field-hint">
+									Required by default. Relax only for an explicit legacy SP exception.
+								</p>
+							</div>
 
 							<div class="form-group">
 								<label for="authnContextClassRefMode" class="form-label">AuthnContext Mode</label>
@@ -1914,10 +1956,10 @@
 					<span>Certificate security warnings</span>
 				</div>
 				<ul>
-						{#each providerCertificatePreview?.warnings ?? [] as warning (warning)}
+					{#each providerCertificatePreview?.warnings ?? [] as warning (warning)}
 						<li>{warning}</li>
 					{/each}
-						{#each federationCertificatePreview?.warnings ?? [] as warning (warning)}
+					{#each federationCertificatePreview?.warnings ?? [] as warning (warning)}
 						<li>{warning}</li>
 					{/each}
 				</ul>

--- a/packages/ar-lib-core/src/types/saml.ts
+++ b/packages/ar-lib-core/src/types/saml.ts
@@ -615,13 +615,13 @@ export interface SAMLIdPConfig {
     allowedClassRefs?: string[];
   };
   /**
-   * Reserved JIT account-linking policy for future federated identity registry work.
-   * Current ACS behavior still performs email-based lookup when an email is present.
+   * Federated identity registry policy for resolving first SAML logins.
+   * Default email_linking resolves existing link, verified local email, then JIT create.
    */
   jitEmailLinkingPolicy?: SAMLJitEmailLinkingPolicy;
   /**
-   * Legacy compatibility escape hatch. When false/omitted, ACS rejects assertions
-   * that cannot produce an email instead of synthesizing `${NameID}@saml.local`.
+   * Legacy compatibility escape hatch. When false/omitted, ACS rejects assertions that
+   * cannot produce an email. When true, ACS uses a non-PII synthetic local email.
    */
   allowSyntheticEmailFallback?: boolean;
   /**

--- a/packages/ar-saml/src/__tests__/saml-integration.test.ts
+++ b/packages/ar-saml/src/__tests__/saml-integration.test.ts
@@ -35,6 +35,7 @@ const {
   mockGetSigningCertificate,
   mockGetSPConfig,
   mockSessionStoreFetch,
+  mockCreateAuditLog,
 } = vi.hoisted(() => ({
   mockValidateCustomClaimWrite: vi.fn().mockResolvedValue({ ok: true }),
   mockPersistCustomClaimWrite: vi.fn().mockResolvedValue(undefined),
@@ -52,6 +53,7 @@ const {
   mockSessionStoreFetch: vi
     .fn()
     .mockResolvedValue(new Response(JSON.stringify({ success: true }), { status: 200 })),
+  mockCreateAuditLog: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock modules
@@ -99,6 +101,7 @@ vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
     validateCustomClaimWrite: mockValidateCustomClaimWrite,
     persistCustomClaimWrite: mockPersistCustomClaimWrite,
     syncUserLifecycleState: mockSyncUserLifecycleState,
+    createAuditLog: mockCreateAuditLog,
     resolveUserStoreRuntimeSourcesFromEnv: mockResolveUserStoreRuntimeSourcesFromEnv,
     resolveCustomClaimRuntimeSourcesFromEnv: vi.fn(async (env: Partial<Env>) => ({
       storageProfile: {
@@ -124,6 +127,7 @@ vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
 function createMockAdapter(
   options: {
     queryOne?: (sql: string, params: unknown[]) => unknown | Promise<unknown>;
+    execute?: (sql: string, params: unknown[]) => unknown | Promise<unknown>;
   } = {}
 ) {
   return {
@@ -131,7 +135,10 @@ function createMockAdapter(
     queryOne: vi.fn(
       async (sql: string, params: unknown[]) => options.queryOne?.(sql, params) ?? null
     ),
-    execute: vi.fn().mockResolvedValue({ rowsAffected: 1, insertId: undefined }),
+    execute: vi.fn(
+      async (sql: string, params: unknown[]) =>
+        options.execute?.(sql, params) ?? { rowsAffected: 1, insertId: undefined }
+    ),
     transaction: vi.fn(async (fn: any) => fn()),
     batch: vi.fn().mockResolvedValue([]),
     isHealthy: vi.fn().mockResolvedValue(true),
@@ -358,6 +365,7 @@ describe('SAML Integration', () => {
       lifecycleState: 'active',
       missingRequiredFields: [],
     });
+    mockCreateAuditLog.mockReset().mockResolvedValue(undefined);
     mockGetSigningKey.mockReset().mockResolvedValue({
       kid: 'mock-kid',
       privateKeyPem: 'mock-key',
@@ -445,8 +453,8 @@ describe('SAML Integration', () => {
           bind: vi.fn().mockReturnThis(),
           first: vi.fn().mockImplementation(async () => {
             // PII/Non-PII separation: users_core (non-PII)
-            if (sql.includes('SELECT id FROM users_core WHERE id')) {
-              return { id: 'user-001' };
+            if (sql.includes('FROM users_core WHERE id')) {
+              return { id: 'user-001', email_verified: 1 };
             }
             return null;
           }),
@@ -1131,6 +1139,606 @@ describe('SAML Integration', () => {
 
       expect(res.status).toBe(302);
       expect(mockPersistCustomClaimWrite).toHaveBeenCalled();
+      expect(mockSyncUserLifecycleState).toHaveBeenCalled();
+    });
+
+    it('should derive synthetic email fallback without embedding raw NameID', async () => {
+      mockGetIdPConfigByEntityId.mockResolvedValueOnce({
+        entityId: 'https://idp.example.com',
+        ssoUrl: 'https://idp.example.com/sso',
+        sloUrl: 'https://idp.example.com/slo',
+        certificate: 'mock-certificate',
+        allowSyntheticEmailFallback: true,
+        attributeMapping: {
+          email: 'email',
+          name: 'displayName',
+        },
+      });
+      const coreAdapter = createMockAdapter();
+      const piiAdapter = createMockAdapter();
+      mockResolveUserStoreRuntimeSourcesFromEnv.mockResolvedValueOnce({
+        storageProfile: {
+          id: 'builtin:storage:standard',
+          kind: 'storage',
+          label: 'Standard D1 Split',
+          slices: {},
+        },
+        coreDb: coreAdapter,
+        piiDb: piiAdapter,
+      });
+
+      const res = await callACSDirectly(
+        createMockSAMLResponse({
+          nameId: 'person@example.com',
+          nameIdFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+        })
+      );
+
+      expect(res.status).toBe(302);
+      const usersPiiInsert = piiAdapter.execute.mock.calls.find(([sql]) =>
+        String(sql).includes('INSERT INTO users_pii')
+      );
+      expect(usersPiiInsert).toBeTruthy();
+      const insertedEmail = usersPiiInsert?.[1][2];
+      expect(insertedEmail).toMatch(/^saml-[0-9a-f]{32}@saml\.local$/);
+      expect(insertedEmail).not.toContain('person');
+      expect(insertedEmail).not.toContain('example.com');
+    });
+
+    it('should resolve existing SAML linked identity before email or JIT provisioning', async () => {
+      const nameIdFormat = 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent';
+      const providerUserKey = `saml:${encodeURIComponent(nameIdFormat)}:${encodeURIComponent('persistent-subject-123')}`;
+      const coreAdapter = createMockAdapter({
+        queryOne: (sql, params) => {
+          if (sql.includes('SELECT id, email_verified FROM users_core WHERE id')) {
+            expect(params).toEqual(['linked-user-001', 'default']);
+            return { id: 'linked-user-001', email_verified: 1 };
+          }
+          return null;
+        },
+      });
+      const piiAdapter = createMockAdapter({
+        queryOne: (sql, params) => {
+          if (sql.includes('WHERE tenant_id = ? AND provider_id = ? AND provider_user_id = ?')) {
+            expect(params).toEqual(['default', 'https://idp.example.com', providerUserKey]);
+            return { id: 'saml-link-001', user_id: 'linked-user-001' };
+          }
+          return null;
+        },
+      });
+      mockResolveUserStoreRuntimeSourcesFromEnv.mockResolvedValueOnce({
+        storageProfile: {
+          id: 'builtin:storage:standard',
+          kind: 'storage',
+          label: 'Standard D1 Split',
+          slices: {},
+        },
+        coreDb: coreAdapter,
+        piiDb: piiAdapter,
+      });
+
+      const res = await callACSDirectly(
+        createMockSAMLResponse({
+          nameId: 'persistent-subject-123',
+          nameIdFormat,
+        })
+      );
+
+      expect(res.status).toBe(302);
+      expect(mockValidateCustomClaimWrite).not.toHaveBeenCalled();
+      expect(piiAdapter.execute).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE linked_identities SET last_used_at'),
+        expect.arrayContaining(['default', 'saml-link-001'])
+      );
+    });
+
+    it('should create a SAML linked identity when verified email matches a provisioned user', async () => {
+      const nameIdFormat = 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent';
+      const providerUserKey = `saml:${encodeURIComponent(nameIdFormat)}:${encodeURIComponent('persistent-subject-456')}`;
+      const coreAdapter = createMockAdapter({
+        queryOne: (sql, params) => {
+          if (sql.includes('SELECT id, email_verified FROM users_core WHERE id')) {
+            expect(params).toEqual(['scim-user-001', 'default']);
+            return { id: 'scim-user-001', email_verified: 1 };
+          }
+          return null;
+        },
+      });
+      const piiAdapter = createMockAdapter({
+        queryOne: (sql, params) => {
+          if (sql.includes('WHERE tenant_id = ? AND provider_id = ? AND provider_user_id = ?')) {
+            expect(params).toEqual(['default', 'https://idp.example.com', providerUserKey]);
+            return null;
+          }
+          if (sql.includes('SELECT id FROM users_pii WHERE tenant_id = ? AND email = ?')) {
+            expect(params).toEqual(['default', 'scim@example.com']);
+            return { id: 'scim-user-001' };
+          }
+          return null;
+        },
+      });
+      mockResolveUserStoreRuntimeSourcesFromEnv.mockResolvedValueOnce({
+        storageProfile: {
+          id: 'builtin:storage:standard',
+          kind: 'storage',
+          label: 'Standard D1 Split',
+          slices: {},
+        },
+        coreDb: coreAdapter,
+        piiDb: piiAdapter,
+      });
+
+      const res = await callACSDirectly(
+        createMockSAMLResponse({
+          nameId: 'persistent-subject-456',
+          nameIdFormat,
+          attributes: [{ name: 'email', value: 'scim@example.com' }],
+        })
+      );
+
+      expect(res.status).toBe(302);
+      expect(coreAdapter.execute).not.toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO users_core'),
+        expect.anything()
+      );
+      expect(piiAdapter.execute).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO linked_identities'),
+        expect.arrayContaining([
+          'default',
+          'scim-user-001',
+          'https://idp.example.com',
+          providerUserKey,
+          'scim@example.com',
+        ])
+      );
+    });
+
+    it('should fail closed when email matches but SAML email linking is disabled', async () => {
+      mockGetIdPConfigByEntityId.mockResolvedValueOnce({
+        entityId: 'https://idp.example.com',
+        ssoUrl: 'https://idp.example.com/sso',
+        sloUrl: 'https://idp.example.com/slo',
+        certificate: 'mock-certificate',
+        jitEmailLinkingPolicy: 'jit_create_only',
+        attributeMapping: {
+          email: 'email',
+          name: 'displayName',
+        },
+      });
+      const coreAdapter = createMockAdapter();
+      const piiAdapter = createMockAdapter({
+        queryOne: (sql) => {
+          if (sql.includes('SELECT id FROM users_pii WHERE tenant_id = ? AND email = ?')) {
+            return { id: 'scim-user-001' };
+          }
+          return null;
+        },
+      });
+      mockResolveUserStoreRuntimeSourcesFromEnv.mockResolvedValueOnce({
+        storageProfile: {
+          id: 'builtin:storage:standard',
+          kind: 'storage',
+          label: 'Standard D1 Split',
+          slices: {},
+        },
+        coreDb: coreAdapter,
+        piiDb: piiAdapter,
+      });
+
+      const res = await callACSDirectly(
+        createMockSAMLResponse({
+          nameId: 'persistent-subject-789',
+          nameIdFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+          attributes: [{ name: 'email', value: 'scim@example.com' }],
+        })
+      );
+
+      expect(res.status).toBe(400);
+      expect(piiAdapter.execute).not.toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO linked_identities'),
+        expect.anything()
+      );
+      const failureAudit = mockCreateAuditLog.mock.calls.find(
+        ([, entry]) => entry.action === 'saml.identity_resolution.failed'
+      )?.[1];
+      expect(failureAudit).toBeTruthy();
+      const auditMetadata = JSON.parse(failureAudit.metadata);
+      expect(auditMetadata).toEqual(
+        expect.objectContaining({
+          protocol: 'saml',
+          failure_reason: 'email_linking_disabled',
+          policy: 'jit_create_only',
+        })
+      );
+      expect(failureAudit.metadata).not.toContain('persistent-subject-789');
+      expect(failureAudit.metadata).not.toContain('scim@example.com');
+      expect(failureAudit.metadata).not.toContain('provider_user_key');
+    });
+
+    it('should fail closed when email matches a local user with unverified email', async () => {
+      const coreAdapter = createMockAdapter({
+        queryOne: (sql) => {
+          if (sql.includes('SELECT id, email_verified FROM users_core WHERE id')) {
+            return { id: 'scim-user-002', email_verified: 0 };
+          }
+          return null;
+        },
+      });
+      const piiAdapter = createMockAdapter({
+        queryOne: (sql) => {
+          if (sql.includes('SELECT id FROM users_pii WHERE tenant_id = ? AND email = ?')) {
+            return { id: 'scim-user-002' };
+          }
+          return null;
+        },
+      });
+      mockResolveUserStoreRuntimeSourcesFromEnv.mockResolvedValueOnce({
+        storageProfile: {
+          id: 'builtin:storage:standard',
+          kind: 'storage',
+          label: 'Standard D1 Split',
+          slices: {},
+        },
+        coreDb: coreAdapter,
+        piiDb: piiAdapter,
+      });
+
+      const res = await callACSDirectly(
+        createMockSAMLResponse({
+          nameId: 'persistent-subject-unverified',
+          nameIdFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+          attributes: [{ name: 'email', value: 'unverified@example.com' }],
+        })
+      );
+
+      expect(res.status).toBe(400);
+      expect(piiAdapter.execute).not.toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO linked_identities'),
+        expect.anything()
+      );
+    });
+
+    it('should fail closed when an existing SAML link email conflicts with another user', async () => {
+      const nameIdFormat = 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent';
+      const providerUserKey = `saml:${encodeURIComponent(nameIdFormat)}:${encodeURIComponent('persistent-subject-conflict')}`;
+      const coreAdapter = createMockAdapter({
+        queryOne: (sql) => {
+          if (sql.includes('SELECT id, email_verified FROM users_core WHERE id')) {
+            return { id: 'linked-user-001', email_verified: 1 };
+          }
+          return null;
+        },
+      });
+      const piiAdapter = createMockAdapter({
+        queryOne: (sql, params) => {
+          if (sql.includes('SELECT id, user_id, provider_user_id FROM linked_identities')) {
+            expect(params).toEqual(['default', 'https://idp.example.com', providerUserKey]);
+            return { id: 'saml-link-001', user_id: 'linked-user-001' };
+          }
+          if (sql.includes('SELECT id FROM users_pii WHERE tenant_id = ? AND email = ?')) {
+            return { id: 'different-user-001' };
+          }
+          return null;
+        },
+      });
+      mockResolveUserStoreRuntimeSourcesFromEnv.mockResolvedValueOnce({
+        storageProfile: {
+          id: 'builtin:storage:standard',
+          kind: 'storage',
+          label: 'Standard D1 Split',
+          slices: {},
+        },
+        coreDb: coreAdapter,
+        piiDb: piiAdapter,
+      });
+
+      const res = await callACSDirectly(
+        createMockSAMLResponse({
+          nameId: 'persistent-subject-conflict',
+          nameIdFormat,
+          attributes: [{ name: 'email', value: 'other-user@example.com' }],
+        })
+      );
+
+      expect(res.status).toBe(400);
+      expect(mockValidateCustomClaimWrite).not.toHaveBeenCalled();
+      expect(piiAdapter.execute).not.toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE linked_identities'),
+        expect.anything()
+      );
+    });
+
+    it('should fail closed when email match user has another subject for the same IdP', async () => {
+      const nameIdFormat = 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent';
+      const providerUserKey = `saml:${encodeURIComponent(nameIdFormat)}:${encodeURIComponent('persistent-subject-new-link')}`;
+      const previousProviderUserKey = `saml:${encodeURIComponent(nameIdFormat)}:${encodeURIComponent('persistent-subject-old-link')}`;
+      const coreAdapter = createMockAdapter({
+        queryOne: (sql) => {
+          if (sql.includes('SELECT id, email_verified FROM users_core WHERE id')) {
+            return { id: 'scim-user-003', email_verified: 1 };
+          }
+          return null;
+        },
+      });
+      const piiAdapter = createMockAdapter({
+        queryOne: (sql, params) => {
+          if (sql.includes('WHERE tenant_id = ? AND provider_id = ? AND provider_user_id = ?')) {
+            expect(params).toEqual(['default', 'https://idp.example.com', providerUserKey]);
+            return null;
+          }
+          if (sql.includes('SELECT id FROM users_pii WHERE tenant_id = ? AND email = ?')) {
+            return { id: 'scim-user-003' };
+          }
+          if (sql.includes('WHERE tenant_id = ? AND user_id = ? AND provider_id = ?')) {
+            expect(params).toEqual(['default', 'scim-user-003', 'https://idp.example.com']);
+            return {
+              id: 'existing-provider-link',
+              user_id: 'scim-user-003',
+              provider_user_id: previousProviderUserKey,
+            };
+          }
+          return null;
+        },
+      });
+      mockResolveUserStoreRuntimeSourcesFromEnv.mockResolvedValueOnce({
+        storageProfile: {
+          id: 'builtin:storage:standard',
+          kind: 'storage',
+          label: 'Standard D1 Split',
+          slices: {},
+        },
+        coreDb: coreAdapter,
+        piiDb: piiAdapter,
+      });
+
+      const res = await callACSDirectly(
+        createMockSAMLResponse({
+          nameId: 'persistent-subject-new-link',
+          nameIdFormat,
+          attributes: [{ name: 'email', value: 'scim-user-003@example.com' }],
+        })
+      );
+
+      expect(res.status).toBe(400);
+      expect(piiAdapter.execute).not.toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO linked_identities'),
+        expect.anything()
+      );
+    });
+
+    it('should fail closed when linked identity insert races with another user', async () => {
+      const nameIdFormat = 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent';
+      const providerUserKey = `saml:${encodeURIComponent(nameIdFormat)}:${encodeURIComponent('persistent-subject-race')}`;
+      let lookupCount = 0;
+      const coreAdapter = createMockAdapter({
+        queryOne: (sql) => {
+          if (sql.includes('SELECT id, email_verified FROM users_core WHERE id')) {
+            return { id: 'scim-user-004', email_verified: 1 };
+          }
+          return null;
+        },
+      });
+      const piiAdapter = createMockAdapter({
+        queryOne: (sql) => {
+          if (sql.includes('WHERE tenant_id = ? AND provider_id = ? AND provider_user_id = ?')) {
+            lookupCount += 1;
+            return lookupCount === 1
+              ? null
+              : {
+                  id: 'raced-provider-link',
+                  user_id: 'different-user-004',
+                  provider_user_id: providerUserKey,
+                };
+          }
+          if (sql.includes('SELECT id FROM users_pii WHERE tenant_id = ? AND email = ?')) {
+            return { id: 'scim-user-004' };
+          }
+          return null;
+        },
+        execute: (sql) => {
+          if (sql.includes('INSERT INTO linked_identities')) {
+            throw new Error('UNIQUE constraint failed: linked_identities');
+          }
+          return { rowsAffected: 1, insertId: undefined };
+        },
+      });
+      mockResolveUserStoreRuntimeSourcesFromEnv.mockResolvedValueOnce({
+        storageProfile: {
+          id: 'builtin:storage:standard',
+          kind: 'storage',
+          label: 'Standard D1 Split',
+          slices: {},
+        },
+        coreDb: coreAdapter,
+        piiDb: piiAdapter,
+      });
+
+      const res = await callACSDirectly(
+        createMockSAMLResponse({
+          nameId: 'persistent-subject-race',
+          nameIdFormat,
+          attributes: [{ name: 'email', value: 'scim-user-004@example.com' }],
+        })
+      );
+
+      expect(res.status).toBe(400);
+      expect(lookupCount).toBe(2);
+    });
+
+    it('should clean up JIT-created rows when lifecycle sync fails', async () => {
+      mockSyncUserLifecycleState.mockRejectedValueOnce(new Error('lifecycle sync failed'));
+      const coreAdapter = createMockAdapter();
+      const piiAdapter = createMockAdapter();
+      mockResolveUserStoreRuntimeSourcesFromEnv.mockResolvedValueOnce({
+        storageProfile: {
+          id: 'builtin:storage:standard',
+          kind: 'storage',
+          label: 'Standard D1 Split',
+          slices: {},
+        },
+        coreDb: coreAdapter,
+        piiDb: piiAdapter,
+      });
+
+      const res = await callACSDirectly(
+        createMockSAMLResponse({
+          nameId: 'persistent-subject-sync-fail',
+          nameIdFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+          attributes: [{ name: 'email', value: 'sync-fail@example.com' }],
+        })
+      );
+
+      expect(res.status).toBe(500);
+      expect(coreAdapter.execute).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO users_core'),
+        expect.anything()
+      );
+      expect(piiAdapter.execute).toHaveBeenCalledWith(
+        'DELETE FROM users_pii WHERE id = ? AND tenant_id = ?',
+        expect.any(Array)
+      );
+      expect(coreAdapter.execute).toHaveBeenCalledWith(
+        'DELETE FROM users_core WHERE id = ? AND tenant_id = ?',
+        expect.any(Array)
+      );
+      expect(piiAdapter.execute).not.toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO linked_identities'),
+        expect.anything()
+      );
+    });
+
+    it('should reject new SAML users when JIT and linking are disabled for the IdP', async () => {
+      mockGetIdPConfigByEntityId.mockResolvedValueOnce({
+        entityId: 'https://idp.example.com',
+        ssoUrl: 'https://idp.example.com/sso',
+        sloUrl: 'https://idp.example.com/slo',
+        certificate: 'mock-certificate',
+        jitEmailLinkingPolicy: 'disabled',
+        attributeMapping: {
+          email: 'email',
+          name: 'displayName',
+        },
+      });
+      const coreAdapter = createMockAdapter();
+      const piiAdapter = createMockAdapter();
+      mockResolveUserStoreRuntimeSourcesFromEnv.mockResolvedValueOnce({
+        storageProfile: {
+          id: 'builtin:storage:standard',
+          kind: 'storage',
+          label: 'Standard D1 Split',
+          slices: {},
+        },
+        coreDb: coreAdapter,
+        piiDb: piiAdapter,
+      });
+
+      const res = await callACSDirectly(
+        createMockSAMLResponse({
+          nameId: 'persistent-subject-disabled',
+          nameIdFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+          attributes: [{ name: 'email', value: 'new-disabled@example.com' }],
+        })
+      );
+
+      expect(res.status).toBe(400);
+      expect(mockValidateCustomClaimWrite).not.toHaveBeenCalled();
+      expect(coreAdapter.execute).not.toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO users_core'),
+        expect.anything()
+      );
+    });
+
+    it('should fail closed when stored IdP JIT linking policy is invalid', async () => {
+      mockGetIdPConfigByEntityId.mockResolvedValueOnce({
+        entityId: 'https://idp.example.com',
+        ssoUrl: 'https://idp.example.com/sso',
+        sloUrl: 'https://idp.example.com/slo',
+        certificate: 'mock-certificate',
+        jitEmailLinkingPolicy: 'unsafe_email_takeover',
+        attributeMapping: {
+          email: 'email',
+          name: 'displayName',
+        },
+      } as any);
+      const coreAdapter = createMockAdapter();
+      const piiAdapter = createMockAdapter();
+      mockResolveUserStoreRuntimeSourcesFromEnv.mockResolvedValueOnce({
+        storageProfile: {
+          id: 'builtin:storage:standard',
+          kind: 'storage',
+          label: 'Standard D1 Split',
+          slices: {},
+        },
+        coreDb: coreAdapter,
+        piiDb: piiAdapter,
+      });
+
+      const res = await callACSDirectly(
+        createMockSAMLResponse({
+          nameId: 'persistent-subject-invalid-policy',
+          nameIdFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+          attributes: [{ name: 'email', value: 'invalid-policy@example.com' }],
+        })
+      );
+
+      expect(res.status).toBe(400);
+      expect(mockValidateCustomClaimWrite).not.toHaveBeenCalled();
+      expect(coreAdapter.execute).not.toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO users_core'),
+        expect.anything()
+      );
+      const failureAudit = mockCreateAuditLog.mock.calls.find(
+        ([, entry]) => entry.action === 'saml.identity_resolution.failed'
+      )?.[1];
+      expect(failureAudit).toBeTruthy();
+      expect(JSON.parse(failureAudit.metadata)).toMatchObject({
+        protocol: 'saml',
+        failure_reason: 'jit_policy_invalid',
+        policy: 'invalid',
+      });
+      expect(failureAudit.metadata).not.toContain('unsafe_email_takeover');
+      expect(failureAudit.metadata).not.toContain('invalid-policy@example.com');
+      expect(failureAudit.metadata).not.toContain('persistent-subject-invalid-policy');
+    });
+
+    it('should create a SAML linked identity for newly JIT-provisioned users', async () => {
+      const nameIdFormat = 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent';
+      const providerUserKey = `saml:${encodeURIComponent(nameIdFormat)}:${encodeURIComponent('persistent-subject-new')}`;
+      const coreAdapter = createMockAdapter();
+      const piiAdapter = createMockAdapter();
+      mockResolveUserStoreRuntimeSourcesFromEnv.mockResolvedValueOnce({
+        storageProfile: {
+          id: 'builtin:storage:standard',
+          kind: 'storage',
+          label: 'Standard D1 Split',
+          slices: {},
+        },
+        coreDb: coreAdapter,
+        piiDb: piiAdapter,
+      });
+
+      const res = await callACSDirectly(
+        createMockSAMLResponse({
+          nameId: 'persistent-subject-new',
+          nameIdFormat,
+          attributes: [{ name: 'email', value: 'new-user@example.com' }],
+        })
+      );
+
+      expect(res.status).toBe(302);
+      expect(coreAdapter.execute).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO users_core'),
+        expect.anything()
+      );
+      expect(piiAdapter.execute).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO linked_identities'),
+        expect.arrayContaining([
+          'default',
+          'https://idp.example.com',
+          providerUserKey,
+          'new-user@example.com',
+        ])
+      );
       expect(mockSyncUserLifecycleState).toHaveBeenCalled();
     });
   });

--- a/packages/ar-saml/src/admin/__tests__/aggregate-provider-api.test.ts
+++ b/packages/ar-saml/src/admin/__tests__/aggregate-provider-api.test.ts
@@ -6,6 +6,7 @@ import {
   handleListAggregatePreviewEntities,
   handlePreviewMetadata,
   handleStartAggregateBatchCreate,
+  handleUpdateProvider,
 } from '../providers';
 
 const mocks = vi.hoisted(() => ({
@@ -352,6 +353,151 @@ describe('SAML aggregate provider API', () => {
     expect(coreAdapter.execute).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO identity_providers'),
       expect.arrayContaining([0])
+    );
+  });
+
+  it('normalizes SAML IdP JIT linking policy defaults on create', async () => {
+    const coreAdapter = createMockAdapter();
+    mocks.createAuthContextFromHono.mockReturnValue({ coreAdapter });
+
+    const response = await handleCreateProvider(
+      createContext({
+        body: {
+          name: 'Example IdP',
+          providerType: 'saml_idp',
+          enabled: true,
+          config: {
+            entityId: 'https://idp.example.test/idp',
+            ssoUrl: 'https://idp.example.test/sso',
+            certificate: 'invalid-test-certificate',
+            nameIdFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+            attributeMapping: { email: 'email' },
+            allowedBindings: ['post'],
+          },
+        },
+      })
+    );
+    const body = (await response.json()) as {
+      config: { jitEmailLinkingPolicy?: string; allowSyntheticEmailFallback?: boolean };
+    };
+
+    expect(response.status).toBe(201);
+    expect(body.config).toMatchObject({
+      jitEmailLinkingPolicy: 'email_linking',
+      allowSyntheticEmailFallback: false,
+    });
+    expect(coreAdapter.execute).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO identity_providers'),
+      expect.arrayContaining([expect.stringContaining('"jitEmailLinkingPolicy":"email_linking"')])
+    );
+  });
+
+  it('rejects invalid SAML IdP JIT linking policy values on create', async () => {
+    const coreAdapter = createMockAdapter();
+    mocks.createAuthContextFromHono.mockReturnValue({ coreAdapter });
+
+    const response = await handleCreateProvider(
+      createContext({
+        body: {
+          name: 'Example IdP',
+          providerType: 'saml_idp',
+          enabled: true,
+          config: {
+            entityId: 'https://idp.example.test/idp',
+            ssoUrl: 'https://idp.example.test/sso',
+            certificate: 'invalid-test-certificate',
+            nameIdFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+            attributeMapping: { email: 'email' },
+            allowedBindings: ['post'],
+            jitEmailLinkingPolicy: 'unsafe_email_takeover',
+          },
+        },
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(coreAdapter.execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid SAML IdP JIT linking policy values on update', async () => {
+    const coreAdapter = createMockAdapter();
+    coreAdapter.queryOne.mockResolvedValue({
+      id: 'idp-1',
+      name: 'Example IdP',
+      provider_type: 'saml_idp',
+      enabled: 1,
+      config_json: JSON.stringify({
+        entityId: 'https://idp.example.test/idp',
+        ssoUrl: 'https://idp.example.test/sso',
+        certificate: 'invalid-test-certificate',
+        nameIdFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+        attributeMapping: { email: 'mail' },
+        allowedBindings: ['post'],
+      }),
+    });
+    mocks.createAuthContextFromHono.mockReturnValue({ coreAdapter });
+
+    const response = await handleUpdateProvider(
+      createContext({
+        params: { id: 'idp-1' },
+        body: {
+          config: {
+            jitEmailLinkingPolicy: 'unsafe_email_takeover',
+          },
+        },
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(coreAdapter.execute).not.toHaveBeenCalled();
+  });
+
+  it('normalizes SAML IdP JIT linking policy updates without dropping existing config', async () => {
+    const coreAdapter = createMockAdapter();
+    coreAdapter.queryOne.mockResolvedValue({
+      id: 'idp-1',
+      name: 'Example IdP',
+      provider_type: 'saml_idp',
+      enabled: 1,
+      config_json: JSON.stringify({
+        entityId: 'https://idp.example.test/idp',
+        ssoUrl: 'https://idp.example.test/sso',
+        certificate: 'invalid-test-certificate',
+        nameIdFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+        attributeMapping: { email: 'mail' },
+        allowedBindings: ['post'],
+      }),
+    });
+    mocks.createAuthContextFromHono.mockReturnValue({ coreAdapter });
+
+    const response = await handleUpdateProvider(
+      createContext({
+        params: { id: 'idp-1' },
+        body: {
+          config: {
+            jitEmailLinkingPolicy: 'disabled',
+            allowSyntheticEmailFallback: true,
+          },
+        },
+      })
+    );
+    const body = (await response.json()) as {
+      config: {
+        jitEmailLinkingPolicy?: string;
+        allowSyntheticEmailFallback?: boolean;
+        attributeMapping?: Record<string, string>;
+      };
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.config).toMatchObject({
+      jitEmailLinkingPolicy: 'disabled',
+      allowSyntheticEmailFallback: true,
+      attributeMapping: { email: 'mail' },
+    });
+    expect(coreAdapter.execute).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE identity_providers'),
+      expect.arrayContaining([expect.stringContaining('"jitEmailLinkingPolicy":"disabled"')])
     );
   });
 

--- a/packages/ar-saml/src/admin/providers.ts
+++ b/packages/ar-saml/src/admin/providers.ts
@@ -32,6 +32,7 @@ import type {
   SAMLMetadataEntityListResponse,
   SAMLMetadataVerificationSummary,
   SAMLCertificateValidationSummary,
+  SAMLJitEmailLinkingPolicy,
 } from '@authrim/ar-lib-core';
 import {
   ADMIN_PERMISSIONS,
@@ -170,6 +171,39 @@ interface SAMLMetadataConfigFields {
   metadataCriticalFields?: SAMLMetadataAnalysis['criticalFields'];
   metadataRefreshStatus?: SAMLMetadataRefreshStatus;
   metadataLastFetched?: number;
+}
+
+const SAML_JIT_EMAIL_LINKING_POLICIES = new Set<SAMLJitEmailLinkingPolicy>([
+  'email_linking',
+  'jit_create_only',
+  'disabled',
+]);
+
+function normalizeSAMLIdPJitLinkingPolicyConfig(
+  config: SAMLIdPConfig
+): SAMLIdPConfig | ResponseValidationError {
+  const policy = config.jitEmailLinkingPolicy ?? 'email_linking';
+  if (!SAML_JIT_EMAIL_LINKING_POLICIES.has(policy)) {
+    return { field: 'jitEmailLinkingPolicy' };
+  }
+
+  return {
+    ...config,
+    jitEmailLinkingPolicy: policy,
+    allowSyntheticEmailFallback: config.allowSyntheticEmailFallback === true,
+  };
+}
+
+interface ResponseValidationError {
+  field: string;
+}
+
+function isResponseValidationError(value: unknown): value is ResponseValidationError {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as ResponseValidationError).field === 'string'
+  );
 }
 
 function collectProviderCertificates(config: SAMLIdPConfig | SAMLSPConfig): string[] {
@@ -1047,7 +1081,12 @@ export async function handleCreateProvider(c: AdminSAMLContext): Promise<Respons
     const normalizedConfig =
       body.providerType === 'saml_sp'
         ? normalizeSAMLSPAttributePresetConfig(config as SAMLSPConfig)
-        : config;
+        : normalizeSAMLIdPJitLinkingPolicyConfig(config as SAMLIdPConfig);
+    if (isResponseValidationError(normalizedConfig)) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
+        variables: { field: normalizedConfig.field },
+      });
+    }
     const normalizedConfigWithValidation =
       await withProviderCertificateValidation(normalizedConfig);
     const providerEnabled =
@@ -1216,7 +1255,12 @@ export async function handleUpdateProvider(c: AdminSAMLContext): Promise<Respons
     const newConfig =
       existing.provider_type === 'saml_sp'
         ? normalizeSAMLSPAttributePresetConfig(mergedConfig as SAMLSPConfig)
-        : mergedConfig;
+        : normalizeSAMLIdPJitLinkingPolicyConfig(mergedConfig as SAMLIdPConfig);
+    if (isResponseValidationError(newConfig)) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE, {
+        variables: { field: newConfig.field },
+      });
+    }
     const newConfigWithValidation = await withProviderCertificateValidation(newConfig);
     const requestedEnabled = body.enabled !== undefined ? body.enabled : existing.enabled === 1;
     const nextEnabled =

--- a/packages/ar-saml/src/sp/acs.ts
+++ b/packages/ar-saml/src/sp/acs.ts
@@ -56,6 +56,7 @@ const SESSION_COOKIE_NAME = 'authrim_session';
 const SESSION_COOKIE_MAX_AGE_SECONDS = 3600;
 const SESSION_HANDOFF_TTL_SECONDS = 60;
 const SAML_SP_HANDOFF_AUDIENCE = 'saml_sp_cookie_handoff';
+const SAML_JIT_EMAIL_LINKING_POLICIES = new Set(['email_linking', 'jit_create_only', 'disabled']);
 const NO_STORE_HEADERS = {
   'Cache-Control': 'no-store',
   Pragma: 'no-cache',
@@ -71,6 +72,7 @@ export async function handleSPACS(c: Context<{ Bindings: Env }>): Promise<Respon
   const log = getLogger(c).module('SAML-SP');
   const tenantId = resolveSAMLTenantIdFromContext(c);
   const { issuerUrl, spEntityId } = await getSAMLLocalEntityIds(env, tenantId);
+  let auditProviderId = 'unknown';
 
   try {
     // Parse POST data
@@ -94,6 +96,7 @@ export async function handleSPACS(c: Context<{ Bindings: Env }>): Promise<Respon
       issuerUrl,
       spEntityId
     );
+    auditProviderId = issuer;
 
     // Get IdP configuration
     const idpConfig = await getIdPConfigByEntityId(env, tenantId, issuer);
@@ -145,8 +148,9 @@ export async function handleSPACS(c: Context<{ Bindings: Env }>): Promise<Respon
     // Extract user information from assertion
     const userInfo = extractUserInfo(assertion, idpConfig);
 
-    // Find or create user
-    const userId = await findOrCreateUser(env, userInfo, idpConfig, tenantId);
+    // Resolve the federated identity before applying any future attribute mapping.
+    const identityResolution = await findOrCreateUser(env, userInfo, idpConfig, tenantId);
+    const userId = identityResolution.userId;
 
     // Create session
     const sessionId = await createSession(env, userId, tenantId);
@@ -199,6 +203,8 @@ export async function handleSPACS(c: Context<{ Bindings: Env }>): Promise<Respon
         method: 'saml',
         idp_entity_id: issuer,
         authn_context_class_ref: authnContextClassRef,
+        federated_identity_resolution: identityResolution.action,
+        linked_identity_id: identityResolution.linkedIdentityId,
       }),
       severity: 'info',
     }).catch((err: unknown) => {
@@ -236,8 +242,15 @@ export async function handleSPACS(c: Context<{ Bindings: Env }>): Promise<Respon
     log.error('ACS Error', {}, error as Error);
 
     if (error instanceof SamlProvisioningError) {
+      scheduleSAMLIdentityResolutionFailureAudit(c, tenantId, auditProviderId, error);
       return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_FORMAT, {
-        variables: { field: 'custom_claims', reason: error.message },
+        variables: {
+          field:
+            error.reason === 'custom_claim_validation_failed'
+              ? 'custom_claims'
+              : 'federated_identity',
+          reason: error.message,
+        },
         extensions: error.missingRequiredFields
           ? {
               missing_required_fields: error.missingRequiredFields.map((field) => ({
@@ -272,6 +285,54 @@ export async function handleSPACS(c: Context<{ Bindings: Env }>): Promise<Respon
 
     return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
   }
+}
+
+function scheduleSAMLIdentityResolutionFailureAudit(
+  c: Context<{ Bindings: Env }>,
+  tenantId: string,
+  providerId: string,
+  error: SamlProvisioningError
+): void {
+  const auditPromise = createAuditLog(c.env, {
+    tenantId,
+    userId: 'saml-sp',
+    action: 'saml.identity_resolution.failed',
+    resource: 'linked_identity',
+    resourceId: providerId,
+    ipAddress:
+      c.req.header('CF-Connecting-IP') ||
+      c.req.header('X-Forwarded-For')?.split(',')[0]?.trim() ||
+      c.req.header('X-Real-IP') ||
+      'unknown',
+    userAgent: c.req.header('User-Agent') || 'unknown',
+    metadata: JSON.stringify({
+      protocol: 'saml',
+      failure_reason: error.reason,
+      ...sanitizeSAMLIdentityResolutionAuditDetails(error.auditDetails),
+    }),
+    severity: 'warning',
+  }).catch((auditError: unknown) => {
+    getLogger(c)
+      .module('SAML-SP')
+      .error(
+        'Failed to create SAML identity resolution failure audit',
+        { reason: error.reason },
+        auditError as Error
+      );
+  });
+
+  c.executionCtx?.waitUntil(auditPromise);
+}
+
+function sanitizeSAMLIdentityResolutionAuditDetails(
+  details: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  if (!details) {
+    return {};
+  }
+
+  const allowedKeys = new Set(['linked_identity_id', 'policy']);
+  return Object.fromEntries(Object.entries(details).filter(([key]) => allowedKeys.has(key)));
 }
 
 async function createSessionHandoffResponse(
@@ -1056,18 +1117,53 @@ interface UserInfo {
   email?: string;
   name?: string;
   nameId: string;
+  nameIdFormat: string;
   attributes: Record<string, string[]>;
   customClaims: Record<string, unknown>;
 }
 
+type SAMLIdentityResolutionAction = 'existing_link' | 'email_link' | 'jit_create';
+
+interface SAMLIdentityResolution {
+  userId: string;
+  action: SAMLIdentityResolutionAction;
+  linkedIdentityId?: string;
+}
+
+interface SAMLLinkedIdentityRow {
+  id: string;
+  user_id: string;
+  provider_user_id?: string;
+}
+
+interface SAMLActiveUserRow {
+  id: string;
+  email_verified?: number | string | boolean | null;
+}
+
+type SAMLIdentityResolutionFailureReason =
+  | 'linked_identity_inactive_user'
+  | 'linked_identity_email_conflict'
+  | 'email_linking_disabled'
+  | 'email_match_inactive_user'
+  | 'email_match_unverified_local_email'
+  | 'email_match_provider_subject_conflict'
+  | 'jit_disabled'
+  | 'jit_policy_invalid'
+  | 'missing_email'
+  | 'custom_claim_validation_failed'
+  | 'linked_identity_subject_conflict';
+
 class SamlProvisioningError extends Error {
   constructor(
     message: string,
+    public readonly reason: SAMLIdentityResolutionFailureReason,
     public readonly missingRequiredFields?: Array<{
       fieldKey: string;
       label: string;
       fieldType: string;
-    }>
+    }>,
+    public readonly auditDetails?: Record<string, unknown>
   ) {
     super(message);
     this.name = 'SamlProvisioningError';
@@ -1080,6 +1176,7 @@ class SamlProvisioningError extends Error {
 function extractUserInfo(assertion: SAMLAssertion, idpConfig: SAMLIdPConfig): UserInfo {
   const userInfo: UserInfo = {
     nameId: assertion.subject.nameId,
+    nameIdFormat: assertion.subject.nameIdFormat,
     attributes: {},
     customClaims: {},
   };
@@ -1127,7 +1224,7 @@ async function findOrCreateUser(
   userInfo: UserInfo,
   idpConfig: SAMLIdPConfig,
   tenantId: string
-): Promise<string> {
+): Promise<SAMLIdentityResolution> {
   const userStoreSources = await resolveUserStoreRuntimeSourcesFromEnv(env, tenantId);
   const coreAdapter: DatabaseAdapter = ensureDatabaseAdapter(
     userStoreSources.coreDb,
@@ -1136,27 +1233,142 @@ async function findOrCreateUser(
   const piiAdapter: DatabaseAdapter | null = userStoreSources.piiDb
     ? ensureDatabaseAdapter(userStoreSources.piiDb, 'saml-acs-pii')
     : null;
-  const customClaimSources = await resolveCustomClaimRuntimeSourcesFromEnv(env, tenantId);
+  const linkedIdentityAdapter = piiAdapter ?? coreAdapter;
+  const providerId = idpConfig.entityId;
+  const providerUserKey = buildSAMLProviderUserKey(userInfo);
+  const normalizedEmail = normalizeEmail(userInfo.email);
+  const jitEmailLinkingPolicy = resolveJitEmailLinkingPolicy(idpConfig);
+
+  const existingLink = await findSAMLLinkedIdentity(
+    linkedIdentityAdapter,
+    tenantId,
+    providerId,
+    providerUserKey
+  );
+  if (existingLink) {
+    const activeUser = await findActiveUser(coreAdapter, tenantId, existingLink.user_id);
+    if (!activeUser) {
+      throw new SamlProvisioningError(
+        'SAML linked identity points to an inactive user',
+        'linked_identity_inactive_user',
+        undefined,
+        { linked_identity_id: existingLink.id }
+      );
+    }
+
+    if (normalizedEmail && piiAdapter) {
+      const emailUser = await findUserIdByEmail(piiAdapter, tenantId, normalizedEmail);
+      if (emailUser && emailUser.id !== activeUser.id) {
+        throw new SamlProvisioningError(
+          'SAML linked identity email conflicts with another local user',
+          'linked_identity_email_conflict',
+          undefined,
+          { linked_identity_id: existingLink.id }
+        );
+      }
+    }
+
+    await touchSAMLLinkedIdentity(
+      linkedIdentityAdapter,
+      tenantId,
+      existingLink.id,
+      Boolean(piiAdapter)
+    );
+    return {
+      userId: activeUser.id,
+      action: 'existing_link',
+      linkedIdentityId: existingLink.id,
+    };
+  }
 
   // Try to find user by email (PII/Non-PII DB separation)
-  if (userInfo.email && piiAdapter) {
+  if (normalizedEmail && piiAdapter) {
     const existingUserPII = await piiAdapter.queryOne<{ id: string }>(
       'SELECT id FROM users_pii WHERE tenant_id = ? AND email = ?',
-      [tenantId, userInfo.email.toLowerCase()]
+      [tenantId, normalizedEmail]
     );
 
     if (existingUserPII) {
-      // Verify user is active in Core DB
-      const userCore = await coreAdapter.queryOne<{ id: string }>(
-        'SELECT id FROM users_core WHERE id = ? AND tenant_id = ? AND is_active = 1',
-        [existingUserPII.id, tenantId]
-      );
-      if (userCore) {
-        return userCore.id;
+      if (jitEmailLinkingPolicy !== 'email_linking') {
+        throw new SamlProvisioningError(
+          'SAML email matched an existing user but email linking is disabled for this IdP',
+          'email_linking_disabled',
+          undefined,
+          { policy: jitEmailLinkingPolicy }
+        );
       }
+
+      const activeUser = await findActiveUser(coreAdapter, tenantId, existingUserPII.id);
+      if (!activeUser) {
+        throw new SamlProvisioningError(
+          'SAML email matched an inactive user',
+          'email_match_inactive_user'
+        );
+      }
+      if (!isTruthyDatabaseFlag(activeUser.email_verified)) {
+        throw new SamlProvisioningError(
+          'SAML email matched a local user with unverified email',
+          'email_match_unverified_local_email'
+        );
+      }
+
+      const existingUserProviderLink = await findUserSAMLLinkedIdentityForProvider(
+        linkedIdentityAdapter,
+        tenantId,
+        activeUser.id,
+        providerId
+      );
+      if (
+        existingUserProviderLink &&
+        existingUserProviderLink.provider_user_id !== providerUserKey
+      ) {
+        throw new SamlProvisioningError(
+          'SAML email matched a user already linked to a different subject for this IdP',
+          'email_match_provider_subject_conflict',
+          undefined,
+          { linked_identity_id: existingUserProviderLink.id }
+        );
+      }
+      if (existingUserProviderLink) {
+        await touchSAMLLinkedIdentity(
+          linkedIdentityAdapter,
+          tenantId,
+          existingUserProviderLink.id,
+          Boolean(piiAdapter)
+        );
+        return {
+          userId: activeUser.id,
+          action: 'email_link',
+          linkedIdentityId: existingUserProviderLink.id,
+        };
+      }
+
+      const linkedIdentityId = await createSAMLLinkedIdentity({
+        adapter: linkedIdentityAdapter,
+        tenantId,
+        userId: activeUser.id,
+        providerId,
+        providerUserKey,
+        userInfo: { ...userInfo, email: normalizedEmail },
+        piiShape: Boolean(piiAdapter),
+      });
+
+      return {
+        userId: activeUser.id,
+        action: 'email_link',
+        linkedIdentityId,
+      };
     }
   }
 
+  if (jitEmailLinkingPolicy === 'disabled') {
+    throw new SamlProvisioningError(
+      'SAML JIT provisioning is disabled for this IdP',
+      'jit_disabled'
+    );
+  }
+
+  const customClaimSources = await resolveCustomClaimRuntimeSourcesFromEnv(env, tenantId);
   const customClaimValidation = await validateCustomClaimWrite({
     db: customClaimSources.nonPiiDb,
     dbPii: customClaimSources.piiDb,
@@ -1169,6 +1381,7 @@ async function findOrCreateUser(
   if (!customClaimValidation.ok) {
     throw new SamlProvisioningError(
       customClaimValidation.error,
+      'custom_claim_validation_failed',
       customClaimValidation.missingRequiredFields
     );
   }
@@ -1176,12 +1389,13 @@ async function findOrCreateUser(
   // Create new user (JIT provisioning - PII/Non-PII DB separation)
   const userId = crypto.randomUUID();
   const now = Math.floor(Date.now() / 1000);
-  if (!userInfo.email && !idpConfig.allowSyntheticEmailFallback) {
+  if (!normalizedEmail && !idpConfig.allowSyntheticEmailFallback) {
     throw new SamlProvisioningError(
-      'SAML JIT provisioning requires an email unless synthetic email fallback is explicitly enabled'
+      'SAML JIT provisioning requires an email unless synthetic email fallback is explicitly enabled',
+      'missing_email'
     );
   }
-  const email = userInfo.email?.toLowerCase() || `${userInfo.nameId}@saml.local`;
+  const email = normalizedEmail || (await buildSyntheticSAMLEmail(providerUserKey));
 
   // Step 1: Insert into users_core with pii_status='pending'
   await coreAdapter.execute(
@@ -1214,37 +1428,260 @@ async function findOrCreateUser(
       userId,
       validation: customClaimValidation,
     });
-  } catch (persistError) {
-    if (piiAdapter) {
-      await piiAdapter.execute('DELETE FROM users_pii WHERE id = ? AND tenant_id = ?', [
-        userId,
-        tenantId,
-      ]);
-    }
-    await ensureDatabaseAdapter(
-      customClaimSources.nonPiiDb,
-      'saml-acs-custom-claim-cleanup'
-    ).execute('DELETE FROM user_custom_fields WHERE user_id = ? AND tenant_id = ?', [
+
+    await syncUserLifecycleState({
+      db: customClaimSources.nonPiiDb,
+      dbPii: customClaimSources.piiDb,
+      schemaDb: customClaimSources.schemaDb,
+      stateDb: coreAdapter,
+      tenantId,
+      userId,
+    });
+
+    const linkedIdentityId = await createSAMLLinkedIdentity({
+      adapter: linkedIdentityAdapter,
+      tenantId,
+      userId,
+      providerId,
+      providerUserKey,
+      userInfo: { ...userInfo, email },
+      piiShape: Boolean(piiAdapter),
+    });
+
+    return {
+      userId,
+      action: 'jit_create',
+      linkedIdentityId,
+    };
+  } catch (jitError) {
+    await cleanupSAMLJitUser({
+      coreAdapter,
+      piiAdapter,
+      customClaimDb: customClaimSources.nonPiiDb,
       userId,
       tenantId,
-    ]);
-    await coreAdapter.execute('DELETE FROM users_core WHERE id = ? AND tenant_id = ?', [
-      userId,
-      tenantId,
-    ]);
-    throw persistError;
+    });
+    throw jitError;
+  }
+}
+
+async function cleanupSAMLJitUser(params: {
+  coreAdapter: DatabaseAdapter;
+  piiAdapter: DatabaseAdapter | null;
+  customClaimDb: Parameters<typeof ensureDatabaseAdapter>[0];
+  userId: string;
+  tenantId: string;
+}): Promise<void> {
+  const operations: Array<Promise<unknown>> = [];
+  if (params.piiAdapter) {
+    operations.push(
+      params.piiAdapter.execute('DELETE FROM users_pii WHERE id = ? AND tenant_id = ?', [
+        params.userId,
+        params.tenantId,
+      ])
+    );
+  }
+  operations.push(
+    ensureDatabaseAdapter(params.customClaimDb, 'saml-acs-custom-claim-cleanup').execute(
+      'DELETE FROM user_custom_fields WHERE user_id = ? AND tenant_id = ?',
+      [params.userId, params.tenantId]
+    )
+  );
+  operations.push(
+    params.coreAdapter.execute('DELETE FROM users_core WHERE id = ? AND tenant_id = ?', [
+      params.userId,
+      params.tenantId,
+    ])
+  );
+
+  await Promise.allSettled(operations);
+}
+
+function buildSAMLProviderUserKey(userInfo: UserInfo): string {
+  return `saml:${encodeURIComponent(userInfo.nameIdFormat)}:${encodeURIComponent(userInfo.nameId)}`;
+}
+
+async function buildSyntheticSAMLEmail(providerUserKey: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(providerUserKey));
+  const localPart = Array.from(new Uint8Array(digest).slice(0, 16))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+  return `saml-${localPart}@saml.local`;
+}
+
+function normalizeEmail(email: string | undefined): string | undefined {
+  const normalized = email?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function resolveJitEmailLinkingPolicy(
+  idpConfig: SAMLIdPConfig
+): 'email_linking' | 'jit_create_only' | 'disabled' {
+  const policy = idpConfig.jitEmailLinkingPolicy ?? 'email_linking';
+  if (SAML_JIT_EMAIL_LINKING_POLICIES.has(policy)) {
+    return policy;
+  }
+  throw new SamlProvisioningError(
+    'SAML IdP has an invalid JIT email linking policy',
+    'jit_policy_invalid',
+    undefined,
+    { policy: 'invalid' }
+  );
+}
+
+function isTruthyDatabaseFlag(value: SAMLActiveUserRow['email_verified']): boolean {
+  return value === true || value === 1 || value === '1';
+}
+
+async function findSAMLLinkedIdentity(
+  adapter: DatabaseAdapter,
+  tenantId: string,
+  providerId: string,
+  providerUserKey: string
+): Promise<SAMLLinkedIdentityRow | null> {
+  return adapter.queryOne<SAMLLinkedIdentityRow>(
+    `SELECT id, user_id, provider_user_id FROM linked_identities
+     WHERE tenant_id = ? AND provider_id = ? AND provider_user_id = ?`,
+    [tenantId, providerId, providerUserKey]
+  );
+}
+
+async function findUserSAMLLinkedIdentityForProvider(
+  adapter: DatabaseAdapter,
+  tenantId: string,
+  userId: string,
+  providerId: string
+): Promise<SAMLLinkedIdentityRow | null> {
+  return adapter.queryOne<SAMLLinkedIdentityRow>(
+    `SELECT id, user_id, provider_user_id FROM linked_identities
+     WHERE tenant_id = ? AND user_id = ? AND provider_id = ?`,
+    [tenantId, userId, providerId]
+  );
+}
+
+async function findUserIdByEmail(
+  adapter: DatabaseAdapter,
+  tenantId: string,
+  email: string
+): Promise<{ id: string } | null> {
+  return adapter.queryOne<{ id: string }>(
+    'SELECT id FROM users_pii WHERE tenant_id = ? AND email = ?',
+    [tenantId, email]
+  );
+}
+
+async function findActiveUser(
+  adapter: DatabaseAdapter,
+  tenantId: string,
+  userId: string
+): Promise<SAMLActiveUserRow | null> {
+  return adapter.queryOne<SAMLActiveUserRow>(
+    'SELECT id, email_verified FROM users_core WHERE id = ? AND tenant_id = ? AND is_active = 1',
+    [userId, tenantId]
+  );
+}
+
+async function touchSAMLLinkedIdentity(
+  adapter: DatabaseAdapter,
+  tenantId: string,
+  linkedIdentityId: string,
+  piiShape: boolean
+): Promise<void> {
+  const now = Date.now();
+  if (piiShape) {
+    await adapter.execute(
+      'UPDATE linked_identities SET last_used_at = ? WHERE tenant_id = ? AND id = ?',
+      [now, tenantId, linkedIdentityId]
+    );
+    return;
   }
 
-  await syncUserLifecycleState({
-    db: customClaimSources.nonPiiDb,
-    dbPii: customClaimSources.piiDb,
-    schemaDb: customClaimSources.schemaDb,
-    stateDb: coreAdapter,
-    tenantId,
-    userId,
+  await adapter.execute(
+    'UPDATE linked_identities SET last_login_at = ?, updated_at = ? WHERE tenant_id = ? AND id = ?',
+    [now, now, tenantId, linkedIdentityId]
+  );
+}
+
+async function createSAMLLinkedIdentity(params: {
+  adapter: DatabaseAdapter;
+  tenantId: string;
+  userId: string;
+  providerId: string;
+  providerUserKey: string;
+  userInfo: UserInfo;
+  piiShape: boolean;
+}): Promise<string> {
+  const id = crypto.randomUUID();
+  const now = Date.now();
+  const rawAttributes = JSON.stringify({
+    source: 'saml_sp_acs',
+    nameId: params.userInfo.nameId,
+    nameIdFormat: params.userInfo.nameIdFormat,
+    attributes: params.userInfo.attributes,
+    customClaims: params.userInfo.customClaims,
   });
 
-  return userId;
+  try {
+    if (params.piiShape) {
+      await params.adapter.execute(
+        `INSERT INTO linked_identities (
+          id, tenant_id, user_id, provider_id, provider_user_id,
+          provider_email, provider_name, raw_attributes, linked_at, last_used_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          id,
+          params.tenantId,
+          params.userId,
+          params.providerId,
+          params.providerUserKey,
+          normalizeEmail(params.userInfo.email) ?? null,
+          params.userInfo.name ?? null,
+          rawAttributes,
+          now,
+          now,
+        ]
+      );
+      return id;
+    }
+
+    await params.adapter.execute(
+      `INSERT INTO linked_identities (
+        id, tenant_id, user_id, provider_id, provider_user_id,
+        provider_email, email_verified, access_token_encrypted, refresh_token_encrypted,
+        token_expires_at, raw_claims, profile_data, linked_at, last_login_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, 1, NULL, NULL, NULL, ?, NULL, ?, ?, ?)`,
+      [
+        id,
+        params.tenantId,
+        params.userId,
+        params.providerId,
+        params.providerUserKey,
+        normalizeEmail(params.userInfo.email) ?? null,
+        rawAttributes,
+        now,
+        now,
+        now,
+      ]
+    );
+    return id;
+  } catch (error) {
+    const existing = await findSAMLLinkedIdentity(
+      params.adapter,
+      params.tenantId,
+      params.providerId,
+      params.providerUserKey
+    );
+    if (existing?.user_id === params.userId) {
+      return existing.id;
+    }
+    if (existing) {
+      throw new SamlProvisioningError(
+        'SAML linked identity subject conflicts with another user',
+        'linked_identity_subject_conflict'
+      );
+    }
+    throw error;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Implement SAML federated identity resolution for ACS using stable linked identity subjects derived from IdP entityID, NameIDFormat, and NameID.
- Add JIT linking policy support for `email_linking`, `jit_create_only`, and `disabled`, with fail-closed handling for inactive users, unverified local email, subject conflicts, email conflicts, insert races, disabled JIT, and invalid stored policies.
- Add Admin API validation/default normalization and Admin UI controls for JIT linking policy and synthetic email fallback.
- Update SAML production readiness documentation and expand ACS/Admin API test coverage.

## Security Notes

- Failure audit metadata is sanitized to avoid logging NameID, assertion email, raw provider subject keys, or invalid raw policy values.
- Synthetic fallback email is opt-in only and uses a non-PII hash-derived local value.
- Runtime rejects invalid stored JIT policies even if they bypassed the Admin API.

## Validation

- `pnpm exec vitest packages/ar-saml/src/admin/__tests__/aggregate-provider-api.test.ts packages/ar-saml/src/__tests__/saml-integration.test.ts --run`
- `pnpm --filter @authrim/ar-saml typecheck`
- `pnpm --filter @authrim/ar-saml test`
- `pnpm typecheck`
- `git diff --check`