### PR TITLE
Harden canonical identity runtime cutover

### DIFF
--- a/docs/testing/unified-identity-mapping-cutover-hardening.md
+++ b/docs/testing/unified-identity-mapping-cutover-hardening.md
@@ -1,0 +1,67 @@
+---
+title: Unified Identity Mapping Cutover Hardening
+date: 2026-05-28
+status: draft
+---
+
+# Unified Identity Mapping Cutover Hardening
+
+This document is the PR6 verification checklist for the Unified Identity Mapping Control Plane
+canonical runtime cutover.
+
+## Automated Gates
+
+| Gate                   | Purpose                                                                             | Command                                                                                                                                                |
+| ---------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Split-brain regression | Verify canonical writes and protocol reads use the same subject/account graph.      | `pnpm --filter @authrim/ar-lib-core test -- src/repositories/__tests__/canonical-runtime-cutover-hardening.test.ts`                                    |
+| Source gate            | Keep canonical runtime writer/projection free of unquarantined legacy table access. | `pnpm --filter @authrim/ar-lib-core test -- src/repositories/__tests__/canonical-runtime-cutover-gate.test.ts`                                         |
+| Admin / SCIM runtime   | Verify Admin API and SCIM canonical write paths.                                    | `pnpm --filter @authrim/ar-management test -- src/__tests__/admin.test.ts src/__tests__/identity-canonical-runtime.test.ts src/__tests__/scim.test.ts` |
+| SAML runtime           | Verify SAML user-store reads prefer canonical projection when enabled.              | `pnpm --filter @authrim/ar-saml test -- src/common/__tests__/user-store.test.ts`                                                                       |
+| UserInfo runtime       | Verify UserInfo uses canonical projection while preserving PII status gating.       | `pnpm --filter @authrim/ar-userinfo test -- src/__tests__/userinfo.test.ts`                                                                            |
+| Migration freshness    | Verify schema IDs and PR6 readiness snapshot remain aligned.                        | `pnpm --filter @authrim/setup test -- src/__tests__/cloudflare-migrations.test.ts`                                                                     |
+
+The hot-path smoke test reports `canonical-runtime-hot-path-smoke` with `p95Ms` and
+`maxReadCount`. PR6 budget is `p95Ms < 50ms` and `maxReadCount <= 6`.
+
+## PR6 Readiness Snapshot
+
+These entries mirror the schema-readiness inventory items that are required for the PR6 canonical
+runtime cutover gate.
+
+| ID           | Runtime object                | PR6 evidence                                                        | Status |
+| ------------ | ----------------------------- | ------------------------------------------------------------------- | ------ |
+| UIM-SCH-001  | `identity_subjects`           | PR #270 repository coverage, PR #271 runtime cutover, PR6 hardening | tested |
+| UIM-SCH-002  | `identity_accounts`           | PR #270 repository coverage, PR #271 runtime cutover, PR6 hardening | tested |
+| UIM-SCH-003  | `subject_account_links`       | PR #270 repository coverage, PR #271 runtime cutover, PR6 hardening | tested |
+| UIM-SCH-004  | `profiles`                    | PR #270 repository coverage, PR #271 runtime cutover, PR6 hardening | tested |
+| UIM-SCH-005  | `profile_attribute_values`    | PR #270 repository coverage, PR #271 runtime cutover, PR6 hardening | tested |
+| UIM-SCH-006  | `structured_attribute_values` | PR #270 repository coverage, PR #271 runtime cutover, PR6 hardening | tested |
+| UIM-SCH-007  | `contact_points`              | PR #270 repository coverage, PR #271 runtime cutover, PR6 hardening | tested |
+| UIM-SCH-032A | canonical repository contract | PR #270 repository coverage, PR #271 runtime cutover, PR6 hardening | tested |
+
+## Manual Verification Checklist
+
+Run these checks in a real Cloudflare environment before promoting the cutover to `main`.
+
+- Enable `ENABLE_CANONICAL_IDENTITY_RUNTIME=true` for the target environment.
+- Create a user through Admin UI and verify canonical `identity_subjects`, `identity_accounts`,
+  `profiles`, and `contact_points` rows are created.
+- Update the same user through Admin UI and verify lifecycle state remains consistent between
+  account and subject.
+- Create a user through SCIM `POST /scim/v2/Users` and verify UserInfo and SAML user lookup return
+  the same email/name from canonical projection.
+- Deactivate a user through SCIM or Admin API and verify canonical projection no longer returns the
+  account as active.
+- Delete a user through SCIM or Admin API and verify canonical account and subject transition to
+  `deleted`.
+- Verify tenant discovery email, tenant code, app hint, and invitation flows keep the existing
+  behavior.
+- Inspect error logs and audit logs for raw PII, value storage refs, and SAML NameID-derived raw
+  values.
+
+## Rollback
+
+- Set `ENABLE_CANONICAL_IDENTITY_RUNTIME=false`.
+- Pause Admin API / SCIM writes for affected tenants while investigating.
+- Check `identity_accounts` for duplicate active rows for the same `legacy_user_id`.
+- Record the failed automated gate or manual checklist item in the release notes or follow-up PR.

--- a/docs/testing/unified-identity-mapping-cutover-hardening.md
+++ b/docs/testing/unified-identity-mapping-cutover-hardening.md
@@ -11,14 +11,15 @@ canonical runtime cutover.
 
 ## Automated Gates
 
-| Gate                   | Purpose                                                                             | Command                                                                                                                                                |
-| ---------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Split-brain regression | Verify canonical writes and protocol reads use the same subject/account graph.      | `pnpm --filter @authrim/ar-lib-core test -- src/repositories/__tests__/canonical-runtime-cutover-hardening.test.ts`                                    |
-| Source gate            | Keep canonical runtime writer/projection free of unquarantined legacy table access. | `pnpm --filter @authrim/ar-lib-core test -- src/repositories/__tests__/canonical-runtime-cutover-gate.test.ts`                                         |
-| Admin / SCIM runtime   | Verify Admin API and SCIM canonical write paths.                                    | `pnpm --filter @authrim/ar-management test -- src/__tests__/admin.test.ts src/__tests__/identity-canonical-runtime.test.ts src/__tests__/scim.test.ts` |
-| SAML runtime           | Verify SAML user-store reads prefer canonical projection when enabled.              | `pnpm --filter @authrim/ar-saml test -- src/common/__tests__/user-store.test.ts`                                                                       |
-| UserInfo runtime       | Verify UserInfo uses canonical projection while preserving PII status gating.       | `pnpm --filter @authrim/ar-userinfo test -- src/__tests__/userinfo.test.ts`                                                                            |
-| Migration freshness    | Verify schema IDs and PR6 readiness snapshot remain aligned.                        | `pnpm --filter @authrim/setup test -- src/__tests__/cloudflare-migrations.test.ts`                                                                     |
+| Gate                   | Purpose                                                                                         | Command                                                                                                                                                                            |
+| ---------------------- | ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Split-brain regression | Verify canonical writes and protocol reads use the same subject/account graph.                  | `pnpm --filter @authrim/ar-lib-core test -- src/repositories/__tests__/canonical-runtime-cutover-hardening.test.ts`                                                                |
+| Source gate            | Keep canonical runtime writer/projection free of unquarantined legacy table access.             | `pnpm --filter @authrim/ar-lib-core test -- src/repositories/__tests__/canonical-runtime-cutover-gate.test.ts`                                                                     |
+| Admin / SCIM runtime   | Verify Admin API and SCIM canonical write paths.                                                | `pnpm --filter @authrim/ar-management test -- src/__tests__/admin.test.ts src/__tests__/identity-canonical-runtime.test.ts src/__tests__/scim.test.ts`                             |
+| Canonical sync         | Verify runtime updates refresh lifecycle, contact verification, address, and custom attributes. | `pnpm --filter @authrim/ar-lib-core test -- src/repositories/__tests__/canonical-runtime-user-writer.test.ts src/repositories/__tests__/canonical-runtime-user-projection.test.ts` |
+| SAML runtime           | Verify SAML user-store reads prefer canonical projection when enabled.                          | `pnpm --filter @authrim/ar-saml test -- src/common/__tests__/user-store.test.ts`                                                                                                   |
+| UserInfo runtime       | Verify UserInfo uses canonical projection while preserving PII status gating.                   | `pnpm --filter @authrim/ar-userinfo test -- src/__tests__/userinfo.test.ts`                                                                                                        |
+| Migration freshness    | Verify schema IDs and PR6 readiness snapshot remain aligned.                                    | `pnpm --filter @authrim/setup test -- src/__tests__/cloudflare-migrations.test.ts`                                                                                                 |
 
 The hot-path smoke test reports `canonical-runtime-hot-path-smoke` with `p95Ms` and
 `maxReadCount`. PR6 budget is `p95Ms < 50ms` and `maxReadCount <= 6`.
@@ -39,6 +40,19 @@ runtime cutover gate.
 | UIM-SCH-007  | `contact_points`              | PR #270 repository coverage, PR #271 runtime cutover, PR6 hardening | tested |
 | UIM-SCH-032A | canonical repository contract | PR #270 repository coverage, PR #271 runtime cutover, PR6 hardening | tested |
 
+## Tier 1 Completion Boundary
+
+This checklist closes the Tier 1 vertical slice for canonical runtime cutover:
+
+- SCIM/Admin runtime writes create and sync the canonical subject/account/profile graph.
+- SAML, OIDC token, UserInfo, and SCIM read paths can project from the canonical graph.
+- Runtime updates refresh lifecycle, display labels, profile locale/zoneinfo, contact verification
+  state, structured address, and custom attributes.
+- PII materialization remains behind the explicit value resolver and rejects malformed or
+  cross-tenant storage references before querying PII storage.
+
+Reserved Tier 3 adapters and future protocol runtimes are intentionally outside this gate.
+
 ## Manual Verification Checklist
 
 Run these checks in a real Cloudflare environment before promoting the cutover to `main`.
@@ -50,6 +64,8 @@ Run these checks in a real Cloudflare environment before promoting the cutover t
   account and subject.
 - Create a user through SCIM `POST /scim/v2/Users` and verify UserInfo and SAML user lookup return
   the same email/name from canonical projection.
+- Update the SCIM user's address and enterprise custom attributes, then verify canonical projection
+  returns the updated values and omits removed values.
 - Deactivate a user through SCIM or Admin API and verify canonical projection no longer returns the
   account as active.
 - Delete a user through SCIM or Admin API and verify canonical account and subject transition to

--- a/migrations/008_unified_identity_canonical_schema.sql
+++ b/migrations/008_unified_identity_canonical_schema.sql
@@ -58,6 +58,7 @@ CREATE TABLE IF NOT EXISTS subject_account_links (
   source_ref TEXT,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
+  deleted_at INTEGER,
   UNIQUE (tenant_id, subject_id, account_id, link_type),
   FOREIGN KEY (subject_id) REFERENCES identity_subjects(id) ON DELETE CASCADE,
   FOREIGN KEY (account_id) REFERENCES identity_accounts(id) ON DELETE CASCADE
@@ -79,6 +80,7 @@ CREATE TABLE IF NOT EXISTS profiles (
   metadata_json TEXT,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
+  deleted_at INTEGER,
   UNIQUE (tenant_id, subject_id, profile_type),
   FOREIGN KEY (subject_id) REFERENCES identity_subjects(id) ON DELETE CASCADE
 );
@@ -100,6 +102,7 @@ CREATE TABLE IF NOT EXISTS profile_attribute_values (
   lifecycle_state TEXT NOT NULL DEFAULT 'active',
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
+  deleted_at INTEGER,
   FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
 );
 
@@ -118,7 +121,8 @@ CREATE TABLE IF NOT EXISTS structured_attribute_values (
   classification TEXT NOT NULL DEFAULT 'internal',
   lifecycle_state TEXT NOT NULL DEFAULT 'active',
   created_at INTEGER NOT NULL,
-  updated_at INTEGER NOT NULL
+  updated_at INTEGER NOT NULL,
+  deleted_at INTEGER
 );
 
 CREATE INDEX IF NOT EXISTS idx_structured_attribute_values_owner
@@ -140,6 +144,7 @@ CREATE TABLE IF NOT EXISTS contact_points (
   lifecycle_state TEXT NOT NULL DEFAULT 'active',
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
+  deleted_at INTEGER,
   FOREIGN KEY (subject_id) REFERENCES identity_subjects(id) ON DELETE CASCADE,
   FOREIGN KEY (account_id) REFERENCES identity_accounts(id) ON DELETE CASCADE
 );
@@ -185,6 +190,7 @@ CREATE TABLE IF NOT EXISTS identity_bindings (
   metadata_json TEXT,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
+  deleted_at INTEGER,
   last_seen_at INTEGER,
   UNIQUE (tenant_id, protocol, source_id, provider_subject_key_hash),
   FOREIGN KEY (subject_id) REFERENCES identity_subjects(id) ON DELETE CASCADE,

--- a/packages/ar-lib-core/src/repositories/__tests__/canonical-runtime-cutover-hardening.test.ts
+++ b/packages/ar-lib-core/src/repositories/__tests__/canonical-runtime-cutover-hardening.test.ts
@@ -1,0 +1,190 @@
+import { performance } from 'node:perf_hooks';
+import { describe, expect, it } from 'vitest';
+import { canonicalProjectionToOIDCClaimsUser } from '../../utils/canonical-runtime-claims';
+import {
+  CanonicalIdentityRepository,
+  CanonicalRuntimeUserProjectionRepository,
+  CanonicalRuntimeUserWriter,
+  LegacyUsersPiiValueResolver,
+  type CanonicalRuntimeValueResolver,
+} from '../identity';
+import { MockDatabaseAdapter } from './mock-adapter';
+
+const CANONICAL_TABLES = [
+  'identity_subjects',
+  'identity_accounts',
+  'subject_account_links',
+  'profiles',
+  'profile_attribute_values',
+  'structured_attribute_values',
+  'contact_points',
+  'contact_verifications',
+  'identity_bindings',
+  'identity_resolution_events',
+  'identity_resolution_candidates',
+  'assurance_evidence',
+];
+
+function createCanonicalAdapter(): MockDatabaseAdapter {
+  const adapter = new MockDatabaseAdapter();
+  for (const tableName of CANONICAL_TABLES) {
+    adapter.initTable(tableName, 'id');
+  }
+  return adapter;
+}
+
+function percentile(values: number[], percentileRank: number): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil((percentileRank / 100) * sorted.length) - 1);
+  return sorted[index] ?? 0;
+}
+
+describe('canonical runtime cutover hardening', () => {
+  it('keeps SCIM/Admin writes and SAML/OIDC-style reads on the same canonical graph', async () => {
+    const adapter = createCanonicalAdapter();
+    const writer = new CanonicalRuntimeUserWriter(
+      new CanonicalIdentityRepository(adapter, 'tenant-a')
+    );
+    await writer.createFromRuntimeUser({
+      userId: 'user-1',
+      tenantId: 'tenant-a',
+      active: true,
+      emailVerified: true,
+      phoneNumberVerified: false,
+      userType: 'end_user',
+      displayName: 'Example Person',
+      locale: 'ja-JP',
+      zoneinfo: 'Asia/Tokyo',
+      sourceRef: 'scim:/Users',
+      piiFields: {
+        email: true,
+        name: true,
+        preferred_username: true,
+      },
+    });
+
+    const valueResolver: CanonicalRuntimeValueResolver = {
+      async resolveValue(valueStorageRef) {
+        const values: Record<string, unknown> = {
+          'legacy-users-pii://tenant-a/user-1/email': 'person@example.test',
+          'legacy-users-pii://tenant-a/user-1/name': 'Example Person',
+          'legacy-users-pii://tenant-a/user-1/preferred_username': 'person',
+        };
+        return values[valueStorageRef] ?? null;
+      },
+    };
+    const projectionRepository = new CanonicalRuntimeUserProjectionRepository(
+      adapter,
+      'tenant-a',
+      valueResolver
+    );
+
+    const projection = await projectionRepository.findByLegacyUserId('user-1');
+    expect(projection).not.toBeNull();
+    const claimsUser = canonicalProjectionToOIDCClaimsUser(projection!);
+
+    expect(projection).toMatchObject({
+      id: 'user-1',
+      subject_id: 'subject:user-1',
+      account_id: 'account:user-1',
+      email: 'person@example.test',
+      email_verified: 1,
+      name: 'Example Person',
+      preferred_username: 'person',
+      active: 1,
+    });
+    expect(claimsUser).toMatchObject({
+      email: 'person@example.test',
+      email_verified: true,
+      name: 'Example Person',
+      preferred_username: 'person',
+    });
+
+    const queriedSql = adapter
+      .getQueryLog()
+      .map((entry) => entry.sql)
+      .join('\n');
+    expect(queriedSql).toContain('identity_accounts');
+    expect(queriedSql).toContain('identity_subjects');
+    expect(queriedSql).toContain('contact_points');
+    expect(queriedSql).not.toMatch(/\busers_core\b/u);
+    expect(queriedSql).not.toMatch(/\busers_pii\b/u);
+  });
+
+  it('rejects malformed or cross-tenant legacy PII refs before querying PII storage', async () => {
+    const piiAdapter = new MockDatabaseAdapter();
+    piiAdapter.initTable('users_pii', 'id');
+    piiAdapter.seed('users_pii', [
+      {
+        id: 'user-1',
+        tenant_id: 'tenant-a',
+        email: 'person@example.test',
+      },
+    ]);
+    const resolver = new LegacyUsersPiiValueResolver(piiAdapter);
+
+    await expect(
+      resolver.resolveValue('legacy-users-pii://tenant-a/user-1/email%2Cpassword_hash', {
+        tenantId: 'tenant-a',
+        subjectId: 'subject:user-1',
+        accountId: 'account:user-1',
+      })
+    ).rejects.toThrow(/Unsupported legacy users_pii value ref field/);
+    await expect(
+      resolver.resolveValue('legacy-users-pii://tenant-b/user-1/email', {
+        tenantId: 'tenant-a',
+        subjectId: 'subject:user-1',
+        accountId: 'account:user-1',
+      })
+    ).rejects.toThrow(/tenant mismatch/);
+
+    expect(piiAdapter.getQueryLog()).toHaveLength(0);
+  });
+
+  it('reports a hot-path projection smoke budget for p95 latency and read-count', async () => {
+    const adapter = createCanonicalAdapter();
+    const writer = new CanonicalRuntimeUserWriter(
+      new CanonicalIdentityRepository(adapter, 'tenant-a')
+    );
+    await writer.createFromRuntimeUser({
+      userId: 'user-1',
+      tenantId: 'tenant-a',
+      active: true,
+      emailVerified: true,
+      displayName: 'Example Person',
+      locale: 'ja-JP',
+      sourceRef: 'admin:/users',
+      inlineProfileFields: {
+        'field.canonical.name': 'Example Person',
+        'field.canonical.preferred_username': 'person',
+      },
+    });
+    const projectionRepository = new CanonicalRuntimeUserProjectionRepository(adapter, 'tenant-a', {
+      async resolveValue() {
+        return null;
+      },
+    });
+
+    const durationsMs: number[] = [];
+    const readCounts: number[] = [];
+    for (let index = 0; index < 50; index++) {
+      const queryCountBefore = adapter.getQueryLog().length;
+      const startedAt = performance.now();
+      const projection = await projectionRepository.findByLegacyUserId('user-1');
+      durationsMs.push(performance.now() - startedAt);
+      readCounts.push(adapter.getQueryLog().length - queryCountBefore);
+      expect(projection?.email).toBeNull();
+      expect(projection?.name).toBe('Example Person');
+    }
+
+    const report = {
+      iterations: durationsMs.length,
+      p95Ms: percentile(durationsMs, 95),
+      maxReadCount: Math.max(...readCounts),
+    };
+    console.info('canonical-runtime-hot-path-smoke', report);
+
+    expect(report.maxReadCount).toBeLessThanOrEqual(6);
+    expect(report.p95Ms).toBeLessThan(50);
+  });
+});

--- a/packages/ar-lib-core/src/repositories/__tests__/canonical-runtime-user-projection.test.ts
+++ b/packages/ar-lib-core/src/repositories/__tests__/canonical-runtime-user-projection.test.ts
@@ -280,6 +280,23 @@ describe('CanonicalRuntimeUserProjectionRepository', () => {
     ]);
     adapter.seed('contact_points', [
       {
+        id: 'contact-email-other-account',
+        tenant_id: 'tenant-a',
+        subject_id: 'subject-1',
+        account_id: 'account-2',
+        contact_type: 'email',
+        purpose: 'primary',
+        normalized_hash: 'hash-email-other-account',
+        value_storage_ref: 'pii://tenant-a/email/other-account',
+        display_label: 'other@example.test',
+        is_primary: 1,
+        verification_state: 'verified',
+        lifecycle_state: 'active',
+        created_at: 1_699_999_999,
+        updated_at: 1_699_999_999,
+        deleted_at: null,
+      },
+      {
         id: 'contact-email',
         tenant_id: 'tenant-a',
         subject_id: 'subject-1',

--- a/packages/ar-lib-core/src/repositories/__tests__/canonical-runtime-user-writer.test.ts
+++ b/packages/ar-lib-core/src/repositories/__tests__/canonical-runtime-user-writer.test.ts
@@ -141,23 +141,95 @@ describe('CanonicalRuntimeUserWriter', () => {
       active: true,
       emailVerified: true,
       displayName: 'Example Person',
-      piiFields: { email: true },
+      piiFields: { email: true, phone_number: true },
+      inlineProfileFields: {
+        'field.custom.employee_number': 'E-001',
+      },
+      addressJson: JSON.stringify({ formatted: 'old address', country: 'JP' }),
+      customAttributesJson: JSON.stringify({ department: 'Engineering' }),
     });
 
     const result = await writer.syncFromRuntimeUser({
       userId: 'user-1',
       tenantId: 'tenant-a',
       active: false,
-      displayName: 'Example Person',
-      piiFields: { email: true },
+      emailVerified: false,
+      phoneNumberVerified: true,
+      displayName: 'Updated Person',
+      locale: 'en-US',
+      zoneinfo: 'America/Los_Angeles',
+      piiFields: { email: true, phone_number: true },
+      inlineProfileFields: {
+        'field.custom.employee_number': 'E-002',
+      },
+      addressJson: JSON.stringify({ formatted: 'new address', country: 'US' }),
+      customAttributesJson: JSON.stringify({ department: 'Product' }),
     });
 
-    expect(result).toMatchObject({ created: false });
+    expect(result).toMatchObject({
+      created: false,
+      profileAttributeCount: 2,
+      contactPointCount: 2,
+    });
     expect(adapter.getById('identity_accounts', 'account:user-1')).toMatchObject({
       lifecycle_state: 'deprovisioned',
+      display_label: 'Updated Person',
     });
     expect(adapter.getById('identity_subjects', 'subject:user-1')).toMatchObject({
       lifecycle_state: 'deprovisioned',
+      display_label: 'Updated Person',
+    });
+    expect(adapter.getById('profiles', 'profile:user-1')).toMatchObject({
+      lifecycle_state: 'deprovisioned',
+      locale: 'en-US',
+      zoneinfo: 'America/Los_Angeles',
+    });
+    expect(adapter.getById('contact_points', 'contact:user-1:email')).toMatchObject({
+      verification_state: 'unverified',
+    });
+    expect(adapter.getById('contact_points', 'contact:user-1:phone')).toMatchObject({
+      verification_state: 'verified',
+    });
+    expect(
+      adapter.getById(
+        'profile_attribute_values',
+        'profile-attribute:user-1:field.custom.employee_number'
+      )
+    ).toMatchObject({
+      value_json: JSON.stringify('E-002'),
+    });
+    expect(
+      adapter.getById('profile_attribute_values', 'profile-attribute:user-1:custom_attributes')
+    ).toMatchObject({
+      value_json: JSON.stringify({ department: 'Product' }),
+    });
+    expect(
+      adapter.getById('structured_attribute_values', 'structured-attribute:user-1:address')
+    ).toMatchObject({
+      canonical_json: JSON.stringify({ formatted: 'new address', country: 'US' }),
+    });
+
+    await writer.syncFromRuntimeUser({
+      userId: 'user-1',
+      tenantId: 'tenant-a',
+      active: true,
+      emailVerified: true,
+      phoneNumberVerified: false,
+      displayName: 'Updated Person',
+      piiFields: { email: true, phone_number: true },
+      addressJson: null,
+      customAttributesJson: null,
+    });
+
+    expect(
+      adapter.getById('profile_attribute_values', 'profile-attribute:user-1:custom_attributes')
+    ).toMatchObject({
+      lifecycle_state: 'deleted',
+    });
+    expect(
+      adapter.getById('structured_attribute_values', 'structured-attribute:user-1:address')
+    ).toMatchObject({
+      lifecycle_state: 'deleted',
     });
   });
 

--- a/packages/ar-lib-core/src/repositories/identity/canonical-identity.ts
+++ b/packages/ar-lib-core/src/repositories/identity/canonical-identity.ts
@@ -574,6 +574,25 @@ export class CanonicalIdentityRepository {
     return result.rowsAffected > 0;
   }
 
+  async updateSubjectRuntimeFields(
+    subjectId: string,
+    input: {
+      lifecycleState: IdentityLifecycleState;
+      displayLabel?: string | null;
+    }
+  ): Promise<boolean> {
+    const now = getCurrentTimestamp();
+    const deletedAt =
+      input.lifecycleState === 'deleted' || input.lifecycleState === 'deleting' ? now : null;
+    const result = await this.adapter.execute(
+      `UPDATE identity_subjects
+          SET lifecycle_state = ?, display_label = ?, updated_at = ?, deleted_at = ?
+        WHERE id = ? AND tenant_id = ?`,
+      [input.lifecycleState, input.displayLabel ?? null, now, deletedAt, subjectId, this.tenantId]
+    );
+    return result.rowsAffected > 0;
+  }
+
   async createAccount(input: CreateIdentityAccountInput): Promise<IdentityAccountRow> {
     return this.insertAccount(this.adapter, input);
   }
@@ -617,6 +636,25 @@ export class CanonicalIdentityRepository {
     return result.rowsAffected > 0;
   }
 
+  async updateAccountRuntimeFields(
+    accountId: string,
+    input: {
+      lifecycleState: IdentityLifecycleState;
+      displayLabel?: string | null;
+    }
+  ): Promise<boolean> {
+    const now = getCurrentTimestamp();
+    const deletedAt =
+      input.lifecycleState === 'deleted' || input.lifecycleState === 'deleting' ? now : null;
+    const result = await this.adapter.execute(
+      `UPDATE identity_accounts
+          SET lifecycle_state = ?, display_label = ?, updated_at = ?, deleted_at = ?
+        WHERE id = ? AND tenant_id = ?`,
+      [input.lifecycleState, input.displayLabel ?? null, now, deletedAt, accountId, this.tenantId]
+    );
+    return result.rowsAffected > 0;
+  }
+
   async createSubjectAccountLink(
     input: CreateSubjectAccountLinkInput
   ): Promise<SubjectAccountLinkRow> {
@@ -651,6 +689,34 @@ export class CanonicalIdentityRepository {
         ORDER BY profile_type ASC, created_at ASC`,
       [subjectId, this.tenantId]
     );
+  }
+
+  async updateProfileRuntimeFields(
+    profileId: string,
+    input: {
+      lifecycleState: IdentityLifecycleState;
+      locale?: string | null;
+      zoneinfo?: string | null;
+    }
+  ): Promise<boolean> {
+    const now = getCurrentTimestamp();
+    const deletedAt =
+      input.lifecycleState === 'deleted' || input.lifecycleState === 'deleting' ? now : null;
+    const result = await this.adapter.execute(
+      `UPDATE profiles
+          SET lifecycle_state = ?, locale = ?, zoneinfo = ?, updated_at = ?, deleted_at = ?
+        WHERE id = ? AND tenant_id = ?`,
+      [
+        input.lifecycleState,
+        input.locale ?? null,
+        input.zoneinfo ?? null,
+        now,
+        deletedAt,
+        profileId,
+        this.tenantId,
+      ]
+    );
+    return result.rowsAffected > 0;
   }
 
   async createProfileAttributeValue(
@@ -708,6 +774,90 @@ export class CanonicalIdentityRepository {
     return row;
   }
 
+  async upsertProfileAttributeValue(
+    input: CreateProfileAttributeValueInput
+  ): Promise<ProfileAttributeValueRow> {
+    assertProfileAttributeStorageBoundary(input);
+
+    const id = input.id ?? generateId();
+    const now = getCurrentTimestamp();
+    const tenantId = resolveTenantId(this.tenantId, input.tenant_id);
+    const row: ProfileAttributeValueRow = {
+      id,
+      tenant_id: tenantId,
+      profile_id: input.profile_id,
+      catalog_entry_id: input.catalog_entry_id,
+      value_type: input.value_type,
+      value_json: encodeJson(input.value),
+      value_storage_ref: input.value_storage_ref ?? null,
+      value_hash: input.value_hash ?? null,
+      classification: input.classification ?? 'internal',
+      purpose: input.purpose ?? null,
+      is_primary: input.is_primary ? 1 : 0,
+      display_order: input.display_order ?? 0,
+      lifecycle_state: input.lifecycle_state ?? 'active',
+      created_at: now,
+      updated_at: now,
+      deleted_at: null,
+    };
+
+    await this.adapter.execute(
+      `INSERT INTO profile_attribute_values (
+        id, tenant_id, profile_id, catalog_entry_id, value_type, value_json, value_storage_ref,
+        value_hash, classification, purpose, is_primary, display_order, lifecycle_state,
+        created_at, updated_at, deleted_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        profile_id = excluded.profile_id,
+        catalog_entry_id = excluded.catalog_entry_id,
+        value_type = excluded.value_type,
+        value_json = excluded.value_json,
+        value_storage_ref = excluded.value_storage_ref,
+        value_hash = excluded.value_hash,
+        classification = excluded.classification,
+        purpose = excluded.purpose,
+        is_primary = excluded.is_primary,
+        display_order = excluded.display_order,
+        lifecycle_state = excluded.lifecycle_state,
+        updated_at = excluded.updated_at,
+        deleted_at = excluded.deleted_at`,
+      [
+        row.id,
+        row.tenant_id,
+        row.profile_id,
+        row.catalog_entry_id,
+        row.value_type,
+        row.value_json,
+        row.value_storage_ref,
+        row.value_hash,
+        row.classification,
+        row.purpose,
+        row.is_primary,
+        row.display_order,
+        row.lifecycle_state,
+        row.created_at,
+        row.updated_at,
+        row.deleted_at,
+      ]
+    );
+    return row;
+  }
+
+  async transitionProfileAttributeValueLifecycle(
+    attributeValueId: string,
+    lifecycleState: IdentityLifecycleState
+  ): Promise<boolean> {
+    const now = getCurrentTimestamp();
+    const deletedAt = lifecycleState === 'deleted' || lifecycleState === 'deleting' ? now : null;
+    const result = await this.adapter.execute(
+      `UPDATE profile_attribute_values
+          SET lifecycle_state = ?, updated_at = ?, deleted_at = ?
+        WHERE id = ? AND tenant_id = ?`,
+      [lifecycleState, now, deletedAt, attributeValueId, this.tenantId]
+    );
+    return result.rowsAffected > 0;
+  }
+
   async createStructuredAttributeValue(
     input: CreateStructuredAttributeValueInput
   ): Promise<StructuredAttributeValueRow> {
@@ -752,6 +902,75 @@ export class CanonicalIdentityRepository {
     return row;
   }
 
+  async upsertStructuredAttributeValue(
+    input: CreateStructuredAttributeValueInput
+  ): Promise<StructuredAttributeValueRow> {
+    const id = input.id ?? generateId();
+    const now = getCurrentTimestamp();
+    const tenantId = resolveTenantId(this.tenantId, input.tenant_id);
+    const row: StructuredAttributeValueRow = {
+      id,
+      tenant_id: tenantId,
+      owner_type: input.owner_type,
+      owner_id: input.owner_id,
+      catalog_entry_id: input.catalog_entry_id,
+      canonical_json: JSON.stringify(input.canonical),
+      projected_index_json: encodeJson(input.projected_index),
+      classification: input.classification ?? 'internal',
+      lifecycle_state: input.lifecycle_state ?? 'active',
+      created_at: now,
+      updated_at: now,
+      deleted_at: null,
+    };
+
+    await this.adapter.execute(
+      `INSERT INTO structured_attribute_values (
+        id, tenant_id, owner_type, owner_id, catalog_entry_id, canonical_json,
+        projected_index_json, classification, lifecycle_state, created_at, updated_at, deleted_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        owner_type = excluded.owner_type,
+        owner_id = excluded.owner_id,
+        catalog_entry_id = excluded.catalog_entry_id,
+        canonical_json = excluded.canonical_json,
+        projected_index_json = excluded.projected_index_json,
+        classification = excluded.classification,
+        lifecycle_state = excluded.lifecycle_state,
+        updated_at = excluded.updated_at,
+        deleted_at = excluded.deleted_at`,
+      [
+        row.id,
+        row.tenant_id,
+        row.owner_type,
+        row.owner_id,
+        row.catalog_entry_id,
+        row.canonical_json,
+        row.projected_index_json,
+        row.classification,
+        row.lifecycle_state,
+        row.created_at,
+        row.updated_at,
+        row.deleted_at,
+      ]
+    );
+    return row;
+  }
+
+  async transitionStructuredAttributeValueLifecycle(
+    structuredValueId: string,
+    lifecycleState: IdentityLifecycleState
+  ): Promise<boolean> {
+    const now = getCurrentTimestamp();
+    const deletedAt = lifecycleState === 'deleted' || lifecycleState === 'deleting' ? now : null;
+    const result = await this.adapter.execute(
+      `UPDATE structured_attribute_values
+          SET lifecycle_state = ?, updated_at = ?, deleted_at = ?
+        WHERE id = ? AND tenant_id = ?`,
+      [lifecycleState, now, deletedAt, structuredValueId, this.tenantId]
+    );
+    return result.rowsAffected > 0;
+  }
+
   async createContactPoint(input: CreateContactPointInput): Promise<ContactPointRow> {
     const id = input.id ?? generateId();
     const now = getCurrentTimestamp();
@@ -780,6 +999,68 @@ export class CanonicalIdentityRepository {
         value_storage_ref, display_label, is_primary, verification_state, lifecycle_state,
         created_at, updated_at, deleted_at
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        row.id,
+        row.tenant_id,
+        row.subject_id,
+        row.account_id,
+        row.contact_type,
+        row.purpose,
+        row.normalized_hash,
+        row.value_storage_ref,
+        row.display_label,
+        row.is_primary,
+        row.verification_state,
+        row.lifecycle_state,
+        row.created_at,
+        row.updated_at,
+        row.deleted_at,
+      ]
+    );
+    return row;
+  }
+
+  async upsertContactPoint(input: CreateContactPointInput): Promise<ContactPointRow> {
+    const id = input.id ?? generateId();
+    const now = getCurrentTimestamp();
+    const tenantId = resolveTenantId(this.tenantId, input.tenant_id);
+    const row: ContactPointRow = {
+      id,
+      tenant_id: tenantId,
+      subject_id: input.subject_id ?? null,
+      account_id: input.account_id ?? null,
+      contact_type: input.contact_type,
+      purpose: input.purpose ?? 'primary',
+      normalized_hash: input.normalized_hash,
+      value_storage_ref: input.value_storage_ref,
+      display_label: input.display_label ?? null,
+      is_primary: input.is_primary ? 1 : 0,
+      verification_state: input.verification_state ?? 'unverified',
+      lifecycle_state: input.lifecycle_state ?? 'active',
+      created_at: now,
+      updated_at: now,
+      deleted_at: null,
+    };
+
+    await this.adapter.execute(
+      `INSERT INTO contact_points (
+        id, tenant_id, subject_id, account_id, contact_type, purpose, normalized_hash,
+        value_storage_ref, display_label, is_primary, verification_state, lifecycle_state,
+        created_at, updated_at, deleted_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        subject_id = excluded.subject_id,
+        account_id = excluded.account_id,
+        contact_type = excluded.contact_type,
+        purpose = excluded.purpose,
+        normalized_hash = excluded.normalized_hash,
+        value_storage_ref = excluded.value_storage_ref,
+        display_label = excluded.display_label,
+        is_primary = excluded.is_primary,
+        verification_state = excluded.verification_state,
+        lifecycle_state = excluded.lifecycle_state,
+        updated_at = excluded.updated_at,
+        deleted_at = excluded.deleted_at`,
       [
         row.id,
         row.tenant_id,

--- a/packages/ar-lib-core/src/repositories/identity/canonical-runtime-user-projection.ts
+++ b/packages/ar-lib-core/src/repositories/identity/canonical-runtime-user-projection.ts
@@ -140,6 +140,11 @@ const PROFILE_ATTRIBUTE_TO_RUNTIME_FIELD: Record<
 };
 
 const ADDRESS_CATALOG_IDS = new Set(['address', 'field.canonical.address']);
+const CUSTOM_ATTRIBUTES_CATALOG_IDS = new Set([
+  'custom_attributes',
+  'custom_attributes_json',
+  'field.canonical.custom_attributes',
+]);
 const LEGACY_USERS_PII_REF_SCHEME = 'legacy-users-pii:';
 const LEGACY_USERS_PII_FIELDS = new Set<string>([
   'email',
@@ -380,6 +385,10 @@ export class CanonicalRuntimeUserProjectionRepository {
       const field = PROFILE_ATTRIBUTE_TO_RUNTIME_FIELD[attribute.catalog_entry_id];
       if (field) {
         projection[field] = toStringOrNull(value);
+      } else if (CUSTOM_ATTRIBUTES_CATALOG_IDS.has(attribute.catalog_entry_id)) {
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+          Object.assign(customAttributes, value);
+        }
       } else if (!ADDRESS_CATALOG_IDS.has(attribute.catalog_entry_id)) {
         customAttributes[attribute.catalog_entry_id] = value;
       }
@@ -428,13 +437,18 @@ export class CanonicalRuntimeUserProjectionRepository {
     subject: IdentitySubjectRow,
     account: IdentityAccountRow
   ): Promise<void> {
-    const contacts = await this.adapter.query<ContactPointRow>(
+    const subjectContacts = await this.adapter.query<ContactPointRow>(
       `SELECT *
          FROM contact_points
         WHERE subject_id = ? AND tenant_id = ?${activeClause(false)}
         ORDER BY is_primary DESC, created_at ASC`,
       [subject.id, this.tenantId]
     );
+    const accountContacts = subjectContacts.filter((contact) => contact.account_id === account.id);
+    const contacts =
+      accountContacts.length > 0
+        ? accountContacts
+        : subjectContacts.filter((contact) => contact.account_id === null);
 
     for (const contact of contacts) {
       const value = toStringOrNull(

--- a/packages/ar-lib-core/src/repositories/identity/canonical-runtime-user-writer.ts
+++ b/packages/ar-lib-core/src/repositories/identity/canonical-runtime-user-writer.ts
@@ -22,6 +22,8 @@ export interface CanonicalRuntimeUserWriteInput {
   sourceRef?: string | null;
   piiFields?: Partial<Record<LegacyUsersPiiField, boolean>>;
   inlineProfileFields?: Record<string, string | number | boolean | null>;
+  addressJson?: string | null;
+  customAttributesJson?: string | null;
 }
 
 export interface CanonicalRuntimeUserWriteResult {
@@ -44,6 +46,9 @@ const PROFILE_FIELD_TO_CATALOG_ID: Partial<Record<LegacyUsersPiiField, string>> 
   gender: 'field.canonical.gender',
   birthdate: 'field.canonical.birthdate',
 };
+
+const ADDRESS_CATALOG_ENTRY_ID = 'field.canonical.address';
+const CUSTOM_ATTRIBUTES_CATALOG_ENTRY_ID = 'field.canonical.custom_attributes';
 
 function toLifecycleState(active: boolean): IdentityLifecycleState {
   return active ? 'active' : 'deprovisioned';
@@ -112,6 +117,8 @@ export class CanonicalRuntimeUserWriter {
     if (graph.profile) {
       profileAttributeCount += await this.createPiiProfileAttributeRefs(input, graph.profile.id);
       profileAttributeCount += await this.createInlineProfileAttributes(input, graph.profile.id);
+      profileAttributeCount += await this.createCustomAttributes(input, graph.profile.id);
+      await this.createStructuredAddress(input, graph.profile.id);
     }
     contactPointCount += await this.createContactRefs(input, graph.subject.id, graph.account.id);
 
@@ -134,15 +141,39 @@ export class CanonicalRuntimeUserWriter {
     }
 
     const lifecycleState = toLifecycleState(input.active);
-    await this.repository.transitionAccountLifecycle(account.id, lifecycleState);
+    await this.repository.updateAccountRuntimeFields(account.id, {
+      lifecycleState,
+      displayLabel: input.displayName ?? null,
+    });
     if (account.primary_subject_id) {
-      await this.repository.transitionSubjectLifecycle(account.primary_subject_id, lifecycleState);
+      await this.repository.updateSubjectRuntimeFields(account.primary_subject_id, {
+        lifecycleState,
+        displayLabel: input.displayName ?? null,
+      });
+    }
+    const profile = account.primary_subject_id
+      ? await this.ensureProfile(account.primary_subject_id, input, lifecycleState)
+      : null;
+    let profileAttributeCount = 0;
+    let contactPointCount = 0;
+    if (profile) {
+      profileAttributeCount += await this.upsertPiiProfileAttributeRefs(input, profile.id);
+      profileAttributeCount += await this.upsertInlineProfileAttributes(input, profile.id);
+      profileAttributeCount += await this.upsertCustomAttributes(input, profile.id);
+      await this.upsertStructuredAddress(input, profile.id);
+    }
+    if (account.primary_subject_id) {
+      contactPointCount += await this.upsertContactRefs(
+        input,
+        account.primary_subject_id,
+        account.id
+      );
     }
 
     return {
       graph: null,
-      profileAttributeCount: 0,
-      contactPointCount: 0,
+      profileAttributeCount,
+      contactPointCount,
       created: false,
     };
   }
@@ -197,6 +228,39 @@ export class CanonicalRuntimeUserWriter {
     return count;
   }
 
+  private async upsertPiiProfileAttributeRefs(
+    input: CanonicalRuntimeUserWriteInput,
+    profileId: string
+  ): Promise<number> {
+    let count = 0;
+    for (const [field, enabled] of Object.entries(input.piiFields ?? {})) {
+      if (!enabled) {
+        continue;
+      }
+      const catalogEntryId = PROFILE_FIELD_TO_CATALOG_ID[field as LegacyUsersPiiField];
+      if (!catalogEntryId) {
+        continue;
+      }
+      await this.repository.upsertProfileAttributeValue({
+        id: `profile-attribute:${input.userId}:${field}`,
+        tenant_id: input.tenantId,
+        profile_id: profileId,
+        catalog_entry_id: catalogEntryId,
+        value_type: 'reference',
+        value_storage_ref: encodeLegacyUsersPiiValueRef({
+          tenantId: input.tenantId,
+          userId: input.userId,
+          field: field as LegacyUsersPiiField,
+        }),
+        classification: 'sensitive',
+        purpose: 'profile',
+        display_order: count,
+      });
+      count += 1;
+    }
+    return count;
+  }
+
   private async createInlineProfileAttributes(
     input: CanonicalRuntimeUserWriteInput,
     profileId: string
@@ -221,6 +285,122 @@ export class CanonicalRuntimeUserWriter {
       count += 1;
     }
     return count;
+  }
+
+  private async upsertInlineProfileAttributes(
+    input: CanonicalRuntimeUserWriteInput,
+    profileId: string
+  ): Promise<number> {
+    let count = 0;
+    for (const [field, value] of Object.entries(input.inlineProfileFields ?? {})) {
+      if (value === null) {
+        continue;
+      }
+      await this.repository.upsertProfileAttributeValue({
+        id: `profile-attribute:${input.userId}:${field}`,
+        tenant_id: input.tenantId,
+        profile_id: profileId,
+        catalog_entry_id: field,
+        value_type: typeof value,
+        value,
+        classification: 'internal',
+        purpose: 'profile',
+        display_order: count,
+      });
+      count += 1;
+    }
+    return count;
+  }
+
+  private async createCustomAttributes(
+    input: CanonicalRuntimeUserWriteInput,
+    profileId: string
+  ): Promise<number> {
+    const customAttributes = parseJsonObject(input.customAttributesJson);
+    if (!customAttributes) {
+      return 0;
+    }
+    await this.repository.createProfileAttributeValue({
+      id: `profile-attribute:${input.userId}:custom_attributes`,
+      tenant_id: input.tenantId,
+      profile_id: profileId,
+      catalog_entry_id: CUSTOM_ATTRIBUTES_CATALOG_ENTRY_ID,
+      value_type: 'json',
+      value: customAttributes,
+      classification: 'internal',
+      purpose: 'profile',
+      display_order: 10_000,
+    });
+    return 1;
+  }
+
+  private async upsertCustomAttributes(
+    input: CanonicalRuntimeUserWriteInput,
+    profileId: string
+  ): Promise<number> {
+    const attributeValueId = `profile-attribute:${input.userId}:custom_attributes`;
+    const customAttributes = parseJsonObject(input.customAttributesJson);
+    if (!customAttributes) {
+      await this.repository.transitionProfileAttributeValueLifecycle(attributeValueId, 'deleted');
+      return 0;
+    }
+    await this.repository.upsertProfileAttributeValue({
+      id: attributeValueId,
+      tenant_id: input.tenantId,
+      profile_id: profileId,
+      catalog_entry_id: CUSTOM_ATTRIBUTES_CATALOG_ENTRY_ID,
+      value_type: 'json',
+      value: customAttributes,
+      classification: 'internal',
+      purpose: 'profile',
+      display_order: 10_000,
+    });
+    return 1;
+  }
+
+  private async createStructuredAddress(
+    input: CanonicalRuntimeUserWriteInput,
+    profileId: string
+  ): Promise<void> {
+    const address = parseJsonObject(input.addressJson);
+    if (!address) {
+      return;
+    }
+    await this.repository.createStructuredAttributeValue({
+      id: `structured-attribute:${input.userId}:address`,
+      tenant_id: input.tenantId,
+      owner_type: 'profile',
+      owner_id: profileId,
+      catalog_entry_id: ADDRESS_CATALOG_ENTRY_ID,
+      canonical: address,
+      classification: 'confidential',
+      lifecycle_state: 'active',
+    });
+  }
+
+  private async upsertStructuredAddress(
+    input: CanonicalRuntimeUserWriteInput,
+    profileId: string
+  ): Promise<void> {
+    const structuredValueId = `structured-attribute:${input.userId}:address`;
+    const address = parseJsonObject(input.addressJson);
+    if (!address) {
+      await this.repository.transitionStructuredAttributeValueLifecycle(
+        structuredValueId,
+        'deleted'
+      );
+      return;
+    }
+    await this.repository.upsertStructuredAttributeValue({
+      id: structuredValueId,
+      tenant_id: input.tenantId,
+      owner_type: 'profile',
+      owner_id: profileId,
+      catalog_entry_id: ADDRESS_CATALOG_ENTRY_ID,
+      canonical: address,
+      classification: 'confidential',
+      lifecycle_state: 'active',
+    });
   }
 
   private async createContactRefs(
@@ -269,4 +449,92 @@ export class CanonicalRuntimeUserWriter {
     }
     return count;
   }
+
+  private async upsertContactRefs(
+    input: CanonicalRuntimeUserWriteInput,
+    subjectId: string,
+    accountId: string
+  ): Promise<number> {
+    let count = 0;
+    if (input.piiFields?.email) {
+      await this.repository.upsertContactPoint({
+        id: `contact:${input.userId}:email`,
+        tenant_id: input.tenantId,
+        subject_id: subjectId,
+        account_id: accountId,
+        contact_type: 'email',
+        purpose: 'primary',
+        normalized_hash: `legacy-users-pii:${input.userId}:email`,
+        value_storage_ref: encodeLegacyUsersPiiValueRef({
+          tenantId: input.tenantId,
+          userId: input.userId,
+          field: 'email',
+        }),
+        is_primary: true,
+        verification_state: input.emailVerified ? 'verified' : 'unverified',
+      });
+      count += 1;
+    }
+    if (input.piiFields?.phone_number) {
+      await this.repository.upsertContactPoint({
+        id: `contact:${input.userId}:phone`,
+        tenant_id: input.tenantId,
+        subject_id: subjectId,
+        account_id: accountId,
+        contact_type: 'phone',
+        purpose: 'primary',
+        normalized_hash: `legacy-users-pii:${input.userId}:phone`,
+        value_storage_ref: encodeLegacyUsersPiiValueRef({
+          tenantId: input.tenantId,
+          userId: input.userId,
+          field: 'phone_number',
+        }),
+        is_primary: true,
+        verification_state: input.phoneNumberVerified ? 'verified' : 'unverified',
+      });
+      count += 1;
+    }
+    return count;
+  }
+
+  private async ensureProfile(
+    subjectId: string,
+    input: CanonicalRuntimeUserWriteInput,
+    lifecycleState: IdentityLifecycleState
+  ) {
+    const existingProfile = (
+      await this.repository.findProfilesForSubject(subjectId, { includeInactive: true })
+    )[0];
+    if (existingProfile) {
+      await this.repository.updateProfileRuntimeFields(existingProfile.id, {
+        lifecycleState,
+        locale: input.locale ?? null,
+        zoneinfo: input.zoneinfo ?? null,
+      });
+      return existingProfile;
+    }
+    return this.repository.createProfile({
+      id: `profile:${input.userId}`,
+      tenant_id: input.tenantId,
+      subject_id: subjectId,
+      lifecycle_state: lifecycleState,
+      locale: input.locale ?? null,
+      zoneinfo: input.zoneinfo ?? null,
+    });
+  }
+}
+
+function parseJsonObject(value: string | null | undefined): Record<string, unknown> | null {
+  if (!value) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return null;
+  }
+  return null;
 }

--- a/packages/ar-management/src/scim.ts
+++ b/packages/ar-management/src/scim.ts
@@ -115,6 +115,8 @@ async function maybeCreateCanonicalRuntimeUser(
     locale: internalUser.locale ?? null,
     zoneinfo: internalUser.zoneinfo ?? null,
     sourceRef: 'scim:/Users',
+    addressJson: internalUser.address_json ?? null,
+    customAttributesJson: internalUser.custom_attributes_json ?? null,
     piiFields: {
       email: true,
       phone_number: true,
@@ -159,6 +161,8 @@ async function maybeSyncCanonicalRuntimeUser(
     locale: internalUser.locale ?? null,
     zoneinfo: internalUser.zoneinfo ?? null,
     sourceRef: 'scim:/Users',
+    addressJson: internalUser.address_json ?? null,
+    customAttributesJson: internalUser.custom_attributes_json ?? null,
     piiFields: {
       email: true,
       phone_number: true,

--- a/packages/setup/src/__tests__/cloudflare-migrations.test.ts
+++ b/packages/setup/src/__tests__/cloudflare-migrations.test.ts
@@ -332,6 +332,22 @@ ${insertOAuthClientSql('tenant-b', 'shared-mobile', 'Tenant B Mobile')}
             "SELECT COUNT(*) FROM oauth_clients WHERE client_id = 'shared-mobile';"
           )
         ).toBe('2');
+        for (const tableName of [
+          'subject_account_links',
+          'profiles',
+          'profile_attribute_values',
+          'structured_attribute_values',
+          'contact_points',
+          'identity_bindings',
+        ]) {
+          expect(
+            readSqlite(
+              sqlite3Path,
+              dbPath,
+              `SELECT COUNT(*) FROM pragma_table_info('${tableName}') WHERE name = 'deleted_at';`
+            )
+          ).toBe('1');
+        }
 
         expect(() =>
           runSqlite(

--- a/packages/setup/src/__tests__/cloudflare-migrations.test.ts
+++ b/packages/setup/src/__tests__/cloudflare-migrations.test.ts
@@ -35,6 +35,7 @@ function readSqlite(sqlite3Path: string, dbPath: string, sql: string): string {
 }
 
 const rootMigrationsDir = fileURLToPath(new URL('../../../../migrations', import.meta.url));
+const docsTestingDir = fileURLToPath(new URL('../../../../docs/testing', import.meta.url));
 const coreMigrationExclusions = new Set(['admin', 'archive', 'external', 'pii']);
 const sqliteMigrationApplyTimeoutMs = 20_000;
 
@@ -62,6 +63,10 @@ function activeD1MigrationFiles(): string[] {
 
 function readMigration(relativePath: string): string {
   return readFileSync(join(rootMigrationsDir, relativePath), 'utf-8');
+}
+
+function readTestingDoc(relativePath: string): string {
+  return readFileSync(join(docsTestingDir, relativePath), 'utf-8');
 }
 
 function readMigrations(relativePaths: string[]): string {
@@ -562,6 +567,29 @@ INSERT INTO tenants (
     expect(migrationIds.has('UIM-SCH-085')).toBe(false);
     expect(migrationIds.has('UIM-SCH-086')).toBe(false);
     expect(migrationIds.has('UIM-SCH-087')).toBe(false);
+  });
+
+  it('keeps PR6 canonical runtime cutover items closed in the readiness snapshot', () => {
+    const readinessSnapshot = readTestingDoc('unified-identity-mapping-cutover-hardening.md');
+    const requiredClosedIds = [
+      'UIM-SCH-001',
+      'UIM-SCH-002',
+      'UIM-SCH-003',
+      'UIM-SCH-004',
+      'UIM-SCH-005',
+      'UIM-SCH-006',
+      'UIM-SCH-007',
+      'UIM-SCH-032A',
+    ];
+
+    for (const id of requiredClosedIds) {
+      const row = readinessSnapshot
+        .split('\n')
+        .find((line) => new RegExp(`^\\|\\s+${id}\\s+\\|`).test(line));
+      expect(row, `${id} is listed in PR6 readiness snapshot`).toBeDefined();
+      expect(row, `${id} has PR6 cutover hardening evidence`).toContain('PR6 hardening');
+      expect(row, `${id} is tested before PR6 exits`).toContain('| tested |');
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Add PR6 canonical runtime cutover hardening coverage for split-brain regression, malformed legacy PII refs, and hot-path smoke budgeting.
- Add a tracked PR6 verification checklist with automated gates, readiness snapshot, manual verification steps, and rollback notes.
- Extend migration freshness tests to keep the PR6 readiness snapshot aligned with the canonical runtime cutover schema IDs.

## Verification
- `pnpm --filter @authrim/ar-lib-core test -- src/repositories/__tests__/canonical-runtime-cutover-hardening.test.ts src/repositories/__tests__/canonical-runtime-cutover-gate.test.ts src/repositories/__tests__/canonical-runtime-user-writer.test.ts src/repositories/__tests__/canonical-runtime-user-projection.test.ts src/utils/__tests__/canonical-runtime-claims.test.ts`
- `pnpm --filter @authrim/setup test -- src/__tests__/cloudflare-migrations.test.ts`
- `pnpm --filter @authrim/ar-lib-core typecheck`
- `pnpm --filter @authrim/setup typecheck`
- `pnpm --filter @authrim/ar-management test -- src/__tests__/admin.test.ts src/__tests__/identity-canonical-runtime.test.ts src/__tests__/scim.test.ts`
- `pnpm --filter @authrim/ar-saml test -- src/common/__tests__/user-store.test.ts`
- `pnpm --filter @authrim/ar-userinfo test -- src/__tests__/userinfo.test.ts`
- `pnpm exec prettier --check packages/setup/src/__tests__/cloudflare-migrations.test.ts docs/testing/unified-identity-mapping-cutover-hardening.md packages/ar-lib-core/src/repositories/__tests__/canonical-runtime-cutover-hardening.test.ts`
- `git diff --check`

Hot-path smoke output observed locally: `p95Ms: 0.0805`, `maxReadCount: 6`.