### PR TITLE
Add identity mapping schema baseline

### DIFF
--- a/migrations/008_unified_identity_canonical_schema.sql
+++ b/migrations/008_unified_identity_canonical_schema.sql
@@ -1,0 +1,533 @@
+-- =============================================================================
+-- Unified Identity Mapping: canonical identity schema baseline
+--
+-- Runtime writes remain disabled until the canonical cutover PR. Each schema
+-- object is linked to private/docs/design/unified-identity-mapping-control-plane/
+-- schema-readiness-inventory.md by UIM-SCH-* comments.
+-- =============================================================================
+
+-- UIM-SCH-001 identity_subjects
+CREATE TABLE IF NOT EXISTS identity_subjects (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  subject_type TEXT NOT NULL,
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  display_label TEXT,
+  primary_account_id TEXT,
+  risk_tier TEXT,
+  assurance_level TEXT,
+  metadata_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  deleted_at INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_identity_subjects_tenant_type
+  ON identity_subjects(tenant_id, subject_type, lifecycle_state);
+
+-- UIM-SCH-002 identity_accounts
+CREATE TABLE IF NOT EXISTS identity_accounts (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  account_type TEXT NOT NULL,
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  legacy_user_id TEXT,
+  primary_subject_id TEXT,
+  display_label TEXT,
+  metadata_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  deleted_at INTEGER,
+  FOREIGN KEY (primary_subject_id) REFERENCES identity_subjects(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_identity_accounts_legacy_user
+  ON identity_accounts(tenant_id, legacy_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_identity_accounts_tenant_state
+  ON identity_accounts(tenant_id, account_type, lifecycle_state);
+
+-- UIM-SCH-003 subject_account_links
+CREATE TABLE IF NOT EXISTS subject_account_links (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  subject_id TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  link_type TEXT NOT NULL DEFAULT 'primary',
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  source_ref TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, subject_id, account_id, link_type),
+  FOREIGN KEY (subject_id) REFERENCES identity_subjects(id) ON DELETE CASCADE,
+  FOREIGN KEY (account_id) REFERENCES identity_accounts(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_subject_account_links_account
+  ON subject_account_links(tenant_id, account_id, lifecycle_state);
+
+-- UIM-SCH-004 profiles
+CREATE TABLE IF NOT EXISTS profiles (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  subject_id TEXT NOT NULL,
+  profile_type TEXT NOT NULL DEFAULT 'person',
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  locale TEXT,
+  zoneinfo TEXT,
+  display_name_ref TEXT,
+  metadata_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, subject_id, profile_type),
+  FOREIGN KEY (subject_id) REFERENCES identity_subjects(id) ON DELETE CASCADE
+);
+
+-- UIM-SCH-005 profile_attribute_values
+CREATE TABLE IF NOT EXISTS profile_attribute_values (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  profile_id TEXT NOT NULL,
+  catalog_entry_id TEXT NOT NULL,
+  value_type TEXT NOT NULL,
+  value_json TEXT,
+  value_storage_ref TEXT,
+  value_hash TEXT,
+  classification TEXT NOT NULL DEFAULT 'internal',
+  purpose TEXT,
+  is_primary INTEGER NOT NULL DEFAULT 0,
+  display_order INTEGER NOT NULL DEFAULT 0,
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_profile_attribute_values_profile
+  ON profile_attribute_values(tenant_id, profile_id, catalog_entry_id, lifecycle_state);
+
+-- UIM-SCH-006 structured_attribute_values
+CREATE TABLE IF NOT EXISTS structured_attribute_values (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  owner_type TEXT NOT NULL,
+  owner_id TEXT NOT NULL,
+  catalog_entry_id TEXT NOT NULL,
+  canonical_json TEXT NOT NULL,
+  projected_index_json TEXT,
+  classification TEXT NOT NULL DEFAULT 'internal',
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_structured_attribute_values_owner
+  ON structured_attribute_values(tenant_id, owner_type, owner_id, catalog_entry_id);
+
+-- UIM-SCH-007 contact_points
+CREATE TABLE IF NOT EXISTS contact_points (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  subject_id TEXT,
+  account_id TEXT,
+  contact_type TEXT NOT NULL,
+  purpose TEXT NOT NULL DEFAULT 'primary',
+  normalized_hash TEXT,
+  value_storage_ref TEXT,
+  display_label TEXT,
+  is_primary INTEGER NOT NULL DEFAULT 0,
+  verification_state TEXT NOT NULL DEFAULT 'unverified',
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (subject_id) REFERENCES identity_subjects(id) ON DELETE CASCADE,
+  FOREIGN KEY (account_id) REFERENCES identity_accounts(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_contact_points_subject
+  ON contact_points(tenant_id, subject_id, contact_type, lifecycle_state);
+
+CREATE INDEX IF NOT EXISTS idx_contact_points_lookup
+  ON contact_points(tenant_id, contact_type, normalized_hash);
+
+-- UIM-SCH-008 contact_verifications
+CREATE TABLE IF NOT EXISTS contact_verifications (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  contact_point_id TEXT NOT NULL,
+  verification_type TEXT NOT NULL,
+  verification_state TEXT NOT NULL,
+  evidence_ref TEXT,
+  verified_at INTEGER,
+  expires_at INTEGER,
+  revoked_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (contact_point_id) REFERENCES contact_points(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_contact_verifications_contact
+  ON contact_verifications(tenant_id, contact_point_id, verification_state);
+
+-- UIM-SCH-009 identity_bindings
+CREATE TABLE IF NOT EXISTS identity_bindings (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  subject_id TEXT NOT NULL,
+  account_id TEXT,
+  protocol TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  provider_subject_key_hash TEXT NOT NULL,
+  binding_kind TEXT NOT NULL DEFAULT 'external_subject',
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  assurance_level TEXT,
+  trust_context_snapshot_id TEXT,
+  metadata_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  last_seen_at INTEGER,
+  UNIQUE (tenant_id, protocol, source_id, provider_subject_key_hash),
+  FOREIGN KEY (subject_id) REFERENCES identity_subjects(id) ON DELETE CASCADE,
+  FOREIGN KEY (account_id) REFERENCES identity_accounts(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_identity_bindings_subject
+  ON identity_bindings(tenant_id, subject_id, lifecycle_state);
+
+-- UIM-SCH-010 identity_resolution_events
+CREATE TABLE IF NOT EXISTS identity_resolution_events (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  subject_id TEXT,
+  account_id TEXT,
+  binding_id TEXT,
+  source_id TEXT NOT NULL,
+  resolution_method TEXT NOT NULL,
+  outcome TEXT NOT NULL,
+  reason_codes_json TEXT,
+  trace_ref TEXT,
+  metadata_json TEXT,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (subject_id) REFERENCES identity_subjects(id) ON DELETE SET NULL,
+  FOREIGN KEY (account_id) REFERENCES identity_accounts(id) ON DELETE SET NULL,
+  FOREIGN KEY (binding_id) REFERENCES identity_bindings(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_identity_resolution_events_subject
+  ON identity_resolution_events(tenant_id, subject_id, created_at);
+
+-- UIM-SCH-011 identity_resolution_candidates
+CREATE TABLE IF NOT EXISTS identity_resolution_candidates (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  source_id TEXT NOT NULL,
+  candidate_subject_id TEXT,
+  candidate_account_id TEXT,
+  candidate_binding_id TEXT,
+  candidate_score INTEGER NOT NULL DEFAULT 0,
+  risk_tier TEXT,
+  decision_state TEXT NOT NULL DEFAULT 'pending',
+  reason_codes_json TEXT,
+  review_task_id TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_identity_resolution_candidates_state
+  ON identity_resolution_candidates(tenant_id, decision_state, created_at);
+
+-- UIM-SCH-012 subject_identifiers
+ALTER TABLE subject_identifiers ADD COLUMN destination_type TEXT DEFAULT 'global';
+ALTER TABLE subject_identifiers ADD COLUMN destination_id TEXT DEFAULT 'default';
+ALTER TABLE subject_identifiers ADD COLUMN identifier_value_hash TEXT;
+ALTER TABLE subject_identifiers ADD COLUMN identifier_storage_ref TEXT;
+ALTER TABLE subject_identifiers ADD COLUMN lifecycle_state TEXT NOT NULL DEFAULT 'active';
+
+CREATE INDEX IF NOT EXISTS idx_subject_identifiers_destination
+  ON subject_identifiers(tenant_id, subject_id, destination_type, lifecycle_state);
+
+-- UIM-SCH-013 assurance_evidence
+CREATE TABLE IF NOT EXISTS assurance_evidence (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  subject_id TEXT,
+  binding_id TEXT,
+  evidence_type TEXT NOT NULL,
+  issuer_ref TEXT,
+  assurance_framework TEXT,
+  assurance_level TEXT,
+  evidence_hash TEXT,
+  evidence_storage_ref TEXT,
+  verified_at INTEGER,
+  expires_at INTEGER,
+  revoked_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_assurance_evidence_subject
+  ON assurance_evidence(tenant_id, subject_id, evidence_type, expires_at);
+
+-- UIM-SCH-014 delegations
+CREATE TABLE IF NOT EXISTS delegations (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  subject_id TEXT NOT NULL,
+  delegate_subject_id TEXT NOT NULL,
+  parent_delegation_id TEXT,
+  chain_id TEXT,
+  delegation_type TEXT NOT NULL,
+  lifecycle_state TEXT NOT NULL DEFAULT 'draft',
+  scope_json TEXT,
+  starts_at INTEGER,
+  expires_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-015 entitlements
+CREATE TABLE IF NOT EXISTS entitlements (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  subject_id TEXT,
+  account_id TEXT,
+  entitlement_type TEXT NOT NULL,
+  entitlement_key TEXT NOT NULL,
+  source_id TEXT,
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  value_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, entitlement_type, entitlement_key, subject_id, account_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_entitlements_subject
+  ON entitlements(tenant_id, subject_id, entitlement_type, lifecycle_state);
+
+-- UIM-SCH-035 value_provenance
+CREATE TABLE IF NOT EXISTS value_provenance (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  owner_table TEXT NOT NULL,
+  owner_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  source_record_id TEXT,
+  source_field_ref TEXT,
+  source_authority_contract_id TEXT,
+  observed_at INTEGER NOT NULL,
+  confidence_score INTEGER,
+  provenance_json TEXT,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_value_provenance_owner
+  ON value_provenance(tenant_id, owner_table, owner_id, observed_at);
+
+-- UIM-SCH-041 contact_point_search_indexes
+CREATE TABLE IF NOT EXISTS contact_point_search_indexes (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  contact_point_id TEXT NOT NULL,
+  index_kind TEXT NOT NULL,
+  index_value TEXT NOT NULL,
+  index_version INTEGER NOT NULL DEFAULT 1,
+  classification TEXT NOT NULL DEFAULT 'internal',
+  status TEXT NOT NULL DEFAULT 'active',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, index_kind, index_value, index_version),
+  FOREIGN KEY (contact_point_id) REFERENCES contact_points(id) ON DELETE CASCADE
+);
+
+-- UIM-SCH-042 identity_binding_lookup_indexes
+CREATE TABLE IF NOT EXISTS identity_binding_lookup_indexes (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  identity_binding_id TEXT NOT NULL,
+  lookup_kind TEXT NOT NULL,
+  lookup_value TEXT NOT NULL,
+  lookup_version INTEGER NOT NULL DEFAULT 1,
+  status TEXT NOT NULL DEFAULT 'active',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, lookup_kind, lookup_value, lookup_version),
+  FOREIGN KEY (identity_binding_id) REFERENCES identity_bindings(id) ON DELETE CASCADE
+);
+
+-- UIM-SCH-061 groups
+CREATE TABLE IF NOT EXISTS "groups" (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  group_key TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  description TEXT,
+  parent_group_id TEXT,
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  metadata_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, group_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_groups_tenant_state
+  ON "groups"(tenant_id, lifecycle_state, display_name);
+
+-- UIM-SCH-062 group_memberships
+CREATE TABLE IF NOT EXISTS group_memberships (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  group_id TEXT NOT NULL,
+  subject_id TEXT,
+  account_id TEXT,
+  membership_type TEXT NOT NULL DEFAULT 'member',
+  assignment_source TEXT NOT NULL DEFAULT 'manual',
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  starts_at INTEGER,
+  expires_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, group_id, subject_id, account_id, membership_type),
+  FOREIGN KEY (group_id) REFERENCES "groups"(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_group_memberships_subject
+  ON group_memberships(tenant_id, subject_id, lifecycle_state);
+
+-- UIM-SCH-063 provisioning_assignment_rules
+CREATE TABLE IF NOT EXISTS provisioning_assignment_rules (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  scope_type TEXT NOT NULL,
+  scope_id TEXT,
+  rule_type TEXT NOT NULL,
+  target_type TEXT NOT NULL,
+  target_id TEXT NOT NULL,
+  condition_json TEXT NOT NULL,
+  priority INTEGER NOT NULL DEFAULT 0,
+  lifecycle_state TEXT NOT NULL DEFAULT 'draft',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-064 provisioning_assignment_events
+CREATE TABLE IF NOT EXISTS provisioning_assignment_events (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  rule_id TEXT,
+  subject_id TEXT,
+  account_id TEXT,
+  target_type TEXT NOT NULL,
+  target_id TEXT NOT NULL,
+  outcome TEXT NOT NULL,
+  reason_codes_json TEXT,
+  trace_ref TEXT,
+  created_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-065 org_domain_mappings migration
+ALTER TABLE org_domain_mappings ADD COLUMN group_id TEXT;
+ALTER TABLE org_domain_mappings ADD COLUMN provisioning_assignment_rule_id TEXT;
+ALTER TABLE org_domain_mappings ADD COLUMN org_to_group_migration_state TEXT DEFAULT 'pending';
+
+-- UIM-SCH-066 provisioning_assignment_ownership
+CREATE TABLE IF NOT EXISTS provisioning_assignment_ownership (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  assignment_type TEXT NOT NULL,
+  assignment_id TEXT NOT NULL,
+  source_id TEXT,
+  ownership_policy TEXT NOT NULL DEFAULT 'source_owned',
+  revoke_policy TEXT NOT NULL DEFAULT 'review',
+  protected_until INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, assignment_type, assignment_id, source_id)
+);
+
+-- UIM-SCH-067 provisioning_revocation_events
+CREATE TABLE IF NOT EXISTS provisioning_revocation_events (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  subject_id TEXT,
+  account_id TEXT,
+  source_event_id TEXT,
+  target_type TEXT NOT NULL,
+  target_id TEXT NOT NULL,
+  decision TEXT NOT NULL,
+  reason_codes_json TEXT,
+  created_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-068 external_lifecycle_signal_events
+CREATE TABLE IF NOT EXISTS external_lifecycle_signal_events (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  source_type TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  source_event_id TEXT NOT NULL,
+  source_timestamp INTEGER,
+  observed_at INTEGER NOT NULL,
+  binding_version TEXT,
+  payload_ref TEXT,
+  signal_type TEXT NOT NULL,
+  dedupe_key TEXT NOT NULL,
+  processing_state TEXT NOT NULL DEFAULT 'pending',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, source_type, source_id, dedupe_key)
+);
+
+-- UIM-SCH-069 external_lifecycle_signal_decisions
+CREATE TABLE IF NOT EXISTS external_lifecycle_signal_decisions (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  signal_event_id TEXT NOT NULL,
+  subject_id TEXT,
+  account_id TEXT,
+  decision TEXT NOT NULL,
+  propagation_targets_json TEXT,
+  reason_codes_json TEXT,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (signal_event_id) REFERENCES external_lifecycle_signal_events(id) ON DELETE CASCADE
+);
+
+-- UIM-SCH-070 subject_lifecycle_timeline_events
+CREATE TABLE IF NOT EXISTS subject_lifecycle_timeline_events (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  subject_id TEXT,
+  account_id TEXT,
+  event_type TEXT NOT NULL,
+  source_type TEXT,
+  source_id TEXT,
+  summary_json TEXT,
+  event_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_subject_lifecycle_timeline_subject
+  ON subject_lifecycle_timeline_events(tenant_id, subject_id, event_at);
+
+-- UIM-SCH-088 attribute_release_consents
+CREATE TABLE IF NOT EXISTS attribute_release_consents (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  subject_id TEXT NOT NULL,
+  account_id TEXT,
+  destination_type TEXT NOT NULL,
+  destination_id TEXT NOT NULL,
+  attribute_set_hash TEXT NOT NULL,
+  consent_mode TEXT NOT NULL,
+  consent_state TEXT NOT NULL DEFAULT 'granted',
+  consent_record_id TEXT,
+  first_granted_at INTEGER,
+  last_confirmed_at INTEGER,
+  expires_at INTEGER,
+  revoked_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, subject_id, destination_type, destination_id, attribute_set_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_attribute_release_consents_destination
+  ON attribute_release_consents(tenant_id, destination_type, destination_id, consent_state);

--- a/migrations/admin/007_identity_mapping_control_plane_schema.sql
+++ b/migrations/admin/007_identity_mapping_control_plane_schema.sql
@@ -1,0 +1,772 @@
+-- =============================================================================
+-- Unified Identity Mapping: control-plane schema baseline
+--
+-- This migration adds policy, catalog, federation, review, activation, and key
+-- control-plane tables. Runtime paths remain disabled until later rollout PRs.
+-- Each object is linked to schema-readiness-inventory.md by UIM-SCH-* comments.
+-- =============================================================================
+
+-- UIM-SCH-016 mapping_policy_sets
+CREATE TABLE IF NOT EXISTS mapping_policy_sets (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  policy_key TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  description TEXT,
+  owner_scope_type TEXT NOT NULL DEFAULT 'tenant',
+  owner_scope_id TEXT,
+  lifecycle_state TEXT NOT NULL DEFAULT 'draft',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, policy_key)
+);
+
+-- UIM-SCH-017 mapping_policy_versions
+CREATE TABLE IF NOT EXISTS mapping_policy_versions (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  policy_set_id TEXT NOT NULL,
+  version_label TEXT NOT NULL,
+  lifecycle_state TEXT NOT NULL DEFAULT 'draft',
+  policy_hash TEXT NOT NULL,
+  compatibility_range TEXT,
+  author_id TEXT,
+  published_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, policy_set_id, version_label),
+  FOREIGN KEY (policy_set_id) REFERENCES mapping_policy_sets(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_mapping_policy_versions_state
+  ON mapping_policy_versions(tenant_id, lifecycle_state, updated_at);
+
+-- UIM-SCH-018 mapping_rules
+CREATE TABLE IF NOT EXISTS mapping_rules (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  policy_version_id TEXT NOT NULL,
+  rule_key TEXT NOT NULL,
+  rule_kind TEXT NOT NULL,
+  action TEXT NOT NULL,
+  priority INTEGER NOT NULL DEFAULT 0,
+  scope_json TEXT,
+  condition_json TEXT,
+  metadata_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, policy_version_id, rule_key),
+  FOREIGN KEY (policy_version_id) REFERENCES mapping_policy_versions(id) ON DELETE CASCADE
+);
+
+-- UIM-SCH-019 mapping_rule_edges
+CREATE TABLE IF NOT EXISTS mapping_rule_edges (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  rule_id TEXT NOT NULL,
+  source_ref_json TEXT NOT NULL,
+  target_ref_json TEXT NOT NULL,
+  edge_kind TEXT NOT NULL DEFAULT 'direct',
+  display_order INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (rule_id) REFERENCES mapping_rules(id) ON DELETE CASCADE
+);
+
+-- UIM-SCH-020 mapping_transform_steps
+CREATE TABLE IF NOT EXISTS mapping_transform_steps (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  rule_id TEXT NOT NULL,
+  edge_id TEXT,
+  step_order INTEGER NOT NULL,
+  operation TEXT NOT NULL,
+  parameters_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, rule_id, edge_id, step_order),
+  FOREIGN KEY (rule_id) REFERENCES mapping_rules(id) ON DELETE CASCADE,
+  FOREIGN KEY (edge_id) REFERENCES mapping_rule_edges(id) ON DELETE CASCADE
+);
+
+-- UIM-SCH-021 mapping_validation_rules
+CREATE TABLE IF NOT EXISTS mapping_validation_rules (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  rule_id TEXT,
+  target_ref_json TEXT NOT NULL,
+  validation_kind TEXT NOT NULL,
+  severity TEXT NOT NULL DEFAULT 'error',
+  parameters_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (rule_id) REFERENCES mapping_rules(id) ON DELETE CASCADE
+);
+
+-- UIM-SCH-022 mapping_release_rules
+CREATE TABLE IF NOT EXISTS mapping_release_rules (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  policy_version_id TEXT NOT NULL,
+  destination_type TEXT NOT NULL,
+  destination_id TEXT,
+  source_ref_json TEXT NOT NULL,
+  release_action TEXT NOT NULL,
+  legal_basis TEXT,
+  purpose TEXT,
+  condition_json TEXT,
+  priority INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (policy_version_id) REFERENCES mapping_policy_versions(id) ON DELETE CASCADE
+);
+
+-- UIM-SCH-023 mapping_conflict_rules
+CREATE TABLE IF NOT EXISTS mapping_conflict_rules (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  policy_version_id TEXT NOT NULL,
+  target_ref_json TEXT NOT NULL,
+  conflict_strategy TEXT NOT NULL,
+  source_priority_json TEXT,
+  condition_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (policy_version_id) REFERENCES mapping_policy_versions(id) ON DELETE CASCADE
+);
+
+-- UIM-SCH-024 mapping_policy_activations
+CREATE TABLE IF NOT EXISTS mapping_policy_activations (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  policy_set_id TEXT NOT NULL,
+  policy_version_id TEXT NOT NULL,
+  activation_scope_json TEXT NOT NULL,
+  lifecycle_state TEXT NOT NULL DEFAULT 'scheduled',
+  active_from INTEGER,
+  active_until INTEGER,
+  activated_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (policy_set_id) REFERENCES mapping_policy_sets(id) ON DELETE CASCADE,
+  FOREIGN KEY (policy_version_id) REFERENCES mapping_policy_versions(id) ON DELETE CASCADE
+);
+
+-- UIM-SCH-025 compiled_mapping_snapshots
+CREATE TABLE IF NOT EXISTS compiled_mapping_snapshots (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  policy_version_id TEXT NOT NULL,
+  catalog_version_id TEXT,
+  snapshot_hash TEXT NOT NULL,
+  compatibility_range TEXT,
+  artifact_ref TEXT,
+  lifecycle_state TEXT NOT NULL DEFAULT 'draft',
+  compiled_at INTEGER NOT NULL,
+  activated_at INTEGER,
+  expires_at INTEGER,
+  metadata_json TEXT,
+  FOREIGN KEY (policy_version_id) REFERENCES mapping_policy_versions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_compiled_mapping_snapshots_state
+  ON compiled_mapping_snapshots(tenant_id, lifecycle_state, activated_at);
+
+-- UIM-SCH-026 field_catalogs
+CREATE TABLE IF NOT EXISTS field_catalogs (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  catalog_key TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  lifecycle_state TEXT NOT NULL DEFAULT 'draft',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, catalog_key)
+);
+
+-- UIM-SCH-027 field_catalog_versions
+CREATE TABLE IF NOT EXISTS field_catalog_versions (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  catalog_id TEXT NOT NULL,
+  version_label TEXT NOT NULL,
+  bundle_hash TEXT NOT NULL,
+  compatibility_range TEXT,
+  lifecycle_state TEXT NOT NULL DEFAULT 'draft',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, catalog_id, version_label),
+  FOREIGN KEY (catalog_id) REFERENCES field_catalogs(id) ON DELETE CASCADE
+);
+
+-- UIM-SCH-028 field_catalog_entries
+CREATE TABLE IF NOT EXISTS field_catalog_entries (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  catalog_version_id TEXT NOT NULL,
+  stable_field_id TEXT NOT NULL,
+  namespace TEXT NOT NULL,
+  path TEXT NOT NULL,
+  target_taxonomy TEXT NOT NULL,
+  value_type TEXT NOT NULL,
+  cardinality TEXT NOT NULL DEFAULT 'single',
+  classification TEXT NOT NULL DEFAULT 'internal',
+  aliases_json TEXT,
+  validation_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, catalog_version_id, stable_field_id),
+  FOREIGN KEY (catalog_version_id) REFERENCES field_catalog_versions(id) ON DELETE CASCADE
+);
+
+-- UIM-SCH-029 custom_field_catalog_entries
+CREATE TABLE IF NOT EXISTS custom_field_catalog_entries (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  catalog_entry_id TEXT,
+  custom_key TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  value_type TEXT NOT NULL,
+  classification TEXT NOT NULL DEFAULT 'internal',
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, custom_key)
+);
+
+-- UIM-SCH-030 protocol_schema_catalogs
+CREATE TABLE IF NOT EXISTS protocol_schema_catalogs (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  protocol TEXT NOT NULL,
+  schema_key TEXT NOT NULL,
+  schema_version TEXT,
+  schema_json TEXT NOT NULL,
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, protocol, schema_key, schema_version)
+);
+
+-- UIM-SCH-031 external_schema_catalogs
+CREATE TABLE IF NOT EXISTS external_schema_catalogs (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  source_type TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  schema_key TEXT NOT NULL,
+  schema_json TEXT NOT NULL,
+  imported_at INTEGER NOT NULL,
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-032 mapping_templates
+CREATE TABLE IF NOT EXISTS mapping_templates (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  template_key TEXT NOT NULL,
+  template_scope TEXT NOT NULL DEFAULT 'system',
+  display_name TEXT NOT NULL,
+  template_json TEXT NOT NULL,
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, template_key)
+);
+
+-- UIM-SCH-033 source_authority_contracts
+CREATE TABLE IF NOT EXISTS source_authority_contracts (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  source_type TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  field_ref_json TEXT NOT NULL,
+  authority_actions_json TEXT NOT NULL,
+  condition_json TEXT,
+  priority INTEGER NOT NULL DEFAULT 0,
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-034 mapping_events
+CREATE TABLE IF NOT EXISTS mapping_events (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  event_type TEXT NOT NULL,
+  policy_version_id TEXT,
+  subject_id TEXT,
+  source_id TEXT,
+  outcome TEXT NOT NULL,
+  reason_codes_json TEXT,
+  trace_ref TEXT,
+  created_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-036 projection_outbox
+CREATE TABLE IF NOT EXISTS projection_outbox (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  event_type TEXT NOT NULL,
+  subject_id TEXT,
+  aggregate_type TEXT NOT NULL,
+  aggregate_id TEXT NOT NULL,
+  payload_json TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  available_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-037 projection_jobs
+CREATE TABLE IF NOT EXISTS projection_jobs (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  job_type TEXT NOT NULL,
+  scope_json TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'queued',
+  cursor_json TEXT,
+  started_at INTEGER,
+  completed_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-038 replay_jobs
+CREATE TABLE IF NOT EXISTS replay_jobs (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  replay_type TEXT NOT NULL,
+  impact_scope_json TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'queued',
+  cursor_json TEXT,
+  result_summary_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-039 dependency_graph_snapshots
+CREATE TABLE IF NOT EXISTS dependency_graph_snapshots (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  policy_version_id TEXT,
+  snapshot_hash TEXT NOT NULL,
+  graph_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-040 tenant_discovery_indexes adjustments
+ALTER TABLE tenant_discovery_indexes ADD COLUMN mapping_snapshot_id TEXT;
+ALTER TABLE tenant_discovery_indexes ADD COLUMN source_projection_version TEXT;
+
+-- UIM-SCH-043 admin_search_projections
+CREATE TABLE IF NOT EXISTS admin_search_projections (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  subject_id TEXT,
+  account_id TEXT,
+  projection_kind TEXT NOT NULL,
+  projection_json TEXT NOT NULL,
+  classification TEXT NOT NULL DEFAULT 'internal',
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  indexed_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-044 review_tasks
+CREATE TABLE IF NOT EXISTS review_tasks (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  task_type TEXT NOT NULL,
+  subject_id TEXT,
+  account_id TEXT,
+  status TEXT NOT NULL DEFAULT 'open',
+  priority INTEGER NOT NULL DEFAULT 0,
+  assigned_to TEXT,
+  payload_json TEXT NOT NULL,
+  due_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-045 review_task_groups
+CREATE TABLE IF NOT EXISTS review_task_groups (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  group_key TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'open',
+  summary_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, group_key)
+);
+
+-- UIM-SCH-046 operational_notification_states
+CREATE TABLE IF NOT EXISTS operational_notification_states (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  notification_event_id TEXT,
+  subject_type TEXT NOT NULL,
+  subject_id TEXT NOT NULL,
+  state TEXT NOT NULL DEFAULT 'open',
+  assigned_to TEXT,
+  acknowledged_at INTEGER,
+  resolved_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-047 mapping_activation_leases
+CREATE TABLE IF NOT EXISTS mapping_activation_leases (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  lease_key TEXT NOT NULL,
+  holder_id TEXT NOT NULL,
+  expires_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, lease_key)
+);
+
+-- UIM-SCH-048 idempotency_records
+CREATE TABLE IF NOT EXISTS idempotency_records (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  idempotency_key TEXT NOT NULL,
+  operation_key TEXT NOT NULL,
+  request_hash TEXT NOT NULL,
+  response_ref TEXT,
+  status TEXT NOT NULL DEFAULT 'in_progress',
+  expires_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, operation_key, idempotency_key)
+);
+
+-- UIM-SCH-049 key_registries
+CREATE TABLE IF NOT EXISTS key_registries (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  key_purpose TEXT NOT NULL,
+  scope_json TEXT NOT NULL,
+  active_version_id TEXT,
+  status TEXT NOT NULL DEFAULT 'active',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-050 key_versions
+CREATE TABLE IF NOT EXISTS key_versions (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  key_registry_id TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  algorithm TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  activated_at INTEGER,
+  retired_at INTEGER,
+  UNIQUE (tenant_id, key_registry_id, version),
+  FOREIGN KEY (key_registry_id) REFERENCES key_registries(id) ON DELETE CASCADE
+);
+
+-- UIM-SCH-051 key_material_refs
+CREATE TABLE IF NOT EXISTS key_material_refs (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  key_version_id TEXT NOT NULL,
+  backend_type TEXT NOT NULL,
+  material_ref TEXT NOT NULL,
+  metadata_json TEXT,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (key_version_id) REFERENCES key_versions(id) ON DELETE CASCADE
+);
+
+-- UIM-SCH-052 key_access_events
+CREATE TABLE IF NOT EXISTS key_access_events (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  key_registry_id TEXT NOT NULL,
+  key_version_id TEXT,
+  actor_id TEXT,
+  access_type TEXT NOT NULL,
+  outcome TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-053 blind_index_rotation_jobs
+CREATE TABLE IF NOT EXISTS blind_index_rotation_jobs (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  key_registry_id TEXT NOT NULL,
+  source_version_id TEXT,
+  target_version_id TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'queued',
+  cursor_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-054 rewrap_jobs
+CREATE TABLE IF NOT EXISTS rewrap_jobs (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  key_registry_id TEXT NOT NULL,
+  source_version_id TEXT,
+  target_version_id TEXT NOT NULL,
+  artifact_scope_json TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'queued',
+  cursor_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-055 recovery_sets
+CREATE TABLE IF NOT EXISTS recovery_sets (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  recovery_key TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'reserved',
+  manifest_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-056 recovery_set_artifacts
+CREATE TABLE IF NOT EXISTS recovery_set_artifacts (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  recovery_set_id TEXT NOT NULL,
+  artifact_type TEXT NOT NULL,
+  artifact_ref TEXT NOT NULL,
+  checksum TEXT,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (recovery_set_id) REFERENCES recovery_sets(id) ON DELETE CASCADE
+);
+
+-- UIM-SCH-057 restore_validation_jobs
+CREATE TABLE IF NOT EXISTS restore_validation_jobs (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  recovery_set_id TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'queued',
+  result_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-058 quota_policies
+CREATE TABLE IF NOT EXISTS quota_policies (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  artifact_class TEXT NOT NULL,
+  quota_json TEXT NOT NULL,
+  lifecycle_state TEXT NOT NULL DEFAULT 'reserved',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, artifact_class)
+);
+
+-- UIM-SCH-059 quota_usage_snapshots
+CREATE TABLE IF NOT EXISTS quota_usage_snapshots (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  artifact_class TEXT NOT NULL,
+  usage_json TEXT NOT NULL,
+  snapshot_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-060 retention_cleanup_jobs
+CREATE TABLE IF NOT EXISTS retention_cleanup_jobs (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  retention_scope_json TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'reserved',
+  cursor_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-071 federation_trust_sources
+CREATE TABLE IF NOT EXISTS federation_trust_sources (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  source_type TEXT NOT NULL,
+  source_key TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  lifecycle_state TEXT NOT NULL DEFAULT 'draft',
+  protocol_payload_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, source_type, source_key)
+);
+
+-- UIM-SCH-072 federation_trust_anchors
+CREATE TABLE IF NOT EXISTS federation_trust_anchors (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  trust_source_id TEXT NOT NULL,
+  anchor_type TEXT NOT NULL,
+  anchor_hash TEXT NOT NULL,
+  anchor_ref TEXT,
+  not_before INTEGER,
+  not_after INTEGER,
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (trust_source_id) REFERENCES federation_trust_sources(id) ON DELETE CASCADE
+);
+
+-- UIM-SCH-073 federation_metadata_documents
+CREATE TABLE IF NOT EXISTS federation_metadata_documents (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  trust_source_id TEXT NOT NULL,
+  document_type TEXT NOT NULL,
+  source_url TEXT,
+  document_hash TEXT NOT NULL,
+  document_ref TEXT,
+  fetched_at INTEGER,
+  validated_at INTEGER,
+  validation_state TEXT NOT NULL DEFAULT 'pending',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (trust_source_id) REFERENCES federation_trust_sources(id) ON DELETE CASCADE
+);
+
+-- UIM-SCH-074 federation_entity_statements
+CREATE TABLE IF NOT EXISTS federation_entity_statements (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  trust_source_id TEXT,
+  issuer TEXT NOT NULL,
+  subject TEXT NOT NULL,
+  statement_hash TEXT NOT NULL,
+  statement_ref TEXT,
+  expires_at INTEGER,
+  lifecycle_state TEXT NOT NULL DEFAULT 'reserved',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-075 federation_trust_chains
+CREATE TABLE IF NOT EXISTS federation_trust_chains (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  trust_source_id TEXT,
+  subject TEXT NOT NULL,
+  chain_hash TEXT NOT NULL,
+  chain_json TEXT,
+  validation_state TEXT NOT NULL DEFAULT 'reserved',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-076 saml_federation_trust_profiles migration
+ALTER TABLE saml_federation_trust_profiles ADD COLUMN federation_trust_source_id TEXT;
+ALTER TABLE saml_federation_trust_profiles ADD COLUMN normalized_migration_state TEXT DEFAULT 'pending';
+
+-- UIM-SCH-077 federation_metadata_refresh_jobs
+CREATE TABLE IF NOT EXISTS federation_metadata_refresh_jobs (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  trust_source_id TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'queued',
+  refresh_mode TEXT NOT NULL DEFAULT 'manual',
+  scheduled_for INTEGER,
+  cursor_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-078 federation_metadata_validation_events
+CREATE TABLE IF NOT EXISTS federation_metadata_validation_events (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  trust_source_id TEXT,
+  metadata_document_id TEXT,
+  validation_state TEXT NOT NULL,
+  reason_codes_json TEXT,
+  trace_ref TEXT,
+  created_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-079 federation_trust_context_snapshots
+CREATE TABLE IF NOT EXISTS federation_trust_context_snapshots (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  trust_source_id TEXT NOT NULL,
+  snapshot_hash TEXT NOT NULL,
+  trust_context_json TEXT NOT NULL,
+  lifecycle_state TEXT NOT NULL DEFAULT 'draft',
+  created_at INTEGER NOT NULL,
+  activated_at INTEGER
+);
+
+-- UIM-SCH-080 federation_trust_rank_profiles
+CREATE TABLE IF NOT EXISTS federation_trust_rank_profiles (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  profile_key TEXT NOT NULL,
+  rank_model_json TEXT NOT NULL,
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, profile_key)
+);
+
+-- UIM-SCH-081 federation_trust_fail_policies
+CREATE TABLE IF NOT EXISTS federation_trust_fail_policies (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  policy_key TEXT NOT NULL,
+  state_policy_json TEXT NOT NULL,
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, policy_key)
+);
+
+-- UIM-SCH-082 federation_trust_scope_bindings
+CREATE TABLE IF NOT EXISTS federation_trust_scope_bindings (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  trust_source_id TEXT NOT NULL,
+  scope_type TEXT NOT NULL,
+  scope_id TEXT,
+  priority INTEGER NOT NULL DEFAULT 0,
+  lifecycle_state TEXT NOT NULL DEFAULT 'active',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- UIM-SCH-083 federation_metadata_entity_summaries
+CREATE TABLE IF NOT EXISTS federation_metadata_entity_summaries (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  metadata_document_id TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  entity_role TEXT NOT NULL,
+  display_name TEXT,
+  summary_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (tenant_id, metadata_document_id, entity_id, entity_role)
+);
+
+-- UIM-SCH-084 federation_selected_entity_import_events
+CREATE TABLE IF NOT EXISTS federation_selected_entity_import_events (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  trust_source_id TEXT NOT NULL,
+  metadata_entity_summary_id TEXT,
+  provider_id TEXT,
+  import_action TEXT NOT NULL,
+  outcome TEXT NOT NULL,
+  reason_codes_json TEXT,
+  created_at INTEGER NOT NULL
+);

--- a/packages/setup/src/__tests__/cloudflare-migrations.test.ts
+++ b/packages/setup/src/__tests__/cloudflare-migrations.test.ts
@@ -494,6 +494,66 @@ INSERT INTO tenants (
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it('applies the unified identity mapping admin control-plane baseline in SQLite', () => {
+    const sqlite3Path = findSqlite3();
+    if (!sqlite3Path) {
+      return;
+    }
+
+    const tempDir = mkdtempSync(join(tmpdir(), 'authrim-uim-admin-migration-'));
+    const dbPath = join(tempDir, 'test.db');
+
+    try {
+      runMigrationFiles(sqlite3Path, dbPath, activeAdminMigrationFiles());
+
+      expect(
+        Number(
+          readSqlite(
+            sqlite3Path,
+            dbPath,
+            "SELECT COUNT(*) FROM pragma_table_info('mapping_rules');"
+          )
+        )
+      ).toBeGreaterThan(0);
+      expect(
+        Number(
+          readSqlite(
+            sqlite3Path,
+            dbPath,
+            "SELECT COUNT(*) FROM pragma_table_info('federation_trust_sources');"
+          )
+        )
+      ).toBeGreaterThan(0);
+      expect(
+        readSqlite(
+          sqlite3Path,
+          dbPath,
+          "SELECT COUNT(*) FROM pragma_table_info('tenant_discovery_indexes') WHERE name = 'mapping_snapshot_id';"
+        )
+      ).toBe('1');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps unified identity mapping schema migrations annotated with schema-readiness IDs', () => {
+    const migrationSql = [
+      readMigration('008_unified_identity_canonical_schema.sql'),
+      readMigration('admin/007_identity_mapping_control_plane_schema.sql'),
+    ].join('\n');
+    const migrationIds = new Set(migrationSql.match(/UIM-SCH-\d{3}/g) ?? []);
+    const expectedIds = [
+      ...Array.from({ length: 84 }, (_, index) => `UIM-SCH-${String(index + 1).padStart(3, '0')}`),
+      'UIM-SCH-088',
+    ];
+
+    expect([...migrationIds].sort()).toEqual(expectedIds.sort());
+    expect(migrationIds.has('UIM-SCH-032A')).toBe(false);
+    expect(migrationIds.has('UIM-SCH-085')).toBe(false);
+    expect(migrationIds.has('UIM-SCH-086')).toBe(false);
+    expect(migrationIds.has('UIM-SCH-087')).toBe(false);
+  });
 });
 
 describe('renderPortableMigrationSql', () => {

--- a/packages/setup/src/__tests__/cloudflare-migrations.test.ts
+++ b/packages/setup/src/__tests__/cloudflare-migrations.test.ts
@@ -36,6 +36,7 @@ function readSqlite(sqlite3Path: string, dbPath: string, sql: string): string {
 
 const rootMigrationsDir = fileURLToPath(new URL('../../../../migrations', import.meta.url));
 const coreMigrationExclusions = new Set(['admin', 'archive', 'external', 'pii']);
+const sqliteMigrationApplyTimeoutMs = 20_000;
 
 function activeCoreMigrationFiles(): string[] {
   return listD1MigrationSqlFiles(rootMigrationsDir, {
@@ -287,22 +288,24 @@ describe('migration seed SQL portability', () => {
     );
   });
 
-  it('applies the consolidated core baseline in SQLite', () => {
-    const sqlite3Path = findSqlite3();
-    if (!sqlite3Path) {
-      return;
-    }
+  it(
+    'applies the consolidated core baseline in SQLite',
+    () => {
+      const sqlite3Path = findSqlite3();
+      if (!sqlite3Path) {
+        return;
+      }
 
-    const tempDir = mkdtempSync(join(tmpdir(), 'authrim-oauth-client-migration-'));
-    const dbPath = join(tempDir, 'test.db');
+      const tempDir = mkdtempSync(join(tmpdir(), 'authrim-oauth-client-migration-'));
+      const dbPath = join(tempDir, 'test.db');
 
-    try {
-      runMigrationFiles(sqlite3Path, dbPath, activeCoreMigrationFiles());
+      try {
+        runMigrationFiles(sqlite3Path, dbPath, activeCoreMigrationFiles());
 
-      runSqlite(
-        sqlite3Path,
-        dbPath,
-        `
+        runSqlite(
+          sqlite3Path,
+          dbPath,
+          `
 PRAGMA foreign_keys = ON;
 INSERT INTO tenants (id, tenant_code, tenant_key, name, created_at, updated_at)
 VALUES ('tenant-a', 'tenant-a', 'tenant-key-a', 'Tenant A', 1, 1);
@@ -315,31 +318,31 @@ VALUES ('session-a', 'tenant-a', 'user-a', 9999999999, 1);
 ${insertOAuthClientSql('tenant-a', 'shared-mobile', 'Tenant A Mobile')}
 ${insertOAuthClientSql('tenant-b', 'shared-mobile', 'Tenant B Mobile')}
 `
-      );
+        );
 
-      expect(
-        readSqlite(
-          sqlite3Path,
-          dbPath,
-          "SELECT COUNT(*) FROM oauth_clients WHERE client_id = 'shared-mobile';"
-        )
-      ).toBe('2');
+        expect(
+          readSqlite(
+            sqlite3Path,
+            dbPath,
+            "SELECT COUNT(*) FROM oauth_clients WHERE client_id = 'shared-mobile';"
+          )
+        ).toBe('2');
 
-      expect(() =>
+        expect(() =>
+          runSqlite(
+            sqlite3Path,
+            dbPath,
+            `
+PRAGMA foreign_keys = ON;
+${insertOAuthClientSql('tenant-a', 'shared-mobile', 'Duplicate Tenant A Mobile')}
+`
+          )
+        ).toThrow();
+
         runSqlite(
           sqlite3Path,
           dbPath,
           `
-PRAGMA foreign_keys = ON;
-${insertOAuthClientSql('tenant-a', 'shared-mobile', 'Duplicate Tenant A Mobile')}
-`
-        )
-      ).toThrow();
-
-      runSqlite(
-        sqlite3Path,
-        dbPath,
-        `
 PRAGMA foreign_keys = ON;
 INSERT INTO session_clients (
   id,
@@ -357,13 +360,13 @@ INSERT INTO session_clients (
   1
 );
 `
-      );
+        );
 
-      expect(() =>
-        runSqlite(
-          sqlite3Path,
-          dbPath,
-          `
+        expect(() =>
+          runSqlite(
+            sqlite3Path,
+            dbPath,
+            `
 PRAGMA foreign_keys = ON;
 INSERT INTO session_clients (
   id,
@@ -381,13 +384,13 @@ INSERT INTO session_clients (
   1
 );
 `
-        )
-      ).toThrow();
+          )
+        ).toThrow();
 
-      runSqlite(
-        sqlite3Path,
-        dbPath,
-        `
+        runSqlite(
+          sqlite3Path,
+          dbPath,
+          `
 PRAGMA foreign_keys = ON;
 INSERT INTO oauth_clients (
   tenant_id,
@@ -417,24 +420,26 @@ INSERT INTO oauth_clients (
   1
 );
 `
-      );
+        );
 
-      expect(
-        readSqlite(
-          sqlite3Path,
-          dbPath,
-          "SELECT device_secret_revoke_enabled || ':' || device_secret_introspection_enabled FROM oauth_clients WHERE tenant_id = 'tenant-a' AND client_id = 'device-policy-client';"
-        )
-      ).toBe('1:1');
+        expect(
+          readSqlite(
+            sqlite3Path,
+            dbPath,
+            "SELECT device_secret_revoke_enabled || ':' || device_secret_introspection_enabled FROM oauth_clients WHERE tenant_id = 'tenant-a' AND client_id = 'device-policy-client';"
+          )
+        ).toBe('1:1');
 
-      expect(readSqlite(sqlite3Path, dbPath, 'SELECT COUNT(*) FROM device_secrets;')).toBe('0');
-      expect(readSqlite(sqlite3Path, dbPath, 'SELECT COUNT(*) FROM device_installations;')).toBe(
-        '0'
-      );
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
-  });
+        expect(readSqlite(sqlite3Path, dbPath, 'SELECT COUNT(*) FROM device_secrets;')).toBe('0');
+        expect(readSqlite(sqlite3Path, dbPath, 'SELECT COUNT(*) FROM device_installations;')).toBe(
+          '0'
+        );
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    },
+    sqliteMigrationApplyTimeoutMs
+  );
 
   it('backfills tenant lifecycle state from is_active and drops the legacy column', () => {
     const sqlite3Path = findSqlite3();
@@ -495,47 +500,51 @@ INSERT INTO tenants (
     }
   });
 
-  it('applies the unified identity mapping admin control-plane baseline in SQLite', () => {
-    const sqlite3Path = findSqlite3();
-    if (!sqlite3Path) {
-      return;
-    }
+  it(
+    'applies the unified identity mapping admin control-plane baseline in SQLite',
+    () => {
+      const sqlite3Path = findSqlite3();
+      if (!sqlite3Path) {
+        return;
+      }
 
-    const tempDir = mkdtempSync(join(tmpdir(), 'authrim-uim-admin-migration-'));
-    const dbPath = join(tempDir, 'test.db');
+      const tempDir = mkdtempSync(join(tmpdir(), 'authrim-uim-admin-migration-'));
+      const dbPath = join(tempDir, 'test.db');
 
-    try {
-      runMigrationFiles(sqlite3Path, dbPath, activeAdminMigrationFiles());
+      try {
+        runMigrationFiles(sqlite3Path, dbPath, activeAdminMigrationFiles());
 
-      expect(
-        Number(
+        expect(
+          Number(
+            readSqlite(
+              sqlite3Path,
+              dbPath,
+              "SELECT COUNT(*) FROM pragma_table_info('mapping_rules');"
+            )
+          )
+        ).toBeGreaterThan(0);
+        expect(
+          Number(
+            readSqlite(
+              sqlite3Path,
+              dbPath,
+              "SELECT COUNT(*) FROM pragma_table_info('federation_trust_sources');"
+            )
+          )
+        ).toBeGreaterThan(0);
+        expect(
           readSqlite(
             sqlite3Path,
             dbPath,
-            "SELECT COUNT(*) FROM pragma_table_info('mapping_rules');"
+            "SELECT COUNT(*) FROM pragma_table_info('tenant_discovery_indexes') WHERE name = 'mapping_snapshot_id';"
           )
-        )
-      ).toBeGreaterThan(0);
-      expect(
-        Number(
-          readSqlite(
-            sqlite3Path,
-            dbPath,
-            "SELECT COUNT(*) FROM pragma_table_info('federation_trust_sources');"
-          )
-        )
-      ).toBeGreaterThan(0);
-      expect(
-        readSqlite(
-          sqlite3Path,
-          dbPath,
-          "SELECT COUNT(*) FROM pragma_table_info('tenant_discovery_indexes') WHERE name = 'mapping_snapshot_id';"
-        )
-      ).toBe('1');
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
-  });
+        ).toBe('1');
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    },
+    sqliteMigrationApplyTimeoutMs
+  );
 
   it('keeps unified identity mapping schema migrations annotated with schema-readiness IDs', () => {
     const migrationSql = [


### PR DESCRIPTION
## Summary

Adds the unified identity mapping schema baseline without wiring runtime writes yet.

- Adds the canonical identity and identity registry baseline migration.
- Adds the Admin/control-plane migration for mapping policies, catalogs, activation, review, federation trust, key lifecycle, and reserved DR/quota/retention schema.
- Extends migration tests to apply the new baseline in SQLite and verify UIM schema-readiness annotations.

## Notes

Runtime write paths remain disabled. This PR intentionally prepares schema only so follow-up repository/cutover work can connect objects without creating split-brain behavior.

## Validation

- `pnpm --filter @authrim/setup test`
- `pnpm --filter @authrim/setup test -- src/__tests__/cloudflare-migrations.test.ts`
- `pnpm --filter @authrim/setup typecheck`
- `pnpm exec prettier --check packages/setup/src/__tests__/cloudflare-migrations.test.ts`
- `git diff --check`
