### PR TITLE
feat: add identity mapping consent review foundations

### DIFF
--- a/migrations/006_core_extended_operations.sql
+++ b/migrations/006_core_extended_operations.sql
@@ -232,6 +232,10 @@ CREATE TABLE IF NOT EXISTS internal_notification_events (
   tenant_id TEXT NOT NULL,
   category TEXT NOT NULL CHECK (
     category IN (
+      'identity_mapping_signal',
+      'identity_mapping_manual_review',
+      'identity_mapping_propagation_failure',
+      'identity_mapping_bulk_impact',
       'storage_registry_security',
       'storage_registry_health',
       'tenant_database_stats',

--- a/packages/ar-lib-core/src/index.ts
+++ b/packages/ar-lib-core/src/index.ts
@@ -196,6 +196,7 @@ export * from './services/object-catalog';
 export * from './services/sensitive-detail-chunk-store';
 export * from './services/identity-identifier-bridge';
 export * from './services/identity-resolution';
+export * from './services/identity-release-consent';
 export * from './services/logging-runtime-policy';
 export * from './services/logging-runtime-emitter';
 export * from './services/pii-compensation-policy';

--- a/packages/ar-lib-core/src/repositories/__tests__/attribute-release-consent.test.ts
+++ b/packages/ar-lib-core/src/repositories/__tests__/attribute-release-consent.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { AttributeReleaseConsentRepository } from '../identity';
+import { MockDatabaseAdapter } from './mock-adapter';
+
+describe('AttributeReleaseConsentRepository', () => {
+  it('stores granted attribute release consent without raw attribute values', async () => {
+    const adapter = new MockDatabaseAdapter();
+    adapter.initTable('attribute_release_consents', 'id');
+    const repository = new AttributeReleaseConsentRepository(adapter);
+
+    const consent = await repository.grant({
+      id: 'attribute-release-consent-1',
+      tenant_id: 'tenant-a',
+      subject_id: 'subject-1',
+      destination_type: 'saml_sp',
+      destination_id: 'https://sp.example.org/saml',
+      attribute_set_hash: 'sha256-attribute-set',
+      consent_mode: 'until_attributes_change',
+      consent_record_id: 'user-consent-record-1',
+    });
+
+    expect(consent.consent_state).toBe('granted');
+    await expect(
+      repository.findGrantedConsent({
+        tenant_id: 'tenant-a',
+        subject_id: 'subject-1',
+        destination_type: 'saml_sp',
+        destination_id: 'https://sp.example.org/saml',
+        attribute_set_hash: 'sha256-attribute-set',
+      })
+    ).resolves.toMatchObject({
+      id: 'attribute-release-consent-1',
+      consent_record_id: 'user-consent-record-1',
+    });
+    expect(JSON.stringify(adapter.getById('attribute_release_consents', consent.id))).not.toContain(
+      'person@example.edu'
+    );
+  });
+
+  it('does not return revoked attribute release consent as granted', async () => {
+    const adapter = new MockDatabaseAdapter();
+    adapter.initTable('attribute_release_consents', 'id');
+    adapter.seed('attribute_release_consents', [
+      {
+        id: 'attribute-release-consent-revoked',
+        tenant_id: 'tenant-a',
+        subject_id: 'subject-1',
+        destination_type: 'saml_sp',
+        destination_id: 'https://sp.example.org/saml',
+        attribute_set_hash: 'sha256-attribute-set',
+        consent_mode: 'once',
+        consent_state: 'revoked',
+        consent_record_id: 'user-consent-record-1',
+        first_granted_at: 1000,
+        last_confirmed_at: 1000,
+        expires_at: null,
+        revoked_at: 1100,
+        created_at: 1000,
+        updated_at: 1100,
+      },
+    ]);
+    const repository = new AttributeReleaseConsentRepository(adapter);
+
+    await expect(
+      repository.findGrantedConsent({
+        tenant_id: 'tenant-a',
+        subject_id: 'subject-1',
+        destination_type: 'saml_sp',
+        destination_id: 'https://sp.example.org/saml',
+        attribute_set_hash: 'sha256-attribute-set',
+      })
+    ).resolves.toBeNull();
+  });
+
+  it('returns the persisted row when a consent grant updates an existing hash', async () => {
+    const adapter = new MockDatabaseAdapter();
+    adapter.initTable('attribute_release_consents', 'id');
+    adapter.seed('attribute_release_consents', [
+      {
+        id: 'existing-consent',
+        tenant_id: 'tenant-a',
+        subject_id: 'subject-1',
+        destination_type: 'saml_sp',
+        destination_id: 'https://sp.example.org/saml',
+        attribute_set_hash: 'sha256-attribute-set',
+        consent_mode: 'once',
+        consent_state: 'revoked',
+        consent_record_id: null,
+        first_granted_at: 1000,
+        last_confirmed_at: 1000,
+        expires_at: null,
+        revoked_at: 1100,
+        created_at: 1000,
+        updated_at: 1100,
+      },
+    ]);
+    const repository = new AttributeReleaseConsentRepository(adapter);
+
+    const consent = await repository.grant({
+      tenant_id: 'tenant-a',
+      subject_id: 'subject-1',
+      destination_type: 'saml_sp',
+      destination_id: 'https://sp.example.org/saml',
+      attribute_set_hash: 'sha256-attribute-set',
+      consent_mode: 'once',
+    });
+
+    expect(consent.id).toBe('existing-consent');
+  });
+});

--- a/packages/ar-lib-core/src/repositories/__tests__/canonical-identity.test.ts
+++ b/packages/ar-lib-core/src/repositories/__tests__/canonical-identity.test.ts
@@ -16,6 +16,7 @@ const CANONICAL_TABLES = [
   'identity_resolution_candidates',
   'assurance_evidence',
   'value_provenance',
+  'subject_lifecycle_timeline_events',
   'contact_point_search_indexes',
   'identity_binding_lookup_indexes',
 ];
@@ -268,6 +269,31 @@ describe('CanonicalIdentityRepository', () => {
     expect(
       adapter.getById('identity_binding_lookup_indexes', 'binding-index-1')?.lookup_value
     ).toBe('blind-index-nameid');
+  });
+
+  it('records subject lifecycle timeline events with redacted summaries', async () => {
+    const event = await repository.recordSubjectLifecycleTimelineEvent({
+      id: 'timeline-event-1',
+      subject_id: 'subject-1',
+      account_id: 'account-1',
+      event_type: 'attribute_release.challenge_required',
+      source_type: 'review_task',
+      source_id: 'review-task-1',
+      summary: {
+        destination: 'https://sp.example.org/saml',
+        reasonCodes: ['release.attribute_consent.attribute_set_changed'],
+      },
+      event_at: 2000,
+    });
+
+    expect(event.event_at).toBe(2000);
+    expect(JSON.parse(event.summary_json ?? '{}')).toEqual({
+      destination: 'https://sp.example.org/saml',
+      reasonCodes: ['release.attribute_consent.attribute_set_changed'],
+    });
+    expect(
+      adapter.getById('subject_lifecycle_timeline_events', 'timeline-event-1')?.event_type
+    ).toBe('attribute_release.challenge_required');
   });
 
   it('transitions subject and account lifecycle without hard deleting rows', async () => {

--- a/packages/ar-lib-core/src/repositories/admin/internal-notification-event.ts
+++ b/packages/ar-lib-core/src/repositories/admin/internal-notification-event.ts
@@ -1,6 +1,10 @@
 import type { DatabaseAdapter } from '../../db/adapter';
 
 export type InternalNotificationEventCategory =
+  | 'identity_mapping_signal'
+  | 'identity_mapping_manual_review'
+  | 'identity_mapping_propagation_failure'
+  | 'identity_mapping_bulk_impact'
   | 'storage_registry_security'
   | 'storage_registry_health'
   | 'tenant_database_stats'

--- a/packages/ar-lib-core/src/repositories/identity/attribute-release-consent.ts
+++ b/packages/ar-lib-core/src/repositories/identity/attribute-release-consent.ts
@@ -1,0 +1,162 @@
+import type { DatabaseAdapter } from '../../db/adapter';
+import { generateId, getCurrentTimestamp } from '../base';
+import type { AttributeReleaseConsentMode } from '../../services/identity-release-consent';
+
+export type AttributeReleaseConsentState = 'granted' | 'denied' | 'revoked' | 'expired' | string;
+
+export interface AttributeReleaseConsentRow {
+  id: string;
+  tenant_id: string;
+  subject_id: string;
+  account_id: string | null;
+  destination_type: string;
+  destination_id: string;
+  attribute_set_hash: string;
+  consent_mode: AttributeReleaseConsentMode;
+  consent_state: AttributeReleaseConsentState;
+  consent_record_id: string | null;
+  first_granted_at: number | null;
+  last_confirmed_at: number | null;
+  expires_at: number | null;
+  revoked_at: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface GrantAttributeReleaseConsentInput {
+  id?: string;
+  tenant_id: string;
+  subject_id: string;
+  account_id?: string | null;
+  destination_type: string;
+  destination_id: string;
+  attribute_set_hash: string;
+  consent_mode: AttributeReleaseConsentMode;
+  consent_record_id?: string | null;
+  expires_at?: number | null;
+}
+
+export class AttributeReleaseConsentRepository {
+  constructor(private readonly adapter: DatabaseAdapter) {}
+
+  async findGrantedConsent(input: {
+    tenant_id: string;
+    subject_id: string;
+    destination_type: string;
+    destination_id: string;
+    attribute_set_hash: string;
+    now?: number;
+  }): Promise<AttributeReleaseConsentRow | null> {
+    const now = input.now ?? getCurrentTimestamp();
+    const rows = await this.adapter.query<AttributeReleaseConsentRow>(
+      `SELECT *
+         FROM attribute_release_consents
+        WHERE tenant_id = ?
+          AND subject_id = ?
+          AND destination_type = ?
+          AND destination_id = ?
+          AND attribute_set_hash = ?
+        LIMIT 1`,
+      [
+        input.tenant_id,
+        input.subject_id,
+        input.destination_type,
+        input.destination_id,
+        input.attribute_set_hash,
+      ]
+    );
+    return (
+      rows.find(
+        (row) =>
+          row.consent_state === 'granted' && (row.expires_at === null || row.expires_at > now)
+      ) ?? null
+    );
+  }
+
+  async grant(input: GrantAttributeReleaseConsentInput): Promise<AttributeReleaseConsentRow> {
+    const now = getCurrentTimestamp();
+    const row: AttributeReleaseConsentRow = {
+      id: input.id ?? generateId(),
+      tenant_id: input.tenant_id,
+      subject_id: input.subject_id,
+      account_id: input.account_id ?? null,
+      destination_type: input.destination_type,
+      destination_id: input.destination_id,
+      attribute_set_hash: input.attribute_set_hash,
+      consent_mode: input.consent_mode,
+      consent_state: 'granted',
+      consent_record_id: input.consent_record_id ?? null,
+      first_granted_at: now,
+      last_confirmed_at: now,
+      expires_at: input.expires_at ?? null,
+      revoked_at: null,
+      created_at: now,
+      updated_at: now,
+    };
+
+    await this.adapter.execute(
+      `INSERT INTO attribute_release_consents (
+        id, tenant_id, subject_id, account_id, destination_type, destination_id,
+        attribute_set_hash, consent_mode, consent_state, consent_record_id,
+        first_granted_at, last_confirmed_at, expires_at, revoked_at, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(tenant_id, subject_id, destination_type, destination_id, attribute_set_hash)
+      DO UPDATE SET
+        consent_mode = excluded.consent_mode,
+        consent_state = excluded.consent_state,
+        consent_record_id = excluded.consent_record_id,
+        last_confirmed_at = excluded.last_confirmed_at,
+        expires_at = excluded.expires_at,
+        revoked_at = NULL,
+        updated_at = excluded.updated_at`,
+      [
+        row.id,
+        row.tenant_id,
+        row.subject_id,
+        row.account_id,
+        row.destination_type,
+        row.destination_id,
+        row.attribute_set_hash,
+        row.consent_mode,
+        row.consent_state,
+        row.consent_record_id,
+        row.first_granted_at,
+        row.last_confirmed_at,
+        row.expires_at,
+        row.revoked_at,
+        row.created_at,
+        row.updated_at,
+      ]
+    );
+    return (
+      (await this.adapter.queryOne<AttributeReleaseConsentRow>(
+        `SELECT *
+           FROM attribute_release_consents
+          WHERE tenant_id = ?
+            AND subject_id = ?
+            AND destination_type = ?
+            AND destination_id = ?
+            AND attribute_set_hash = ?
+          LIMIT 1`,
+        [
+          row.tenant_id,
+          row.subject_id,
+          row.destination_type,
+          row.destination_id,
+          row.attribute_set_hash,
+        ]
+      )) ?? row
+    );
+  }
+
+  async revoke(id: string, tenantId: string): Promise<boolean> {
+    const now = getCurrentTimestamp();
+    const result = await this.adapter.execute(
+      `UPDATE attribute_release_consents
+          SET consent_state = ?, revoked_at = ?, updated_at = ?
+        WHERE id = ? AND tenant_id = ? AND consent_state = ?`,
+      ['revoked', now, now, id, tenantId, 'granted']
+    );
+    return result.rowsAffected > 0;
+  }
+}

--- a/packages/ar-lib-core/src/repositories/identity/canonical-identity.ts
+++ b/packages/ar-lib-core/src/repositories/identity/canonical-identity.ts
@@ -263,6 +263,19 @@ export interface ValueProvenanceRow {
   created_at: number;
 }
 
+export interface SubjectLifecycleTimelineEventRow {
+  id: string;
+  tenant_id: string;
+  subject_id: string | null;
+  account_id: string | null;
+  event_type: string;
+  source_type: string | null;
+  source_id: string | null;
+  summary_json: string | null;
+  event_at: number;
+  created_at: number;
+}
+
 export interface ContactPointSearchIndexRow {
   id: string;
   tenant_id: string;
@@ -461,6 +474,18 @@ export interface CreateValueProvenanceInput {
   observed_at?: number;
   confidence_score?: number | null;
   provenance?: JsonObject | null;
+}
+
+export interface CreateSubjectLifecycleTimelineEventInput {
+  id?: string;
+  tenant_id?: string;
+  subject_id?: string | null;
+  account_id?: string | null;
+  event_type: string;
+  source_type?: string | null;
+  source_id?: string | null;
+  summary?: JsonObject | null;
+  event_at?: number;
 }
 
 export interface CreateContactPointSearchIndexInput {
@@ -1475,6 +1500,46 @@ export class CanonicalIdentityRepository {
         row.observed_at,
         row.confidence_score,
         row.provenance_json,
+        row.created_at,
+      ]
+    );
+    return row;
+  }
+
+  async recordSubjectLifecycleTimelineEvent(
+    input: CreateSubjectLifecycleTimelineEventInput
+  ): Promise<SubjectLifecycleTimelineEventRow> {
+    const id = input.id ?? generateId();
+    const now = getCurrentTimestamp();
+    const tenantId = resolveTenantId(this.tenantId, input.tenant_id);
+    const row: SubjectLifecycleTimelineEventRow = {
+      id,
+      tenant_id: tenantId,
+      subject_id: input.subject_id ?? null,
+      account_id: input.account_id ?? null,
+      event_type: input.event_type,
+      source_type: input.source_type ?? null,
+      source_id: input.source_id ?? null,
+      summary_json: encodeJson(input.summary),
+      event_at: input.event_at ?? now,
+      created_at: now,
+    };
+
+    await this.adapter.execute(
+      `INSERT INTO subject_lifecycle_timeline_events (
+        id, tenant_id, subject_id, account_id, event_type, source_type, source_id,
+        summary_json, event_at, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        row.id,
+        row.tenant_id,
+        row.subject_id,
+        row.account_id,
+        row.event_type,
+        row.source_type,
+        row.source_id,
+        row.summary_json,
+        row.event_at,
         row.created_at,
       ]
     );

--- a/packages/ar-lib-core/src/repositories/identity/index.ts
+++ b/packages/ar-lib-core/src/repositories/identity/index.ts
@@ -23,6 +23,7 @@ export {
   type CreateProfileInput,
   type CreateStructuredAttributeValueInput,
   type CreateSubjectAccountLinkInput,
+  type CreateSubjectLifecycleTimelineEventInput,
   type CreateValueProvenanceInput,
   type IdentityAccountRow,
   type IdentityAccountType,
@@ -44,6 +45,7 @@ export {
   type StructuredAttributeValueRow,
   type SubjectAccountLinkRow,
   type SubjectAccountLinkType,
+  type SubjectLifecycleTimelineEventRow,
   type ValueProvenanceRow,
 } from './canonical-identity';
 
@@ -64,3 +66,10 @@ export {
   type CanonicalRuntimeUserWriteInput,
   type CanonicalRuntimeUserWriteResult,
 } from './canonical-runtime-user-writer';
+
+export {
+  AttributeReleaseConsentRepository,
+  type AttributeReleaseConsentRow,
+  type AttributeReleaseConsentState,
+  type GrantAttributeReleaseConsentInput,
+} from './attribute-release-consent';

--- a/packages/ar-lib-core/src/services/__tests__/identity-release-consent.test.ts
+++ b/packages/ar-lib-core/src/services/__tests__/identity-release-consent.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateReleaseConsentGate,
+  RELEASE_DECISION_REASON_CODES,
+} from '../identity-release-consent';
+
+describe('evaluateReleaseConsentGate', () => {
+  it('requires a consent challenge for consent legal basis without satisfied consent', () => {
+    expect(
+      evaluateReleaseConsentGate({
+        fieldRef: { namespace: 'authrim.profile', path: 'email' },
+        legalBasis: 'consent',
+        consentSatisfied: false,
+        consentStatementId: 'statement-email-release',
+      })
+    ).toMatchObject({
+      action: 'challenge',
+      challenge: {
+        challengeType: 'consent_statement',
+        statementId: 'statement-email-release',
+      },
+      reasonCodes: [RELEASE_DECISION_REASON_CODES.consentMissing],
+    });
+  });
+
+  it('denies regulated legal obligation release when purpose does not match', () => {
+    expect(
+      evaluateReleaseConsentGate({
+        fieldRef: { namespace: 'authrim.regulated', path: 'individualNumber' },
+        legalBasis: 'legal_obligation',
+        classification: 'regulated',
+        purpose: 'analytics',
+        requiredPurpose: 'tax_reporting',
+        consentSatisfied: true,
+      })
+    ).toMatchObject({
+      action: 'deny',
+      reasonCodes: [RELEASE_DECISION_REASON_CODES.legalObligationPurposeMismatch],
+    });
+  });
+
+  it('records contract and legitimate interest as trace-only release basis', () => {
+    expect(
+      evaluateReleaseConsentGate({
+        fieldRef: { namespace: 'authrim.profile', path: 'department' },
+        legalBasis: 'contract',
+      })
+    ).toMatchObject({
+      action: 'release',
+      reasonCodes: [RELEASE_DECISION_REASON_CODES.disclosureBasisTraceOnly],
+    });
+  });
+
+  it('re-challenges attribute release consent when the released attribute set changes', () => {
+    expect(
+      evaluateReleaseConsentGate({
+        fieldRef: { namespace: 'saml', path: 'attributes' },
+        legalBasis: 'consent',
+        consentSatisfied: true,
+        attributeRelease: {
+          mode: 'until_attributes_change',
+          currentAttributeSetHash: 'hash-v2',
+          existingAttributeSetHash: 'hash-v1',
+          existingConsentState: 'granted',
+        },
+      })
+    ).toMatchObject({
+      action: 'challenge',
+      challenge: {
+        challengeType: 'attribute_release',
+        consentMode: 'until_attributes_change',
+        attributeSetHash: 'hash-v2',
+      },
+      reasonCodes: [
+        RELEASE_DECISION_REASON_CODES.consentSatisfied,
+        RELEASE_DECISION_REASON_CODES.attributeReleaseChanged,
+      ],
+    });
+  });
+
+  it('does not allow raw released attribute values in release trace metadata', () => {
+    expect(() =>
+      evaluateReleaseConsentGate({
+        fieldRef: { namespace: 'saml', path: 'mail' },
+        legalBasis: 'contract',
+        traceMetadata: { rawValue: 'person@example.edu' },
+      })
+    ).toThrow(/raw released attribute values/);
+  });
+});

--- a/packages/ar-lib-core/src/services/identity-release-consent.ts
+++ b/packages/ar-lib-core/src/services/identity-release-consent.ts
@@ -1,0 +1,227 @@
+export type ReleaseLegalBasis = 'consent' | 'legal_obligation' | 'contract' | 'legitimate_interest';
+
+export type AttributeReleaseConsentMode = 'once' | 'every_time' | 'until_attributes_change';
+export type ReleaseDecisionAction = 'release' | 'challenge' | 'deny';
+
+export interface AttributeReleaseConsentContext {
+  mode: AttributeReleaseConsentMode;
+  currentAttributeSetHash: string;
+  existingConsentState?: 'granted' | 'denied' | 'revoked' | 'expired' | null;
+  existingAttributeSetHash?: string | null;
+  consentRecordId?: string | null;
+}
+
+export interface ReleaseDecisionInput {
+  fieldRef: Record<string, unknown>;
+  legalBasis: ReleaseLegalBasis;
+  classification?: string | null;
+  purpose?: string | null;
+  requiredPurpose?: string | null;
+  consentSatisfied?: boolean;
+  consentStatementId?: string | null;
+  attributeRelease?: AttributeReleaseConsentContext | null;
+  traceMetadata?: Record<string, unknown> | null;
+}
+
+export interface ReleaseDecisionResult {
+  action: ReleaseDecisionAction;
+  legalBasis: ReleaseLegalBasis;
+  reasonCodes: string[];
+  challenge?: {
+    challengeType: 'consent_statement' | 'attribute_release';
+    statementId?: string | null;
+    consentMode?: AttributeReleaseConsentMode | null;
+    attributeSetHash?: string | null;
+  };
+  trace: {
+    fieldRef: Record<string, unknown>;
+    classification: string;
+    purpose: string | null;
+    basis: ReleaseLegalBasis;
+    consentRecordId: string | null;
+    metadata: Record<string, unknown> | null;
+  };
+}
+
+const RAW_VALUE_KEYS = new Set([
+  'attributeValue',
+  'email',
+  'nameId',
+  'phoneNumber',
+  'raw',
+  'rawValue',
+  'secret',
+  'sub',
+  'token',
+  'value',
+]);
+
+export const RELEASE_DECISION_REASON_CODES = {
+  consentMissing: 'release.consent.missing',
+  consentSatisfied: 'release.consent.satisfied',
+  attributeReleaseMissing: 'release.attribute_consent.missing',
+  attributeReleaseEveryTime: 'release.attribute_consent.every_time',
+  attributeReleaseChanged: 'release.attribute_consent.attribute_set_changed',
+  attributeReleaseSatisfied: 'release.attribute_consent.satisfied',
+  legalObligationPurposeMismatch: 'release.legal_obligation.purpose_mismatch',
+  legalObligationSatisfied: 'release.legal_obligation.satisfied',
+  disclosureBasisTraceOnly: 'release.disclosure_basis.trace_only',
+} as const;
+
+export function evaluateReleaseConsentGate(input: ReleaseDecisionInput): ReleaseDecisionResult {
+  assertNoRawReleaseMetadata(input.fieldRef, 'fieldRef');
+  assertNoRawReleaseMetadata(input.traceMetadata ?? null, 'traceMetadata');
+
+  const classification = input.classification ?? 'internal';
+  const baseTrace = {
+    fieldRef: input.fieldRef,
+    classification,
+    purpose: input.purpose ?? null,
+    basis: input.legalBasis,
+    consentRecordId: input.attributeRelease?.consentRecordId ?? null,
+    metadata: input.traceMetadata ?? null,
+  };
+
+  if (
+    input.legalBasis === 'legal_obligation' &&
+    classification === 'regulated' &&
+    input.requiredPurpose &&
+    input.purpose !== input.requiredPurpose
+  ) {
+    return {
+      action: 'deny',
+      legalBasis: input.legalBasis,
+      reasonCodes: [RELEASE_DECISION_REASON_CODES.legalObligationPurposeMismatch],
+      trace: baseTrace,
+    };
+  }
+
+  if (input.legalBasis === 'legal_obligation') {
+    return {
+      action: 'release',
+      legalBasis: input.legalBasis,
+      reasonCodes: [RELEASE_DECISION_REASON_CODES.legalObligationSatisfied],
+      trace: baseTrace,
+    };
+  }
+
+  if (input.legalBasis === 'contract' || input.legalBasis === 'legitimate_interest') {
+    return {
+      action: 'release',
+      legalBasis: input.legalBasis,
+      reasonCodes: [RELEASE_DECISION_REASON_CODES.disclosureBasisTraceOnly],
+      trace: baseTrace,
+    };
+  }
+
+  if (!input.consentSatisfied) {
+    return {
+      action: 'challenge',
+      legalBasis: input.legalBasis,
+      reasonCodes: [RELEASE_DECISION_REASON_CODES.consentMissing],
+      challenge: {
+        challengeType: 'consent_statement',
+        statementId: input.consentStatementId ?? null,
+      },
+      trace: baseTrace,
+    };
+  }
+
+  const attributeReleaseDecision = evaluateAttributeReleaseConsent(input.attributeRelease ?? null);
+  if (attributeReleaseDecision.action === 'challenge') {
+    return {
+      action: 'challenge',
+      legalBasis: input.legalBasis,
+      reasonCodes: [
+        RELEASE_DECISION_REASON_CODES.consentSatisfied,
+        ...attributeReleaseDecision.reasonCodes,
+      ],
+      challenge: attributeReleaseDecision.challenge,
+      trace: baseTrace,
+    };
+  }
+
+  return {
+    action: 'release',
+    legalBasis: input.legalBasis,
+    reasonCodes: [
+      RELEASE_DECISION_REASON_CODES.consentSatisfied,
+      ...attributeReleaseDecision.reasonCodes,
+    ],
+    trace: baseTrace,
+  };
+}
+
+function evaluateAttributeReleaseConsent(attributeRelease: AttributeReleaseConsentContext | null): {
+  action: 'release' | 'challenge';
+  reasonCodes: string[];
+  challenge?: ReleaseDecisionResult['challenge'];
+} {
+  if (!attributeRelease) {
+    return { action: 'release', reasonCodes: [] };
+  }
+
+  if (attributeRelease.mode === 'every_time') {
+    return {
+      action: 'challenge',
+      reasonCodes: [RELEASE_DECISION_REASON_CODES.attributeReleaseEveryTime],
+      challenge: {
+        challengeType: 'attribute_release',
+        consentMode: attributeRelease.mode,
+        attributeSetHash: attributeRelease.currentAttributeSetHash,
+      },
+    };
+  }
+
+  if (attributeRelease.existingConsentState !== 'granted') {
+    return {
+      action: 'challenge',
+      reasonCodes: [RELEASE_DECISION_REASON_CODES.attributeReleaseMissing],
+      challenge: {
+        challengeType: 'attribute_release',
+        consentMode: attributeRelease.mode,
+        attributeSetHash: attributeRelease.currentAttributeSetHash,
+      },
+    };
+  }
+
+  if (
+    attributeRelease.mode === 'until_attributes_change' &&
+    attributeRelease.existingAttributeSetHash !== attributeRelease.currentAttributeSetHash
+  ) {
+    return {
+      action: 'challenge',
+      reasonCodes: [RELEASE_DECISION_REASON_CODES.attributeReleaseChanged],
+      challenge: {
+        challengeType: 'attribute_release',
+        consentMode: attributeRelease.mode,
+        attributeSetHash: attributeRelease.currentAttributeSetHash,
+      },
+    };
+  }
+
+  return {
+    action: 'release',
+    reasonCodes: [RELEASE_DECISION_REASON_CODES.attributeReleaseSatisfied],
+  };
+}
+
+function assertNoRawReleaseMetadata(value: unknown, path: string): void {
+  if (value === null || value === undefined) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoRawReleaseMetadata(item, `${path}[${index}]`));
+    return;
+  }
+  if (typeof value !== 'object') {
+    return;
+  }
+
+  for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+    if (RAW_VALUE_KEYS.has(key)) {
+      throw new Error(`${path}.${key} must not contain raw released attribute values`);
+    }
+    assertNoRawReleaseMetadata(item, `${path}.${key}`);
+  }
+}

--- a/packages/ar-management/src/__tests__/identity-mapping-control-plane.test.ts
+++ b/packages/ar-management/src/__tests__/identity-mapping-control-plane.test.ts
@@ -416,6 +416,240 @@ describe('IdentityMappingControlPlaneRepository identity registry operations', (
   });
 });
 
+describe('IdentityMappingControlPlaneRepository review and notification operations', () => {
+  it('creates redacted review tasks and records idempotent state transitions', async () => {
+    const adapter = createAdapter({
+      queryOneRows: [
+        {
+          id: 'review-task-1',
+          status: 'open',
+          subject_id: 'subject-1',
+          account_id: 'account-1',
+        },
+      ],
+    });
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    const task = await repository.createReviewTask('tenant_a', {
+      taskType: 'identity_link_review',
+      subjectId: 'subject-1',
+      accountId: 'account-1',
+      priority: 20,
+      payload: {
+        source: 'saml',
+        destination: 'oidc',
+        riskSummary: 'verified-anchor candidate requires admin approval',
+      },
+    });
+    const transition = await repository.transitionReviewTask('tenant_a', 'review-task-1', {
+      status: 'approved',
+      assignedTo: 'admin-1',
+      reasonCodes: ['admin_approved_candidate_link'],
+    });
+
+    expect(task.status).toBe('open');
+    expect(transition).toMatchObject({
+      previousStatus: 'open',
+      status: 'approved',
+      idempotent: false,
+    });
+    expect(adapter.executes.map((item) => item.sql)).toEqual([
+      expect.stringContaining('INSERT INTO review_tasks'),
+      expect.stringContaining('UPDATE review_tasks'),
+      expect.stringContaining('INSERT INTO mapping_events'),
+    ]);
+  });
+
+  it('groups bulk review impact without storing raw values', async () => {
+    const adapter = createAdapter({});
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    const group = await repository.createReviewTaskGroup('tenant_a', {
+      groupKey: 'bulk-impact:policy-version-1',
+      summary: {
+        affectedTenant: 'tenant_a',
+        source: 'scim-directory',
+        destination: 'saml-sp',
+        affectedSubjects: 35,
+        risk: 'medium',
+      },
+    });
+
+    expect(group.groupKey).toBe('bulk-impact:policy-version-1');
+    expect(adapter.executes[0].sql).toContain('INSERT INTO review_task_groups');
+    expect(String(adapter.executes[0].params[4])).toContain('"affectedSubjects":35');
+  });
+
+  it('creates operational notification state for high priority identity mapping events', async () => {
+    const adapter = createAdapter({});
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    const notification = await repository.enqueueOperationalNotification('tenant_a', {
+      category: 'identity_mapping_manual_review',
+      eventType: 'identity_mapping.review_required',
+      severity: 'high',
+      subjectType: 'review_task',
+      subjectId: 'review-task-1',
+      deduplicationKey: 'review-task-1:manual-review',
+      payload: {
+        reviewTaskId: 'review-task-1',
+        reasonCodes: ['candidate_requires_admin_approval'],
+      },
+    });
+
+    expect(notification).toMatchObject({
+      state: 'open',
+      severity: 'high',
+      category: 'identity_mapping_manual_review',
+    });
+    expect(adapter.executes.map((item) => item.sql)).toEqual([
+      expect.stringContaining('INSERT INTO internal_notification_events'),
+      expect.stringContaining('INSERT INTO operational_notification_states'),
+    ]);
+    expect(adapter.executes[0].params[6]).toBe('tenant_a:review-task-1:manual-review');
+  });
+
+  it('returns an existing operational notification state for duplicate deduplication keys', async () => {
+    const adapter = createAdapter({
+      queryOneRows: [
+        {
+          id: 'notification-state-1',
+          notification_event_id: 'notification-event-1',
+          state: 'open',
+        },
+      ],
+    });
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    const notification = await repository.enqueueOperationalNotification('tenant_a', {
+      category: 'identity_mapping_manual_review',
+      eventType: 'identity_mapping.review_required',
+      severity: 'high',
+      subjectType: 'review_task',
+      subjectId: 'review-task-1',
+      deduplicationKey: 'review-task-1:manual-review',
+      payload: {
+        reviewTaskId: 'review-task-1',
+        reasonCodes: ['candidate_requires_admin_approval'],
+      },
+    });
+
+    expect(notification).toMatchObject({
+      id: 'notification-state-1',
+      notificationEventId: 'notification-event-1',
+      idempotent: true,
+    });
+    expect(adapter.executes).toHaveLength(0);
+  });
+
+  it('acknowledges and resolves operational notification states idempotently', async () => {
+    const adapter = createAdapter({
+      queryOneRows: [
+        {
+          id: 'notification-state-1',
+          state: 'open',
+        },
+        {
+          id: 'notification-state-1',
+          state: 'resolved',
+        },
+      ],
+    });
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    await expect(
+      repository.transitionOperationalNotificationState('tenant_a', 'notification-state-1', {
+        state: 'resolved',
+        assignedTo: 'admin-1',
+      })
+    ).resolves.toMatchObject({
+      previousState: 'open',
+      state: 'resolved',
+      idempotent: false,
+    });
+    await expect(
+      repository.transitionOperationalNotificationState('tenant_a', 'notification-state-1', {
+        state: 'resolved',
+      })
+    ).resolves.toMatchObject({
+      state: 'resolved',
+      idempotent: true,
+    });
+    expect(adapter.executes).toHaveLength(1);
+    expect(adapter.executes[0].sql).toContain('UPDATE operational_notification_states');
+  });
+
+  it('rejects raw values in review and notification payloads', async () => {
+    const adapter = createAdapter({});
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    await expect(
+      repository.createReviewTask('tenant_a', {
+        taskType: 'release_review',
+        payload: { email: 'person@example.edu' },
+      })
+    ).rejects.toMatchObject({
+      status: 400,
+      code: 'invalid_request',
+    });
+
+    await expect(
+      repository.enqueueOperationalNotification('tenant_a', {
+        category: 'identity_mapping_signal',
+        eventType: 'identity_mapping.high_signal',
+        severity: 'critical',
+        subjectType: 'subject',
+        subjectId: 'subject-1',
+        payload: { token: 'secret-token' },
+      })
+    ).rejects.toMatchObject({
+      status: 400,
+      code: 'invalid_request',
+    });
+    expect(adapter.executes).toHaveLength(0);
+  });
+
+  it('rejects unsupported review statuses and notification categories before storage', async () => {
+    const adapter = createAdapter({
+      queryOneRows: [
+        {
+          id: 'review-task-1',
+          status: 'open',
+          subject_id: 'subject-1',
+          account_id: null,
+        },
+      ],
+    });
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    await expect(
+      repository.transitionReviewTask('tenant_a', 'review-task-1', {
+        status: 'raw_user_supplied_status',
+      })
+    ).rejects.toMatchObject({
+      status: 400,
+      code: 'invalid_request',
+    });
+
+    await expect(
+      repository.enqueueOperationalNotification('tenant_a', {
+        category: 'storage_registry_security',
+        eventType: 'identity_mapping.review_required',
+        severity: 'high',
+        subjectType: 'review_task',
+        subjectId: 'review-task-1',
+        payload: {
+          reviewTaskId: 'review-task-1',
+        },
+      })
+    ).rejects.toMatchObject({
+      status: 400,
+      code: 'invalid_request',
+    });
+    expect(adapter.executes).toHaveLength(0);
+  });
+});
+
 describe('IdentityMappingControlPlaneRepository schema and template catalogs', () => {
   it('stores protocol schemas, external schemas, and mapping templates', async () => {
     const adapter = createAdapter({});

--- a/packages/ar-management/src/identity-mapping-control-plane.ts
+++ b/packages/ar-management/src/identity-mapping-control-plane.ts
@@ -278,6 +278,62 @@ interface UpsertAdminSearchProjectionRequest {
   lifecycleState?: string;
 }
 
+interface CreateReviewTaskRequest {
+  taskType: string;
+  subjectId?: string;
+  accountId?: string;
+  priority?: number;
+  assignedTo?: string;
+  payload: Record<string, unknown>;
+  dueAt?: number;
+}
+
+interface TransitionReviewTaskRequest {
+  status: string;
+  assignedTo?: string | null;
+  reasonCodes?: string[];
+}
+
+interface CreateReviewTaskGroupRequest {
+  groupKey: string;
+  summary: Record<string, unknown>;
+}
+
+interface EnqueueOperationalNotificationRequest {
+  category: string;
+  eventType: string;
+  severity: string;
+  subjectType: string;
+  subjectId: string;
+  payload: Record<string, unknown>;
+  deduplicationKey?: string;
+}
+
+interface TransitionOperationalNotificationStateRequest {
+  state: string;
+  assignedTo?: string | null;
+}
+
+const REVIEW_TASK_STATUSES = new Set([
+  'open',
+  'in_review',
+  'approved',
+  'rejected',
+  'resolved',
+  'dismissed',
+]);
+
+const OPERATIONAL_NOTIFICATION_STATES = new Set(['open', 'acknowledged', 'resolved']);
+
+const IDENTITY_MAPPING_NOTIFICATION_CATEGORIES = new Set([
+  'identity_mapping_signal',
+  'identity_mapping_manual_review',
+  'identity_mapping_propagation_failure',
+  'identity_mapping_bulk_impact',
+]);
+
+const OPERATIONAL_NOTIFICATION_SEVERITIES = new Set(['critical', 'high', 'medium', 'low', 'info']);
+
 interface RepositoryResult<T> {
   result: T;
 }
@@ -1262,6 +1318,291 @@ export class IdentityMappingControlPlaneRepository {
     };
   }
 
+  async createReviewTask(tenantId: string, input: CreateReviewTaskRequest) {
+    validateRequiredString(input.taskType, 'taskType');
+    if (!isRecord(input.payload)) {
+      throw badRequest('payload must be an object');
+    }
+    assertNoReviewPayloadRawIdentifiers(input.payload, 'payload');
+
+    const now = this.now();
+    const id = createId('review_task');
+    await this.adapter.execute(
+      `INSERT INTO review_tasks (
+        id, tenant_id, task_type, subject_id, account_id, status, priority,
+        assigned_to, payload_json, due_at, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        id,
+        tenantId,
+        input.taskType,
+        input.subjectId ?? null,
+        input.accountId ?? null,
+        'open',
+        input.priority ?? 0,
+        input.assignedTo ?? null,
+        stableJson(input.payload),
+        input.dueAt ?? null,
+        now,
+        now,
+      ]
+    );
+    return {
+      id,
+      tenantId,
+      taskType: input.taskType,
+      status: 'open',
+      priority: input.priority ?? 0,
+      payload: input.payload,
+    };
+  }
+
+  async transitionReviewTask(
+    tenantId: string,
+    reviewTaskId: string,
+    input: TransitionReviewTaskRequest
+  ) {
+    validateRequiredString(reviewTaskId, 'reviewTaskId');
+    validateRequiredString(input.status, 'status');
+    if (!REVIEW_TASK_STATUSES.has(input.status)) {
+      throw badRequest('status is not supported for review task transitions');
+    }
+    const existing = await this.adapter.queryOne<{
+      id: string;
+      status: string;
+      subject_id: string | null;
+      account_id: string | null;
+    }>(
+      'SELECT id, status, subject_id, account_id FROM review_tasks WHERE tenant_id = ? AND id = ?',
+      [tenantId, reviewTaskId]
+    );
+    if (!existing) {
+      throw notFound('review task not found');
+    }
+    if (existing.status === input.status) {
+      return {
+        id: reviewTaskId,
+        status: input.status,
+        idempotent: true,
+      };
+    }
+
+    const now = this.now();
+    await this.adapter.execute(
+      `UPDATE review_tasks
+          SET status = ?, assigned_to = ?, updated_at = ?
+        WHERE tenant_id = ? AND id = ?`,
+      [input.status, input.assignedTo ?? null, now, tenantId, reviewTaskId]
+    );
+    await this.recordMappingEvent(tenantId, {
+      eventType: 'review_task.transition',
+      subjectId: existing.subject_id ?? undefined,
+      outcome: input.status,
+      reasonCodes: input.reasonCodes ?? [],
+      traceRef: `review_task:${reviewTaskId}`,
+    });
+    return {
+      id: reviewTaskId,
+      previousStatus: existing.status,
+      status: input.status,
+      idempotent: false,
+    };
+  }
+
+  async createReviewTaskGroup(tenantId: string, input: CreateReviewTaskGroupRequest) {
+    validateRequiredString(input.groupKey, 'groupKey');
+    if (!isRecord(input.summary)) {
+      throw badRequest('summary must be an object');
+    }
+    assertNoReviewPayloadRawIdentifiers(input.summary, 'summary');
+
+    const now = this.now();
+    const id = createId('review_task_group');
+    await this.adapter.execute(
+      `INSERT INTO review_task_groups (
+        id, tenant_id, group_key, status, summary_json, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(tenant_id, group_key) DO UPDATE SET
+        summary_json = excluded.summary_json,
+        updated_at = excluded.updated_at`,
+      [id, tenantId, input.groupKey, 'open', stableJson(input.summary), now, now]
+    );
+    const group = await this.adapter.queryOne<{
+      id: string;
+      status: string;
+      summary_json: string | null;
+    }>(
+      `SELECT id, status, summary_json
+         FROM review_task_groups
+        WHERE tenant_id = ? AND group_key = ?
+        LIMIT 1`,
+      [tenantId, input.groupKey]
+    );
+    return {
+      id: group?.id ?? id,
+      tenantId,
+      groupKey: input.groupKey,
+      status: group?.status ?? 'open',
+      summary: group?.summary_json ? parseJsonObject(group.summary_json, {}) : input.summary,
+    };
+  }
+
+  async enqueueOperationalNotification(
+    tenantId: string,
+    input: EnqueueOperationalNotificationRequest
+  ) {
+    validateRequiredString(input.category, 'category');
+    validateRequiredString(input.eventType, 'eventType');
+    validateRequiredString(input.severity, 'severity');
+    validateRequiredString(input.subjectType, 'subjectType');
+    validateRequiredString(input.subjectId, 'subjectId');
+    if (!IDENTITY_MAPPING_NOTIFICATION_CATEGORIES.has(input.category)) {
+      throw badRequest('category is not supported for identity mapping notifications');
+    }
+    if (!OPERATIONAL_NOTIFICATION_SEVERITIES.has(input.severity)) {
+      throw badRequest('severity is not supported for operational notifications');
+    }
+    if (!isRecord(input.payload)) {
+      throw badRequest('payload must be an object');
+    }
+    assertNoReviewPayloadRawIdentifiers(input.payload, 'payload');
+
+    const now = this.now();
+    const deduplicationKey = input.deduplicationKey
+      ? `${tenantId}:${input.deduplicationKey}`
+      : null;
+    if (deduplicationKey) {
+      const existing = await this.adapter.queryOne<{
+        id: string;
+        notification_event_id: string;
+        state: string;
+      }>(
+        `SELECT s.id, s.notification_event_id, s.state
+           FROM operational_notification_states s
+           JOIN internal_notification_events e ON e.id = s.notification_event_id
+          WHERE e.tenant_id = ? AND e.deduplication_key = ?
+          LIMIT 1`,
+        [tenantId, deduplicationKey]
+      );
+      if (existing) {
+        return {
+          id: existing.id,
+          tenantId,
+          notificationEventId: existing.notification_event_id,
+          state: existing.state,
+          severity: input.severity,
+          category: input.category,
+          idempotent: true,
+        };
+      }
+    }
+
+    const notificationEventId = createId('notification_event');
+    const stateId = createId('operational_notification_state');
+    await this.adapter.execute(
+      `INSERT INTO internal_notification_events (
+        id, tenant_id, category, event_type, severity, status, deduplication_key,
+        payload_json, attempts, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        notificationEventId,
+        tenantId,
+        input.category,
+        input.eventType,
+        input.severity,
+        'pending',
+        deduplicationKey,
+        stableJson(input.payload),
+        0,
+        new Date(now).toISOString(),
+        new Date(now).toISOString(),
+      ]
+    );
+    await this.adapter.execute(
+      `INSERT INTO operational_notification_states (
+        id, tenant_id, notification_event_id, subject_type, subject_id, state,
+        assigned_to, acknowledged_at, resolved_at, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        stateId,
+        tenantId,
+        notificationEventId,
+        input.subjectType,
+        input.subjectId,
+        'open',
+        null,
+        null,
+        null,
+        now,
+        now,
+      ]
+    );
+    return {
+      id: stateId,
+      tenantId,
+      notificationEventId,
+      state: 'open',
+      severity: input.severity,
+      category: input.category,
+    };
+  }
+
+  async transitionOperationalNotificationState(
+    tenantId: string,
+    stateId: string,
+    input: TransitionOperationalNotificationStateRequest
+  ) {
+    validateRequiredString(stateId, 'stateId');
+    if (!OPERATIONAL_NOTIFICATION_STATES.has(input.state) || input.state === 'open') {
+      throw badRequest('state is not supported for notification state transitions');
+    }
+    const existing = await this.adapter.queryOne<{
+      id: string;
+      state: string;
+    }>('SELECT id, state FROM operational_notification_states WHERE tenant_id = ? AND id = ?', [
+      tenantId,
+      stateId,
+    ]);
+    if (!existing) {
+      throw notFound('notification state not found');
+    }
+    if (existing.state === input.state) {
+      return {
+        id: stateId,
+        state: input.state,
+        idempotent: true,
+      };
+    }
+
+    const now = this.now();
+    await this.adapter.execute(
+      `UPDATE operational_notification_states
+          SET state = ?,
+              assigned_to = ?,
+              acknowledged_at = CASE WHEN ? = 'acknowledged' THEN ? ELSE acknowledged_at END,
+              resolved_at = CASE WHEN ? = 'resolved' THEN ? ELSE resolved_at END,
+              updated_at = ?
+        WHERE tenant_id = ? AND id = ?`,
+      [
+        input.state,
+        input.assignedTo ?? null,
+        input.state,
+        now,
+        input.state,
+        now,
+        now,
+        tenantId,
+        stateId,
+      ]
+    );
+    return {
+      id: stateId,
+      previousState: existing.state,
+      state: input.state,
+      idempotent: false,
+    };
+  }
+
   async runIdempotent<T>(
     tenantId: string,
     operationKey: string,
@@ -1669,6 +2010,59 @@ export async function adminIdentityMappingSourceAuthorityEvaluateHandler(c: Admi
   );
 }
 
+export async function adminIdentityMappingReviewTaskCreateHandler(c: AdminContext) {
+  return handleMutation(c, 'review-task.create', async (repository, tenantId, body) =>
+    repository.createReviewTask(tenantId, body as CreateReviewTaskRequest)
+  );
+}
+
+export async function adminIdentityMappingReviewTaskTransitionHandler(c: AdminContext) {
+  const reviewTaskId = c.req.param('reviewTaskId') ?? '';
+  return handleMutation(c, 'review-task.transition', async (repository, tenantId, body) =>
+    repository.transitionReviewTask(tenantId, reviewTaskId, body as TransitionReviewTaskRequest)
+  );
+}
+
+export async function adminIdentityMappingReviewTaskGroupCreateHandler(c: AdminContext) {
+  return handleMutation(c, 'review-task-group.create', async (repository, tenantId, body) =>
+    repository.createReviewTaskGroup(tenantId, body as CreateReviewTaskGroupRequest)
+  );
+}
+
+export async function adminIdentityMappingOperationalNotificationCreateHandler(c: AdminContext) {
+  return handleMutation(c, 'operational-notification.create', async (repository, tenantId, body) =>
+    repository.enqueueOperationalNotification(
+      tenantId,
+      body as EnqueueOperationalNotificationRequest
+    )
+  );
+}
+
+export async function adminIdentityMappingOperationalNotificationAcknowledgeHandler(
+  c: AdminContext
+) {
+  const stateId = c.req.param('stateId') ?? '';
+  return handleMutation(
+    c,
+    'operational-notification.acknowledge',
+    async (repository, tenantId, body) =>
+      repository.transitionOperationalNotificationState(tenantId, stateId, {
+        ...(body as Omit<TransitionOperationalNotificationStateRequest, 'state'>),
+        state: 'acknowledged',
+      })
+  );
+}
+
+export async function adminIdentityMappingOperationalNotificationResolveHandler(c: AdminContext) {
+  const stateId = c.req.param('stateId') ?? '';
+  return handleMutation(c, 'operational-notification.resolve', async (repository, tenantId, body) =>
+    repository.transitionOperationalNotificationState(tenantId, stateId, {
+      ...(body as Omit<TransitionOperationalNotificationStateRequest, 'state'>),
+      state: 'resolved',
+    })
+  );
+}
+
 async function handleControlPlane<T>(
   c: AdminContext,
   operation: (repository: IdentityMappingControlPlaneRepository, tenantId: string) => Promise<T>
@@ -1817,8 +2211,50 @@ function assertNoSensitiveMetadata(value: unknown, path: string): void {
   }
 }
 
+function assertNoReviewPayloadRawIdentifiers(value: unknown, path: string): void {
+  assertNoSensitiveMetadata(value, path);
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoReviewPayloadRawIdentifiers(item, `${path}[${index}]`));
+    return;
+  }
+  if (!isRecord(value)) {
+    return;
+  }
+  for (const [key, item] of Object.entries(value)) {
+    const normalized = key.toLowerCase().replace(/[_-]/g, '');
+    if (
+      normalized === 'email' ||
+      normalized === 'mail' ||
+      normalized === 'nameid' ||
+      normalized === 'phone' ||
+      normalized === 'phonenumber' ||
+      normalized === 'sub' ||
+      normalized === 'uid' ||
+      normalized === 'userid'
+    ) {
+      throw badRequest(`${path}.${key} is not allowed in identity mapping review payloads`);
+    }
+    assertNoReviewPayloadRawIdentifiers(item, `${path}.${key}`);
+  }
+}
+
 function createId(prefix: string): string {
   return `${prefix}_${crypto.randomUUID()}`;
+}
+
+function parseJsonObject(
+  value: string,
+  fallback: Record<string, unknown>
+): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(value);
+    return isRecord(parsed) ? parsed : fallback;
+  } catch {
+    return fallback;
+  }
 }
 
 async function hashStableJson(value: unknown): Promise<string> {

--- a/packages/ar-management/src/index.ts
+++ b/packages/ar-management/src/index.ts
@@ -656,6 +656,12 @@ import {
   adminIdentityMappingPolicyVersionPublishHandler,
   adminIdentityMappingProtocolSchemaCreateHandler,
   adminIdentityMappingProtocolSchemasListHandler,
+  adminIdentityMappingOperationalNotificationAcknowledgeHandler,
+  adminIdentityMappingOperationalNotificationCreateHandler,
+  adminIdentityMappingOperationalNotificationResolveHandler,
+  adminIdentityMappingReviewTaskCreateHandler,
+  adminIdentityMappingReviewTaskGroupCreateHandler,
+  adminIdentityMappingReviewTaskTransitionHandler,
   adminIdentityMappingSourceAuthorityContractCreateHandler,
   adminIdentityMappingSourceAuthorityContractsListHandler,
   adminIdentityMappingSourceAuthorityEvaluateHandler,
@@ -2289,6 +2295,36 @@ app.post(
   '/api/admin/identity-mapping/source-authority-contracts/evaluate',
   requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
   adminIdentityMappingSourceAuthorityEvaluateHandler
+);
+app.post(
+  '/api/admin/identity-mapping/review-tasks',
+  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
+  adminIdentityMappingReviewTaskCreateHandler
+);
+app.post(
+  '/api/admin/identity-mapping/review-tasks/:reviewTaskId/transition',
+  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
+  adminIdentityMappingReviewTaskTransitionHandler
+);
+app.post(
+  '/api/admin/identity-mapping/review-task-groups',
+  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
+  adminIdentityMappingReviewTaskGroupCreateHandler
+);
+app.post(
+  '/api/admin/identity-mapping/operational-notifications',
+  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
+  adminIdentityMappingOperationalNotificationCreateHandler
+);
+app.post(
+  '/api/admin/identity-mapping/operational-notification-states/:stateId/acknowledge',
+  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
+  adminIdentityMappingOperationalNotificationAcknowledgeHandler
+);
+app.post(
+  '/api/admin/identity-mapping/operational-notification-states/:stateId/resolve',
+  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
+  adminIdentityMappingOperationalNotificationResolveHandler
 );
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Add the release consent gate service for legal-basis branching and attribute release challenge decisions.
- Add the attribute release consent repository and subject lifecycle timeline event persistence.
- Add identity mapping review task and operational notification Admin API foundations with redacted payload validation and idempotent notification deduplication.

## Tests
- `pnpm --filter @authrim/ar-lib-core test -- canonical-identity identity-release-consent attribute-release-consent`
- `pnpm --filter @authrim/ar-management test -- identity-mapping-control-plane`
- `pnpm --filter @authrim/ar-lib-core typecheck`
- `pnpm --filter @authrim/ar-management typecheck`
- `pnpm format:check`
- `git diff --check`