### PR TITLE
Add federation trust and key lifecycle foundations

### DIFF
--- a/packages/ar-management/src/__tests__/identity-mapping-control-plane.test.ts
+++ b/packages/ar-management/src/__tests__/identity-mapping-control-plane.test.ts
@@ -1235,7 +1235,27 @@ describe('IdentityMappingControlPlaneRepository federation trust and key lifecyc
       expect.stringContaining('INSERT INTO federation_trust_sources'),
       expect.stringContaining('INSERT INTO federation_trust_anchors'),
       expect.stringContaining('INSERT INTO federation_trust_scope_bindings'),
+      expect.stringContaining('INSERT INTO federation_trust_context_snapshots'),
     ]);
+    expect(String(adapter.executes[3].params[4])).toContain('sourceKey');
+  });
+
+  it('rejects unsupported federation trust source lifecycle states', async () => {
+    const adapter = createAdapter({});
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    await expect(
+      repository.createFederationTrustSource('tenant_a', {
+        sourceType: 'saml_aggregate',
+        sourceKey: 'edugain-pilot',
+        displayName: 'eduGAIN pilot',
+        lifecycleState: 'deleted' as never,
+      })
+    ).rejects.toMatchObject({
+      status: 400,
+      code: 'invalid_request',
+    });
+    expect(adapter.executes).toHaveLength(0);
   });
 
   it('lists normalized federation trust source metadata for Admin UI migration', async () => {
@@ -1271,7 +1291,7 @@ describe('IdentityMappingControlPlaneRepository federation trust and key lifecyc
   });
 
   it('registers federation metadata documents with validation and entity summaries', async () => {
-    const adapter = createAdapter({});
+    const adapter = createAdapter({ queryOneRows: [{ id: 'trust-source-1' }] });
     const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
 
     await expect(
@@ -1301,6 +1321,58 @@ describe('IdentityMappingControlPlaneRepository federation trust and key lifecyc
       expect.stringContaining('INSERT INTO federation_metadata_entity_summaries'),
     ]);
     expect(String(adapter.executes[2].params[6])).toContain('requestedAttributes');
+  });
+
+  it('rejects federation metadata documents for unknown trust sources', async () => {
+    const adapter = createAdapter({ queryOneRows: [null] });
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    await expect(
+      repository.registerFederationMetadataDocument('tenant_a', {
+        trustSourceId: 'missing-source',
+        documentType: 'saml_aggregate',
+        documentHash: 'sha256:metadata',
+      })
+    ).rejects.toMatchObject({
+      status: 404,
+      code: 'not_found',
+    });
+    expect(adapter.executes).toHaveLength(0);
+  });
+
+  it('records key access only for existing tenant-scoped registries and versions', async () => {
+    const adapter = createAdapter({
+      queryOneRows: [{ id: 'key-registry-1' }, { id: 'key-version-1' }],
+    });
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    await expect(
+      repository.recordKeyAccess('tenant_a', 'key-registry-1', {
+        keyVersionId: 'key-version-1',
+        accessType: 'material.sign',
+        outcome: 'success',
+        actorId: 'admin-1',
+      })
+    ).resolves.toEqual({ keyRegistryId: 'key-registry-1', recorded: true });
+    expect(adapter.executes.map((item) => item.sql)).toEqual([
+      expect.stringContaining('INSERT INTO key_access_events'),
+    ]);
+  });
+
+  it('rejects unsupported key access event values before writing audit rows', async () => {
+    const adapter = createAdapter({});
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    await expect(
+      repository.recordKeyAccess('tenant_a', 'key-registry-1', {
+        accessType: 'arbitrary.event',
+        outcome: 'success',
+      })
+    ).rejects.toMatchObject({
+      status: 400,
+      code: 'invalid_request',
+    });
+    expect(adapter.executes).toHaveLength(0);
   });
 
   it('migrates legacy SAML federation trust profiles into normalized trust context', async () => {

--- a/packages/ar-management/src/__tests__/identity-mapping-control-plane.test.ts
+++ b/packages/ar-management/src/__tests__/identity-mapping-control-plane.test.ts
@@ -1092,6 +1092,302 @@ describe('IdentityMappingControlPlaneRepository provisioning assignment operatio
   });
 });
 
+describe('IdentityMappingControlPlaneRepository federation trust and key lifecycle operations', () => {
+  it('creates key registries with external material references only', async () => {
+    const adapter = createAdapter({});
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    await expect(
+      repository.createKeyRegistry('tenant_a', {
+        keyPurpose: 'blind_index',
+        scope: { table: 'contact_points', field: 'normalized_hash' },
+        algorithm: 'hmac-sha256',
+        backendType: 'wrangler_secret',
+        materialRef: 'wrangler-secret:CONTACT_BLIND_INDEX_KEY_V1',
+        materialMetadata: { rotationWindowDays: 30 },
+        actorId: 'admin-1',
+      })
+    ).resolves.toMatchObject({
+      tenantId: 'tenant_a',
+      keyPurpose: 'blind_index',
+      status: 'active',
+    });
+    expect(adapter.executes.map((item) => item.sql)).toEqual([
+      expect.stringContaining('INSERT INTO key_registries'),
+      expect.stringContaining('INSERT INTO key_versions'),
+      expect.stringContaining('INSERT INTO key_material_refs'),
+      expect.stringContaining('INSERT INTO key_access_events'),
+    ]);
+    expect(adapter.executes[2].params[4]).toBe('wrangler-secret:CONTACT_BLIND_INDEX_KEY_V1');
+  });
+
+  it('lists key registry metadata without material references', async () => {
+    const adapter = createAdapter({
+      queryRows: [
+        {
+          id: 'key-registry-1',
+          key_purpose: 'blind_index',
+          scope_json: JSON.stringify({ table: 'contact_points' }),
+          active_version_id: 'key-version-1',
+          status: 'active',
+          created_at: 1000,
+          updated_at: 1100,
+        },
+      ],
+    });
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    await expect(repository.listKeyRegistries('tenant_a')).resolves.toEqual([
+      {
+        id: 'key-registry-1',
+        tenantId: 'tenant_a',
+        keyPurpose: 'blind_index',
+        scope: { table: 'contact_points' },
+        activeVersionId: 'key-version-1',
+        status: 'active',
+        createdAt: 1000,
+        updatedAt: 1100,
+      },
+    ]);
+  });
+
+  it('rejects inline private key material for key lifecycle references', async () => {
+    const adapter = createAdapter({});
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    await expect(
+      repository.createKeyRegistry('tenant_a', {
+        keyPurpose: 'signing',
+        scope: { surface: 'saml' },
+        algorithm: 'rsa-pss-sha256',
+        backendType: 'inline',
+        materialRef: '-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----',
+      })
+    ).rejects.toMatchObject({
+      status: 400,
+      code: 'invalid_request',
+    });
+    expect(adapter.executes).toHaveLength(0);
+  });
+
+  it('rotates key registries and queues resumable rewrap and blind-index jobs', async () => {
+    const adapter = createAdapter({
+      queryOneRows: [{ active_version_id: 'key-version-1' }, { version: 1 }],
+    });
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    await expect(
+      repository.rotateKeyRegistry('tenant_a', 'key-registry-1', {
+        algorithm: 'hmac-sha256',
+        backendType: 'wrangler_secret',
+        materialRef: 'wrangler-secret:CONTACT_BLIND_INDEX_KEY_V2',
+        jobMode: 'both',
+        artifactScope: { tables: ['contact_points', 'identity_binding_lookup_indexes'] },
+        actorId: 'admin-1',
+      })
+    ).resolves.toMatchObject({
+      keyRegistryId: 'key-registry-1',
+      version: 2,
+      jobs: [{ type: 'rewrap' }, { type: 'blind_index_rotation' }],
+    });
+    expect(adapter.executes.map((item) => item.sql)).toEqual([
+      expect.stringContaining('INSERT INTO key_versions'),
+      expect.stringContaining('INSERT INTO key_material_refs'),
+      expect.stringContaining('UPDATE key_versions'),
+      expect.stringContaining('UPDATE key_registries'),
+      expect.stringContaining('INSERT INTO rewrap_jobs'),
+      expect.stringContaining('INSERT INTO blind_index_rotation_jobs'),
+      expect.stringContaining('INSERT INTO key_access_events'),
+    ]);
+    expect(String(adapter.executes[5].params[6])).toContain('dual_read');
+  });
+
+  it('creates normalized SAML federation trust sources with anchors and scope bindings', async () => {
+    const adapter = createAdapter({});
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    await expect(
+      repository.createFederationTrustSource('tenant_a', {
+        sourceType: 'saml_aggregate',
+        sourceKey: 'edugain-pilot',
+        displayName: 'eduGAIN pilot',
+        lifecycleState: 'active',
+        protocolPayload: {
+          metadataUrlPatterns: ['https://metadata.example.test/*.xml'],
+          policy: 'strict',
+        },
+        anchors: [
+          {
+            anchorType: 'x509_sha256',
+            anchorHash: 'sha256:abc',
+            anchorRef: 'cert-1',
+          },
+        ],
+        scopeBindings: [{ scopeType: 'tenant', scopeId: 'tenant_a' }],
+      })
+    ).resolves.toMatchObject({
+      tenantId: 'tenant_a',
+      sourceType: 'saml_aggregate',
+      sourceKey: 'edugain-pilot',
+      lifecycleState: 'active',
+    });
+    expect(adapter.executes.map((item) => item.sql)).toEqual([
+      expect.stringContaining('INSERT INTO federation_trust_sources'),
+      expect.stringContaining('INSERT INTO federation_trust_anchors'),
+      expect.stringContaining('INSERT INTO federation_trust_scope_bindings'),
+    ]);
+  });
+
+  it('lists normalized federation trust source metadata for Admin UI migration', async () => {
+    const adapter = createAdapter({
+      queryRows: [
+        {
+          id: 'trust-source-1',
+          source_type: 'saml_aggregate',
+          source_key: 'legacy-saml-profile:profile-1',
+          display_name: 'Legacy Federation',
+          lifecycle_state: 'active',
+          protocol_payload_json: JSON.stringify({ policy: 'strict' }),
+          created_at: 1000,
+          updated_at: 1100,
+        },
+      ],
+    });
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    await expect(repository.listFederationTrustSources('tenant_a')).resolves.toEqual([
+      {
+        id: 'trust-source-1',
+        tenantId: 'tenant_a',
+        sourceType: 'saml_aggregate',
+        sourceKey: 'legacy-saml-profile:profile-1',
+        displayName: 'Legacy Federation',
+        lifecycleState: 'active',
+        protocolPayload: { policy: 'strict' },
+        createdAt: 1000,
+        updatedAt: 1100,
+      },
+    ]);
+  });
+
+  it('registers federation metadata documents with validation and entity summaries', async () => {
+    const adapter = createAdapter({});
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    await expect(
+      repository.registerFederationMetadataDocument('tenant_a', {
+        trustSourceId: 'trust-source-1',
+        documentType: 'saml_aggregate',
+        sourceUrl: 'https://metadata.example.test/aggregate.xml',
+        documentHash: 'sha256:metadata',
+        documentRef: 'r2://metadata/aggregate.xml',
+        validationState: 'valid',
+        entitySummaries: [
+          {
+            entityId: 'https://sp.example.test/sp',
+            entityRole: 'sp',
+            displayName: 'Example SP',
+            summary: { requestedAttributes: ['mail'] },
+          },
+        ],
+      })
+    ).resolves.toMatchObject({
+      trustSourceId: 'trust-source-1',
+      validationState: 'valid',
+    });
+    expect(adapter.executes.map((item) => item.sql)).toEqual([
+      expect.stringContaining('INSERT INTO federation_metadata_documents'),
+      expect.stringContaining('INSERT INTO federation_metadata_validation_events'),
+      expect.stringContaining('INSERT INTO federation_metadata_entity_summaries'),
+    ]);
+    expect(String(adapter.executes[2].params[6])).toContain('requestedAttributes');
+  });
+
+  it('migrates legacy SAML federation trust profiles into normalized trust context', async () => {
+    const adapter = createAdapter({
+      queryOneRows: [
+        {
+          id: 'legacy-profile-1',
+          tenant_id: 'tenant_a',
+          name: 'Legacy Federation',
+          description: 'legacy trust profile',
+          metadata_url_patterns_json: JSON.stringify(['https://metadata.example.test/*.xml']),
+          certificates_json: JSON.stringify([
+            {
+              id: 'cert-1',
+              name: 'Signing CA',
+              certificate: '-----BEGIN CERTIFICATE-----public-----END CERTIFICATE-----',
+              fingerprintSha256: 'sha256:cert-1',
+              createdAt: 900,
+            },
+          ]),
+          policy: 'strict',
+          enabled: 1,
+          federation_trust_source_id: null,
+          normalized_migration_state: 'pending',
+          created_at: 900,
+          updated_at: 900,
+        },
+      ],
+    });
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    await expect(
+      repository.migrateSamlFederationTrustProfile('tenant_a', {
+        profileId: 'legacy-profile-1',
+      })
+    ).resolves.toMatchObject({
+      profileId: 'legacy-profile-1',
+      migrationState: 'migrated',
+      snapshotHash: expect.any(String),
+    });
+    expect(adapter.executes.map((item) => item.sql)).toEqual([
+      expect.stringContaining('INSERT INTO federation_trust_sources'),
+      expect.stringContaining('INSERT INTO federation_trust_anchors'),
+      expect.stringContaining('INSERT INTO federation_trust_context_snapshots'),
+      expect.stringContaining('INSERT INTO federation_trust_scope_bindings'),
+      expect.stringContaining('UPDATE saml_federation_trust_profiles'),
+      expect.stringContaining('INSERT INTO federation_metadata_validation_events'),
+    ]);
+    expect(adapter.executes[1].params[4]).toBe('sha256:cert-1');
+    expect(String(adapter.executes[2].params[4])).toContain('legacyProfileId');
+  });
+
+  it('returns migrated legacy SAML trust profile migrations idempotently', async () => {
+    const adapter = createAdapter({
+      queryOneRows: [
+        {
+          id: 'legacy-profile-1',
+          tenant_id: 'tenant_a',
+          name: 'Legacy Federation',
+          description: null,
+          metadata_url_patterns_json: '[]',
+          certificates_json: '[]',
+          policy: 'warn',
+          enabled: 1,
+          federation_trust_source_id: 'trust-source-1',
+          normalized_migration_state: 'migrated',
+          created_at: 900,
+          updated_at: 900,
+        },
+      ],
+    });
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    await expect(
+      repository.migrateSamlFederationTrustProfile('tenant_a', {
+        profileId: 'legacy-profile-1',
+      })
+    ).resolves.toMatchObject({
+      profileId: 'legacy-profile-1',
+      trustSourceId: 'trust-source-1',
+      migrationState: 'migrated',
+      idempotent: true,
+    });
+    expect(adapter.executes).toHaveLength(0);
+  });
+});
+
 describe('IdentityMappingControlPlaneRepository schema and template catalogs', () => {
   it('stores protocol schemas, external schemas, and mapping templates', async () => {
     const adapter = createAdapter({});

--- a/packages/ar-management/src/identity-mapping-control-plane.ts
+++ b/packages/ar-management/src/identity-mapping-control-plane.ts
@@ -511,6 +511,20 @@ const FEDERATION_TRUST_SOURCE_TYPES = new Set([
   'saml_metadata',
   'saml_federation',
 ]);
+const FEDERATION_TRUST_LIFECYCLE_STATES = new Set(['draft', 'active', 'retired']);
+const FEDERATION_METADATA_VALIDATION_STATES = new Set(['pending', 'valid', 'invalid', 'warning']);
+const KEY_ACCESS_TYPES = new Set([
+  'registry.create',
+  'registry.rotate',
+  'material.ref.read',
+  'material.unwrap',
+  'material.sign',
+  'material.verify',
+  'blind_index.derive',
+  'rewrap.read',
+  'debug_metadata.read',
+]);
+const KEY_ACCESS_OUTCOMES = new Set(['success', 'denied', 'failed']);
 
 interface RepositoryResult<T> {
   result: T;
@@ -2583,6 +2597,16 @@ export class IdentityMappingControlPlaneRepository {
     validateRequiredString(keyRegistryId, 'keyRegistryId');
     validateRequiredString(input.accessType, 'accessType');
     validateRequiredString(input.outcome, 'outcome');
+    if (!KEY_ACCESS_TYPES.has(input.accessType)) {
+      throw badRequest('accessType is not supported for key access events');
+    }
+    if (!KEY_ACCESS_OUTCOMES.has(input.outcome)) {
+      throw badRequest('outcome is not supported for key access events');
+    }
+    await this.ensureKeyRegistry(tenantId, keyRegistryId);
+    if (input.keyVersionId) {
+      await this.ensureKeyVersion(tenantId, keyRegistryId, input.keyVersionId);
+    }
     await this.recordKeyAccessEvent(tenantId, keyRegistryId, input);
     return { keyRegistryId, recorded: true };
   }
@@ -2594,11 +2618,30 @@ export class IdentityMappingControlPlaneRepository {
     if (!FEDERATION_TRUST_SOURCE_TYPES.has(input.sourceType)) {
       throw badRequest('sourceType is not supported for federation trust');
     }
+    const lifecycleState = input.lifecycleState ?? 'draft';
+    if (!FEDERATION_TRUST_LIFECYCLE_STATES.has(lifecycleState)) {
+      throw badRequest('lifecycleState is not supported for federation trust sources');
+    }
     if (input.protocolPayload) {
       assertNoSensitiveMetadata(input.protocolPayload, 'protocolPayload');
     }
+    if (input.anchors !== undefined && !Array.isArray(input.anchors)) {
+      throw badRequest('anchors must be an array');
+    }
+    if (input.scopeBindings !== undefined && !Array.isArray(input.scopeBindings)) {
+      throw badRequest('scopeBindings must be an array');
+    }
     const now = this.now();
     const sourceId = createId('federation_trust_source');
+    const trustContext = {
+      sourceType: input.sourceType,
+      sourceKey: input.sourceKey,
+      displayName: input.displayName,
+      protocolPayload: input.protocolPayload ?? null,
+      anchors: input.anchors ?? [],
+      scopeBindings: input.scopeBindings ?? [],
+    };
+    const snapshotHash = await hashStableJson(trustContext);
     await this.adapter.transaction(async (tx) => {
       await tx.execute(
         `INSERT INTO federation_trust_sources (
@@ -2611,7 +2654,7 @@ export class IdentityMappingControlPlaneRepository {
           input.sourceType,
           input.sourceKey,
           input.displayName,
-          input.lifecycleState ?? 'draft',
+          lifecycleState,
           input.protocolPayload ? stableJson(input.protocolPayload) : null,
           now,
           now,
@@ -2660,13 +2703,30 @@ export class IdentityMappingControlPlaneRepository {
           ]
         );
       }
+      await tx.execute(
+        `INSERT INTO federation_trust_context_snapshots (
+          id, tenant_id, trust_source_id, snapshot_hash, trust_context_json,
+          lifecycle_state, created_at, activated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          createId('federation_trust_context_snapshot'),
+          tenantId,
+          sourceId,
+          snapshotHash,
+          stableJson(trustContext),
+          lifecycleState === 'active' ? 'active' : 'draft',
+          now,
+          lifecycleState === 'active' ? now : null,
+        ]
+      );
     });
     return {
       id: sourceId,
       tenantId,
       sourceType: input.sourceType,
       sourceKey: input.sourceKey,
-      lifecycleState: input.lifecycleState ?? 'draft',
+      lifecycleState,
+      snapshotHash,
     };
   }
 
@@ -2710,6 +2770,14 @@ export class IdentityMappingControlPlaneRepository {
     validateRequiredString(input.trustSourceId, 'trustSourceId');
     validateRequiredString(input.documentType, 'documentType');
     validateRequiredString(input.documentHash, 'documentHash');
+    const validationState = input.validationState ?? 'pending';
+    if (!FEDERATION_METADATA_VALIDATION_STATES.has(validationState)) {
+      throw badRequest('validationState is not supported for federation metadata documents');
+    }
+    if (input.entitySummaries !== undefined && !Array.isArray(input.entitySummaries)) {
+      throw badRequest('entitySummaries must be an array');
+    }
+    await this.ensureFederationTrustSource(tenantId, input.trustSourceId);
     const now = this.now();
     const documentId = createId('federation_metadata_document');
     await this.adapter.transaction(async (tx) => {
@@ -2727,8 +2795,8 @@ export class IdentityMappingControlPlaneRepository {
           input.documentHash,
           input.documentRef ?? null,
           now,
-          input.validationState && input.validationState !== 'pending' ? now : null,
-          input.validationState ?? 'pending',
+          validationState !== 'pending' ? now : null,
+          validationState,
           now,
           now,
         ]
@@ -2743,8 +2811,8 @@ export class IdentityMappingControlPlaneRepository {
           tenantId,
           input.trustSourceId,
           documentId,
-          input.validationState ?? 'pending',
-          stableJson([`federation.metadata.${input.validationState ?? 'pending'}`]),
+          validationState,
+          stableJson([`federation.metadata.${validationState}`]),
           `metadata-document:${documentId}`,
           now,
         ]
@@ -2774,7 +2842,7 @@ export class IdentityMappingControlPlaneRepository {
     return {
       id: documentId,
       trustSourceId: input.trustSourceId,
-      validationState: input.validationState ?? 'pending',
+      validationState,
     };
   }
 
@@ -2967,6 +3035,49 @@ export class IdentityMappingControlPlaneRepository {
         this.now(),
       ]
     );
+  }
+
+  private async ensureKeyRegistry(tenantId: string, keyRegistryId: string): Promise<void> {
+    const row = await this.adapter.queryOne<{ id: string }>(
+      `SELECT id
+         FROM key_registries
+        WHERE tenant_id = ? AND id = ?`,
+      [tenantId, keyRegistryId]
+    );
+    if (!row) {
+      throw notFound('key registry not found');
+    }
+  }
+
+  private async ensureKeyVersion(
+    tenantId: string,
+    keyRegistryId: string,
+    keyVersionId: string
+  ): Promise<void> {
+    const row = await this.adapter.queryOne<{ id: string }>(
+      `SELECT id
+         FROM key_versions
+        WHERE tenant_id = ? AND key_registry_id = ? AND id = ?`,
+      [tenantId, keyRegistryId, keyVersionId]
+    );
+    if (!row) {
+      throw notFound('key version not found');
+    }
+  }
+
+  private async ensureFederationTrustSource(
+    tenantId: string,
+    trustSourceId: string
+  ): Promise<void> {
+    const row = await this.adapter.queryOne<{ id: string }>(
+      `SELECT id
+         FROM federation_trust_sources
+        WHERE tenant_id = ? AND id = ?`,
+      [tenantId, trustSourceId]
+    );
+    if (!row) {
+      throw notFound('federation trust source not found');
+    }
   }
 
   private async applyProvisioningAssignment(

--- a/packages/ar-management/src/identity-mapping-control-plane.ts
+++ b/packages/ar-management/src/identity-mapping-control-plane.ts
@@ -411,6 +411,74 @@ interface RecordLifecycleSignalRequest {
   ownership?: ProvisioningAssignmentOwnershipContext | null;
 }
 
+interface CreateKeyRegistryRequest {
+  keyPurpose: string;
+  scope: Record<string, unknown>;
+  algorithm: string;
+  backendType: string;
+  materialRef: string;
+  materialMetadata?: Record<string, unknown>;
+  actorId?: string;
+}
+
+interface RotateKeyRegistryRequest {
+  algorithm: string;
+  backendType: string;
+  materialRef: string;
+  materialMetadata?: Record<string, unknown>;
+  actorId?: string;
+  jobMode?: 'rewrap' | 'blind_index' | 'both' | 'none';
+  artifactScope?: Record<string, unknown>;
+}
+
+interface RecordKeyAccessRequest {
+  keyVersionId?: string | null;
+  actorId?: string | null;
+  accessType: string;
+  outcome: string;
+}
+
+interface CreateFederationTrustSourceRequest {
+  sourceType: 'saml_aggregate' | 'saml_metadata' | 'saml_federation';
+  sourceKey: string;
+  displayName: string;
+  lifecycleState?: 'draft' | 'active' | 'retired';
+  protocolPayload?: Record<string, unknown>;
+  anchors?: Array<{
+    anchorType: string;
+    anchorHash: string;
+    anchorRef?: string | null;
+    notBefore?: number | null;
+    notAfter?: number | null;
+  }>;
+  scopeBindings?: Array<{
+    scopeType: string;
+    scopeId?: string | null;
+    priority?: number;
+  }>;
+}
+
+interface RegisterFederationMetadataDocumentRequest {
+  trustSourceId: string;
+  documentType: string;
+  sourceUrl?: string | null;
+  documentHash: string;
+  documentRef?: string | null;
+  validationState?: 'pending' | 'valid' | 'invalid' | 'warning';
+  entitySummaries?: Array<{
+    entityId: string;
+    entityRole: string;
+    displayName?: string | null;
+    summary?: Record<string, unknown>;
+  }>;
+}
+
+interface MigrateSamlFederationTrustProfileRequest {
+  profileId: string;
+  sourceKey?: string;
+  activate?: boolean;
+}
+
 const REVIEW_TASK_STATUSES = new Set([
   'open',
   'in_review',
@@ -436,6 +504,12 @@ const LIFECYCLE_SIGNAL_TYPES = new Set([
   'scim_group_removed',
   'csv_diff_removed',
   'claim_disappeared',
+]);
+const KEY_JOB_MODES = new Set(['rewrap', 'blind_index', 'both', 'none']);
+const FEDERATION_TRUST_SOURCE_TYPES = new Set([
+  'saml_aggregate',
+  'saml_metadata',
+  'saml_federation',
 ]);
 
 interface RepositoryResult<T> {
@@ -2262,6 +2336,639 @@ export class IdentityMappingControlPlaneRepository {
     };
   }
 
+  async createKeyRegistry(tenantId: string, input: CreateKeyRegistryRequest) {
+    validateRequiredString(input.keyPurpose, 'keyPurpose');
+    validateRequiredString(input.algorithm, 'algorithm');
+    validateRequiredString(input.backendType, 'backendType');
+    validateRequiredString(input.materialRef, 'materialRef');
+    if (!isRecord(input.scope)) {
+      throw badRequest('scope must be an object');
+    }
+    if (input.materialMetadata) {
+      assertNoSensitiveMetadata(input.materialMetadata, 'materialMetadata');
+    }
+    assertSafeMaterialBackend(input.backendType);
+    assertSafeMaterialRef(input.materialRef);
+
+    const now = this.now();
+    const registryId = createId('key_registry');
+    const versionId = createId('key_version');
+    const materialRefId = createId('key_material_ref');
+    await this.adapter.transaction(async (tx) => {
+      await tx.execute(
+        `INSERT INTO key_registries (
+          id, tenant_id, key_purpose, scope_json, active_version_id, status, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          registryId,
+          tenantId,
+          input.keyPurpose,
+          stableJson(input.scope),
+          versionId,
+          'active',
+          now,
+          now,
+        ]
+      );
+      await tx.execute(
+        `INSERT INTO key_versions (
+          id, tenant_id, key_registry_id, version, status, algorithm,
+          created_at, activated_at, retired_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [versionId, tenantId, registryId, 1, 'active', input.algorithm, now, now, null]
+      );
+      await tx.execute(
+        `INSERT INTO key_material_refs (
+          id, tenant_id, key_version_id, backend_type, material_ref, metadata_json, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [
+          materialRefId,
+          tenantId,
+          versionId,
+          input.backendType,
+          input.materialRef,
+          input.materialMetadata ? stableJson(input.materialMetadata) : null,
+          now,
+        ]
+      );
+      await this.recordKeyAccessEvent(
+        tenantId,
+        registryId,
+        {
+          keyVersionId: versionId,
+          actorId: input.actorId ?? null,
+          accessType: 'registry.create',
+          outcome: 'success',
+        },
+        tx
+      );
+    });
+    return {
+      id: registryId,
+      tenantId,
+      activeVersionId: versionId,
+      keyPurpose: input.keyPurpose,
+      status: 'active',
+    };
+  }
+
+  async listKeyRegistries(tenantId: string) {
+    const rows = await this.adapter.query<{
+      id: string;
+      key_purpose: string;
+      scope_json: string;
+      active_version_id: string | null;
+      status: string;
+      created_at: number;
+      updated_at: number;
+    }>(
+      `SELECT id, key_purpose, scope_json, active_version_id, status, created_at, updated_at
+         FROM key_registries
+        WHERE tenant_id = ?
+        ORDER BY updated_at DESC`,
+      [tenantId]
+    );
+    return rows.map((row) => ({
+      id: row.id,
+      tenantId,
+      keyPurpose: row.key_purpose,
+      scope: parseJsonObject(row.scope_json, {}),
+      activeVersionId: row.active_version_id,
+      status: row.status,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
+  }
+
+  async rotateKeyRegistry(
+    tenantId: string,
+    keyRegistryId: string,
+    input: RotateKeyRegistryRequest
+  ) {
+    validateRequiredString(keyRegistryId, 'keyRegistryId');
+    validateRequiredString(input.algorithm, 'algorithm');
+    validateRequiredString(input.backendType, 'backendType');
+    validateRequiredString(input.materialRef, 'materialRef');
+    if (input.materialMetadata) {
+      assertNoSensitiveMetadata(input.materialMetadata, 'materialMetadata');
+    }
+    assertSafeMaterialBackend(input.backendType);
+    assertSafeMaterialRef(input.materialRef);
+    const jobMode = input.jobMode ?? 'rewrap';
+    if (!KEY_JOB_MODES.has(jobMode)) {
+      throw badRequest('jobMode is not supported');
+    }
+    const registry = await this.adapter.queryOne<{ active_version_id: string | null }>(
+      `SELECT active_version_id
+         FROM key_registries
+        WHERE tenant_id = ? AND id = ? AND status = ?`,
+      [tenantId, keyRegistryId, 'active']
+    );
+    if (!registry) {
+      throw notFound('key registry not found');
+    }
+    const latest = await this.adapter.queryOne<{ version: number }>(
+      `SELECT version
+         FROM key_versions
+        WHERE tenant_id = ? AND key_registry_id = ?
+        ORDER BY version DESC
+        LIMIT 1`,
+      [tenantId, keyRegistryId]
+    );
+    const now = this.now();
+    const nextVersion = (latest?.version ?? 0) + 1;
+    const versionId = createId('key_version');
+    const materialRefId = createId('key_material_ref');
+    const jobs: Array<{ id: string; type: 'rewrap' | 'blind_index_rotation' }> = [];
+    await this.adapter.transaction(async (tx) => {
+      await tx.execute(
+        `INSERT INTO key_versions (
+          id, tenant_id, key_registry_id, version, status, algorithm,
+          created_at, activated_at, retired_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [versionId, tenantId, keyRegistryId, nextVersion, 'active', input.algorithm, now, now, null]
+      );
+      await tx.execute(
+        `INSERT INTO key_material_refs (
+          id, tenant_id, key_version_id, backend_type, material_ref, metadata_json, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [
+          materialRefId,
+          tenantId,
+          versionId,
+          input.backendType,
+          input.materialRef,
+          input.materialMetadata ? stableJson(input.materialMetadata) : null,
+          now,
+        ]
+      );
+      if (registry.active_version_id) {
+        await tx.execute(
+          `UPDATE key_versions
+              SET status = ?, retired_at = ?
+            WHERE tenant_id = ? AND id = ?`,
+          ['retiring', now, tenantId, registry.active_version_id]
+        );
+      }
+      await tx.execute(
+        `UPDATE key_registries
+            SET active_version_id = ?, updated_at = ?
+          WHERE tenant_id = ? AND id = ?`,
+        [versionId, now, tenantId, keyRegistryId]
+      );
+      if (jobMode === 'rewrap' || jobMode === 'both') {
+        const jobId = createId('rewrap_job');
+        jobs.push({ id: jobId, type: 'rewrap' });
+        await tx.execute(
+          `INSERT INTO rewrap_jobs (
+            id, tenant_id, key_registry_id, source_version_id, target_version_id,
+            artifact_scope_json, status, cursor_json, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          [
+            jobId,
+            tenantId,
+            keyRegistryId,
+            registry.active_version_id ?? null,
+            versionId,
+            stableJson(input.artifactScope ?? { scope: 'registry', keyRegistryId }),
+            'queued',
+            stableJson({ offset: 0 }),
+            now,
+            now,
+          ]
+        );
+      }
+      if (jobMode === 'blind_index' || jobMode === 'both') {
+        const jobId = createId('blind_index_rotation_job');
+        jobs.push({ id: jobId, type: 'blind_index_rotation' });
+        await tx.execute(
+          `INSERT INTO blind_index_rotation_jobs (
+            id, tenant_id, key_registry_id, source_version_id, target_version_id,
+            status, cursor_json, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          [
+            jobId,
+            tenantId,
+            keyRegistryId,
+            registry.active_version_id ?? null,
+            versionId,
+            'queued',
+            stableJson({ phase: 'dual_read', offset: 0 }),
+            now,
+            now,
+          ]
+        );
+      }
+      await this.recordKeyAccessEvent(
+        tenantId,
+        keyRegistryId,
+        {
+          keyVersionId: versionId,
+          actorId: input.actorId ?? null,
+          accessType: 'registry.rotate',
+          outcome: 'success',
+        },
+        tx
+      );
+    });
+    return {
+      keyRegistryId,
+      activeVersionId: versionId,
+      version: nextVersion,
+      jobs,
+    };
+  }
+
+  async recordKeyAccess(tenantId: string, keyRegistryId: string, input: RecordKeyAccessRequest) {
+    validateRequiredString(keyRegistryId, 'keyRegistryId');
+    validateRequiredString(input.accessType, 'accessType');
+    validateRequiredString(input.outcome, 'outcome');
+    await this.recordKeyAccessEvent(tenantId, keyRegistryId, input);
+    return { keyRegistryId, recorded: true };
+  }
+
+  async createFederationTrustSource(tenantId: string, input: CreateFederationTrustSourceRequest) {
+    validateRequiredString(input.sourceType, 'sourceType');
+    validateRequiredString(input.sourceKey, 'sourceKey');
+    validateRequiredString(input.displayName, 'displayName');
+    if (!FEDERATION_TRUST_SOURCE_TYPES.has(input.sourceType)) {
+      throw badRequest('sourceType is not supported for federation trust');
+    }
+    if (input.protocolPayload) {
+      assertNoSensitiveMetadata(input.protocolPayload, 'protocolPayload');
+    }
+    const now = this.now();
+    const sourceId = createId('federation_trust_source');
+    await this.adapter.transaction(async (tx) => {
+      await tx.execute(
+        `INSERT INTO federation_trust_sources (
+          id, tenant_id, source_type, source_key, display_name, lifecycle_state,
+          protocol_payload_json, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          sourceId,
+          tenantId,
+          input.sourceType,
+          input.sourceKey,
+          input.displayName,
+          input.lifecycleState ?? 'draft',
+          input.protocolPayload ? stableJson(input.protocolPayload) : null,
+          now,
+          now,
+        ]
+      );
+      for (const anchor of input.anchors ?? []) {
+        validateRequiredString(anchor.anchorType, 'anchor.anchorType');
+        validateRequiredString(anchor.anchorHash, 'anchor.anchorHash');
+        await tx.execute(
+          `INSERT INTO federation_trust_anchors (
+            id, tenant_id, trust_source_id, anchor_type, anchor_hash, anchor_ref,
+            not_before, not_after, lifecycle_state, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          [
+            createId('federation_trust_anchor'),
+            tenantId,
+            sourceId,
+            anchor.anchorType,
+            anchor.anchorHash,
+            anchor.anchorRef ?? null,
+            anchor.notBefore ?? null,
+            anchor.notAfter ?? null,
+            'active',
+            now,
+            now,
+          ]
+        );
+      }
+      for (const binding of input.scopeBindings ?? []) {
+        validateRequiredString(binding.scopeType, 'scopeBinding.scopeType');
+        await tx.execute(
+          `INSERT INTO federation_trust_scope_bindings (
+            id, tenant_id, trust_source_id, scope_type, scope_id, priority,
+            lifecycle_state, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          [
+            createId('federation_trust_scope_binding'),
+            tenantId,
+            sourceId,
+            binding.scopeType,
+            binding.scopeId ?? null,
+            binding.priority ?? 0,
+            'active',
+            now,
+            now,
+          ]
+        );
+      }
+    });
+    return {
+      id: sourceId,
+      tenantId,
+      sourceType: input.sourceType,
+      sourceKey: input.sourceKey,
+      lifecycleState: input.lifecycleState ?? 'draft',
+    };
+  }
+
+  async listFederationTrustSources(tenantId: string) {
+    const rows = await this.adapter.query<{
+      id: string;
+      source_type: string;
+      source_key: string;
+      display_name: string;
+      lifecycle_state: string;
+      protocol_payload_json: string | null;
+      created_at: number;
+      updated_at: number;
+    }>(
+      `SELECT id, source_type, source_key, display_name, lifecycle_state,
+              protocol_payload_json, created_at, updated_at
+         FROM federation_trust_sources
+        WHERE tenant_id = ?
+        ORDER BY updated_at DESC`,
+      [tenantId]
+    );
+    return rows.map((row) => ({
+      id: row.id,
+      tenantId,
+      sourceType: row.source_type,
+      sourceKey: row.source_key,
+      displayName: row.display_name,
+      lifecycleState: row.lifecycle_state,
+      protocolPayload: row.protocol_payload_json
+        ? parseJsonObject(row.protocol_payload_json, {})
+        : null,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
+  }
+
+  async registerFederationMetadataDocument(
+    tenantId: string,
+    input: RegisterFederationMetadataDocumentRequest
+  ) {
+    validateRequiredString(input.trustSourceId, 'trustSourceId');
+    validateRequiredString(input.documentType, 'documentType');
+    validateRequiredString(input.documentHash, 'documentHash');
+    const now = this.now();
+    const documentId = createId('federation_metadata_document');
+    await this.adapter.transaction(async (tx) => {
+      await tx.execute(
+        `INSERT INTO federation_metadata_documents (
+          id, tenant_id, trust_source_id, document_type, source_url, document_hash,
+          document_ref, fetched_at, validated_at, validation_state, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          documentId,
+          tenantId,
+          input.trustSourceId,
+          input.documentType,
+          input.sourceUrl ?? null,
+          input.documentHash,
+          input.documentRef ?? null,
+          now,
+          input.validationState && input.validationState !== 'pending' ? now : null,
+          input.validationState ?? 'pending',
+          now,
+          now,
+        ]
+      );
+      await tx.execute(
+        `INSERT INTO federation_metadata_validation_events (
+          id, tenant_id, trust_source_id, metadata_document_id, validation_state,
+          reason_codes_json, trace_ref, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          createId('federation_metadata_validation_event'),
+          tenantId,
+          input.trustSourceId,
+          documentId,
+          input.validationState ?? 'pending',
+          stableJson([`federation.metadata.${input.validationState ?? 'pending'}`]),
+          `metadata-document:${documentId}`,
+          now,
+        ]
+      );
+      for (const summary of input.entitySummaries ?? []) {
+        validateRequiredString(summary.entityId, 'entitySummary.entityId');
+        validateRequiredString(summary.entityRole, 'entitySummary.entityRole');
+        await tx.execute(
+          `INSERT INTO federation_metadata_entity_summaries (
+            id, tenant_id, metadata_document_id, entity_id, entity_role,
+            display_name, summary_json, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          [
+            createId('federation_metadata_entity_summary'),
+            tenantId,
+            documentId,
+            summary.entityId,
+            summary.entityRole,
+            summary.displayName ?? null,
+            summary.summary ? stableJson(summary.summary) : null,
+            now,
+            now,
+          ]
+        );
+      }
+    });
+    return {
+      id: documentId,
+      trustSourceId: input.trustSourceId,
+      validationState: input.validationState ?? 'pending',
+    };
+  }
+
+  async migrateSamlFederationTrustProfile(
+    tenantId: string,
+    input: MigrateSamlFederationTrustProfileRequest
+  ) {
+    validateRequiredString(input.profileId, 'profileId');
+    const row = await this.adapter.queryOne<{
+      id: string;
+      tenant_id: string;
+      name: string;
+      description: string | null;
+      metadata_url_patterns_json: string;
+      certificates_json: string;
+      policy: string | null;
+      enabled: number;
+      federation_trust_source_id: string | null;
+      normalized_migration_state: string | null;
+      created_at: number;
+      updated_at: number;
+    }>(
+      `SELECT id, tenant_id, name, description, metadata_url_patterns_json, certificates_json,
+              policy, enabled, federation_trust_source_id, normalized_migration_state,
+              created_at, updated_at
+         FROM saml_federation_trust_profiles
+        WHERE tenant_id = ? AND id = ?`,
+      [tenantId, input.profileId]
+    );
+    if (!row) {
+      throw notFound('SAML federation trust profile not found');
+    }
+    if (row.federation_trust_source_id && row.normalized_migration_state === 'migrated') {
+      return {
+        profileId: row.id,
+        trustSourceId: row.federation_trust_source_id,
+        migrationState: 'migrated',
+        idempotent: true,
+      };
+    }
+
+    const metadataUrlPatterns = parseJsonStringArray(row.metadata_url_patterns_json);
+    const certificates = parseJsonRecords(row.certificates_json);
+    if (metadataUrlPatterns.length === 0 || certificates.length === 0) {
+      throw badRequest('legacy SAML federation trust profile is not migration-ready');
+    }
+    const now = this.now();
+    const trustSourceId = createId('federation_trust_source');
+    const sourceKey = input.sourceKey ?? `legacy-saml-profile:${row.id}`;
+    const trustContext = {
+      protocol: 'saml',
+      legacyProfileId: row.id,
+      policy: normalizeSamlFederationPolicy(row.policy),
+      enabled: row.enabled === 1,
+      metadataUrlPatterns,
+      anchorHashes: certificates.map((certificate) => readCertificateFingerprint(certificate)),
+    };
+    const snapshotHash = await hashStableJson(trustContext);
+    await this.adapter.transaction(async (tx) => {
+      await tx.execute(
+        `INSERT INTO federation_trust_sources (
+          id, tenant_id, source_type, source_key, display_name, lifecycle_state,
+          protocol_payload_json, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          trustSourceId,
+          tenantId,
+          'saml_aggregate',
+          sourceKey,
+          row.name,
+          input.activate === false || row.enabled !== 1 ? 'draft' : 'active',
+          stableJson({
+            legacyProfileId: row.id,
+            description: row.description,
+            metadataUrlPatterns,
+            policy: normalizeSamlFederationPolicy(row.policy),
+            certificates,
+          }),
+          now,
+          now,
+        ]
+      );
+      for (const certificate of certificates) {
+        const anchorHash = readCertificateFingerprint(certificate);
+        await tx.execute(
+          `INSERT INTO federation_trust_anchors (
+            id, tenant_id, trust_source_id, anchor_type, anchor_hash, anchor_ref,
+            not_before, not_after, lifecycle_state, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          [
+            createId('federation_trust_anchor'),
+            tenantId,
+            trustSourceId,
+            'x509_sha256',
+            anchorHash,
+            readOptionalString(certificate.id) ?? null,
+            null,
+            null,
+            'active',
+            now,
+            now,
+          ]
+        );
+      }
+      await tx.execute(
+        `INSERT INTO federation_trust_context_snapshots (
+          id, tenant_id, trust_source_id, snapshot_hash, trust_context_json,
+          lifecycle_state, created_at, activated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          createId('federation_trust_context_snapshot'),
+          tenantId,
+          trustSourceId,
+          snapshotHash,
+          stableJson(trustContext),
+          input.activate === false || row.enabled !== 1 ? 'draft' : 'active',
+          now,
+          input.activate === false || row.enabled !== 1 ? null : now,
+        ]
+      );
+      await tx.execute(
+        `INSERT INTO federation_trust_scope_bindings (
+          id, tenant_id, trust_source_id, scope_type, scope_id, priority,
+          lifecycle_state, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          createId('federation_trust_scope_binding'),
+          tenantId,
+          trustSourceId,
+          'tenant',
+          tenantId,
+          0,
+          'active',
+          now,
+          now,
+        ]
+      );
+      await tx.execute(
+        `UPDATE saml_federation_trust_profiles
+            SET federation_trust_source_id = ?,
+                normalized_migration_state = ?,
+                updated_at = ?
+          WHERE tenant_id = ? AND id = ?`,
+        [trustSourceId, 'migrated', now, tenantId, row.id]
+      );
+      await tx.execute(
+        `INSERT INTO federation_metadata_validation_events (
+          id, tenant_id, trust_source_id, metadata_document_id, validation_state,
+          reason_codes_json, trace_ref, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          createId('federation_metadata_validation_event'),
+          tenantId,
+          trustSourceId,
+          null,
+          'valid',
+          stableJson(['federation.saml_legacy_profile.migrated']),
+          `saml-federation-trust-profile:${row.id}`,
+          now,
+        ]
+      );
+    });
+    return {
+      profileId: row.id,
+      trustSourceId,
+      migrationState: 'migrated',
+      snapshotHash,
+    };
+  }
+
+  private async recordKeyAccessEvent(
+    tenantId: string,
+    keyRegistryId: string,
+    input: RecordKeyAccessRequest,
+    executor: SqlExecutor = this.adapter
+  ) {
+    await executor.execute(
+      `INSERT INTO key_access_events (
+        id, tenant_id, key_registry_id, key_version_id, actor_id,
+        access_type, outcome, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        createId('key_access_event'),
+        tenantId,
+        keyRegistryId,
+        input.keyVersionId ?? null,
+        input.actorId ?? null,
+        input.accessType,
+        input.outcome,
+        this.now(),
+      ]
+    );
+  }
+
   private async applyProvisioningAssignment(
     tenantId: string,
     rule: ProvisioningAssignmentRuleRow,
@@ -2998,6 +3705,76 @@ export async function adminIdentityMappingLifecycleSignalRecordHandler(c: AdminC
   );
 }
 
+export async function adminIdentityMappingKeyRegistryCreateHandler(c: AdminContext) {
+  return handleMutation(c, 'key-registry.create', async (repository, tenantId, body) =>
+    repository.createKeyRegistry(tenantId, body as CreateKeyRegistryRequest)
+  );
+}
+
+export async function adminIdentityMappingKeyRegistriesListHandler(c: AdminContext) {
+  return handleControlPlane(c, async (repository, tenantId) => ({
+    keyRegistries: await repository.listKeyRegistries(tenantId),
+  }));
+}
+
+export async function adminIdentityMappingKeyRegistryRotateHandler(c: AdminContext) {
+  return handleMutation(c, 'key-registry.rotate', async (repository, tenantId, body) =>
+    repository.rotateKeyRegistry(
+      tenantId,
+      requiredParam(c, 'keyRegistryId'),
+      body as RotateKeyRegistryRequest
+    )
+  );
+}
+
+export async function adminIdentityMappingKeyAccessRecordHandler(c: AdminContext) {
+  return handleMutation(c, 'key-access.record', async (repository, tenantId, body) =>
+    repository.recordKeyAccess(
+      tenantId,
+      requiredParam(c, 'keyRegistryId'),
+      body as RecordKeyAccessRequest
+    )
+  );
+}
+
+export async function adminIdentityMappingFederationTrustSourceCreateHandler(c: AdminContext) {
+  return handleMutation(c, 'federation-trust-source.create', async (repository, tenantId, body) =>
+    repository.createFederationTrustSource(tenantId, body as CreateFederationTrustSourceRequest)
+  );
+}
+
+export async function adminIdentityMappingFederationTrustSourcesListHandler(c: AdminContext) {
+  return handleControlPlane(c, async (repository, tenantId) => ({
+    federationTrustSources: await repository.listFederationTrustSources(tenantId),
+  }));
+}
+
+export async function adminIdentityMappingFederationMetadataDocumentCreateHandler(c: AdminContext) {
+  return handleMutation(
+    c,
+    'federation-metadata-document.create',
+    async (repository, tenantId, body) =>
+      repository.registerFederationMetadataDocument(
+        tenantId,
+        body as RegisterFederationMetadataDocumentRequest
+      )
+  );
+}
+
+export async function adminIdentityMappingSamlFederationTrustProfileMigrateHandler(
+  c: AdminContext
+) {
+  return handleMutation(
+    c,
+    'saml-federation-trust-profile.migrate',
+    async (repository, tenantId, body) =>
+      repository.migrateSamlFederationTrustProfile(
+        tenantId,
+        body as MigrateSamlFederationTrustProfileRequest
+      )
+  );
+}
+
 async function handleControlPlane<T>(
   c: AdminContext,
   operation: (repository: IdentityMappingControlPlaneRepository, tenantId: string) => Promise<T>
@@ -3219,6 +3996,66 @@ function parseJsonArray(value: string | null): string[] {
   } catch {
     return [];
   }
+}
+
+function parseJsonStringArray(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseJsonRecords(value: string): Array<Record<string, unknown>> {
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter(isRecord) : [];
+  } catch {
+    return [];
+  }
+}
+
+function assertSafeMaterialRef(materialRef: string): void {
+  const normalized = materialRef.trim().toLowerCase();
+  if (!normalized.includes('://') && !normalized.startsWith('wrangler-secret:')) {
+    throw badRequest('materialRef must be an external reference, not inline key material');
+  }
+  if (
+    /-----begin [^-]+key-----/i.test(materialRef) ||
+    /-----begin certificate-----/i.test(materialRef) ||
+    normalized.includes('private_key=') ||
+    normalized.includes('client_secret=') ||
+    normalized.includes('password=') ||
+    normalized.includes('token=')
+  ) {
+    throw badRequest('materialRef must not contain inline key material or secrets');
+  }
+}
+
+function assertSafeMaterialBackend(backendType: string): void {
+  const normalized = backendType.trim().toLowerCase().replace(/[_-]/g, '');
+  if (normalized === 'inline' || normalized === 'localfile' || normalized === 'plaintext') {
+    throw badRequest('backendType must reference an external key material backend');
+  }
+}
+
+function normalizeSamlFederationPolicy(value: string | null): 'strict' | 'warn' | 'disabled' {
+  return value === 'strict' || value === 'disabled' ? value : 'warn';
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function readCertificateFingerprint(certificate: Record<string, unknown>): string {
+  const fingerprint = readOptionalString(certificate.fingerprintSha256);
+  if (fingerprint) {
+    return fingerprint;
+  }
+  throw badRequest('legacy SAML federation trust certificate is missing a fingerprint');
 }
 
 async function hashStableJson(value: unknown): Promise<string> {

--- a/packages/ar-management/src/index.ts
+++ b/packages/ar-management/src/index.ts
@@ -2378,22 +2378,34 @@ app.post(
 );
 app.post(
   '/api/admin/identity-mapping/key-registries',
-  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
+  requireAdminPermissions([
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.ADMIN_AUDIT_DETAIL_READ,
+  ]),
   adminIdentityMappingKeyRegistryCreateHandler
 );
 app.get(
   '/api/admin/identity-mapping/key-registries',
-  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_READ]),
+  requireAdminPermissions([
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.ADMIN_AUDIT_DETAIL_READ,
+  ]),
   adminIdentityMappingKeyRegistriesListHandler
 );
 app.post(
   '/api/admin/identity-mapping/key-registries/:keyRegistryId/rotate',
-  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
+  requireAdminPermissions([
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.ADMIN_AUDIT_DETAIL_READ,
+  ]),
   adminIdentityMappingKeyRegistryRotateHandler
 );
 app.post(
   '/api/admin/identity-mapping/key-registries/:keyRegistryId/access-events',
-  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
+  requireAdminPermissions([
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.ADMIN_AUDIT_DETAIL_READ,
+  ]),
   adminIdentityMappingKeyAccessRecordHandler
 );
 app.post(

--- a/packages/ar-management/src/index.ts
+++ b/packages/ar-management/src/index.ts
@@ -655,8 +655,14 @@ import {
   adminIdentityMappingPolicyVersionCreateHandler,
   adminIdentityMappingPolicyVersionPublishHandler,
   adminIdentityMappingEntitlementGrantHandler,
+  adminIdentityMappingFederationMetadataDocumentCreateHandler,
+  adminIdentityMappingFederationTrustSourceCreateHandler,
   adminIdentityMappingGroupCreateHandler,
   adminIdentityMappingGroupMembershipCreateHandler,
+  adminIdentityMappingKeyAccessRecordHandler,
+  adminIdentityMappingKeyRegistriesListHandler,
+  adminIdentityMappingKeyRegistryCreateHandler,
+  adminIdentityMappingKeyRegistryRotateHandler,
   adminIdentityMappingLifecycleSignalRecordHandler,
   adminIdentityMappingOrgDomainMappingMigrateHandler,
   adminIdentityMappingProtocolSchemaCreateHandler,
@@ -669,9 +675,11 @@ import {
   adminIdentityMappingReviewTaskCreateHandler,
   adminIdentityMappingReviewTaskGroupCreateHandler,
   adminIdentityMappingReviewTaskTransitionHandler,
+  adminIdentityMappingSamlFederationTrustProfileMigrateHandler,
   adminIdentityMappingSourceAuthorityContractCreateHandler,
   adminIdentityMappingSourceAuthorityContractsListHandler,
   adminIdentityMappingSourceAuthorityEvaluateHandler,
+  adminIdentityMappingFederationTrustSourcesListHandler,
   adminIdentityMappingTemplateCreateHandler,
   adminIdentityMappingTemplatesListHandler,
 } from './identity-mapping-control-plane';
@@ -2367,6 +2375,46 @@ app.post(
   '/api/admin/identity-mapping/lifecycle-signals',
   requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
   adminIdentityMappingLifecycleSignalRecordHandler
+);
+app.post(
+  '/api/admin/identity-mapping/key-registries',
+  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
+  adminIdentityMappingKeyRegistryCreateHandler
+);
+app.get(
+  '/api/admin/identity-mapping/key-registries',
+  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_READ]),
+  adminIdentityMappingKeyRegistriesListHandler
+);
+app.post(
+  '/api/admin/identity-mapping/key-registries/:keyRegistryId/rotate',
+  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
+  adminIdentityMappingKeyRegistryRotateHandler
+);
+app.post(
+  '/api/admin/identity-mapping/key-registries/:keyRegistryId/access-events',
+  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
+  adminIdentityMappingKeyAccessRecordHandler
+);
+app.post(
+  '/api/admin/identity-mapping/federation-trust-sources',
+  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
+  adminIdentityMappingFederationTrustSourceCreateHandler
+);
+app.get(
+  '/api/admin/identity-mapping/federation-trust-sources',
+  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_READ]),
+  adminIdentityMappingFederationTrustSourcesListHandler
+);
+app.post(
+  '/api/admin/identity-mapping/federation-metadata-documents',
+  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
+  adminIdentityMappingFederationMetadataDocumentCreateHandler
+);
+app.post(
+  '/api/admin/identity-mapping/saml-federation-trust-profiles/migrate',
+  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
+  adminIdentityMappingSamlFederationTrustProfileMigrateHandler
 );
 
 // =============================================================================

--- a/packages/ar-saml/src/admin/__tests__/aggregate-provider-api.test.ts
+++ b/packages/ar-saml/src/admin/__tests__/aggregate-provider-api.test.ts
@@ -280,6 +280,51 @@ describe('SAML aggregate provider API', () => {
     );
   });
 
+  it('loads normalized SAML federation trust sources during aggregate preview', async () => {
+    const adminAdapter = createMockAdapter();
+    adminAdapter.query.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      {
+        id: 'trust-source-1',
+        tenant_id: 'tenant-a',
+        source_type: 'saml_aggregate',
+        display_name: 'Normalized federation',
+        lifecycle_state: 'active',
+        protocol_payload_json: JSON.stringify({
+          metadataUrlPatterns: ['https://metadata.example.test/*.xml'],
+          certificates: [
+            {
+              id: 'cert-1',
+              certificate: expiredCertificate,
+              fingerprintSha256: 'sha256:cert-1',
+              createdAt: 1_700_000_000_000,
+            },
+          ],
+          policy: 'warn',
+        }),
+        created_at: 1_700_000_000_000,
+        updated_at: 1_700_000_000_000,
+      },
+    ]);
+    mocks.safeFetchText.mockResolvedValue(aggregateXml);
+
+    const response = await handlePreviewMetadata(
+      createContext({
+        body: { metadataUrl: 'https://metadata.example.test/aggregate.xml' },
+        env: {
+          DB_ADMIN: adminAdapter as never,
+          SAML_AGGREGATE_METADATA_STORE: createAggregateStoreNamespace({}) as never,
+          SAML_AGGREGATE_METADATA_SIGNATURE_POLICY: 'disabled',
+        },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(adminAdapter.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM federation_trust_sources'),
+      ['tenant-a']
+    );
+  });
+
   it('returns a validation error for unsafe XML during metadata preview', async () => {
     const response = await handlePreviewMetadata(
       createContext({

--- a/packages/ar-saml/src/admin/__tests__/aggregate-provider-api.test.ts
+++ b/packages/ar-saml/src/admin/__tests__/aggregate-provider-api.test.ts
@@ -2,6 +2,8 @@ import type { Env } from '@authrim/ar-lib-core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   handleCreateProvider,
+  handleCreateFederationTrustProfile,
+  handleDeleteFederationTrustProfile,
   handleGetAggregateBatchStatus,
   handleListAggregatePreviewEntities,
   handlePreviewMetadata,
@@ -103,16 +105,17 @@ interface StoredBatch {
 }
 
 function createMockAdapter() {
-  return {
+  const adapter = {
     query: vi.fn().mockResolvedValue([]),
     queryOne: vi.fn().mockResolvedValue(null),
     execute: vi.fn().mockResolvedValue({ rowsAffected: 1, insertId: undefined }),
-    transaction: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+    transaction: vi.fn(async (fn: (tx: typeof adapter) => Promise<unknown>) => fn(adapter)),
     batch: vi.fn().mockResolvedValue([]),
     isHealthy: vi.fn().mockResolvedValue(true),
     getType: vi.fn().mockReturnValue('mock'),
     close: vi.fn().mockResolvedValue(undefined),
   };
+  return adapter;
 }
 
 function createAggregateStoreNamespace(input: {
@@ -322,6 +325,54 @@ describe('SAML aggregate provider API', () => {
     expect(adminAdapter.query).toHaveBeenCalledWith(
       expect.stringContaining('FROM federation_trust_sources'),
       ['tenant-a']
+    );
+  });
+
+  it('replaces legacy federation trust profile writes with normalized trust sources', async () => {
+    const adminAdapter = createMockAdapter();
+
+    const response = await handleCreateFederationTrustProfile(
+      createContext({
+        body: {
+          name: 'Normalized Federation',
+          metadataUrlPatterns: ['https://metadata.example.test/*.xml'],
+          certificates: [{ certificate: expiredCertificate }],
+          policy: 'warn',
+          enabled: true,
+        },
+        env: { DB_ADMIN: adminAdapter as never },
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect(adminAdapter.execute).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO federation_trust_sources'),
+      expect.any(Array)
+    );
+    expect(adminAdapter.execute).not.toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO saml_federation_trust_profiles'),
+      expect.any(Array)
+    );
+  });
+
+  it('deletes normalized and legacy federation trust rows through the compatibility endpoint', async () => {
+    const adminAdapter = createMockAdapter();
+
+    const response = await handleDeleteFederationTrustProfile(
+      createContext({
+        params: { id: 'trust-source-1' },
+        env: { DB_ADMIN: adminAdapter as never },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(adminAdapter.execute).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM federation_trust_sources'),
+      ['tenant-a', 'trust-source-1']
+    );
+    expect(adminAdapter.execute).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM saml_federation_trust_profiles'),
+      ['tenant-a', 'trust-source-1']
     );
   });
 
@@ -550,18 +601,24 @@ describe('SAML aggregate provider API', () => {
     'creates selected aggregate entities through the batch API using the runtime storage resolver: %s',
     async () => {
       const coreAdapter = createMockAdapter();
+      const adminAdapter = createMockAdapter();
       const waitUntil: Array<Promise<unknown>> = [];
       mocks.resolveAuthCorePersistenceAdapterFromEnv.mockResolvedValue(coreAdapter);
       const previewId = 'preview-1';
       const env = {
         DEFAULT_TENANT_ID: 'tenant-a',
+        DB_ADMIN: adminAdapter as never,
         SAML_AGGREGATE_METADATA_STORE: createAggregateStoreNamespace({
           previewId,
           preview: {
             tenantId: 'tenant-a',
             metadataXml: aggregateXml,
             metadataUrl: 'https://metadata.example.test/aggregate.xml',
-            verification: { status: 'skipped', policy: 'disabled' },
+            verification: {
+              status: 'skipped',
+              policy: 'disabled',
+              trustProfileId: 'trust-source-1',
+            },
           },
         }) as never,
       };
@@ -617,6 +674,10 @@ describe('SAML aggregate provider API', () => {
           expect.any(Number),
           expect.any(Number),
         ])
+      );
+      expect(adminAdapter.execute).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO federation_selected_entity_import_events'),
+        expect.arrayContaining(['tenant-a', 'trust-source-1', null, expect.any(String)])
       );
     }
   );

--- a/packages/ar-saml/src/admin/providers.ts
+++ b/packages/ar-saml/src/admin/providers.ts
@@ -1803,12 +1803,31 @@ export async function handleDeleteFederationTrustProfile(c: AdminSAMLContext): P
   try {
     const forbidden = await requireSAMLAdminPermission(c, ADMIN_PERMISSIONS.SAML_PROVIDERS_UPDATE);
     if (forbidden) return forbidden;
+    if (!id) return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
     const tenantId = resolveSAMLTenantIdFromContext(c);
     const adapter = requireDedicatedAdminDatabaseAdapter(c.env, 'saml-federation-trust');
-    await adapter.execute(
-      'DELETE FROM saml_federation_trust_profiles WHERE tenant_id = ? AND id = ?',
-      [tenantId, id]
-    );
+    await adapter.transaction(async (tx) => {
+      await tx.execute(
+        'DELETE FROM federation_trust_anchors WHERE tenant_id = ? AND trust_source_id = ?',
+        [tenantId, id]
+      );
+      await tx.execute(
+        'DELETE FROM federation_trust_scope_bindings WHERE tenant_id = ? AND trust_source_id = ?',
+        [tenantId, id]
+      );
+      await tx.execute(
+        'DELETE FROM federation_trust_context_snapshots WHERE tenant_id = ? AND trust_source_id = ?',
+        [tenantId, id]
+      );
+      await tx.execute('DELETE FROM federation_trust_sources WHERE tenant_id = ? AND id = ?', [
+        tenantId,
+        id,
+      ]);
+      await tx.execute(
+        'DELETE FROM saml_federation_trust_profiles WHERE tenant_id = ? AND id = ?',
+        [tenantId, id]
+      );
+    });
     await createSAMLAdminAudit(c, {
       tenantId,
       action: 'saml.federation_trust_profile.deleted',
@@ -2478,29 +2497,32 @@ async function listFederationTrustProfiles(
     certificates_json: string;
     policy: string | null;
     enabled: number;
+    normalized_migration_state?: string | null;
     created_at: number;
     updated_at: number;
   }>(
     `SELECT id, tenant_id, name, description, metadata_url_patterns_json, certificates_json,
-            policy, enabled, created_at, updated_at
+            policy, enabled, normalized_migration_state, created_at, updated_at
        FROM saml_federation_trust_profiles
        WHERE tenant_id = ?
        ORDER BY name ASC`,
     [tenantId]
   );
 
-  const legacyProfiles: SAMLFederationTrustProfile[] = rows.map((row) => ({
-    id: row.id,
-    tenantId: row.tenant_id,
-    name: row.name,
-    description: row.description ?? undefined,
-    metadataUrlPatterns: JSON.parse(row.metadata_url_patterns_json),
-    certificates: JSON.parse(row.certificates_json),
-    policy: normalizeFederationTrustPolicy(row.policy),
-    enabled: row.enabled === 1,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-  }));
+  const legacyProfiles: SAMLFederationTrustProfile[] = rows
+    .filter((row) => row.normalized_migration_state !== 'migrated')
+    .map((row) => ({
+      id: row.id,
+      tenantId: row.tenant_id,
+      name: row.name,
+      description: row.description ?? undefined,
+      metadataUrlPatterns: JSON.parse(row.metadata_url_patterns_json),
+      certificates: JSON.parse(row.certificates_json),
+      policy: normalizeFederationTrustPolicy(row.policy),
+      enabled: row.enabled === 1,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
   const normalizedProfiles = await listNormalizedSamlFederationTrustProfiles(env, tenantId);
   return [...legacyProfiles, ...normalizedProfiles].sort((a, b) => a.name.localeCompare(b.name));
 }
@@ -2574,6 +2596,36 @@ function normalizeFederationTrustPolicy(value: unknown): SAMLFederationTrustProf
   return value === 'strict' || value === 'warn' || value === 'disabled' ? value : undefined;
 }
 
+async function hashStableJson(value: unknown): Promise<string> {
+  const bytes = new TextEncoder().encode(stableJson(value));
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(sortForStableJson(value));
+}
+
+function sortForStableJson(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortForStableJson);
+  }
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+  return Object.keys(value)
+    .sort()
+    .reduce<Record<string, unknown>>((sorted, key) => {
+      const item = (value as Record<string, unknown>)[key];
+      if (item !== undefined) {
+        sorted[key] = sortForStableJson(item);
+      }
+      return sorted;
+    }, {});
+}
+
 function isSamlFederationTrustCertificate(
   value: unknown
 ): value is SAMLFederationTrustProfile['certificates'][number] {
@@ -2604,32 +2656,119 @@ async function upsertFederationTrustProfile(
   profile: SAMLFederationTrustProfile
 ): Promise<void> {
   const adapter = requireDedicatedAdminDatabaseAdapter(env, 'saml-federation-trust');
-  await adapter.execute(
-    `INSERT INTO saml_federation_trust_profiles
-       (id, tenant_id, name, description, metadata_url_patterns_json, certificates_json,
-        policy, enabled, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT(id) DO UPDATE SET
-       name = excluded.name,
-       description = excluded.description,
-       metadata_url_patterns_json = excluded.metadata_url_patterns_json,
-       certificates_json = excluded.certificates_json,
-       policy = excluded.policy,
-       enabled = excluded.enabled,
-       updated_at = excluded.updated_at`,
-    [
-      profile.id,
-      profile.tenantId,
-      profile.name,
-      profile.description ?? null,
-      JSON.stringify(profile.metadataUrlPatterns),
-      JSON.stringify(profile.certificates),
-      profile.policy ?? null,
-      profile.enabled ? 1 : 0,
-      profile.createdAt,
-      profile.updatedAt,
-    ]
-  );
+  const payload = {
+    description: profile.description ?? null,
+    metadataUrlPatterns: profile.metadataUrlPatterns,
+    policy: profile.policy ?? 'warn',
+    certificates: profile.certificates,
+  };
+  const trustContext = {
+    protocol: 'saml',
+    profileId: profile.id,
+    policy: profile.policy ?? 'warn',
+    enabled: profile.enabled,
+    metadataUrlPatterns: profile.metadataUrlPatterns,
+    anchorHashes: profile.certificates.map((certificate) => certificate.fingerprintSha256),
+  };
+  const snapshotHash = await hashStableJson(trustContext);
+  const lifecycleState = profile.enabled ? 'active' : 'draft';
+
+  await adapter.transaction(async (tx) => {
+    await tx.execute(
+      `INSERT INTO federation_trust_sources (
+        id, tenant_id, source_type, source_key, display_name, lifecycle_state,
+        protocol_payload_json, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        source_type = excluded.source_type,
+        source_key = excluded.source_key,
+        display_name = excluded.display_name,
+        lifecycle_state = excluded.lifecycle_state,
+        protocol_payload_json = excluded.protocol_payload_json,
+        updated_at = excluded.updated_at`,
+      [
+        profile.id,
+        profile.tenantId,
+        'saml_aggregate',
+        `saml-profile:${profile.id}`,
+        profile.name,
+        lifecycleState,
+        stableJson(payload),
+        profile.createdAt,
+        profile.updatedAt,
+      ]
+    );
+    await tx.execute(
+      'DELETE FROM federation_trust_anchors WHERE tenant_id = ? AND trust_source_id = ?',
+      [profile.tenantId, profile.id]
+    );
+    await tx.execute(
+      'DELETE FROM federation_trust_scope_bindings WHERE tenant_id = ? AND trust_source_id = ?',
+      [profile.tenantId, profile.id]
+    );
+    for (const certificate of profile.certificates) {
+      await tx.execute(
+        `INSERT INTO federation_trust_anchors (
+          id, tenant_id, trust_source_id, anchor_type, anchor_hash, anchor_ref,
+          not_before, not_after, lifecycle_state, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          crypto.randomUUID(),
+          profile.tenantId,
+          profile.id,
+          'x509_sha256',
+          certificate.fingerprintSha256,
+          certificate.id,
+          null,
+          null,
+          'active',
+          profile.updatedAt,
+          profile.updatedAt,
+        ]
+      );
+    }
+    await tx.execute(
+      `INSERT INTO federation_trust_scope_bindings (
+        id, tenant_id, trust_source_id, scope_type, scope_id, priority,
+        lifecycle_state, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        crypto.randomUUID(),
+        profile.tenantId,
+        profile.id,
+        'tenant',
+        profile.tenantId,
+        0,
+        'active',
+        profile.updatedAt,
+        profile.updatedAt,
+      ]
+    );
+    await tx.execute(
+      `INSERT INTO federation_trust_context_snapshots (
+        id, tenant_id, trust_source_id, snapshot_hash, trust_context_json,
+        lifecycle_state, created_at, activated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        crypto.randomUUID(),
+        profile.tenantId,
+        profile.id,
+        snapshotHash,
+        stableJson(trustContext),
+        lifecycleState,
+        profile.updatedAt,
+        profile.enabled ? profile.updatedAt : null,
+      ]
+    );
+    await tx.execute(
+      `UPDATE saml_federation_trust_profiles
+          SET federation_trust_source_id = ?,
+              normalized_migration_state = ?,
+              updated_at = ?
+        WHERE tenant_id = ? AND id = ?`,
+      [profile.id, 'migrated', profile.updatedAt, profile.tenantId, profile.id]
+    );
+  });
 }
 
 async function storeAggregatePreview(
@@ -2819,12 +2958,27 @@ async function processAggregateBatchCreate(
           providerType,
           name,
         });
+        await recordFederationSelectedEntityImportEvent(env, {
+          tenantId: input.tenantId,
+          trustSourceId: preview.verification.trustProfileId,
+          providerId,
+          importAction: 'create_provider',
+          outcome: 'success',
+          reasonCodes: ['federation.selected_entity.imported'],
+        });
         existingEntityKeys.add(entityKey);
       } catch (error) {
         await recordAggregateBatchResult(env, input.batchId, {
           entityId,
           success: false,
           error: error instanceof Error ? error.message : 'Import failed',
+        });
+        await recordFederationSelectedEntityImportEvent(env, {
+          tenantId: input.tenantId,
+          trustSourceId: preview.verification.trustProfileId,
+          importAction: 'create_provider',
+          outcome: 'failed',
+          reasonCodes: ['federation.selected_entity.import_failed'],
         });
       }
     }
@@ -2836,6 +2990,44 @@ async function processAggregateBatchCreate(
       input.batchId,
       error instanceof Error ? error.message : 'Batch failed'
     );
+  }
+}
+
+async function recordFederationSelectedEntityImportEvent(
+  env: Env,
+  input: {
+    tenantId: string;
+    trustSourceId?: string;
+    providerId?: string;
+    importAction: string;
+    outcome: string;
+    reasonCodes: string[];
+  }
+): Promise<void> {
+  if (!input.trustSourceId) {
+    return;
+  }
+  try {
+    const adapter = requireDedicatedAdminDatabaseAdapter(env, 'saml-federation-trust');
+    await adapter.execute(
+      `INSERT INTO federation_selected_entity_import_events (
+        id, tenant_id, trust_source_id, metadata_entity_summary_id, provider_id,
+        import_action, outcome, reason_codes_json, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        crypto.randomUUID(),
+        input.tenantId,
+        input.trustSourceId,
+        null,
+        input.providerId ?? null,
+        input.importAction,
+        input.outcome,
+        stableJson(input.reasonCodes),
+        Date.now(),
+      ]
+    );
+  } catch {
+    // Best-effort operational evidence must not fail the provider import itself.
   }
 }
 

--- a/packages/ar-saml/src/admin/providers.ts
+++ b/packages/ar-saml/src/admin/providers.ts
@@ -715,6 +715,13 @@ interface SAMLFederationTrustProfileRequest {
   enabled?: boolean;
 }
 
+interface NormalizedSAMLFederationTrustPayload {
+  description?: string;
+  metadataUrlPatterns?: string[];
+  certificates?: SAMLFederationTrustProfile['certificates'];
+  policy?: 'strict' | 'warn' | 'disabled';
+}
+
 interface SAMLMetadataBatchCreateRequest {
   entityIds?: string[];
   providerType?: 'saml_idp' | 'saml_sp';
@@ -2482,21 +2489,104 @@ async function listFederationTrustProfiles(
     [tenantId]
   );
 
-  return rows.map((row) => ({
+  const legacyProfiles: SAMLFederationTrustProfile[] = rows.map((row) => ({
     id: row.id,
     tenantId: row.tenant_id,
     name: row.name,
     description: row.description ?? undefined,
     metadataUrlPatterns: JSON.parse(row.metadata_url_patterns_json),
     certificates: JSON.parse(row.certificates_json),
-    policy:
-      row.policy === 'strict' || row.policy === 'warn' || row.policy === 'disabled'
-        ? row.policy
-        : undefined,
+    policy: normalizeFederationTrustPolicy(row.policy),
     enabled: row.enabled === 1,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }));
+  const normalizedProfiles = await listNormalizedSamlFederationTrustProfiles(env, tenantId);
+  return [...legacyProfiles, ...normalizedProfiles].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function listNormalizedSamlFederationTrustProfiles(
+  env: Env,
+  tenantId: string
+): Promise<SAMLFederationTrustProfile[]> {
+  const adapter = requireDedicatedAdminDatabaseAdapter(env, 'saml-federation-trust');
+  const rows = await adapter.query<{
+    id: string;
+    tenant_id: string;
+    source_type: string;
+    display_name: string;
+    lifecycle_state: string;
+    protocol_payload_json: string | null;
+    created_at: number;
+    updated_at: number;
+  }>(
+    `SELECT id, tenant_id, source_type, display_name, lifecycle_state, protocol_payload_json,
+            created_at, updated_at
+       FROM federation_trust_sources
+       WHERE tenant_id = ?
+         AND source_type IN ('saml_aggregate', 'saml_metadata', 'saml_federation')
+         AND lifecycle_state IN ('active', 'draft')
+       ORDER BY display_name ASC`,
+    [tenantId]
+  );
+
+  return rows.flatMap((row) => {
+    const payload = parseNormalizedSamlFederationPayload(row.protocol_payload_json);
+    if (payload.metadataUrlPatterns.length === 0 || payload.certificates.length === 0) {
+      return [];
+    }
+    return [
+      {
+        id: row.id,
+        tenantId: row.tenant_id,
+        name: row.display_name,
+        description: payload.description,
+        metadataUrlPatterns: payload.metadataUrlPatterns,
+        certificates: payload.certificates,
+        policy: payload.policy,
+        enabled: row.lifecycle_state === 'active',
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+      },
+    ];
+  });
+}
+
+function parseNormalizedSamlFederationPayload(
+  value: string | null
+): Required<NormalizedSAMLFederationTrustPayload> {
+  const parsed = value ? (JSON.parse(value) as NormalizedSAMLFederationTrustPayload) : {};
+  return {
+    description: typeof parsed.description === 'string' ? parsed.description : '',
+    metadataUrlPatterns: Array.isArray(parsed.metadataUrlPatterns)
+      ? parsed.metadataUrlPatterns.filter(
+          (pattern): pattern is string => typeof pattern === 'string'
+        )
+      : [],
+    certificates: Array.isArray(parsed.certificates)
+      ? parsed.certificates.filter(isSamlFederationTrustCertificate)
+      : [],
+    policy: normalizeFederationTrustPolicy(parsed.policy) ?? 'warn',
+  };
+}
+
+function normalizeFederationTrustPolicy(value: unknown): SAMLFederationTrustProfile['policy'] {
+  return value === 'strict' || value === 'warn' || value === 'disabled' ? value : undefined;
+}
+
+function isSamlFederationTrustCertificate(
+  value: unknown
+): value is SAMLFederationTrustProfile['certificates'][number] {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const certificate = value as Partial<SAMLFederationTrustProfile['certificates'][number]>;
+  return (
+    typeof certificate.id === 'string' &&
+    typeof certificate.certificate === 'string' &&
+    typeof certificate.fingerprintSha256 === 'string' &&
+    typeof certificate.createdAt === 'number'
+  );
 }
 
 async function getFederationTrustProfile(


### PR DESCRIPTION
## Summary
- add admin repository and API routes for key registries, key rotation, key access events, federation trust sources, federation metadata documents, and SAML federation trust migration
- connect normalized SAML federation trust sources back into aggregate metadata verification
- add regression coverage for key material safety, rotation job enqueueing, SAML trust migration, metadata registration, and normalized aggregate trust reads

## Validation
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm --filter @authrim/ar-management test
- pnpm --filter @authrim/ar-saml test