### PR TITLE
feat: add identity mapping admin UI surfaces

### DIFF
--- a/packages/ar-admin-ui/src/lib/admin/__tests__/identity-mapping-profile-settings.test.ts
+++ b/packages/ar-admin-ui/src/lib/admin/__tests__/identity-mapping-profile-settings.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+	createDestinationConsentSettingsDraft,
+	summarizeDestinationConsentSettings
+} from '../identity-mapping-profile-settings';
+
+describe('identity mapping destination profile settings', () => {
+	it('creates privacy-preserving tenant default release consent settings', () => {
+		const draft = createDestinationConsentSettingsDraft('profile_oidc');
+
+		expect(draft).toMatchObject({
+			scope: 'tenant_default',
+			profileId: 'profile_oidc',
+			consentMode: 'until_attributes_change',
+			legalBasis: 'consent',
+			purpose: 'profile_release',
+			regulatedPurposeGuard: true,
+			rawValueDisplay: 'hidden'
+		});
+	});
+
+	it('summarizes client overrides without exposing raw attribute values', () => {
+		const draft = {
+			...createDestinationConsentSettingsDraft('profile_saml', 'client_override'),
+			clientId: 'client_academic_sp',
+			consentMode: 'every_time' as const
+		};
+
+		expect(summarizeDestinationConsentSettings(draft)).toContain(
+			'client override client_academic_sp'
+		);
+		expect(summarizeDestinationConsentSettings(draft)).toContain('every_time');
+		expect(summarizeDestinationConsentSettings(draft)).not.toContain('raw');
+	});
+});

--- a/packages/ar-admin-ui/src/lib/admin/__tests__/identity-mapping-ui-smoke.test.ts
+++ b/packages/ar-admin-ui/src/lib/admin/__tests__/identity-mapping-ui-smoke.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+function readRoute(relativePath: string): string {
+	const path = fileURLToPath(new URL(`../../../routes/${relativePath}`, import.meta.url));
+	return readFileSync(path, 'utf8');
+}
+
+function readApi(relativePath: string): string {
+	const path = fileURLToPath(new URL(`../../api/${relativePath}`, import.meta.url));
+	return readFileSync(path, 'utf8');
+}
+
+function readComponent(relativePath: string): string {
+	const path = fileURLToPath(new URL(`../../components/${relativePath}`, import.meta.url));
+	return readFileSync(path, 'utf8');
+}
+
+describe('identity mapping Admin UI smoke checks', () => {
+	it('keeps the Tier 2 identity mapping routes linked from the main page', () => {
+		const layout = readRoute('admin/+layout.svelte');
+		const page = readRoute('admin/identity-mapping/+page.svelte');
+
+		expect(layout).toContain('/admin/identity-mapping');
+		expect(page).toContain('/admin/identity-mapping/profiles');
+		expect(page).toContain('/admin/identity-mapping/operations');
+		expect(page).toContain('/admin/identity-mapping/resolution-center');
+		expect(page).toContain('/admin/identity-mapping/federation-trust');
+		expect(page).toContain('/admin/identity-mapping/schema-readiness');
+	});
+
+	it('keeps the flow editor graph interaction affordances present', () => {
+		const flowEditor = readComponent('identity-mapping/IdentityMappingFlowEditor.svelte');
+
+		expect(flowEditor).toContain('startConnectionDrag');
+		expect(flowEditor).toContain('drag-edge');
+		expect(flowEditor).toContain('edge-selected');
+		expect(flowEditor).toContain('adapter-hidden');
+		expect(flowEditor).toContain('node-handle output');
+		expect(flowEditor).toContain('node-handle input');
+		expect(flowEditor).toContain('Consent status');
+		expect(flowEditor).toContain('Challenge mode');
+		expect(flowEditor).toContain("role === 'source' && toNode.role === 'target'");
+		expect(flowEditor).toContain("role === 'target' && toNode.role === 'destination'");
+	});
+
+	it('wires operation, profile, resolution, and federation pages to their APIs', () => {
+		const api = readApi('admin-identity-mapping.ts');
+		const operations = readRoute('admin/identity-mapping/operations/+page.svelte');
+		const profiles = readRoute('admin/identity-mapping/profiles/+page.svelte');
+		const resolution = readRoute('admin/identity-mapping/resolution-center/+page.svelte');
+		const federation = readRoute('admin/identity-mapping/federation-trust/+page.svelte');
+
+		expect(api).toContain('/api/admin/identity-mapping/review-tasks');
+		expect(api).toContain('/api/admin/identity-mapping/federation-trust-sources');
+		expect(api).toContain('/metadata-documents');
+		expect(api).toContain('/api/admin/identity-mapping/protocol-schemas');
+		expect(api).toContain('/api/admin/identity-mapping/external-schemas');
+		expect(api).toContain('/api/admin/identity-mapping/templates');
+		expect(api).toContain('/rollback');
+		expect(api).toContain('/publish');
+		expect(api).toContain('/compile');
+		expect(api).toContain('/activate');
+		expect(api).toContain('/transition');
+		expect(operations).toContain('Confirm rollback');
+		expect(operations).toContain('rollbackPolicy');
+		expect(operations).toContain('runPolicyOperation');
+		expect(profiles).toContain('listProtocolSchemas');
+		expect(profiles).toContain('listExternalSchemas');
+		expect(profiles).toContain('listTemplates');
+		expect(resolution).toContain('listReviewTasks');
+		expect(resolution).toContain('transitionResolutionItem');
+		expect(federation).toContain('listFederationTrustSources');
+		expect(federation).toContain('listFederationMetadataDocuments');
+		expect(federation).toContain('listAggregatePreviewEntities');
+	});
+
+	it('keeps operator naming separate from internal review task storage names', () => {
+		const resolution = readRoute('admin/identity-mapping/resolution-center/+page.svelte');
+
+		expect(resolution).toContain('Mapping Resolution Center');
+		expect(resolution).not.toContain('review_tasks');
+		expect(resolution).not.toContain('Review Queue');
+	});
+});

--- a/packages/ar-admin-ui/src/lib/admin/__tests__/identity-mapping-ui-smoke.test.ts
+++ b/packages/ar-admin-ui/src/lib/admin/__tests__/identity-mapping-ui-smoke.test.ts
@@ -41,6 +41,8 @@ describe('identity mapping Admin UI smoke checks', () => {
 		expect(flowEditor).toContain('node-handle input');
 		expect(flowEditor).toContain('Consent status');
 		expect(flowEditor).toContain('Challenge mode');
+		expect(flowEditor).toContain('Release policy');
+		expect(flowEditor).toContain('Privacy Policy');
 		expect(flowEditor).toContain("role === 'source' && toNode.role === 'target'");
 		expect(flowEditor).toContain("role === 'target' && toNode.role === 'destination'");
 	});
@@ -58,6 +60,7 @@ describe('identity mapping Admin UI smoke checks', () => {
 		expect(api).toContain('/api/admin/identity-mapping/protocol-schemas');
 		expect(api).toContain('/api/admin/identity-mapping/external-schemas');
 		expect(api).toContain('/api/admin/identity-mapping/templates');
+		expect(api).toContain('/api/admin/identity-mapping/schema-readiness');
 		expect(api).toContain('/rollback');
 		expect(api).toContain('/publish');
 		expect(api).toContain('/compile');
@@ -69,11 +72,24 @@ describe('identity mapping Admin UI smoke checks', () => {
 		expect(profiles).toContain('listProtocolSchemas');
 		expect(profiles).toContain('listExternalSchemas');
 		expect(profiles).toContain('listTemplates');
+		expect(profiles).toContain('Destination Consent Settings');
+		expect(profiles).toContain('Tenant default');
+		expect(profiles).toContain('Client override');
 		expect(resolution).toContain('listReviewTasks');
+		expect(resolution).toContain("status: 'in_review'");
 		expect(resolution).toContain('transitionResolutionItem');
 		expect(federation).toContain('listFederationTrustSources');
 		expect(federation).toContain('listFederationMetadataDocuments');
 		expect(federation).toContain('listAggregatePreviewEntities');
+	});
+
+	it('loads schema readiness from the control-plane API instead of hardcoded rows', () => {
+		const readiness = readRoute('admin/identity-mapping/schema-readiness/+page.svelte');
+
+		expect(readiness).toContain('getSchemaReadiness');
+		expect(readiness).toContain('schemaPresent');
+		expect(readiness).toContain('gateState');
+		expect(readiness).not.toContain('const rows: ReadinessRow[]');
 	});
 
 	it('keeps operator naming separate from internal review task storage names', () => {

--- a/packages/ar-admin-ui/src/lib/admin/identity-mapping-profile-settings.ts
+++ b/packages/ar-admin-ui/src/lib/admin/identity-mapping-profile-settings.ts
@@ -1,0 +1,55 @@
+export type DestinationConsentScope = 'tenant_default' | 'client_override';
+
+export type DestinationConsentMode = 'once' | 'every_time' | 'until_attributes_change';
+
+export type DestinationLegalBasis =
+	| 'consent'
+	| 'legal_obligation'
+	| 'contract'
+	| 'legitimate_interest';
+
+export interface DestinationConsentSettingsDraft {
+	scope: DestinationConsentScope;
+	profileId: string;
+	clientId: string;
+	consentMode: DestinationConsentMode;
+	legalBasis: DestinationLegalBasis;
+	purpose: string;
+	attributeSetPolicyVersion: string;
+	termsVersion: string;
+	privacyPolicyVersion: string;
+	regulatedPurposeGuard: boolean;
+	challengeExperience: 'login_flow' | 'step_up_required';
+	rawValueDisplay: 'hidden';
+}
+
+export function createDestinationConsentSettingsDraft(
+	profileId: string,
+	scope: DestinationConsentScope = 'tenant_default'
+): DestinationConsentSettingsDraft {
+	return {
+		scope,
+		profileId,
+		clientId: '',
+		consentMode: 'until_attributes_change',
+		legalBasis: 'consent',
+		purpose: 'profile_release',
+		attributeSetPolicyVersion: 'release-policy-v1',
+		termsVersion: 'current',
+		privacyPolicyVersion: 'current',
+		regulatedPurposeGuard: true,
+		challengeExperience: 'login_flow',
+		rawValueDisplay: 'hidden'
+	};
+}
+
+export function summarizeDestinationConsentSettings(
+	settings: DestinationConsentSettingsDraft
+): string {
+	const scopeLabel =
+		settings.scope === 'tenant_default' ? 'tenant default' : `client override ${settings.clientId}`;
+	const challengeLabel =
+		settings.challengeExperience === 'login_flow' ? 'login flow challenge' : 'step-up challenge';
+	const guardLabel = settings.regulatedPurposeGuard ? 'purpose guard enabled' : 'purpose guard off';
+	return `${scopeLabel}: ${settings.legalBasis}, ${settings.consentMode}, ${settings.purpose}, ${challengeLabel}, ${guardLabel}`;
+}

--- a/packages/ar-admin-ui/src/lib/api/admin-identity-mapping.test.ts
+++ b/packages/ar-admin-ui/src/lib/api/admin-identity-mapping.test.ts
@@ -14,6 +14,8 @@ describe('adminIdentityMappingAPI', () => {
 						protocolSchemas: [],
 						externalSchemas: [],
 						templates: [],
+						rows: [],
+						summary: { total: 0, pass: 0, attention: 0, blocked: 0, deferred: 0 },
 						federationTrustSources: [],
 						federationMetadataDocuments: [],
 						reviewTasks: []
@@ -43,6 +45,7 @@ describe('adminIdentityMappingAPI', () => {
 		await adminIdentityMappingAPI.listProtocolSchemas();
 		await adminIdentityMappingAPI.listExternalSchemas();
 		await adminIdentityMappingAPI.listTemplates();
+		await adminIdentityMappingAPI.getSchemaReadiness();
 		await adminIdentityMappingAPI.listFederationTrustSources();
 		await adminIdentityMappingAPI.listFederationMetadataDocuments('trust/source 1');
 		await adminIdentityMappingAPI.listReviewTasks({ status: 'open', limit: 25 });
@@ -66,6 +69,7 @@ describe('adminIdentityMappingAPI', () => {
 			'/api/admin/identity-mapping/protocol-schemas',
 			'/api/admin/identity-mapping/external-schemas',
 			'/api/admin/identity-mapping/templates',
+			'/api/admin/identity-mapping/schema-readiness',
 			'/api/admin/identity-mapping/federation-trust-sources',
 			'/api/admin/identity-mapping/federation-trust-sources/trust%2Fsource%201/metadata-documents',
 			'/api/admin/identity-mapping/review-tasks?status=open&limit=25',
@@ -75,11 +79,11 @@ describe('adminIdentityMappingAPI', () => {
 			'/api/admin/identity-mapping/policies/policy%20set%201/versions/version%201/activate',
 			'/api/admin/identity-mapping/review-tasks/review%20task%201/transition'
 		]);
-		expect(fetchMock.mock.calls[8][1]).toMatchObject({ method: 'POST' });
 		expect(fetchMock.mock.calls[9][1]).toMatchObject({ method: 'POST' });
 		expect(fetchMock.mock.calls[10][1]).toMatchObject({ method: 'POST' });
 		expect(fetchMock.mock.calls[11][1]).toMatchObject({ method: 'POST' });
 		expect(fetchMock.mock.calls[12][1]).toMatchObject({ method: 'POST' });
+		expect(fetchMock.mock.calls[13][1]).toMatchObject({ method: 'POST' });
 	});
 
 	it('surfaces API error descriptions', async () => {

--- a/packages/ar-admin-ui/src/lib/api/admin-identity-mapping.test.ts
+++ b/packages/ar-admin-ui/src/lib/api/admin-identity-mapping.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { adminIdentityMappingAPI } from './admin-identity-mapping';
+
+describe('adminIdentityMappingAPI', () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchMock = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						policies: [],
+						catalogs: [],
+						protocolSchemas: [],
+						externalSchemas: [],
+						templates: [],
+						federationTrustSources: [],
+						federationMetadataDocuments: [],
+						reviewTasks: []
+					}),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } }
+				)
+		);
+		vi.stubGlobal('fetch', fetchMock);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	function requestPath(input: unknown): string {
+		const value = String(input);
+		if (value.startsWith('http://') || value.startsWith('https://')) {
+			const url = new URL(value);
+			return `${url.pathname}${url.search}`;
+		}
+		return value;
+	}
+
+	it('loads identity mapping control-plane collections from admin endpoints', async () => {
+		await adminIdentityMappingAPI.listPolicies();
+		await adminIdentityMappingAPI.listCatalogs();
+		await adminIdentityMappingAPI.listProtocolSchemas();
+		await adminIdentityMappingAPI.listExternalSchemas();
+		await adminIdentityMappingAPI.listTemplates();
+		await adminIdentityMappingAPI.listFederationTrustSources();
+		await adminIdentityMappingAPI.listFederationMetadataDocuments('trust/source 1');
+		await adminIdentityMappingAPI.listReviewTasks({ status: 'open', limit: 25 });
+		await adminIdentityMappingAPI.rollbackPolicy('policy set 1');
+		await adminIdentityMappingAPI.publishPolicyVersion('policy set 1', 'version 1');
+		await adminIdentityMappingAPI.compilePolicyVersion('policy set 1', 'version 1', {
+			catalogVersionId: 'catalog version 1'
+		});
+		await adminIdentityMappingAPI.activatePolicyVersion('policy set 1', 'version 1', {
+			snapshotId: 'snapshot 1',
+			activationScope: { kind: 'tenant', id: 'tenant_a' }
+		});
+		await adminIdentityMappingAPI.transitionReviewTask('review task 1', {
+			status: 'resolved',
+			reasonCodes: ['operator_resolved']
+		});
+
+		expect(fetchMock.mock.calls.map((call) => requestPath(call[0]))).toEqual([
+			'/api/admin/identity-mapping/policies',
+			'/api/admin/identity-mapping/catalogs',
+			'/api/admin/identity-mapping/protocol-schemas',
+			'/api/admin/identity-mapping/external-schemas',
+			'/api/admin/identity-mapping/templates',
+			'/api/admin/identity-mapping/federation-trust-sources',
+			'/api/admin/identity-mapping/federation-trust-sources/trust%2Fsource%201/metadata-documents',
+			'/api/admin/identity-mapping/review-tasks?status=open&limit=25',
+			'/api/admin/identity-mapping/policies/policy%20set%201/rollback',
+			'/api/admin/identity-mapping/policies/policy%20set%201/versions/version%201/publish',
+			'/api/admin/identity-mapping/policies/policy%20set%201/versions/version%201/compile',
+			'/api/admin/identity-mapping/policies/policy%20set%201/versions/version%201/activate',
+			'/api/admin/identity-mapping/review-tasks/review%20task%201/transition'
+		]);
+		expect(fetchMock.mock.calls[8][1]).toMatchObject({ method: 'POST' });
+		expect(fetchMock.mock.calls[9][1]).toMatchObject({ method: 'POST' });
+		expect(fetchMock.mock.calls[10][1]).toMatchObject({ method: 'POST' });
+		expect(fetchMock.mock.calls[11][1]).toMatchObject({ method: 'POST' });
+		expect(fetchMock.mock.calls[12][1]).toMatchObject({ method: 'POST' });
+	});
+
+	it('surfaces API error descriptions', async () => {
+		fetchMock.mockResolvedValueOnce(
+			new Response(JSON.stringify({ error_description: 'schema-readiness gate failed' }), {
+				status: 409,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+
+		await expect(adminIdentityMappingAPI.listPolicies()).rejects.toThrow(
+			'schema-readiness gate failed'
+		);
+	});
+});

--- a/packages/ar-admin-ui/src/lib/api/admin-identity-mapping.ts
+++ b/packages/ar-admin-ui/src/lib/api/admin-identity-mapping.ts
@@ -1,0 +1,276 @@
+import { adminFetch } from '$lib/api/admin-request';
+
+const API_BASE_URL = import.meta.env.PUBLIC_API_BASE_URL || '';
+
+export interface IdentityMappingPolicySummary {
+	id: string;
+	tenantId: string;
+	policyKey: string;
+	displayName: string;
+	description?: string | null;
+	lifecycleState: string;
+}
+
+export interface IdentityMappingCatalogSummary {
+	id: string;
+	tenantId: string;
+	catalogKey: string;
+	displayName: string;
+	versionLabel: string;
+	lifecycleState: string;
+}
+
+export interface IdentityMappingProtocolSchemaSummary {
+	id: string;
+	tenantId: string;
+	protocol: string;
+	schemaKey: string;
+	displayName: string;
+	versionLabel: string;
+	lifecycleState: string;
+}
+
+export interface IdentityMappingExternalSchemaSummary {
+	id: string;
+	tenantId: string;
+	sourceType: string;
+	sourceKey: string;
+	displayName: string;
+	versionLabel: string;
+	lifecycleState: string;
+}
+
+export interface IdentityMappingTemplateSummary {
+	id: string;
+	tenantId: string;
+	templateKey: string;
+	displayName: string;
+	protocol: string;
+	lifecycleState: string;
+}
+
+export interface IdentityMappingFederationTrustSourceSummary {
+	id: string;
+	tenantId: string;
+	sourceType: string;
+	sourceKey: string;
+	displayName: string;
+	lifecycleState: string;
+	protocolPayload?: Record<string, unknown> | null;
+	createdAt?: number;
+	updatedAt?: number;
+}
+
+export interface IdentityMappingFederationMetadataDocument {
+	id: string;
+	tenantId: string;
+	trustSourceId: string;
+	documentType: string;
+	sourceUrl?: string | null;
+	documentHash: string;
+	documentRef?: string | null;
+	fetchedAt?: number | null;
+	validatedAt?: number | null;
+	validationState: string;
+	createdAt?: number;
+	updatedAt?: number;
+	entitySummaries: Array<{
+		id: string;
+		entityId: string;
+		entityRole: string;
+		displayName?: string | null;
+		summary?: Record<string, unknown> | null;
+	}>;
+}
+
+export interface IdentityMappingReviewTask {
+	id: string;
+	tenantId: string;
+	taskType: string;
+	subjectId?: string | null;
+	accountId?: string | null;
+	status: string;
+	priority: number;
+	assignedTo?: string | null;
+	payload: Record<string, unknown>;
+	dueAt?: number | null;
+	createdAt?: number;
+	updatedAt?: number;
+}
+
+export interface IdentityMappingReviewTaskFilters {
+	status?: string;
+	taskType?: string;
+	assignedTo?: string;
+	limit?: number;
+}
+
+export interface IdentityMappingCompilePolicyRequest {
+	catalogVersionId: string;
+	compatibilityRange?: string;
+	artifactRef?: string;
+	metadata?: Record<string, unknown>;
+}
+
+export interface IdentityMappingActivatePolicyRequest {
+	snapshotId: string;
+	activationScope: Record<string, unknown>;
+	holderId?: string;
+}
+
+async function parseJson<T>(response: Response, fallbackMessage: string): Promise<T> {
+	if (response.ok) {
+		return (await response.json()) as T;
+	}
+
+	let message = fallbackMessage;
+	try {
+		const body = (await response.json()) as {
+			error_description?: string;
+			message?: string;
+			error?: string;
+		};
+		message = body.error_description || body.message || body.error || fallbackMessage;
+	} catch {
+		// Keep the stable fallback when the server returns an empty or non-JSON error body.
+	}
+	throw new Error(message);
+}
+
+function toQueryString(filters: IdentityMappingReviewTaskFilters = {}): string {
+	const params = new URLSearchParams();
+	if (filters.status) params.set('status', filters.status);
+	if (filters.taskType) params.set('taskType', filters.taskType);
+	if (filters.assignedTo) params.set('assignedTo', filters.assignedTo);
+	if (filters.limit !== undefined) params.set('limit', String(filters.limit));
+	const query = params.toString();
+	return query ? `?${query}` : '';
+}
+
+export const adminIdentityMappingAPI = {
+	async listPolicies(): Promise<{ policies: IdentityMappingPolicySummary[] }> {
+		const response = await adminFetch(`${API_BASE_URL}/api/admin/identity-mapping/policies`);
+		return parseJson(response, 'Failed to load identity mapping policies');
+	},
+
+	async rollbackPolicy(policySetId: string): Promise<Record<string, unknown>> {
+		const response = await adminFetch(
+			`${API_BASE_URL}/api/admin/identity-mapping/policies/${encodeURIComponent(policySetId)}/rollback`,
+			{ method: 'POST' }
+		);
+		return parseJson(response, 'Failed to rollback identity mapping policy');
+	},
+
+	async publishPolicyVersion(
+		policySetId: string,
+		policyVersionId: string
+	): Promise<Record<string, unknown>> {
+		const response = await adminFetch(
+			`${API_BASE_URL}/api/admin/identity-mapping/policies/${encodeURIComponent(policySetId)}/versions/${encodeURIComponent(policyVersionId)}/publish`,
+			{ method: 'POST' }
+		);
+		return parseJson(response, 'Failed to publish identity mapping policy version');
+	},
+
+	async compilePolicyVersion(
+		policySetId: string,
+		policyVersionId: string,
+		request: IdentityMappingCompilePolicyRequest
+	): Promise<Record<string, unknown>> {
+		const response = await adminFetch(
+			`${API_BASE_URL}/api/admin/identity-mapping/policies/${encodeURIComponent(policySetId)}/versions/${encodeURIComponent(policyVersionId)}/compile`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(request)
+			}
+		);
+		return parseJson(response, 'Failed to compile identity mapping policy version');
+	},
+
+	async activatePolicyVersion(
+		policySetId: string,
+		policyVersionId: string,
+		request: IdentityMappingActivatePolicyRequest
+	): Promise<Record<string, unknown>> {
+		const response = await adminFetch(
+			`${API_BASE_URL}/api/admin/identity-mapping/policies/${encodeURIComponent(policySetId)}/versions/${encodeURIComponent(policyVersionId)}/activate`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(request)
+			}
+		);
+		return parseJson(response, 'Failed to activate identity mapping policy version');
+	},
+
+	async listCatalogs(): Promise<{ catalogs: IdentityMappingCatalogSummary[] }> {
+		const response = await adminFetch(`${API_BASE_URL}/api/admin/identity-mapping/catalogs`);
+		return parseJson(response, 'Failed to load identity mapping catalogs');
+	},
+
+	async listProtocolSchemas(): Promise<{
+		protocolSchemas: IdentityMappingProtocolSchemaSummary[];
+	}> {
+		const response = await adminFetch(
+			`${API_BASE_URL}/api/admin/identity-mapping/protocol-schemas`
+		);
+		return parseJson(response, 'Failed to load identity mapping protocol schemas');
+	},
+
+	async listExternalSchemas(): Promise<{
+		externalSchemas: IdentityMappingExternalSchemaSummary[];
+	}> {
+		const response = await adminFetch(
+			`${API_BASE_URL}/api/admin/identity-mapping/external-schemas`
+		);
+		return parseJson(response, 'Failed to load identity mapping external schemas');
+	},
+
+	async listTemplates(): Promise<{ templates: IdentityMappingTemplateSummary[] }> {
+		const response = await adminFetch(`${API_BASE_URL}/api/admin/identity-mapping/templates`);
+		return parseJson(response, 'Failed to load identity mapping templates');
+	},
+
+	async listFederationTrustSources(): Promise<{
+		federationTrustSources: IdentityMappingFederationTrustSourceSummary[];
+	}> {
+		const response = await adminFetch(
+			`${API_BASE_URL}/api/admin/identity-mapping/federation-trust-sources`
+		);
+		return parseJson(response, 'Failed to load federation trust sources');
+	},
+
+	async listFederationMetadataDocuments(
+		trustSourceId: string
+	): Promise<{ federationMetadataDocuments: IdentityMappingFederationMetadataDocument[] }> {
+		const response = await adminFetch(
+			`${API_BASE_URL}/api/admin/identity-mapping/federation-trust-sources/${encodeURIComponent(trustSourceId)}/metadata-documents`
+		);
+		return parseJson(response, 'Failed to load federation metadata documents');
+	},
+
+	async listReviewTasks(
+		filters: IdentityMappingReviewTaskFilters = {}
+	): Promise<{ reviewTasks: IdentityMappingReviewTask[] }> {
+		const response = await adminFetch(
+			`${API_BASE_URL}/api/admin/identity-mapping/review-tasks${toQueryString(filters)}`
+		);
+		return parseJson(response, 'Failed to load identity mapping review tasks');
+	},
+
+	async transitionReviewTask(
+		reviewTaskId: string,
+		request: { status: string; assignedTo?: string | null; reasonCodes?: string[] }
+	): Promise<Record<string, unknown>> {
+		const response = await adminFetch(
+			`${API_BASE_URL}/api/admin/identity-mapping/review-tasks/${encodeURIComponent(reviewTaskId)}/transition`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(request)
+			}
+		);
+		return parseJson(response, 'Failed to transition identity mapping review task');
+	}
+};

--- a/packages/ar-admin-ui/src/lib/api/admin-identity-mapping.ts
+++ b/packages/ar-admin-ui/src/lib/api/admin-identity-mapping.ts
@@ -105,6 +105,29 @@ export interface IdentityMappingReviewTaskFilters {
 	limit?: number;
 }
 
+export interface IdentityMappingSchemaReadinessRow {
+	id: string;
+	objectName: string;
+	area: string;
+	introducedPr: string;
+	expectedConnectionPr: string;
+	runtimePath: string;
+	status: string;
+	gate: string;
+	schemaObject?: string;
+	requiredForTier2Gate?: boolean;
+	schemaPresent: boolean | null;
+	gateState: 'pass' | 'attention' | 'blocked' | 'deferred';
+}
+
+export interface IdentityMappingSchemaReadinessSummary {
+	total: number;
+	pass: number;
+	attention: number;
+	blocked: number;
+	deferred: number;
+}
+
 export interface IdentityMappingCompilePolicyRequest {
 	catalogVersionId: string;
 	compatibilityRange?: string;
@@ -230,6 +253,16 @@ export const adminIdentityMappingAPI = {
 	async listTemplates(): Promise<{ templates: IdentityMappingTemplateSummary[] }> {
 		const response = await adminFetch(`${API_BASE_URL}/api/admin/identity-mapping/templates`);
 		return parseJson(response, 'Failed to load identity mapping templates');
+	},
+
+	async getSchemaReadiness(): Promise<{
+		rows: IdentityMappingSchemaReadinessRow[];
+		summary: IdentityMappingSchemaReadinessSummary;
+	}> {
+		const response = await adminFetch(
+			`${API_BASE_URL}/api/admin/identity-mapping/schema-readiness`
+		);
+		return parseJson(response, 'Failed to load schema readiness inventory');
 	},
 
 	async listFederationTrustSources(): Promise<{

--- a/packages/ar-admin-ui/src/lib/components/identity-mapping/IdentityMappingFlowEditor.svelte
+++ b/packages/ar-admin-ui/src/lib/components/identity-mapping/IdentityMappingFlowEditor.svelte
@@ -1,0 +1,1431 @@
+<script lang="ts">
+	import { onDestroy, onMount } from 'svelte';
+	import {
+		mappingSamples,
+		type MappingAdapter,
+		type MappingEdge,
+		type MappingNode
+	} from './sample-data';
+
+	const adapters: MappingAdapter[] = ['SAML', 'CSV', 'OIDC', 'SCIM'];
+	const initialSample = mappingSamples[0];
+	const nodeHeight = 30;
+	const targetHeight = 46;
+	const graphBaseTop = 48;
+	const graphStep = 50;
+	const rowGap = 12;
+
+	let canvas: HTMLDivElement;
+	let canvasWidth = $state(1000);
+	let sample = $state(initialSample);
+	let inboundAdapter = $state<MappingAdapter>(sample.inboundAdapter);
+	let outboundAdapter = $state<MappingAdapter>(sample.outboundAdapter);
+	let activeRuleId = $state(sample.activeRuleId);
+	let activeTab = $state<'rule' | 'dryrun' | 'diff'>('rule');
+	let viewMode = $state<'preview' | 'edit' | 'dryrun'>('preview');
+	let activeTheme = $state<'light' | 'dark'>('dark');
+	let customCounter = $state(0);
+	let nodes = $state<MappingNode[]>([...sample.nodes]);
+	let edges = $state<MappingEdge[]>([...sample.edges]);
+	let hoverNodeId = $state<string | null>(null);
+	let selectedNodeId = $state<string | null>(
+		initialSample.nodes.find((node) => node.ruleId === initialSample.activeRuleId)?.id ?? null
+	);
+	let dragState = $state<{
+		fromNodeId: string;
+		from: Point;
+		to: Point;
+	} | null>(null);
+
+	interface Point {
+		x: number;
+		y: number;
+	}
+
+	interface LayoutNode extends MappingNode {
+		top: number;
+		left: number;
+		width: number;
+		height: number;
+		hidden: boolean;
+		stackIndex: number;
+	}
+
+	const sourceNodes = $derived(nodes.filter((node) => node.role === 'source'));
+	const targetNodes = $derived(nodes.filter((node) => node.role === 'target'));
+	const destinationNodes = $derived(nodes.filter((node) => node.role === 'destination'));
+	const rule = $derived(sample.rules[activeRuleId] ?? fallbackRule());
+	const layout = $derived(buildLayout());
+	const laidOutNodes = $derived(layout.nodes);
+	const graphEdges = $derived(edges.filter((edge) => nodeById(edge.from) && nodeById(edge.to)));
+	const selectedEdges = $derived(connectedEdgeIds(selectedNodeId));
+	const hoverEdges = $derived(connectedEdgeIds(hoverNodeId));
+
+	onMount(() => {
+		const resize = () => {
+			const rect = canvas?.getBoundingClientRect();
+			if (!rect) return;
+			canvasWidth = Math.max(720, rect.width);
+		};
+		resize();
+		const observer = new ResizeObserver(resize);
+		if (canvas) observer.observe(canvas);
+		window.addEventListener('resize', resize);
+		return () => {
+			observer.disconnect();
+			window.removeEventListener('resize', resize);
+		};
+	});
+
+	onDestroy(() => {
+		window.removeEventListener('pointermove', handlePointerMove);
+		window.removeEventListener('pointerup', handlePointerUp);
+	});
+
+	function nodeById(id: string): MappingNode | undefined {
+		return nodes.find((node) => node.id === id);
+	}
+
+	function nodeForRule(ruleId: string): MappingNode | undefined {
+		return nodes.find((node) => node.ruleId === ruleId);
+	}
+
+	function layoutNodeById(id: string): LayoutNode | undefined {
+		return laidOutNodes.find((node) => node.id === id);
+	}
+
+	function selectRule(ruleId: string) {
+		activeRuleId = ruleId;
+		selectedNodeId = nodeForRule(ruleId)?.id ?? null;
+	}
+
+	function connectedEdgeIds(nodeId: string | null): Set<string> {
+		if (!nodeId) return new Set();
+		return new Set(
+			edges.filter((edge) => edge.from === nodeId || edge.to === nodeId).map((edge) => edge.id)
+		);
+	}
+
+	function connectedNodeIds(nodeId: string | null): Set<string> {
+		if (!nodeId) return new Set();
+		return new Set(
+			edges
+				.filter((edge) => edge.from === nodeId || edge.to === nodeId)
+				.flatMap((edge) => (edge.from === nodeId ? [edge.to] : [edge.from]))
+		);
+	}
+
+	function targetForSource(sourceId: string): string | null {
+		return (
+			edges.find(
+				(edge) => edge.from === sourceId && targetNodes.some((node) => node.id === edge.to)
+			)?.to ?? null
+		);
+	}
+
+	function targetForDestination(destinationId: string): string | null {
+		return (
+			edges.find(
+				(edge) => edge.to === destinationId && targetNodes.some((node) => node.id === edge.from)
+			)?.from ?? null
+		);
+	}
+
+	function buildLayout(): { nodes: LayoutNode[]; height: number } {
+		const rowTops: Record<string, number> = {};
+		let cursor = graphBaseTop;
+
+		for (const target of targetNodes) {
+			const sourceCount = sourceNodes.filter(
+				(node) => node.adapter === inboundAdapter && targetForSource(node.id) === target.id
+			).length;
+			const destinationCount = destinationNodes.filter(
+				(node) => node.adapter === outboundAdapter && targetForDestination(node.id) === target.id
+			).length;
+			const rowSpan = Math.max(1, sourceCount, destinationCount);
+			rowTops[target.id] = cursor;
+			cursor += rowSpan * graphStep + rowGap;
+		}
+
+		const width = Math.max(190, canvasWidth * 0.23);
+		const sourceLeft = 26;
+		const targetLeft = canvasWidth * 0.385;
+		const destinationLeft = Math.max(targetLeft + width + 90, canvasWidth - width - 26);
+		const minHeight = Math.max(520, cursor + 36);
+		const orderedTargets = Object.fromEntries(
+			targetNodes.map((target) => [target.id, rowTops[target.id] ?? graphBaseTop])
+		);
+
+		const groupOffsets: Record<string, number> = {};
+		function nextOffset(groupKey: string): number {
+			const current = groupOffsets[groupKey] ?? 0;
+			groupOffsets[groupKey] = current + 1;
+			return current;
+		}
+
+		const sourceLayout = sourceNodes.map((node) => {
+			const targetId = targetForSource(node.id);
+			const groupKey = targetId ?? `fallback:${node.adapter}`;
+			const selected = node.adapter === inboundAdapter;
+			const visibleOffset = selected ? nextOffset(`source:${groupKey}`) : 0;
+			const hiddenOffset = selected ? 0 : nextOffset(`source-hidden:${groupKey}`) + 1;
+			const top = (targetId ? orderedTargets[targetId] : cursor) ?? graphBaseTop;
+			return {
+				...node,
+				top: top + (selected ? visibleOffset * graphStep : 0),
+				left: sourceLeft,
+				width,
+				height: nodeHeight,
+				hidden: !selected,
+				stackIndex: hiddenOffset
+			};
+		});
+
+		const targetLayout = targetNodes.map((node) => ({
+			...node,
+			top: rowTops[node.id] ?? graphBaseTop,
+			left: targetLeft,
+			width,
+			height: targetHeight,
+			hidden: false,
+			stackIndex: 0
+		}));
+
+		const destinationLayout = destinationNodes.map((node) => {
+			const targetId = targetForDestination(node.id);
+			const groupKey = targetId ?? `fallback:${node.adapter}`;
+			const selected = node.adapter === outboundAdapter;
+			const visibleOffset = selected ? nextOffset(`destination:${groupKey}`) : 0;
+			const hiddenOffset = selected ? 0 : nextOffset(`destination-hidden:${groupKey}`) + 1;
+			const top = (targetId ? orderedTargets[targetId] : cursor) ?? graphBaseTop;
+			return {
+				...node,
+				top: top + (selected ? visibleOffset * graphStep : 0),
+				left: destinationLeft,
+				width,
+				height: nodeHeight,
+				hidden: !selected,
+				stackIndex: hiddenOffset
+			};
+		});
+
+		return {
+			nodes: [...sourceLayout, ...targetLayout, ...destinationLayout],
+			height: minHeight
+		};
+	}
+
+	function nodeStyle(node: LayoutNode): string {
+		const stackX = node.hidden ? 12 + node.stackIndex * 8 : 0;
+		const stackY = node.hidden ? 7 + node.stackIndex * 6 : 0;
+		const zIndex = node.hidden ? Math.max(1, 4 - node.stackIndex) : node.role === 'target' ? 3 : 5;
+		return [
+			`left:${node.left}px`,
+			`top:${node.top}px`,
+			`width:${node.width}px`,
+			`min-height:${node.height}px`,
+			`z-index:${zIndex}`,
+			`--stack-x:${stackX}px`,
+			`--stack-y:${stackY}px`,
+			`--stack-shadow-x:${22 + node.stackIndex * 8}px`,
+			`--stack-shadow-y:${14 + node.stackIndex * 6}px`
+		].join(';');
+	}
+
+	function edgePoint(node: LayoutNode, direction: 'from' | 'to'): Point {
+		return {
+			x: direction === 'from' ? node.left + node.width : node.left,
+			y: node.top + node.height / 2
+		};
+	}
+
+	function pathBetween(from: Point, to: Point): string {
+		const dx = to.x - from.x;
+		const distance = dx > 0 ? Math.max(8, Math.min(80, dx * 0.45)) : 24;
+		return `M ${from.x} ${from.y} C ${from.x + distance} ${from.y}, ${to.x - distance} ${to.y}, ${to.x} ${to.y}`;
+	}
+
+	function edgePath(edge: MappingEdge): string {
+		const fromNode = layoutNodeById(edge.from);
+		const toNode = layoutNodeById(edge.to);
+		if (!fromNode || !toNode) return '';
+		return pathBetween(edgePoint(fromNode, 'from'), edgePoint(toNode, 'to'));
+	}
+
+	function edgeAccent(edge: MappingEdge): string {
+		const fromNode = nodeById(edge.from);
+		const toNode = nodeById(edge.to);
+		const adapter = fromNode?.role === 'target' ? toNode?.adapter : fromNode?.adapter;
+		if (adapter === 'SAML') return 'var(--map-violet)';
+		if (adapter === 'OIDC') return 'var(--map-amber)';
+		if (adapter === 'SCIM') return 'var(--map-brand)';
+		if (adapter === 'CSV') return 'var(--map-teal)';
+		return 'var(--map-brand)';
+	}
+
+	function edgeClasses(edge: MappingEdge): string {
+		const fromNode = layoutNodeById(edge.from);
+		const toNode = layoutNodeById(edge.to);
+		return [
+			'edge',
+			edge.outbound ? 'outbound-edge' : '',
+			edge.custom ? 'custom-edge' : '',
+			edge.id === activeRuleId ? 'active' : '',
+			hoverEdges.has(edge.id) ? 'edge-connected' : '',
+			selectedEdges.has(edge.id) ? 'edge-selected' : '',
+			fromNode?.hidden || toNode?.hidden ? 'edge-muted' : ''
+		]
+			.filter(Boolean)
+			.join(' ');
+	}
+
+	function nodeClasses(node: LayoutNode): string {
+		const selectedRelated = connectedNodeIds(selectedNodeId).has(node.id);
+		const hoverRelated = connectedNodeIds(hoverNodeId).has(node.id);
+		return [
+			'graph-node',
+			`${node.role}-node`,
+			node.hidden ? 'adapter-hidden' : '',
+			node.ruleId === activeRuleId ? 'active' : '',
+			node.id === selectedNodeId ? 'selection-origin' : '',
+			selectedRelated ? 'selection-related' : '',
+			node.id === hoverNodeId ? 'connection-origin' : '',
+			hoverRelated ? 'connection-related' : ''
+		]
+			.filter(Boolean)
+			.join(' ');
+	}
+
+	function isValidConnection(
+		fromNode: MappingNode | undefined,
+		toNode: MappingNode | undefined
+	): boolean {
+		if (!fromNode || !toNode || fromNode.id === toNode.id) return false;
+		return (
+			(fromNode.role === 'source' && toNode.role === 'target') ||
+			(fromNode.role === 'target' && toNode.role === 'destination')
+		);
+	}
+
+	function canvasPoint(event: PointerEvent): Point {
+		const rect = canvas.getBoundingClientRect();
+		return {
+			x: event.clientX - rect.left,
+			y: event.clientY - rect.top
+		};
+	}
+
+	function startConnectionDrag(event: PointerEvent, node: LayoutNode) {
+		if (node.hidden || node.role === 'destination') return;
+		event.preventDefault();
+		event.stopPropagation();
+		const from = edgePoint(node, 'from');
+		dragState = {
+			fromNodeId: node.id,
+			from,
+			to: canvasPoint(event)
+		};
+		window.addEventListener('pointermove', handlePointerMove);
+		window.addEventListener('pointerup', handlePointerUp);
+	}
+
+	function handlePointerMove(event: PointerEvent) {
+		if (!dragState) return;
+		dragState = {
+			...dragState,
+			to: canvasPoint(event)
+		};
+	}
+
+	function handlePointerUp(event: PointerEvent) {
+		if (!dragState) return;
+		const target = document.elementFromPoint(event.clientX, event.clientY) as HTMLElement | null;
+		const handle = target?.closest?.('.node-handle.input') as HTMLElement | null;
+		const toNodeId = handle?.dataset.nodeId;
+		const fromNode = nodeById(dragState.fromNodeId);
+		const toNode = toNodeId ? nodeById(toNodeId) : undefined;
+		if (isValidConnection(fromNode, toNode) && toNodeId) {
+			addEdge(dragState.fromNodeId, toNodeId);
+		}
+		dragState = null;
+		window.removeEventListener('pointermove', handlePointerMove);
+		window.removeEventListener('pointerup', handlePointerUp);
+	}
+
+	function addEdge(from: string, to: string) {
+		if (edges.some((edge) => edge.from === from && edge.to === to)) return;
+		customCounter += 1;
+		edges = [
+			...edges,
+			{
+				id: `custom-edge-${customCounter}`,
+				from,
+				to,
+				outbound: nodeById(from)?.role === 'target',
+				custom: true
+			}
+		];
+	}
+
+	function addNode(role: 'source' | 'destination') {
+		customCounter += 1;
+		const adapter = role === 'source' ? inboundAdapter : outboundAdapter;
+		const node: MappingNode = {
+			id: `${role}-${adapter.toLowerCase()}-custom-${customCounter}`,
+			ruleId: `custom-${role}-${adapter.toLowerCase()}-${customCounter}`,
+			role,
+			adapter,
+			label: role === 'source' ? `custom_field_${customCounter}` : `${adapter} custom projection`,
+			caption: 'drag handle to connect'
+		};
+		nodes = [...nodes, node];
+		sample.rules[node.ruleId] = {
+			...fallbackRule(),
+			title: node.label,
+			source: role === 'source' ? `${adapter} adapter / ${node.label}` : 'Custom graph edge',
+			destination:
+				role === 'destination' ? `${adapter} adapter / ${node.label}` : 'Not connected yet',
+			trace: 'Custom draft node added. Drag a connection handle to attach it to canonical schema.'
+		};
+		selectRule(node.ruleId);
+	}
+
+	function fallbackRule() {
+		return {
+			title: 'Mapping node',
+			risk: 'medium' as const,
+			source: 'Selected graph node',
+			target: 'Connected canonical target',
+			destination: 'Connected destination',
+			transform: 'not configured',
+			validation: 'not configured',
+			release: 'not configured',
+			consentStatus: 'not_required' as const,
+			legalBasis: 'legitimate_interest' as const,
+			purpose: 'not configured',
+			attributeSetHash: 'not configured',
+			consentMode: 'not_applicable' as const,
+			runtime: 'graph preview',
+			conflict: 'sample policy decides precedence',
+			disclosure: 'redacted summary',
+			dryrunStatus: 'pending',
+			dryrunTone: 'warn' as const,
+			input: '[sample fixture]',
+			output: 'No mapping edge yet.',
+			trace: 'Select a mapping node to inspect rule behavior.',
+			review: '0 tasks',
+			replay: 'no',
+			diffSeverity: 'medium' as const,
+			diffTitle: 'Draft-only node',
+			diff: ['This node exists only in the local draft preview.']
+		};
+	}
+</script>
+
+<section class="mapping-shell" data-theme={activeTheme}>
+	<header class="mapping-topbar">
+		<div>
+			<p class="section-kicker">Authrim Admin</p>
+			<h1>Identity Mapping Control Plane</h1>
+		</div>
+		<div class="topbar-actions">
+			<div class="profile-select">
+				<label for="sourceProfile">Source profile</label>
+				<select id="sourceProfile" value={sample.id}>
+					<option value="saml-salesforce">SAML Salesforce columns</option>
+				</select>
+			</div>
+			<div class="mode-toggle" aria-label="View mode">
+				{#each ['preview', 'edit', 'dryrun'] as mode (mode)}
+					<button
+						class:active={viewMode === mode}
+						type="button"
+						onclick={() => (viewMode = mode as typeof viewMode)}
+					>
+						{mode === 'dryrun' ? 'Dry-run' : mode[0].toUpperCase() + mode.slice(1)}
+					</button>
+				{/each}
+			</div>
+			<div class="mode-toggle" aria-label="Theme">
+				<button
+					class:active={activeTheme === 'light'}
+					type="button"
+					onclick={() => (activeTheme = 'light')}
+				>
+					Light
+				</button>
+				<button
+					class:active={activeTheme === 'dark'}
+					type="button"
+					onclick={() => (activeTheme = 'dark')}
+				>
+					Dark
+				</button>
+			</div>
+			<button class="primary-action" type="button">Compile draft</button>
+		</div>
+	</header>
+
+	<div class="workspace">
+		<section class="pane graph-pane" aria-label="Mapping graph">
+			<div class="graph-toolbar">
+				<div>
+					<p class="section-kicker">Policy draft</p>
+					<h2>{sample.title}</h2>
+				</div>
+				<div class="health-strip">
+					<span><strong>Snapshot</strong> {sample.snapshot}</span>
+					<span class="status-ok">{sample.status}</span>
+					<span class="status-warn">{sample.reviewGates}</span>
+				</div>
+			</div>
+
+			<div class="metric-row">
+				<div class="metric">
+					<span>Mapped fields</span>
+					<strong>{sample.metrics[0]}</strong>
+				</div>
+				<div class="metric">
+					<span>Hot-path reads</span>
+					<strong>{sample.metrics[1]}</strong>
+				</div>
+				<div class="metric">
+					<span>Release denies</span>
+					<strong>{sample.metrics[2]}</strong>
+				</div>
+				<div class="metric">
+					<span>Catalog version</span>
+					<strong>{sample.metrics[3]}</strong>
+				</div>
+			</div>
+
+			<div class="graph-canvas" bind:this={canvas} style={`height:${layout.height}px`}>
+				<div class="lane-label lane-inbound">
+					<span>Inbound adapter</span>
+					<select bind:value={inboundAdapter}>
+						{#each adapters as adapter (adapter)}
+							<option value={adapter}>{adapter}</option>
+						{/each}
+					</select>
+					<button class="mini-tool-button" type="button" onclick={() => addNode('source')}>+</button
+					>
+				</div>
+				<div class="lane-label lane-canonical">
+					<span>Canonical targets</span>
+				</div>
+				<div class="lane-label lane-outbound">
+					<span>Outbound adapter</span>
+					<select bind:value={outboundAdapter}>
+						{#each adapters as adapter (adapter)}
+							<option value={adapter}>{adapter}</option>
+						{/each}
+					</select>
+					<button class="mini-tool-button" type="button" onclick={() => addNode('destination')}
+						>+</button
+					>
+				</div>
+
+				<svg class="edge-layer" viewBox={`0 0 ${canvasWidth} ${layout.height}`} aria-hidden="true">
+					{#each graphEdges as edge (edge.id)}
+						<path
+							class={edgeClasses(edge)}
+							style={`--edge-accent:${edgeAccent(edge)}`}
+							d={edgePath(edge)}
+						/>
+					{/each}
+					{#if dragState}
+						<path class="edge drag-edge" d={pathBetween(dragState.from, dragState.to)} />
+					{/if}
+				</svg>
+
+				{#each laidOutNodes as node (node.id)}
+					<button
+						class={nodeClasses(node)}
+						style={nodeStyle(node)}
+						type="button"
+						data-node-id={node.id}
+						data-adapter={node.adapter}
+						aria-hidden={node.hidden}
+						tabindex={node.hidden ? -1 : 0}
+						onclick={() => !node.hidden && selectRule(node.ruleId)}
+						onpointerover={() => !node.hidden && (hoverNodeId = node.id)}
+						onpointerout={() => (hoverNodeId = null)}
+					>
+						{#if node.role !== 'source'}
+							<span class="node-handle input" data-node-id={node.id} aria-hidden="true"></span>
+						{/if}
+						<span>{node.label}</span>
+						<small>{node.caption}</small>
+						{#if node.role === 'target'}
+							<span class="target-badge-row">
+								<span class="target-badges">
+									{#if node.type}<span class="target-badge type">{node.type}</span>{/if}
+								</span>
+								<span class="target-badges meta-badges">
+									{#if node.required}<span class="target-badge required">Required</span>{/if}
+									{#if node.privacy}
+										<span
+											class={`target-badge ${node.privacy.toLowerCase().replace(/[^a-z]+/g, '-')}`}
+										>
+											{node.privacy}
+										</span>
+									{/if}
+								</span>
+							</span>
+						{/if}
+						{#if node.role !== 'destination'}
+							<span
+								class="node-handle output"
+								data-node-id={node.id}
+								aria-hidden="true"
+								onpointerdown={(event) => startConnectionDrag(event, node)}
+							></span>
+						{/if}
+					</button>
+				{/each}
+			</div>
+		</section>
+
+		<aside class="pane right-pane" aria-label="Mapping inspector">
+			<div class="pane-header">
+				<div>
+					<p class="section-kicker">Inspector</p>
+					<h2>{rule.title}</h2>
+				</div>
+				<span class={`risk-badge risk-${rule.risk}`}>{rule.risk}</span>
+			</div>
+
+			<div class="tab-bar" role="tablist" aria-label="Inspector tabs">
+				<button
+					class:active={activeTab === 'rule'}
+					type="button"
+					onclick={() => (activeTab = 'rule')}
+				>
+					Rule
+				</button>
+				<button
+					class:active={activeTab === 'dryrun'}
+					type="button"
+					onclick={() => (activeTab = 'dryrun')}
+				>
+					Dry-run
+				</button>
+				<button
+					class:active={activeTab === 'diff'}
+					type="button"
+					onclick={() => (activeTab = 'diff')}
+				>
+					Diff
+				</button>
+			</div>
+
+			{#if activeTab === 'rule'}
+				<dl class="detail-list">
+					<div>
+						<dt>Source</dt>
+						<dd>{rule.source}</dd>
+					</div>
+					<div>
+						<dt>Target</dt>
+						<dd>{rule.target}</dd>
+					</div>
+					<div>
+						<dt>Destination</dt>
+						<dd>{rule.destination}</dd>
+					</div>
+					<div>
+						<dt>Transform</dt>
+						<dd>{rule.transform}</dd>
+					</div>
+					<div>
+						<dt>Validation</dt>
+						<dd>{rule.validation}</dd>
+					</div>
+					<div>
+						<dt>Release</dt>
+						<dd>{rule.release}</dd>
+					</div>
+				</dl>
+			{:else if activeTab === 'dryrun'}
+				<section class="dryrun-card">
+					<div class="dryrun-header">
+						<h3>Sample Evaluation</h3>
+						<span class={`dryrun-status ${rule.dryrunTone}`}>{rule.dryrunStatus}</span>
+					</div>
+					<div class="value-pair">
+						<span>Input</span>
+						<code>{rule.input}</code>
+					</div>
+					<div class="value-pair">
+						<span>Output</span>
+						<code>{rule.output}</code>
+					</div>
+					<p class="trace-box">{rule.trace}</p>
+				</section>
+			{:else}
+				<section class="diff-card">
+					<div class="diff-summary">
+						<h3>{rule.diffTitle}</h3>
+						<span class={`risk-badge risk-${rule.diffSeverity}`}>{rule.diffSeverity}</span>
+					</div>
+					<ul class="diff-list">
+						{#each rule.diff as item (item)}
+							<li>{item}</li>
+						{/each}
+					</ul>
+				</section>
+			{/if}
+
+			<div class="control-block">
+				<div class="control-row">
+					<span>Consent status</span>
+					<strong>{rule.consentStatus.replaceAll('_', ' ')}</strong>
+				</div>
+				<div class="control-row">
+					<span>Legal basis</span>
+					<strong>{rule.legalBasis.replaceAll('_', ' ')}</strong>
+				</div>
+				<div class="control-row">
+					<span>Purpose</span>
+					<strong>{rule.purpose}</strong>
+				</div>
+				<div class="control-row">
+					<span>Attribute set</span>
+					<strong>{rule.attributeSetHash}</strong>
+				</div>
+				<div class="control-row">
+					<span>Challenge mode</span>
+					<strong>{rule.consentMode.replaceAll('_', ' ')}</strong>
+				</div>
+			</div>
+
+			<div class="control-block">
+				<div class="control-row">
+					<span>Runtime exposure</span>
+					<strong>{rule.runtime}</strong>
+				</div>
+				<div class="control-row">
+					<span>Conflict policy</span>
+					<strong>{rule.conflict}</strong>
+				</div>
+				<div class="control-row">
+					<span>Trace disclosure</span>
+					<strong>{rule.disclosure}</strong>
+				</div>
+			</div>
+		</aside>
+	</div>
+</section>
+
+<style>
+	.mapping-shell {
+		--map-bg: rgb(6, 9, 15);
+		--map-surface: #0b111d;
+		--map-surface-muted: #080d16;
+		--map-canvas: rgb(6, 9, 15);
+		--map-line: #253143;
+		--map-line-strong: #344156;
+		--map-text: #e5edf6;
+		--map-muted: #8ea0b7;
+		--map-brand: #60a5fa;
+		--map-teal: #2dd4bf;
+		--map-green: #4ade80;
+		--map-amber: #fbbf24;
+		--map-red: #f87171;
+		--map-violet: #a78bfa;
+		--map-radius: 4px;
+		overflow: hidden;
+		border: 1px solid var(--map-line);
+		border-radius: 8px;
+		background: var(--map-bg);
+		color: var(--map-text);
+	}
+
+	.mapping-shell[data-theme='light'] {
+		--map-bg: #f3f5f7;
+		--map-surface: #ffffff;
+		--map-surface-muted: #f8fafc;
+		--map-canvas: #fbfcfe;
+		--map-line: #d9e0e8;
+		--map-line-strong: #bdc7d3;
+		--map-text: #1e2933;
+		--map-muted: #64748b;
+		--map-brand: #2563eb;
+		--map-teal: #0f766e;
+		--map-green: #15803d;
+		--map-amber: #b45309;
+		--map-red: #b91c1c;
+		--map-violet: #6d28d9;
+	}
+
+	.mapping-topbar,
+	.topbar-actions,
+	.graph-toolbar,
+	.pane-header,
+	.dryrun-header,
+	.diff-summary,
+	.control-row {
+		display: flex;
+		align-items: center;
+	}
+
+	.mapping-topbar {
+		min-height: 62px;
+		justify-content: space-between;
+		gap: 16px;
+		padding: 10px 14px;
+		border-bottom: 1px solid var(--map-line);
+		background: color-mix(in srgb, var(--map-bg) 92%, transparent);
+	}
+
+	.section-kicker {
+		margin: 0;
+		color: var(--map-muted);
+		font-size: 11px;
+		font-weight: 800;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	h1,
+	h2,
+	h3 {
+		margin: 0;
+		letter-spacing: 0;
+	}
+
+	h1 {
+		font-size: 20px;
+		line-height: 1.25;
+	}
+
+	h2 {
+		font-size: 16px;
+		line-height: 1.3;
+	}
+
+	h3 {
+		font-size: 14px;
+	}
+
+	.topbar-actions {
+		flex-wrap: wrap;
+		justify-content: flex-end;
+		gap: 10px;
+	}
+
+	.profile-select,
+	.mode-toggle {
+		min-height: 40px;
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		padding: 4px;
+		border: 1px solid var(--map-line);
+		border-radius: var(--map-radius);
+		background: var(--map-surface-muted);
+	}
+
+	.profile-select label {
+		padding-left: 6px;
+		color: var(--map-muted);
+		font-size: 11px;
+		font-weight: 800;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+	}
+
+	select,
+	button {
+		font: inherit;
+	}
+
+	select {
+		height: 30px;
+		border: 1px solid var(--map-line);
+		border-radius: 4px;
+		color: var(--map-text);
+		background: var(--map-surface);
+		font-size: 12px;
+		font-weight: 700;
+	}
+
+	button {
+		cursor: pointer;
+	}
+
+	.mode-toggle button,
+	.primary-action {
+		height: 30px;
+		border: 0;
+		border-radius: 4px;
+		color: var(--map-muted);
+		background: transparent;
+		font-size: 12px;
+		font-weight: 800;
+	}
+
+	.mode-toggle button {
+		min-width: 72px;
+	}
+
+	.mode-toggle button.active {
+		color: var(--map-text);
+		background: var(--map-surface);
+		box-shadow: inset 0 0 0 1px var(--map-line);
+	}
+
+	.primary-action {
+		height: 40px;
+		padding: 0 16px;
+		color: #ffffff;
+		background: var(--map-brand);
+	}
+
+	.workspace {
+		display: grid;
+		grid-template-columns: minmax(720px, 1fr) minmax(300px, 360px);
+		gap: 14px;
+		padding: 14px;
+	}
+
+	.pane {
+		min-width: 0;
+		border: 1px solid var(--map-line);
+		border-radius: var(--map-radius);
+		background: var(--map-surface);
+	}
+
+	.graph-toolbar,
+	.pane-header {
+		justify-content: space-between;
+		gap: 12px;
+		padding: 14px 16px;
+	}
+
+	.health-strip {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		color: var(--map-muted);
+		font-size: 12px;
+		font-weight: 700;
+	}
+
+	.status-ok,
+	.status-warn,
+	.risk-badge,
+	.dryrun-status {
+		padding: 5px 10px;
+		border-radius: 999px;
+		font-size: 11px;
+		font-weight: 900;
+	}
+
+	.status-ok {
+		color: var(--map-green);
+		background: color-mix(in srgb, var(--map-green) 15%, transparent);
+	}
+
+	.status-warn {
+		color: var(--map-amber);
+		background: color-mix(in srgb, var(--map-amber) 15%, transparent);
+	}
+
+	.metric-row {
+		display: grid;
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+		border-top: 1px solid var(--map-line);
+		border-bottom: 1px solid var(--map-line);
+	}
+
+	.metric {
+		display: grid;
+		gap: 4px;
+		padding: 10px 16px;
+		border-right: 1px solid var(--map-line);
+	}
+
+	.metric:last-child {
+		border-right: 0;
+	}
+
+	.metric span,
+	.control-row span,
+	.value-pair span {
+		color: var(--map-muted);
+		font-size: 12px;
+	}
+
+	.metric strong {
+		font-size: 19px;
+	}
+
+	.graph-canvas {
+		position: relative;
+		overflow: hidden;
+		background: var(--map-canvas);
+	}
+
+	.lane-label {
+		position: absolute;
+		top: 12px;
+		z-index: 4;
+		display: flex;
+		align-items: center;
+		gap: 7px;
+		color: var(--map-muted);
+		font-size: 11px;
+		font-weight: 800;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	.lane-inbound {
+		left: 16px;
+	}
+
+	.lane-canonical {
+		left: 38%;
+	}
+
+	.lane-outbound {
+		right: 16px;
+	}
+
+	.mini-tool-button {
+		height: 24px;
+		min-width: 24px;
+		padding: 0 7px;
+		border: 1px solid var(--map-line);
+		border-radius: 6px;
+		color: var(--map-text);
+		background: var(--map-surface);
+		font-size: 11px;
+		font-weight: 900;
+	}
+
+	.edge-layer {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		z-index: 1;
+		pointer-events: none;
+	}
+
+	.edge {
+		fill: none;
+		stroke: #5f7085;
+		stroke-width: 1.5;
+		opacity: 0.72;
+		transition:
+			opacity 180ms ease,
+			stroke 180ms ease,
+			stroke-width 180ms ease;
+	}
+
+	@keyframes edge-flow {
+		to {
+			stroke-dashoffset: -28;
+		}
+	}
+
+	@keyframes connection-pulse {
+		0%,
+		100% {
+			stroke-opacity: 0.72;
+		}
+
+		50% {
+			stroke-opacity: 1;
+		}
+	}
+
+	.edge-muted {
+		opacity: 0.1;
+	}
+
+	.edge.active {
+		stroke: var(--edge-accent, var(--map-brand));
+		stroke-width: 2.2;
+		opacity: 1;
+	}
+
+	.edge.edge-connected,
+	.edge.edge-selected {
+		stroke: var(--edge-accent, var(--map-brand));
+		stroke-dasharray: 6 6;
+		opacity: 1;
+		animation:
+			edge-flow 680ms linear infinite,
+			connection-pulse 1.2s ease-in-out infinite;
+	}
+
+	.edge.edge-connected {
+		stroke-width: 2.1;
+	}
+
+	.edge.edge-selected {
+		stroke-width: 2.7;
+	}
+
+	.outbound-edge {
+		stroke: #6f8198;
+		stroke-dasharray: 5 5;
+		opacity: 0.55;
+	}
+
+	.custom-edge,
+	.drag-edge {
+		stroke: var(--map-teal);
+		stroke-width: 2.6;
+		stroke-dasharray: 4 3;
+	}
+
+	.drag-edge {
+		stroke: var(--map-brand);
+		opacity: 0.82;
+		animation: edge-flow 620ms linear infinite;
+	}
+
+	.graph-node {
+		--node-accent: var(--map-brand);
+		position: absolute;
+		display: grid;
+		gap: 1px;
+		padding: 3px 8px;
+		border: 1px solid var(--map-line-strong);
+		border-radius: 3px;
+		color: var(--map-text);
+		background: var(--map-surface);
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.22);
+		overflow: visible;
+		text-align: left;
+		transition:
+			opacity 180ms ease,
+			transform 220ms ease,
+			top 220ms ease,
+			border-color 180ms ease,
+			box-shadow 180ms ease;
+	}
+
+	.graph-node[data-adapter='SAML'] {
+		--node-accent: var(--map-violet);
+	}
+
+	.graph-node[data-adapter='OIDC'] {
+		--node-accent: var(--map-amber);
+	}
+
+	.graph-node[data-adapter='SCIM'] {
+		--node-accent: var(--map-brand);
+	}
+
+	.graph-node[data-adapter='CSV'] {
+		--node-accent: var(--map-teal);
+	}
+
+	.source-node,
+	.destination-node {
+		border-color: color-mix(in srgb, var(--node-accent) 72%, transparent);
+	}
+
+	.target-node {
+		padding-bottom: 18px;
+		border-color: rgba(96, 165, 250, 0.64);
+	}
+
+	.adapter-hidden {
+		opacity: 0.22;
+		filter: saturate(0.65);
+		transform: translate(var(--stack-x), var(--stack-y));
+	}
+
+	.adapter-hidden::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		border: 1px solid var(--map-line-strong);
+		border-radius: inherit;
+		transform: translate(var(--stack-shadow-x), var(--stack-shadow-y));
+		opacity: 0.38;
+		pointer-events: none;
+	}
+
+	.graph-node span:not(.node-handle):not(.target-badge-row):not(.target-badge):not(.target-badges) {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-size: 11.2px;
+		font-weight: 400;
+		line-height: 1.15;
+	}
+
+	.graph-node small {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-size: 9.6px;
+		font-weight: 400;
+		line-height: 1.2;
+	}
+
+	.graph-node:hover,
+	.graph-node.active,
+	.graph-node.connection-origin,
+	.graph-node.selection-origin {
+		border-color: var(--node-accent);
+		box-shadow:
+			0 0 0 2px color-mix(in srgb, var(--node-accent) 20%, transparent),
+			0 4px 12px rgba(0, 0, 0, 0.28);
+	}
+
+	.graph-node.selection-origin,
+	.graph-node.active.selection-origin {
+		background: color-mix(in srgb, var(--node-accent) 42%, var(--map-surface));
+	}
+
+	.graph-node.connection-related,
+	.graph-node.selection-related {
+		border-color: color-mix(in srgb, var(--node-accent) 84%, transparent);
+		background: color-mix(in srgb, var(--node-accent) 18%, var(--map-surface));
+	}
+
+	.node-handle {
+		position: absolute;
+		top: 50%;
+		width: 9px;
+		height: 9px;
+		border: 2px solid var(--map-canvas);
+		border-radius: 999px;
+		background: #7f8ea3;
+		box-shadow: 0 0 0 1px rgba(213, 224, 238, 0.18);
+		cursor: crosshair;
+		transform: translateY(-50%);
+		z-index: 3;
+	}
+
+	.node-handle.output {
+		right: -5px;
+	}
+
+	.node-handle.input {
+		left: -5px;
+	}
+
+	.source-node .node-handle.output,
+	.destination-node .node-handle.input {
+		background: var(--node-accent);
+	}
+
+	.target-node .node-handle {
+		background: var(--map-brand);
+	}
+
+	.target-badge-row {
+		position: absolute;
+		left: 7px;
+		right: 7px;
+		bottom: 5px;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 3px;
+		pointer-events: none;
+	}
+
+	.target-badges {
+		display: flex;
+		align-items: center;
+		gap: 3px;
+	}
+
+	.target-badge {
+		height: 9px;
+		padding: 0 3px;
+		border: 1px solid color-mix(in srgb, var(--map-brand) 36%, transparent);
+		border-radius: 2px;
+		color: var(--map-muted);
+		background: color-mix(in srgb, var(--map-surface-muted) 86%, transparent);
+		font-family:
+			ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+			monospace;
+		font-size: 7px;
+		font-weight: 700;
+		line-height: 8px;
+	}
+
+	.target-badge.required {
+		color: var(--map-amber);
+		border-color: color-mix(in srgb, var(--map-amber) 56%, transparent);
+	}
+
+	.target-badge.type {
+		color: var(--map-brand);
+		border-color: color-mix(in srgb, var(--map-brand) 52%, transparent);
+	}
+
+	.target-badge.pii {
+		color: var(--map-red);
+		border-color: color-mix(in srgb, var(--map-red) 52%, transparent);
+	}
+
+	.target-badge.non-pii {
+		color: var(--map-green);
+		border-color: color-mix(in srgb, var(--map-green) 52%, transparent);
+	}
+
+	.right-pane {
+		overflow: auto;
+	}
+
+	.tab-bar {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: 4px;
+		margin: 14px 14px 0;
+		padding: 4px;
+		border: 1px solid var(--map-line);
+		border-radius: var(--map-radius);
+		background: var(--map-surface-muted);
+	}
+
+	.tab-bar button {
+		height: 32px;
+		border: 0;
+		border-radius: 4px;
+		color: var(--map-muted);
+		background: transparent;
+		font-size: 12px;
+		font-weight: 900;
+	}
+
+	.tab-bar button.active {
+		color: var(--map-text);
+		background: var(--map-surface);
+	}
+
+	.detail-list {
+		display: grid;
+		gap: 10px;
+		margin: 0;
+		padding: 14px;
+	}
+
+	.detail-list div,
+	.dryrun-card,
+	.diff-card,
+	.control-block {
+		border: 1px solid var(--map-line);
+		border-radius: var(--map-radius);
+		background: var(--map-surface-muted);
+	}
+
+	.detail-list div {
+		padding: 10px;
+	}
+
+	.detail-list dt {
+		margin-bottom: 4px;
+		color: var(--map-muted);
+		font-size: 11px;
+		font-weight: 900;
+		text-transform: uppercase;
+	}
+
+	.detail-list dd {
+		margin: 0;
+		font-size: 13px;
+		font-weight: 700;
+		line-height: 1.4;
+	}
+
+	.dryrun-card,
+	.diff-card,
+	.control-block {
+		margin: 14px;
+		padding: 12px;
+	}
+
+	.value-pair {
+		display: grid;
+		gap: 5px;
+		margin-bottom: 10px;
+	}
+
+	code {
+		display: block;
+		padding: 10px;
+		border: 1px solid var(--map-line);
+		border-radius: 4px;
+		background: #0b1220;
+		color: var(--map-text);
+		font-family: SFMono-Regular, Consolas, monospace;
+		font-size: 12px;
+		white-space: normal;
+	}
+
+	.trace-box {
+		padding: 10px;
+		border-left: 3px solid var(--map-brand);
+		border-radius: 4px;
+		background: rgba(96, 165, 250, 0.12);
+		font-size: 13px;
+		line-height: 1.45;
+	}
+
+	.diff-list {
+		display: grid;
+		gap: 8px;
+		margin: 12px 0 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.diff-list li,
+	.control-row {
+		padding: 10px 12px;
+		border: 1px solid var(--map-line);
+		border-radius: var(--map-radius);
+		background: var(--map-surface);
+		font-size: 13px;
+		line-height: 1.45;
+	}
+
+	.control-block {
+		display: grid;
+		gap: 8px;
+	}
+
+	.control-row {
+		justify-content: space-between;
+		gap: 12px;
+	}
+
+	.risk-low,
+	.dryrun-status.ok {
+		color: var(--map-green);
+		background: rgba(74, 222, 128, 0.12);
+	}
+
+	.risk-medium,
+	.dryrun-status.warn {
+		color: var(--map-amber);
+		background: rgba(251, 191, 36, 0.12);
+	}
+
+	.risk-high,
+	.dryrun-status.stop {
+		color: var(--map-red);
+		background: rgba(248, 113, 113, 0.12);
+	}
+
+	@media (max-width: 1180px) {
+		.workspace {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/packages/ar-admin-ui/src/lib/components/identity-mapping/IdentityMappingFlowEditor.svelte
+++ b/packages/ar-admin-ui/src/lib/components/identity-mapping/IdentityMappingFlowEditor.svelte
@@ -405,6 +405,10 @@
 			purpose: 'not configured',
 			attributeSetHash: 'not configured',
 			consentMode: 'not_applicable' as const,
+			releasePolicyVersion: 'not configured',
+			termsVersion: 'not configured',
+			privacyPolicyVersion: 'not configured',
+			denyReason: 'none',
 			runtime: 'graph preview',
 			conflict: 'sample policy decides precedence',
 			disclosure: 'redacted summary',
@@ -693,11 +697,27 @@
 					<span>Attribute set</span>
 					<strong>{rule.attributeSetHash}</strong>
 				</div>
-				<div class="control-row">
-					<span>Challenge mode</span>
-					<strong>{rule.consentMode.replaceAll('_', ' ')}</strong>
+					<div class="control-row">
+						<span>Challenge mode</span>
+						<strong>{rule.consentMode.replaceAll('_', ' ')}</strong>
+					</div>
+					<div class="control-row">
+						<span>Release policy</span>
+						<strong>{rule.releasePolicyVersion}</strong>
+					</div>
+					<div class="control-row">
+						<span>Terms</span>
+						<strong>{rule.termsVersion}</strong>
+					</div>
+					<div class="control-row">
+						<span>Privacy Policy</span>
+						<strong>{rule.privacyPolicyVersion}</strong>
+					</div>
+					<div class="control-row">
+						<span>Deny reason</span>
+						<strong>{rule.denyReason}</strong>
+					</div>
 				</div>
-			</div>
 
 			<div class="control-block">
 				<div class="control-row">

--- a/packages/ar-admin-ui/src/lib/components/identity-mapping/__tests__/sample-data.test.ts
+++ b/packages/ar-admin-ui/src/lib/components/identity-mapping/__tests__/sample-data.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { buildSalesforceSamlPreviewSample } from '../sample-data';
+
+describe('identity mapping preview sample', () => {
+	it('keeps the three-lane graph connected through canonical targets', () => {
+		const sample = buildSalesforceSamlPreviewSample();
+		const sourceIds = new Set(
+			sample.nodes.filter((node) => node.role === 'source').map((node) => node.id)
+		);
+		const targetIds = new Set(
+			sample.nodes.filter((node) => node.role === 'target').map((node) => node.id)
+		);
+		const destinationIds = new Set(
+			sample.nodes.filter((node) => node.role === 'destination').map((node) => node.id)
+		);
+
+		expect(sourceIds.size).toBeGreaterThan(20);
+		expect(targetIds.size).toBeGreaterThan(8);
+		expect(destinationIds.size).toBeGreaterThan(3);
+		expect(sample.edges.some((edge) => sourceIds.has(edge.from) && targetIds.has(edge.to))).toBe(
+			true
+		);
+		expect(
+			sample.edges.some((edge) => targetIds.has(edge.from) && destinationIds.has(edge.to))
+		).toBe(true);
+	});
+
+	it('does not infer an OIDC subject from imported login columns', () => {
+		const sample = buildSalesforceSamlPreviewSample();
+		const usernameRule = sample.rules['rule-sf-user-username'];
+
+		expect(usernameRule.target).toContain('identity_bindings.provider_subject_key_hash');
+		expect(usernameRule.destination).not.toContain('OIDC ID token');
+		expect(usernameRule.release).toBe('sample policy preview only');
+	});
+
+	it('keeps attribute release consent preview separate from raw values', () => {
+		const sample = buildSalesforceSamlPreviewSample();
+		const emailRule = sample.rules['rule-sf-user-email'];
+		const departmentRule = sample.rules['rule-sf-user-department'];
+
+		expect(emailRule.consentStatus).toBe('required');
+		expect(emailRule.legalBasis).toBe('consent');
+		expect(emailRule.consentMode).toBe('until_attributes_change');
+		expect(emailRule.attributeSetHash).toMatch(/^attrset_/);
+		expect(departmentRule.consentStatus).toBe('not_required');
+		expect(JSON.stringify(emailRule)).not.toContain('person@example');
+	});
+});

--- a/packages/ar-admin-ui/src/lib/components/identity-mapping/__tests__/sample-data.test.ts
+++ b/packages/ar-admin-ui/src/lib/components/identity-mapping/__tests__/sample-data.test.ts
@@ -43,6 +43,9 @@ describe('identity mapping preview sample', () => {
 		expect(emailRule.legalBasis).toBe('consent');
 		expect(emailRule.consentMode).toBe('until_attributes_change');
 		expect(emailRule.attributeSetHash).toMatch(/^attrset_/);
+		expect(emailRule.releasePolicyVersion).toBe('release-policy-v1');
+		expect(emailRule.termsVersion).toBe('terms-current');
+		expect(emailRule.privacyPolicyVersion).toBe('privacy-current');
 		expect(departmentRule.consentStatus).toBe('not_required');
 		expect(JSON.stringify(emailRule)).not.toContain('person@example');
 	});

--- a/packages/ar-admin-ui/src/lib/components/identity-mapping/sample-data.ts
+++ b/packages/ar-admin-ui/src/lib/components/identity-mapping/sample-data.ts
@@ -1,0 +1,550 @@
+export type MappingAdapter = 'CSV' | 'SAML' | 'OIDC' | 'SCIM';
+export type MappingRisk = 'low' | 'medium' | 'high';
+export type NodeRole = 'source' | 'target' | 'destination';
+
+export interface MappingNode {
+	id: string;
+	ruleId: string;
+	role: NodeRole;
+	adapter?: MappingAdapter;
+	label: string;
+	caption: string;
+	type?: string;
+	privacy?: 'PII' | 'non-PII' | 'Other';
+	required?: boolean;
+}
+
+export interface MappingEdge {
+	id: string;
+	from: string;
+	to: string;
+	outbound?: boolean;
+	custom?: boolean;
+}
+
+export interface RuleDetail {
+	title: string;
+	risk: MappingRisk;
+	source: string;
+	target: string;
+	destination: string;
+	transform: string;
+	validation: string;
+	release: string;
+	consentStatus: 'not_required' | 'required' | 'granted' | 'version_upgrade_required';
+	legalBasis: 'consent' | 'legal_obligation' | 'contract' | 'legitimate_interest';
+	purpose: string;
+	attributeSetHash: string;
+	consentMode: 'once' | 'every_time' | 'until_attributes_change' | 'not_applicable';
+	runtime: string;
+	conflict: string;
+	disclosure: string;
+	dryrunStatus: string;
+	dryrunTone: 'ok' | 'warn' | 'stop';
+	input: string;
+	output: string;
+	trace: string;
+	review: string;
+	replay: string;
+	diffSeverity: MappingRisk;
+	diffTitle: string;
+	diff: string[];
+}
+
+export interface MappingSample {
+	id: string;
+	title: string;
+	snapshot: string;
+	status: string;
+	reviewGates: string;
+	inboundAdapter: MappingAdapter;
+	outboundAdapter: MappingAdapter;
+	activeRuleId: string;
+	metrics: [string, string, string, string];
+	nodes: MappingNode[];
+	edges: MappingEdge[];
+	rules: Record<string, RuleDetail>;
+}
+
+interface ColumnField {
+	name: string;
+	meta: string;
+	targetId: string;
+	transform: string;
+	risk?: MappingRisk;
+}
+
+const canonicalTargets: MappingNode[] = [
+	{
+		id: 'canon-email',
+		ruleId: 'target-email',
+		role: 'target',
+		label: 'contact_points.value_storage_ref',
+		caption: 'contact_type=email',
+		type: 'text',
+		privacy: 'PII',
+		required: true
+	},
+	{
+		id: 'canon-phone',
+		ruleId: 'target-phone',
+		role: 'target',
+		label: 'contact_points.value_storage_ref',
+		caption: 'contact_type=phone',
+		type: 'text',
+		privacy: 'PII'
+	},
+	{
+		id: 'canon-address',
+		ruleId: 'target-address',
+		role: 'target',
+		label: 'contact_points.value_storage_ref',
+		caption: 'contact_type=address',
+		type: 'json',
+		privacy: 'PII'
+	},
+	{
+		id: 'canon-given-name',
+		ruleId: 'target-given',
+		role: 'target',
+		label: 'profile_attribute_values.value_storage_ref',
+		caption: 'catalog_entry_id=given_name',
+		type: 'text',
+		privacy: 'PII',
+		required: true
+	},
+	{
+		id: 'canon-family-name',
+		ruleId: 'target-family',
+		role: 'target',
+		label: 'profile_attribute_values.value_storage_ref',
+		caption: 'catalog_entry_id=family_name',
+		type: 'text',
+		privacy: 'PII',
+		required: true
+	},
+	{
+		id: 'canon-display-name',
+		ruleId: 'target-display',
+		role: 'target',
+		label: 'profile_attribute_values.value_storage_ref',
+		caption: 'catalog_entry_id=display_name',
+		type: 'text',
+		privacy: 'PII'
+	},
+	{
+		id: 'canon-org-unit',
+		ruleId: 'target-org',
+		role: 'target',
+		label: 'profile_attribute_values.value_storage_ref',
+		caption: 'catalog_entry_id=org_unit',
+		type: 'text',
+		privacy: 'non-PII'
+	},
+	{
+		id: 'canon-groups',
+		ruleId: 'target-groups',
+		role: 'target',
+		label: 'group_memberships.group_id',
+		caption: 'assignment_source=mapped_column',
+		type: 'uuid',
+		privacy: 'non-PII'
+	},
+	{
+		id: 'canon-binding',
+		ruleId: 'target-binding',
+		role: 'target',
+		label: 'identity_bindings.provider_subject_key_hash',
+		caption: 'provider + source scoped',
+		type: 'bytes',
+		privacy: 'Other',
+		required: true
+	},
+	{
+		id: 'canon-subject',
+		ruleId: 'target-subject',
+		role: 'target',
+		label: 'subject_identifiers.identifier_value_hash',
+		caption: 'destination scoped',
+		type: 'bytes',
+		privacy: 'Other',
+		required: true
+	},
+	{
+		id: 'canon-lifecycle',
+		ruleId: 'target-lifecycle',
+		role: 'target',
+		label: 'identity_accounts.lifecycle_state',
+		caption: 'active / suspended / deleted',
+		type: 'enum',
+		privacy: 'non-PII',
+		required: true
+	},
+	{
+		id: 'canon-assurance',
+		ruleId: 'target-assurance',
+		role: 'target',
+		label: 'identity_assurance_events.evidence_ref',
+		caption: 'assurance evidence',
+		type: 'json',
+		privacy: 'Other'
+	},
+	{
+		id: 'canon-policy',
+		ruleId: 'target-policy',
+		role: 'target',
+		label: 'policy_decisions.evidence_ref',
+		caption: 'release and purpose evidence',
+		type: 'json',
+		privacy: 'Other'
+	},
+	{
+		id: 'canon-audit',
+		ruleId: 'target-audit',
+		role: 'target',
+		label: 'audit_identity_events.event_payload_ref',
+		caption: 'column-level trace',
+		type: 'json',
+		privacy: 'Other'
+	}
+];
+
+const destinations: MappingNode[] = [
+	{
+		id: 'dest-oidc-id-token',
+		ruleId: 'dest-id-token',
+		role: 'destination',
+		adapter: 'OIDC',
+		label: 'OIDC ID token',
+		caption: 'standard and custom claims'
+	},
+	{
+		id: 'dest-oidc-userinfo',
+		ruleId: 'dest-userinfo',
+		role: 'destination',
+		adapter: 'OIDC',
+		label: 'OIDC UserInfo',
+		caption: 'profile/contact claims'
+	},
+	{
+		id: 'dest-saml-assertion',
+		ruleId: 'dest-saml-assertion',
+		role: 'destination',
+		adapter: 'SAML',
+		label: 'SAML assertion',
+		caption: 'attribute statement'
+	},
+	{
+		id: 'dest-scim-users',
+		ruleId: 'dest-scim-users',
+		role: 'destination',
+		adapter: 'SCIM',
+		label: 'SCIM Users',
+		caption: 'provisioning payload'
+	},
+	{
+		id: 'dest-admin-search',
+		ruleId: 'dest-admin-search',
+		role: 'destination',
+		adapter: 'CSV',
+		label: 'Admin search index',
+		caption: 'operator projection'
+	},
+	{
+		id: 'dest-resolution-center',
+		ruleId: 'dest-resolution-center',
+		role: 'destination',
+		adapter: 'CSV',
+		label: 'Mapping Resolution Center',
+		caption: 'conflicts and blockers'
+	},
+	{
+		id: 'dest-audit-log',
+		ruleId: 'dest-audit-log',
+		role: 'destination',
+		adapter: 'CSV',
+		label: 'Audit log',
+		caption: 'trace evidence'
+	}
+];
+
+const destinationByTarget: Record<string, string[]> = {
+	'canon-email': ['dest-oidc-userinfo', 'dest-saml-assertion'],
+	'canon-phone': ['dest-oidc-userinfo', 'dest-scim-users'],
+	'canon-address': ['dest-oidc-userinfo', 'dest-scim-users'],
+	'canon-given-name': ['dest-oidc-id-token', 'dest-saml-assertion'],
+	'canon-family-name': ['dest-oidc-id-token', 'dest-saml-assertion'],
+	'canon-display-name': ['dest-oidc-id-token', 'dest-admin-search'],
+	'canon-org-unit': ['dest-scim-users', 'dest-admin-search'],
+	'canon-groups': ['dest-scim-users', 'dest-saml-assertion'],
+	'canon-binding': ['dest-saml-assertion', 'dest-admin-search'],
+	'canon-subject': ['dest-oidc-id-token', 'dest-saml-assertion'],
+	'canon-lifecycle': ['dest-scim-users', 'dest-resolution-center'],
+	'canon-assurance': ['dest-oidc-id-token', 'dest-resolution-center'],
+	'canon-policy': ['dest-resolution-center', 'dest-audit-log'],
+	'canon-audit': ['dest-audit-log']
+};
+
+const fields: ColumnField[] = [
+	{
+		name: 'FederationIdentifier',
+		meta: 'binding / stable',
+		targetId: 'canon-binding',
+		transform: 'hash federation id',
+		risk: 'high'
+	},
+	{
+		name: 'User.Username',
+		meta: 'login / string',
+		targetId: 'canon-binding',
+		transform: 'normalize login'
+	},
+	{
+		name: 'User.Email',
+		meta: 'pii / email',
+		targetId: 'canon-email',
+		transform: 'normalize email'
+	},
+	{
+		name: 'User.Phone',
+		meta: 'pii / phone',
+		targetId: 'canon-phone',
+		transform: 'normalize phone'
+	},
+	{
+		name: 'User.MobilePhone',
+		meta: 'pii / phone',
+		targetId: 'canon-phone',
+		transform: 'normalize mobile'
+	},
+	{
+		name: 'User.Street',
+		meta: 'pii / address',
+		targetId: 'canon-address',
+		transform: 'address line'
+	},
+	{
+		name: 'User.City',
+		meta: 'pii / address',
+		targetId: 'canon-address',
+		transform: 'city normalize'
+	},
+	{
+		name: 'User.State',
+		meta: 'pii / address',
+		targetId: 'canon-address',
+		transform: 'region normalize'
+	},
+	{
+		name: 'User.Country',
+		meta: 'pii / address',
+		targetId: 'canon-address',
+		transform: 'country code'
+	},
+	{
+		name: 'User.PostalCode',
+		meta: 'pii / address',
+		targetId: 'canon-address',
+		transform: 'postal normalize'
+	},
+	{
+		name: 'User.FirstName',
+		meta: 'pii / profile',
+		targetId: 'canon-given-name',
+		transform: 'trim string'
+	},
+	{
+		name: 'User.LastName',
+		meta: 'pii / profile',
+		targetId: 'canon-family-name',
+		transform: 'trim string'
+	},
+	{
+		name: 'User.Name',
+		meta: 'pii / profile',
+		targetId: 'canon-display-name',
+		transform: 'display label'
+	},
+	{
+		name: 'User.Title',
+		meta: 'profile / title',
+		targetId: 'canon-display-name',
+		transform: 'title overlay'
+	},
+	{
+		name: 'User.Department',
+		meta: 'org / string',
+		targetId: 'canon-org-unit',
+		transform: 'department catalog'
+	},
+	{
+		name: 'User.Division',
+		meta: 'org / string',
+		targetId: 'canon-org-unit',
+		transform: 'division catalog'
+	},
+	{
+		name: 'User.CompanyName',
+		meta: 'org / company',
+		targetId: 'canon-org-unit',
+		transform: 'company catalog'
+	},
+	{
+		name: 'User.ProfileId',
+		meta: 'assignment / salesforce',
+		targetId: 'canon-groups',
+		transform: 'profile lookup'
+	},
+	{
+		name: 'User.UserRoleId',
+		meta: 'assignment / salesforce',
+		targetId: 'canon-groups',
+		transform: 'role lookup'
+	},
+	{
+		name: 'User.IsActive',
+		meta: 'lifecycle / boolean',
+		targetId: 'canon-lifecycle',
+		transform: 'boolean lifecycle',
+		risk: 'high'
+	},
+	{
+		name: 'User.LocaleSidKey',
+		meta: 'profile / locale',
+		targetId: 'canon-assurance',
+		transform: 'locale evidence'
+	},
+	{
+		name: 'User.TimeZoneSidKey',
+		meta: 'profile / timezone',
+		targetId: 'canon-assurance',
+		transform: 'timezone evidence'
+	},
+	{
+		name: 'User.UserType',
+		meta: 'policy / enum',
+		targetId: 'canon-policy',
+		transform: 'release tier'
+	},
+	{
+		name: 'User.ManagerId',
+		meta: 'relation / id',
+		targetId: 'canon-audit',
+		transform: 'manager evidence'
+	},
+	{
+		name: 'WorkdayID__c',
+		meta: 'custom / hr id',
+		targetId: 'canon-binding',
+		transform: 'workday binding'
+	}
+];
+
+function slug(input: string): string {
+	return input
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-|-$/g, '');
+}
+
+function ruleDetail(
+	field: ColumnField,
+	target?: MappingNode,
+	destination?: MappingNode
+): RuleDetail {
+	return {
+		title: `SAML ${field.name}`,
+		risk: field.risk ?? (field.meta.includes('pii') ? 'medium' : 'low'),
+		source: `SAML adapter / ${field.name}`,
+		target: target?.label ?? field.targetId,
+		destination: destination
+			? `${destination.label} / ${destination.caption}`
+			: 'No outbound projection',
+		transform: field.transform,
+		validation: `${field.meta}; mapped from loaded column sample`,
+		release: 'sample policy preview only',
+		consentStatus: field.meta.includes('pii') ? 'required' : 'not_required',
+		legalBasis: field.meta.includes('pii') ? 'consent' : 'legitimate_interest',
+		purpose: field.meta.includes('pii') ? 'profile_release' : 'provisioning',
+		attributeSetHash: `attrset_${slug(field.targetId).slice(0, 18)}`,
+		consentMode: field.meta.includes('pii') ? 'until_attributes_change' : 'not_applicable',
+		runtime: 'column sample preview',
+		conflict: 'sample policy decides precedence',
+		disclosure: 'redacted summary',
+		dryrunStatus: field.risk === 'high' ? 'review_required' : 'mapped',
+		dryrunTone: field.risk === 'high' ? 'warn' : 'ok',
+		input: `[column: ${field.name}, adapter=SAML]`,
+		output: `${target?.label ?? field.targetId} <= ${field.name}`,
+		trace: `${field.name} loaded from a column-heavy sample to test node density and edge readability.`,
+		review: field.risk === 'high' ? '1 task' : '0 tasks',
+		replay: field.risk === 'high' ? 'yes' : 'no',
+		diffSeverity: field.risk ?? 'low',
+		diffTitle: 'Column sample mapping',
+		diff: [
+			'This rule was generated from the selected sample column set.',
+			'Adapter selectors bring each source family to the front without moving nodes freely.'
+		]
+	};
+}
+
+export function buildSalesforceSamlPreviewSample(): MappingSample {
+	const sourceNodes: MappingNode[] = fields.map((field) => {
+		const ruleId = `rule-sf-${slug(field.name)}`;
+		return {
+			id: `src-sf-${slug(field.name)}`,
+			ruleId,
+			role: 'source',
+			adapter: 'SAML',
+			label: field.name,
+			caption: field.transform
+		};
+	});
+	const usedTargetIds = [...new Set(fields.map((field) => field.targetId))];
+	const targetNodes = canonicalTargets.filter((target) => usedTargetIds.includes(target.id));
+	const usedDestinationIds = [
+		...new Set(usedTargetIds.flatMap((targetId) => destinationByTarget[targetId] ?? []))
+	];
+	const destinationNodes = destinations.filter((destination) =>
+		usedDestinationIds.includes(destination.id)
+	);
+	const inboundEdges = fields.map((field) => ({
+		id: `rule-sf-${slug(field.name)}`,
+		from: `src-sf-${slug(field.name)}`,
+		to: field.targetId
+	}));
+	const outboundEdges = usedTargetIds.flatMap((targetId) =>
+		(destinationByTarget[targetId] ?? [])
+			.filter((destinationId) => usedDestinationIds.includes(destinationId))
+			.map((destinationId) => ({
+				id: `out-${targetId}-${destinationId}`,
+				from: targetId,
+				to: destinationId,
+				outbound: true
+			}))
+	);
+
+	const ruleEntries = fields.map((field) => {
+		const target = targetNodes.find((candidate) => candidate.id === field.targetId);
+		const destination = destinationNodes.find((candidate) =>
+			(destinationByTarget[field.targetId] ?? []).includes(candidate.id)
+		);
+		return [`rule-sf-${slug(field.name)}`, ruleDetail(field, target, destination)] as const;
+	});
+
+	return {
+		id: 'saml-salesforce',
+		title: 'SAML Salesforce column set',
+		snapshot: 'columns_saml_salesforce_025',
+		status: 'Dense',
+		reviewGates: '25 columns',
+		inboundAdapter: 'SAML',
+		outboundAdapter: 'OIDC',
+		activeRuleId: 'rule-sf-user-email',
+		metrics: ['25 / 25', '1.6 avg', '4', 'cat_34'],
+		nodes: [...sourceNodes, ...targetNodes, ...destinationNodes],
+		edges: [...inboundEdges, ...outboundEdges],
+		rules: Object.fromEntries(ruleEntries)
+	};
+}
+
+export const mappingSamples: MappingSample[] = [buildSalesforceSamlPreviewSample()];

--- a/packages/ar-admin-ui/src/lib/components/identity-mapping/sample-data.ts
+++ b/packages/ar-admin-ui/src/lib/components/identity-mapping/sample-data.ts
@@ -36,6 +36,10 @@ export interface RuleDetail {
 	purpose: string;
 	attributeSetHash: string;
 	consentMode: 'once' | 'every_time' | 'until_attributes_change' | 'not_applicable';
+	releasePolicyVersion: string;
+	termsVersion: string;
+	privacyPolicyVersion: string;
+	denyReason: string;
 	runtime: string;
 	conflict: string;
 	disclosure: string;
@@ -468,6 +472,10 @@ function ruleDetail(
 		purpose: field.meta.includes('pii') ? 'profile_release' : 'provisioning',
 		attributeSetHash: `attrset_${slug(field.targetId).slice(0, 18)}`,
 		consentMode: field.meta.includes('pii') ? 'until_attributes_change' : 'not_applicable',
+		releasePolicyVersion: 'release-policy-v1',
+		termsVersion: field.meta.includes('pii') ? 'terms-current' : 'not_required',
+		privacyPolicyVersion: field.meta.includes('pii') ? 'privacy-current' : 'not_required',
+		denyReason: field.meta.includes('regulated') ? 'purpose_not_allowed' : 'none',
 		runtime: 'column sample preview',
 		conflict: 'sample policy decides precedence',
 		disclosure: 'redacted summary',

--- a/packages/ar-admin-ui/src/routes/admin/+layout.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/+layout.svelte
@@ -86,6 +86,7 @@
 			{ path: '/admin/consent-statements', label: 'Consent Statements', icon: 'i-ph-list-checks' }
 		],
 		identitySchema: [
+			{ path: '/admin/identity-mapping', label: 'Identity Mapping', icon: 'i-ph-graph' },
 			{ path: '/admin/custom-claims', label: 'Schema Settings', icon: 'i-ph-tag' },
 			{ path: '/admin/scim-tokens', label: 'SCIM Tokens', icon: 'i-ph-identification-card' }
 		],

--- a/packages/ar-admin-ui/src/routes/admin/identity-mapping/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/identity-mapping/+page.svelte
@@ -1,0 +1,263 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { adminIdentityMappingAPI } from '$lib/api/admin-identity-mapping';
+	import IdentityMappingFlowEditor from '$lib/components/identity-mapping/IdentityMappingFlowEditor.svelte';
+
+	let loading = $state(true);
+	let loadError = $state<string | null>(null);
+	let summary = $state({
+		policies: 0,
+		catalogs: 0,
+		profiles: 0,
+		federationTrustSources: 0
+	});
+
+	onMount(async () => {
+		try {
+			const [policies, catalogs, protocolSchemas, externalSchemas, federationTrustSources] =
+				await Promise.all([
+					adminIdentityMappingAPI.listPolicies(),
+					adminIdentityMappingAPI.listCatalogs(),
+					adminIdentityMappingAPI.listProtocolSchemas(),
+					adminIdentityMappingAPI.listExternalSchemas(),
+					adminIdentityMappingAPI.listFederationTrustSources()
+				]);
+
+			summary = {
+				policies: policies.policies.length,
+				catalogs: catalogs.catalogs.length,
+				profiles: protocolSchemas.protocolSchemas.length + externalSchemas.externalSchemas.length,
+				federationTrustSources: federationTrustSources.federationTrustSources.length
+			};
+		} catch (error) {
+			loadError = error instanceof Error ? error.message : 'Failed to load identity mapping state';
+		} finally {
+			loading = false;
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>Identity Mapping - Authrim Admin</title>
+</svelte:head>
+
+<div class="identity-mapping-page">
+	<div class="page-heading">
+		<div>
+			<p class="eyebrow">Tier 2 Operations</p>
+			<h1>Identity Mapping</h1>
+			<p class="summary">
+				Preview inbound sources, canonical identity targets, and outbound projections from one
+				control-plane view.
+			</p>
+		</div>
+		<div class="status-panel">
+			<span class="status-dot"></span>
+			<div>
+				<strong
+					>{loading
+						? 'Loading control plane'
+						: loadError
+							? 'Preview fallback'
+							: 'Control plane ready'}</strong
+				>
+				<small>
+					{#if loading}
+						Loading policy, catalog, profile, and federation trust summaries.
+					{:else if loadError}
+						{loadError}
+					{:else}
+						{summary.policies} policies, {summary.catalogs} catalogs, {summary.profiles} source/destination
+						profiles.
+					{/if}
+				</small>
+			</div>
+		</div>
+	</div>
+
+	<IdentityMappingFlowEditor />
+
+	<section class="operations-grid" aria-label="Identity mapping operations">
+		<div class="operation-card">
+			<p>Activation</p>
+			<a href="/admin/identity-mapping/operations">{summary.policies} policy sets</a>
+			<span
+				>Policy activation, rollback, and degraded-state controls are grouped in the operations
+				surface.</span
+			>
+		</div>
+		<div class="operation-card">
+			<p>Federation Trust</p>
+			<a href="/admin/identity-mapping/federation-trust"
+				>{summary.federationTrustSources} trust sources</a
+			>
+			<span>Trust sources and SAML aggregate entity selection are managed beside the editor.</span>
+		</div>
+		<div class="operation-card">
+			<p>Profiles</p>
+			<a href="/admin/identity-mapping/profiles">{summary.profiles} profiles</a>
+			<span
+				>Inbound sources and outbound destinations are prepared here before they are selected in
+				the graph.</span
+			>
+		</div>
+		<div class="operation-card">
+			<p>Schema Readiness</p>
+			<a href="/admin/identity-mapping/schema-readiness">Inventory gate</a>
+			<span
+				>Schema-readiness IDs and migration cross-references are shown before activation.</span
+			>
+		</div>
+		<div class="operation-card">
+			<p>Resolution</p>
+			<a href="/admin/identity-mapping/resolution-center">Mapping Resolution Center</a>
+			<span
+				>Conflicts, missing mappings, linking decisions, consent blockers, and protected lifecycle
+				actions are resolved outside the graph and filtered back into this editor.</span
+			>
+		</div>
+		<div class="operation-card">
+			<p>Consent Preview</p>
+			<strong>Destination Profile first</strong>
+			<span
+				>Attribute release consent settings live with destination profiles; this editor previews
+				challenge requirements and redacted release traces.</span
+			>
+		</div>
+	</section>
+</div>
+
+<style>
+	.identity-mapping-page {
+		display: grid;
+		gap: 18px;
+	}
+
+	.page-heading {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 18px;
+	}
+
+	.eyebrow {
+		margin: 0 0 4px;
+		color: var(--text-muted);
+		font-size: 12px;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	h1 {
+		margin: 0;
+		color: var(--text-primary);
+		font-size: 28px;
+		line-height: 1.2;
+	}
+
+	.summary {
+		max-width: 760px;
+		margin: 8px 0 0;
+		color: var(--text-secondary);
+		font-size: 14px;
+		line-height: 1.5;
+	}
+
+	.status-panel {
+		min-width: 260px;
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 12px;
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		background: var(--bg-card);
+	}
+
+	.status-panel strong,
+	.status-panel small {
+		display: block;
+	}
+
+	.status-panel strong {
+		color: var(--text-primary);
+		font-size: 13px;
+	}
+
+	.status-panel small {
+		margin-top: 2px;
+		color: var(--text-muted);
+		font-size: 12px;
+		line-height: 1.35;
+	}
+
+	.status-dot {
+		width: 10px;
+		height: 10px;
+		border-radius: 999px;
+		background: #f59e0b;
+		box-shadow: 0 0 0 4px rgba(245, 158, 11, 0.16);
+	}
+
+	.operations-grid {
+		display: grid;
+		grid-template-columns: repeat(6, minmax(0, 1fr));
+		gap: 12px;
+	}
+
+	.operation-card {
+		display: grid;
+		gap: 6px;
+		padding: 14px;
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		background: var(--bg-card);
+	}
+
+	.operation-card p {
+		margin: 0;
+		color: var(--text-muted);
+		font-size: 12px;
+		font-weight: 700;
+		text-transform: uppercase;
+	}
+
+	.operation-card strong {
+		color: var(--text-primary);
+		font-size: 15px;
+	}
+
+	.operation-card a {
+		color: var(--color-primary);
+		font-size: 15px;
+		font-weight: 800;
+		text-decoration: none;
+	}
+
+	.operation-card span {
+		color: var(--text-secondary);
+		font-size: 13px;
+		line-height: 1.45;
+	}
+
+	@media (max-width: 1400px) {
+		.operations-grid {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+	}
+
+	@media (max-width: 980px) {
+		.page-heading {
+			display: grid;
+		}
+
+		.status-panel {
+			min-width: 0;
+		}
+
+		.operations-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/packages/ar-admin-ui/src/routes/admin/identity-mapping/federation-trust/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/identity-mapping/federation-trust/+page.svelte
@@ -1,0 +1,472 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import {
+		adminIdentityMappingAPI,
+		type IdentityMappingFederationMetadataDocument,
+		type IdentityMappingFederationTrustSourceSummary
+	} from '$lib/api/admin-identity-mapping';
+	import {
+		adminSAMLAPI,
+		type SAMLMetadataEntitySummary
+	} from '$lib/api/admin-saml';
+
+	let trustSources = $state<IdentityMappingFederationTrustSourceSummary[]>([]);
+	let loading = $state(true);
+	let errorMessage = $state<string | null>(null);
+	let selectedSourceId = $state<string | null>(null);
+	let previewId = $state('');
+	let entityQuery = $state('');
+	let entityLoading = $state(false);
+	let entityError = $state<string | null>(null);
+	let aggregateEntities = $state<SAMLMetadataEntitySummary[]>([]);
+	let metadataDocuments = $state<IdentityMappingFederationMetadataDocument[]>([]);
+	let metadataLoading = $state(false);
+	let metadataError = $state<string | null>(null);
+	let loadedMetadataSourceId = $state<string | null>(null);
+
+	onMount(() => {
+		void loadTrustSources();
+	});
+
+	$effect(() => {
+		if (selectedSourceId && selectedSourceId !== loadedMetadataSourceId) {
+			void loadMetadataDocuments(selectedSourceId);
+		}
+	});
+
+	async function loadTrustSources() {
+		loading = true;
+		errorMessage = null;
+		try {
+			const result = await adminIdentityMappingAPI.listFederationTrustSources();
+			trustSources = result.federationTrustSources;
+			loadedMetadataSourceId = null;
+			selectedSourceId = trustSources[0]?.id ?? null;
+		} catch (error) {
+			errorMessage = error instanceof Error ? error.message : 'Failed to load federation trust';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function loadMetadataDocuments(trustSourceId: string) {
+		metadataLoading = true;
+		metadataError = null;
+		loadedMetadataSourceId = trustSourceId;
+		try {
+			const result = await adminIdentityMappingAPI.listFederationMetadataDocuments(trustSourceId);
+			if (loadedMetadataSourceId === trustSourceId) {
+				metadataDocuments = result.federationMetadataDocuments;
+			}
+		} catch (error) {
+			if (loadedMetadataSourceId === trustSourceId) {
+				metadataError =
+					error instanceof Error ? error.message : 'Failed to load federation metadata documents';
+				metadataDocuments = [];
+			}
+		} finally {
+			if (loadedMetadataSourceId === trustSourceId) {
+				metadataLoading = false;
+			}
+		}
+	}
+
+	async function loadAggregateEntities() {
+		if (!previewId.trim()) {
+			entityError = 'Enter a SAML aggregate preview ID first.';
+			return;
+		}
+		entityLoading = true;
+		entityError = null;
+		try {
+			const result = await adminSAMLAPI.listAggregatePreviewEntities(previewId.trim(), {
+				query: entityQuery.trim() || undefined,
+				limit: 25
+			});
+			aggregateEntities = result.entities;
+		} catch (error) {
+			entityError = error instanceof Error ? error.message : 'Failed to load aggregate entities';
+		} finally {
+			entityLoading = false;
+		}
+	}
+
+	const selectedSource = $derived(
+		trustSources.find((source) => source.id === selectedSourceId) ?? trustSources[0] ?? null
+	);
+
+	function payloadValue(source: IdentityMappingFederationTrustSourceSummary, key: string): string {
+		const value = source.protocolPayload?.[key];
+		return typeof value === 'string' ? value : 'not configured';
+	}
+</script>
+
+<svelte:head>
+	<title>Federation Trust - Authrim Admin</title>
+</svelte:head>
+
+<div class="trust-page">
+	<div class="page-heading">
+		<div>
+			<a class="back-link" href="/admin/identity-mapping">Back to Identity Mapping</a>
+			<p class="eyebrow">Identity Mapping</p>
+			<h1>Federation Trust</h1>
+			<p class="summary">
+				Manage normalized federation trust sources and inspect SAML aggregate entities before binding
+				them to mapping profiles.
+			</p>
+		</div>
+		<div class="status-panel">
+			<strong>{trustSources.length}</strong>
+			<span>trust sources</span>
+		</div>
+	</div>
+
+	<div class="trust-layout">
+		<section class="source-list" aria-label="Federation trust sources">
+			<div class="panel-heading">
+				<p class="eyebrow">Sources</p>
+				<button type="button" onclick={loadTrustSources} disabled={loading}>Refresh</button>
+			</div>
+			{#if loading}
+				<div class="empty-state">Loading trust sources.</div>
+			{:else if errorMessage}
+				<div class="empty-state">{errorMessage}</div>
+			{:else if trustSources.length === 0}
+				<div class="empty-state">No federation trust sources have been registered.</div>
+			{:else}
+				{#each trustSources as source (source.id)}
+					<button
+						type="button"
+						class:active={selectedSource?.id === source.id}
+						onclick={() => (selectedSourceId = source.id)}
+					>
+						<span>{source.sourceType}</span>
+						<strong>{source.displayName}</strong>
+						<small>{source.lifecycleState}</small>
+					</button>
+				{/each}
+			{/if}
+		</section>
+
+		<section class="detail-panel">
+			<div class="panel-heading">
+				<div>
+					<p class="eyebrow">Detail</p>
+					<h2>{selectedSource?.displayName ?? 'Select a trust source'}</h2>
+				</div>
+				{#if selectedSource}
+					<strong class="badge">{selectedSource.lifecycleState}</strong>
+				{/if}
+			</div>
+
+			{#if selectedSource}
+				<div class="detail-grid">
+					<div>
+						<span>Source key</span>
+						<strong>{selectedSource.sourceKey}</strong>
+					</div>
+					<div>
+						<span>Source type</span>
+						<strong>{selectedSource.sourceType}</strong>
+					</div>
+					<div>
+						<span>Policy</span>
+						<strong>{payloadValue(selectedSource, 'policy')}</strong>
+					</div>
+					<div>
+						<span>Updated</span>
+						<strong>{selectedSource.updatedAt ?? 'unknown'}</strong>
+					</div>
+				</div>
+			{/if}
+
+			<div class="aggregate-panel">
+				<div>
+					<p class="eyebrow">Metadata Ledger</p>
+					<h2>Imported documents and entity summaries</h2>
+				</div>
+				{#if metadataLoading}
+					<div class="empty-state">Loading metadata documents.</div>
+				{:else if metadataError}
+					<div class="empty-state">{metadataError}</div>
+				{:else if metadataDocuments.length === 0}
+					<div class="empty-state">No metadata documents are registered for this source.</div>
+				{:else}
+					<div class="document-list">
+						{#each metadataDocuments as document (document.id)}
+							<article>
+								<div>
+									<p>{document.documentType}</p>
+									<h3>{document.sourceUrl ?? document.documentHash}</h3>
+									<span>{document.validationState} / {document.entitySummaries.length} entities</span>
+								</div>
+								<strong>{document.validatedAt ?? document.fetchedAt ?? 'pending'}</strong>
+							</article>
+						{/each}
+					</div>
+				{/if}
+			</div>
+
+			<div class="aggregate-panel">
+				<div>
+					<p class="eyebrow">SAML Aggregate Entity Selection</p>
+					<h2>Preview entity candidates</h2>
+				</div>
+				<div class="aggregate-form">
+					<label>
+						<span>Preview ID</span>
+						<input bind:value={previewId} placeholder="metadata preview id" />
+					</label>
+					<label>
+						<span>Search</span>
+						<input bind:value={entityQuery} placeholder="entity ID, display name, keyword" />
+					</label>
+					<button type="button" onclick={loadAggregateEntities} disabled={entityLoading}>
+						Load entities
+					</button>
+				</div>
+				{#if entityError}
+					<div class="empty-state">{entityError}</div>
+				{:else if aggregateEntities.length > 0}
+					<div class="entity-list">
+						{#each aggregateEntities as entity (entity.entityId)}
+							<article>
+								<div>
+									<p>{entity.role}</p>
+									<h3>{entity.displayName ?? entity.entityId}</h3>
+									<span>{entity.entityId}</span>
+								</div>
+								<strong>{entity.certificateCount} certs</strong>
+							</article>
+						{/each}
+					</div>
+				{/if}
+			</div>
+		</section>
+	</div>
+</div>
+
+<style>
+	.trust-page {
+		display: grid;
+		gap: 18px;
+	}
+
+	.page-heading,
+	.panel-heading,
+	.document-list article,
+	.entity-list article {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 18px;
+	}
+
+	.back-link {
+		display: inline-flex;
+		margin-bottom: 12px;
+		color: var(--color-primary);
+		font-size: 13px;
+		font-weight: 700;
+		text-decoration: none;
+	}
+
+	.eyebrow,
+	.detail-grid span,
+	.aggregate-form span,
+	.entity-list p,
+	.document-list p,
+	.status-panel span {
+		margin: 0;
+		color: var(--text-muted);
+		font-size: 12px;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+	}
+
+	h1,
+	h2,
+	h3,
+	p {
+		margin: 0;
+	}
+
+	h1 {
+		color: var(--text-primary);
+		font-size: 28px;
+	}
+
+	h2,
+	h3,
+	.detail-grid strong,
+	.entity-list strong,
+	.document-list strong,
+	.source-list button strong,
+	.status-panel strong {
+		color: var(--text-primary);
+	}
+
+	h2 {
+		font-size: 18px;
+	}
+
+	h3 {
+		font-size: 15px;
+	}
+
+	.summary,
+	.entity-list span,
+	.document-list span,
+	.source-list button small {
+		color: var(--text-secondary);
+		font-size: 13px;
+		line-height: 1.45;
+	}
+
+	.summary {
+		max-width: 760px;
+		margin-top: 8px;
+		font-size: 14px;
+	}
+
+	.status-panel,
+	.source-list,
+	.detail-panel,
+	.empty-state,
+	.detail-grid > div,
+	.aggregate-panel,
+	.document-list article,
+	.entity-list article {
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		background: var(--bg-card);
+	}
+
+	.status-panel {
+		min-width: 180px;
+		padding: 14px;
+		text-align: right;
+	}
+
+	.status-panel strong {
+		display: block;
+		font-size: 24px;
+	}
+
+	.trust-layout {
+		display: grid;
+		grid-template-columns: minmax(260px, 340px) minmax(0, 1fr);
+		gap: 14px;
+	}
+
+	.source-list,
+	.detail-panel {
+		padding: 14px;
+	}
+
+	button {
+		min-height: 36px;
+		padding: 0 12px;
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		color: var(--text-primary);
+		background: var(--bg-card);
+		font-weight: 800;
+	}
+
+	button:disabled {
+		cursor: not-allowed;
+		opacity: 0.55;
+	}
+
+	.source-list > button {
+		width: 100%;
+		height: auto;
+		display: grid;
+		justify-items: start;
+		gap: 3px;
+		margin-top: 8px;
+		padding: 12px;
+		text-align: left;
+	}
+
+	.source-list > button.active {
+		border-color: var(--color-primary);
+		background: var(--bg-hover);
+	}
+
+	.badge {
+		padding: 4px 9px;
+		border-radius: 999px;
+		color: #047857;
+		background: rgba(16, 185, 129, 0.14);
+		font-size: 12px;
+	}
+
+	.detail-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 10px;
+		margin-top: 14px;
+	}
+
+	.detail-grid > div,
+	.aggregate-panel,
+	.document-list article,
+	.entity-list article,
+	.empty-state {
+		padding: 14px;
+	}
+
+	.aggregate-panel {
+		display: grid;
+		gap: 14px;
+		margin-top: 14px;
+	}
+
+	.aggregate-form {
+		display: grid;
+		grid-template-columns: minmax(220px, 1fr) minmax(220px, 1fr) auto;
+		gap: 10px;
+		align-items: end;
+	}
+
+	label {
+		display: grid;
+		gap: 6px;
+	}
+
+	input {
+		min-height: 36px;
+		padding: 0 10px;
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		color: var(--text-primary);
+		background: var(--bg-input);
+	}
+
+	.entity-list,
+	.document-list {
+		display: grid;
+		gap: 10px;
+	}
+
+	@media (max-width: 1000px) {
+		.page-heading,
+		.trust-layout,
+		.panel-heading,
+		.aggregate-form,
+		.detail-grid,
+		.entity-list article {
+			display: grid;
+			grid-template-columns: 1fr;
+		}
+
+		.status-panel {
+			min-width: 0;
+			text-align: left;
+		}
+	}
+</style>

--- a/packages/ar-admin-ui/src/routes/admin/identity-mapping/operations/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/identity-mapping/operations/+page.svelte
@@ -1,0 +1,425 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import {
+		adminIdentityMappingAPI,
+		type IdentityMappingPolicySummary
+	} from '$lib/api/admin-identity-mapping';
+
+	let policies = $state<IdentityMappingPolicySummary[]>([]);
+	let loading = $state(true);
+	let errorMessage = $state<string | null>(null);
+	let rollbackState = $state<Record<string, string>>({});
+	let confirmRollbackId = $state<string | null>(null);
+	let policySetId = $state('');
+	let policyVersionId = $state('');
+	let catalogVersionId = $state('');
+	let snapshotId = $state('');
+	let operationStatus = $state<string | null>(null);
+	let operationBusy = $state(false);
+
+	onMount(() => {
+		void loadPolicies();
+	});
+
+	async function loadPolicies() {
+		loading = true;
+		errorMessage = null;
+		try {
+			const result = await adminIdentityMappingAPI.listPolicies();
+			policies = result.policies;
+		} catch (error) {
+			errorMessage = error instanceof Error ? error.message : 'Failed to load policy operations';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function rollbackPolicy(policy: IdentityMappingPolicySummary) {
+		if (confirmRollbackId !== policy.id) {
+			confirmRollbackId = policy.id;
+			rollbackState = { ...rollbackState, [policy.id]: 'Confirm rollback to continue' };
+			return;
+		}
+		rollbackState = { ...rollbackState, [policy.id]: 'Rolling back' };
+		try {
+			await adminIdentityMappingAPI.rollbackPolicy(policy.id);
+			confirmRollbackId = null;
+			rollbackState = { ...rollbackState, [policy.id]: 'Rollback requested' };
+			await loadPolicies();
+		} catch (error) {
+			rollbackState = {
+				...rollbackState,
+				[policy.id]: error instanceof Error ? error.message : 'Rollback failed'
+			};
+		}
+	}
+
+	async function runPolicyOperation(action: 'publish' | 'compile' | 'activate') {
+		operationBusy = true;
+		operationStatus = null;
+		try {
+			if (!policySetId.trim() || !policyVersionId.trim()) {
+				throw new Error('Policy set ID and version ID are required');
+			}
+			if (action === 'publish') {
+				await adminIdentityMappingAPI.publishPolicyVersion(policySetId.trim(), policyVersionId.trim());
+			} else if (action === 'compile') {
+				if (!catalogVersionId.trim()) {
+					throw new Error('Catalog version ID is required for compile');
+				}
+				await adminIdentityMappingAPI.compilePolicyVersion(policySetId.trim(), policyVersionId.trim(), {
+					catalogVersionId: catalogVersionId.trim(),
+					metadata: { source: 'admin-ui-operations' }
+				});
+			} else {
+				if (!snapshotId.trim()) {
+					throw new Error('Snapshot ID is required for activation');
+				}
+				await adminIdentityMappingAPI.activatePolicyVersion(policySetId.trim(), policyVersionId.trim(), {
+					snapshotId: snapshotId.trim(),
+					activationScope: { kind: 'tenant' }
+				});
+			}
+			operationStatus = `${action} requested`;
+			await loadPolicies();
+		} catch (error) {
+			operationStatus = error instanceof Error ? error.message : `${action} failed`;
+		} finally {
+			operationBusy = false;
+		}
+	}
+
+	const activePolicies = $derived(
+		policies.filter((policy) => policy.lifecycleState === 'active').length
+	);
+	const degradedPolicies = $derived(
+		policies.filter((policy) => ['draft', 'scheduled'].includes(policy.lifecycleState)).length
+	);
+</script>
+
+<svelte:head>
+	<title>Identity Mapping Operations - Authrim Admin</title>
+</svelte:head>
+
+<div class="operations-page">
+	<div class="page-heading">
+		<div>
+			<a class="back-link" href="/admin/identity-mapping">Back to Identity Mapping</a>
+			<p class="eyebrow">Identity Mapping</p>
+			<h1>Operations</h1>
+			<p class="summary">
+				Review activation status, rollback readiness, and degraded policy states before promoting a
+				compiled mapping bundle.
+			</p>
+		</div>
+		<div class="status-panel">
+			<div>
+				<span>Active policies</span>
+				<strong>{activePolicies}</strong>
+			</div>
+			<div>
+				<span>Needs attention</span>
+				<strong>{degradedPolicies}</strong>
+			</div>
+		</div>
+	</div>
+
+	<section class="policy-panel">
+		<div class="panel-heading">
+			<div>
+				<p class="eyebrow">Policy Activation</p>
+				<h2>Activation and rollback status</h2>
+			</div>
+			<button type="button" onclick={loadPolicies} disabled={loading}>Refresh</button>
+		</div>
+
+		{#if loading}
+			<div class="empty-state">Loading policy operations.</div>
+		{:else if errorMessage}
+			<div class="empty-state">{errorMessage}</div>
+		{:else if policies.length === 0}
+			<div class="empty-state">No mapping policies are registered yet.</div>
+		{:else}
+			<div class="policy-list">
+				{#each policies as policy (policy.id)}
+					<article class="policy-row">
+						<div>
+							<p>{policy.policyKey}</p>
+							<h3>{policy.displayName}</h3>
+							<span>{policy.description ?? 'No description'}</span>
+						</div>
+						<div class="policy-actions">
+							<strong class:active={policy.lifecycleState === 'active'}
+								>{policy.lifecycleState}</strong
+							>
+							<button type="button" onclick={() => rollbackPolicy(policy)}>
+								{confirmRollbackId === policy.id ? 'Confirm rollback' : 'Request rollback'}
+							</button>
+							{#if rollbackState[policy.id]}
+								<span>{rollbackState[policy.id]}</span>
+							{/if}
+						</div>
+					</article>
+				{/each}
+			</div>
+		{/if}
+	</section>
+
+	<section class="policy-panel">
+		<div class="panel-heading">
+			<div>
+				<p class="eyebrow">Action Panel</p>
+				<h2>Publish, compile, and activate a policy version</h2>
+			</div>
+		</div>
+
+		<div class="action-grid">
+			<label>
+				<span>Policy set ID</span>
+				<input bind:value={policySetId} placeholder="mapping policy set id" />
+			</label>
+			<label>
+				<span>Policy version ID</span>
+				<input bind:value={policyVersionId} placeholder="mapping policy version id" />
+			</label>
+			<label>
+				<span>Catalog version ID</span>
+				<input bind:value={catalogVersionId} placeholder="required for compile" />
+			</label>
+			<label>
+				<span>Snapshot ID</span>
+				<input bind:value={snapshotId} placeholder="required for activate" />
+			</label>
+		</div>
+
+		<div class="action-row">
+			<button type="button" onclick={() => runPolicyOperation('publish')} disabled={operationBusy}>
+				Publish
+			</button>
+			<button type="button" onclick={() => runPolicyOperation('compile')} disabled={operationBusy}>
+				Compile
+			</button>
+			<button type="button" onclick={() => runPolicyOperation('activate')} disabled={operationBusy}>
+				Activate
+			</button>
+			{#if operationStatus}
+				<span>{operationStatus}</span>
+			{/if}
+		</div>
+	</section>
+</div>
+
+<style>
+	.operations-page {
+		display: grid;
+		gap: 18px;
+	}
+
+	.page-heading,
+	.panel-heading,
+	.policy-row {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 18px;
+	}
+
+	.back-link {
+		display: inline-flex;
+		margin-bottom: 12px;
+		color: var(--color-primary);
+		font-size: 13px;
+		font-weight: 700;
+		text-decoration: none;
+	}
+
+	.eyebrow,
+	.policy-row p,
+	.status-panel span {
+		margin: 0;
+		color: var(--text-muted);
+		font-size: 12px;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+	}
+
+	h1,
+	h2,
+	h3,
+	p {
+		margin: 0;
+	}
+
+	h1 {
+		color: var(--text-primary);
+		font-size: 28px;
+		line-height: 1.2;
+	}
+
+	h2,
+	h3,
+	.policy-actions strong,
+	.status-panel strong {
+		color: var(--text-primary);
+	}
+
+	h2 {
+		font-size: 18px;
+	}
+
+	h3 {
+		font-size: 16px;
+	}
+
+	.summary,
+	.policy-row span,
+	.policy-actions span {
+		color: var(--text-secondary);
+		font-size: 13px;
+		line-height: 1.45;
+	}
+
+	.summary {
+		max-width: 760px;
+		margin-top: 8px;
+		font-size: 14px;
+	}
+
+	.status-panel,
+	.policy-panel,
+	.empty-state,
+	.policy-row {
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		background: var(--bg-card);
+	}
+
+	.status-panel {
+		min-width: 300px;
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 12px;
+		padding: 14px;
+	}
+
+	.status-panel strong {
+		display: block;
+		margin-top: 4px;
+		font-size: 20px;
+	}
+
+	.policy-panel {
+		padding: 16px;
+	}
+
+	button {
+		min-height: 36px;
+		padding: 0 12px;
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		color: var(--text-primary);
+		background: var(--bg-card);
+		font-weight: 800;
+	}
+
+	button:disabled {
+		cursor: not-allowed;
+		opacity: 0.55;
+	}
+
+	.empty-state {
+		margin-top: 14px;
+		padding: 18px;
+		color: var(--text-secondary);
+	}
+
+	.policy-list {
+		display: grid;
+		gap: 10px;
+		margin-top: 14px;
+	}
+
+	.policy-row {
+		padding: 14px;
+	}
+
+	.policy-actions {
+		min-width: 180px;
+		display: grid;
+		justify-items: end;
+		gap: 8px;
+	}
+
+	.action-grid {
+		display: grid;
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+		gap: 10px;
+		margin-top: 14px;
+	}
+
+	label {
+		display: grid;
+		gap: 6px;
+	}
+
+	label span {
+		color: var(--text-muted);
+		font-size: 12px;
+		font-weight: 800;
+		text-transform: uppercase;
+	}
+
+	input {
+		min-height: 36px;
+		padding: 0 10px;
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		color: var(--text-primary);
+		background: var(--bg-input);
+	}
+
+	.action-row {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 10px;
+		margin-top: 12px;
+	}
+
+	.action-row span {
+		color: var(--text-secondary);
+		font-size: 13px;
+	}
+
+	.policy-actions strong {
+		padding: 4px 9px;
+		border-radius: 999px;
+		background: var(--bg-muted);
+		font-size: 12px;
+	}
+
+	.policy-actions strong.active {
+		color: #047857;
+		background: rgba(16, 185, 129, 0.14);
+	}
+
+	@media (max-width: 900px) {
+		.page-heading,
+		.panel-heading,
+		.policy-row {
+			display: grid;
+		}
+
+		.status-panel,
+		.policy-actions,
+		.action-grid {
+			min-width: 0;
+			justify-items: stretch;
+		}
+
+		.action-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/packages/ar-admin-ui/src/routes/admin/identity-mapping/profiles/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/identity-mapping/profiles/+page.svelte
@@ -6,6 +6,11 @@
 		type IdentityMappingProtocolSchemaSummary,
 		type IdentityMappingTemplateSummary
 	} from '$lib/api/admin-identity-mapping';
+	import {
+		createDestinationConsentSettingsDraft,
+		summarizeDestinationConsentSettings,
+		type DestinationConsentSettingsDraft
+	} from '$lib/admin/identity-mapping-profile-settings';
 
 	type ProfileKind = 'inbound' | 'outbound' | 'template';
 
@@ -23,6 +28,8 @@
 	let loading = $state(true);
 	let errorMessage = $state<string | null>(null);
 	let activeKind = $state<ProfileKind | 'all'>('all');
+	let selectedProfileId = $state<string | null>(null);
+	let consentDrafts = $state<Record<string, DestinationConsentSettingsDraft>>({});
 	const profileKinds: Array<ProfileKind | 'all'> = ['all', 'inbound', 'outbound', 'template'];
 
 	onMount(() => {
@@ -38,11 +45,16 @@
 				adminIdentityMappingAPI.listExternalSchemas(),
 				adminIdentityMappingAPI.listTemplates()
 			]);
-			profiles = [
+			const loadedProfiles = [
 				...protocolSchemas.protocolSchemas.map(protocolSchemaToProfile),
 				...externalSchemas.externalSchemas.map(externalSchemaToProfile),
 				...templates.templates.map(templateToProfile)
 			];
+			profiles = loadedProfiles;
+			const firstOutbound = loadedProfiles.find((profile) => profile.kind === 'outbound');
+			if (!selectedProfileId && firstOutbound) {
+				selectConsentProfile(firstOutbound);
+			}
 		} catch (error) {
 			errorMessage = error instanceof Error ? error.message : 'Failed to load mapping profiles';
 		} finally {
@@ -53,8 +65,42 @@
 	const visibleProfiles = $derived(
 		activeKind === 'all' ? profiles : profiles.filter((profile) => profile.kind === activeKind)
 	);
+	const selectedProfile = $derived(profiles.find((profile) => profile.id === selectedProfileId) ?? null);
+	const selectedConsentDraft = $derived(
+		selectedProfileId ? consentDrafts[selectedProfileId] ?? null : null
+	);
 	const inboundCount = $derived(profiles.filter((profile) => profile.kind === 'inbound').length);
 	const outboundCount = $derived(profiles.filter((profile) => profile.kind === 'outbound').length);
+
+	function selectConsentProfile(profile: ProfileItem) {
+		if (profile.kind !== 'outbound') return;
+		const existingDraft = consentDrafts[profile.id];
+		selectedProfileId = profile.id;
+		if (!existingDraft) {
+			consentDrafts = {
+				...consentDrafts,
+				[profile.id]: createDestinationConsentSettingsDraft(profile.id)
+			};
+		}
+	}
+
+	function updateSelectedConsentDraft(patch: Partial<DestinationConsentSettingsDraft>) {
+		if (!selectedProfileId || !selectedConsentDraft) return;
+		consentDrafts = {
+			...consentDrafts,
+			[selectedProfileId]: {
+				...selectedConsentDraft,
+				...patch
+			}
+		};
+	}
+
+	function getInputValue(event: Event): string {
+		return event.currentTarget instanceof HTMLInputElement ||
+			event.currentTarget instanceof HTMLSelectElement
+			? event.currentTarget.value
+			: '';
+	}
 
 	function protocolSchemaToProfile(schema: IdentityMappingProtocolSchemaSummary): ProfileItem {
 		return {
@@ -143,22 +189,171 @@
 		{:else if visibleProfiles.length === 0}
 			<div class="empty-state">No profiles match this filter.</div>
 		{:else}
-			<div class="profile-grid">
-				{#each visibleProfiles as profile (profile.id)}
-					<article>
-						<div class="profile-heading">
-							<span>{profile.kind}</span>
-							<strong>{profile.lifecycleState}</strong>
-						</div>
-						<h2>{profile.displayName}</h2>
-						<p>{profile.protocol} / {profile.source}</p>
-						<small>{profile.versionLabel}</small>
-					</article>
-				{/each}
-			</div>
+				<div class="profile-grid">
+					{#each visibleProfiles as profile (profile.id)}
+						<article class:selected={profile.id === selectedProfileId}>
+							<div class="profile-heading">
+								<span>{profile.kind}</span>
+								<strong>{profile.lifecycleState}</strong>
+							</div>
+							<h2>{profile.displayName}</h2>
+							<p>{profile.protocol} / {profile.source}</p>
+							<small>{profile.versionLabel}</small>
+							{#if profile.kind === 'outbound'}
+								<button type="button" onclick={() => selectConsentProfile(profile)}>
+									Configure release consent
+								</button>
+							{/if}
+						</article>
+					{/each}
+				</div>
+			{/if}
+		</section>
+
+		{#if selectedProfile && selectedConsentDraft}
+			<section class="consent-panel" aria-label="Destination attribute release consent settings">
+				<div>
+					<p class="eyebrow">Destination Consent Settings</p>
+					<h2>{selectedProfile.displayName}</h2>
+					<p class="summary">
+						Set tenant defaults and client overrides for attribute release consent. Flow Editor
+						previews use the same legal basis, challenge mode, and policy version fields without
+						showing raw attribute values.
+					</p>
+				</div>
+
+				<div class="settings-grid">
+					<label>
+						<span>Scope</span>
+						<select
+							value={selectedConsentDraft.scope}
+							onchange={(event) =>
+								updateSelectedConsentDraft({
+									scope: getInputValue(event) as DestinationConsentSettingsDraft['scope']
+								})}
+						>
+							<option value="tenant_default">Tenant default</option>
+							<option value="client_override">Client override</option>
+						</select>
+					</label>
+
+					<label>
+						<span>Client override ID</span>
+						<input
+							value={selectedConsentDraft.clientId}
+							placeholder="client id for override"
+							disabled={selectedConsentDraft.scope === 'tenant_default'}
+							oninput={(event) => updateSelectedConsentDraft({ clientId: getInputValue(event) })}
+						/>
+					</label>
+
+					<label>
+						<span>Consent mode</span>
+						<select
+							value={selectedConsentDraft.consentMode}
+							onchange={(event) =>
+								updateSelectedConsentDraft({
+									consentMode: getInputValue(
+										event
+									) as DestinationConsentSettingsDraft['consentMode']
+								})}
+						>
+							<option value="once">Once</option>
+							<option value="every_time">Every time</option>
+							<option value="until_attributes_change">Until attributes change</option>
+						</select>
+					</label>
+
+					<label>
+						<span>Legal basis</span>
+						<select
+							value={selectedConsentDraft.legalBasis}
+							onchange={(event) =>
+								updateSelectedConsentDraft({
+									legalBasis: getInputValue(event) as DestinationConsentSettingsDraft['legalBasis']
+								})}
+						>
+							<option value="consent">Consent</option>
+							<option value="legal_obligation">Legal obligation</option>
+							<option value="contract">Contract</option>
+							<option value="legitimate_interest">Legitimate interest</option>
+						</select>
+					</label>
+
+					<label>
+						<span>Purpose</span>
+						<input
+							value={selectedConsentDraft.purpose}
+							oninput={(event) => updateSelectedConsentDraft({ purpose: getInputValue(event) })}
+						/>
+					</label>
+
+					<label>
+						<span>Attribute set policy version</span>
+						<input
+							value={selectedConsentDraft.attributeSetPolicyVersion}
+							oninput={(event) =>
+								updateSelectedConsentDraft({ attributeSetPolicyVersion: getInputValue(event) })}
+						/>
+					</label>
+
+					<label>
+						<span>Terms version</span>
+						<input
+							value={selectedConsentDraft.termsVersion}
+							oninput={(event) => updateSelectedConsentDraft({ termsVersion: getInputValue(event) })}
+						/>
+					</label>
+
+					<label>
+						<span>Privacy Policy version</span>
+						<input
+							value={selectedConsentDraft.privacyPolicyVersion}
+							oninput={(event) =>
+								updateSelectedConsentDraft({ privacyPolicyVersion: getInputValue(event) })}
+						/>
+					</label>
+
+					<label>
+						<span>Challenge handling</span>
+						<select
+							value={selectedConsentDraft.challengeExperience}
+							onchange={(event) =>
+								updateSelectedConsentDraft({
+									challengeExperience: getInputValue(
+										event
+									) as DestinationConsentSettingsDraft['challengeExperience']
+								})}
+						>
+							<option value="login_flow">Login flow challenge</option>
+							<option value="step_up_required">Step-up required</option>
+						</select>
+					</label>
+
+					<label class="checkbox-row">
+						<input
+							type="checkbox"
+							checked={selectedConsentDraft.regulatedPurposeGuard}
+							onchange={(event) =>
+								updateSelectedConsentDraft({
+									regulatedPurposeGuard:
+										event.currentTarget instanceof HTMLInputElement
+											? event.currentTarget.checked
+											: true
+								})}
+						/>
+						<span>Require purpose guard for regulated attributes</span>
+					</label>
+				</div>
+
+				<div class="consent-preview">
+					<span>Preview</span>
+					<strong>{summarizeDestinationConsentSettings(selectedConsentDraft)}</strong>
+					<small>Raw attribute values remain {selectedConsentDraft.rawValueDisplay}.</small>
+				</div>
+			</section>
 		{/if}
-	</section>
-</div>
+	</div>
 
 <style>
 	.profiles-page {
@@ -233,6 +428,7 @@
 
 	.status-panel,
 	.profiles-panel,
+	.consent-panel,
 	.empty-state,
 	.profile-grid article {
 		border: 1px solid var(--border-color);
@@ -257,6 +453,12 @@
 	.profiles-panel {
 		display: grid;
 		gap: 14px;
+		padding: 16px;
+	}
+
+	.consent-panel {
+		display: grid;
+		gap: 18px;
 		padding: 16px;
 	}
 
@@ -303,6 +505,79 @@
 		display: grid;
 		gap: 8px;
 		padding: 14px;
+	}
+
+	.profile-grid article.selected {
+		border-color: var(--color-primary);
+		background: var(--bg-hover);
+	}
+
+	.settings-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+		gap: 14px;
+	}
+
+	label {
+		display: grid;
+		gap: 6px;
+		color: var(--text-secondary);
+		font-size: 13px;
+		font-weight: 700;
+	}
+
+	label span {
+		color: var(--text-muted);
+		font-size: 12px;
+		text-transform: uppercase;
+	}
+
+	input,
+	select {
+		width: 100%;
+		min-height: 38px;
+		padding: 0 10px;
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		color: var(--text-primary);
+		background: var(--bg-card);
+	}
+
+	input:disabled {
+		color: var(--text-muted);
+		background: var(--bg-muted);
+	}
+
+	.checkbox-row {
+		grid-template-columns: auto 1fr;
+		align-items: center;
+	}
+
+	.checkbox-row input {
+		width: 18px;
+		min-height: 18px;
+	}
+
+	.consent-preview {
+		display: grid;
+		gap: 6px;
+		padding: 14px;
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		background: var(--bg-muted);
+	}
+
+	.consent-preview span,
+	.consent-preview small {
+		color: var(--text-muted);
+		font-size: 12px;
+		font-weight: 800;
+		text-transform: uppercase;
+	}
+
+	.consent-preview strong {
+		color: var(--text-primary);
+		line-height: 1.45;
 	}
 
 	.profile-heading strong {

--- a/packages/ar-admin-ui/src/routes/admin/identity-mapping/profiles/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/identity-mapping/profiles/+page.svelte
@@ -1,0 +1,334 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import {
+		adminIdentityMappingAPI,
+		type IdentityMappingExternalSchemaSummary,
+		type IdentityMappingProtocolSchemaSummary,
+		type IdentityMappingTemplateSummary
+	} from '$lib/api/admin-identity-mapping';
+
+	type ProfileKind = 'inbound' | 'outbound' | 'template';
+
+	interface ProfileItem {
+		id: string;
+		kind: ProfileKind;
+		protocol: string;
+		displayName: string;
+		versionLabel: string;
+		lifecycleState: string;
+		source: string;
+	}
+
+	let profiles = $state<ProfileItem[]>([]);
+	let loading = $state(true);
+	let errorMessage = $state<string | null>(null);
+	let activeKind = $state<ProfileKind | 'all'>('all');
+	const profileKinds: Array<ProfileKind | 'all'> = ['all', 'inbound', 'outbound', 'template'];
+
+	onMount(() => {
+		void loadProfiles();
+	});
+
+	async function loadProfiles() {
+		loading = true;
+		errorMessage = null;
+		try {
+			const [protocolSchemas, externalSchemas, templates] = await Promise.all([
+				adminIdentityMappingAPI.listProtocolSchemas(),
+				adminIdentityMappingAPI.listExternalSchemas(),
+				adminIdentityMappingAPI.listTemplates()
+			]);
+			profiles = [
+				...protocolSchemas.protocolSchemas.map(protocolSchemaToProfile),
+				...externalSchemas.externalSchemas.map(externalSchemaToProfile),
+				...templates.templates.map(templateToProfile)
+			];
+		} catch (error) {
+			errorMessage = error instanceof Error ? error.message : 'Failed to load mapping profiles';
+		} finally {
+			loading = false;
+		}
+	}
+
+	const visibleProfiles = $derived(
+		activeKind === 'all' ? profiles : profiles.filter((profile) => profile.kind === activeKind)
+	);
+	const inboundCount = $derived(profiles.filter((profile) => profile.kind === 'inbound').length);
+	const outboundCount = $derived(profiles.filter((profile) => profile.kind === 'outbound').length);
+
+	function protocolSchemaToProfile(schema: IdentityMappingProtocolSchemaSummary): ProfileItem {
+		return {
+			id: schema.id,
+			kind: ['saml', 'oidc'].includes(schema.protocol.toLowerCase()) ? 'outbound' : 'inbound',
+			protocol: schema.protocol,
+			displayName: schema.displayName,
+			versionLabel: schema.versionLabel,
+			lifecycleState: schema.lifecycleState,
+			source: schema.schemaKey
+		};
+	}
+
+	function externalSchemaToProfile(schema: IdentityMappingExternalSchemaSummary): ProfileItem {
+		return {
+			id: schema.id,
+			kind: 'inbound',
+			protocol: schema.sourceType,
+			displayName: schema.displayName,
+			versionLabel: schema.versionLabel,
+			lifecycleState: schema.lifecycleState,
+			source: schema.sourceKey
+		};
+	}
+
+	function templateToProfile(template: IdentityMappingTemplateSummary): ProfileItem {
+		return {
+			id: template.id,
+			kind: 'template',
+			protocol: template.protocol,
+			displayName: template.displayName,
+			versionLabel: template.templateKey,
+			lifecycleState: template.lifecycleState,
+			source: template.templateKey
+		};
+	}
+</script>
+
+<svelte:head>
+	<title>Source & Destination Profiles - Authrim Admin</title>
+</svelte:head>
+
+<div class="profiles-page">
+	<div class="page-heading">
+		<div>
+			<a class="back-link" href="/admin/identity-mapping">Back to Identity Mapping</a>
+			<p class="eyebrow">Identity Mapping</p>
+			<h1>Source &amp; Destination Profiles</h1>
+			<p class="summary">
+				Prepare inbound adapters and outbound destinations before selecting them in the Flow Editor.
+				SAML, OIDC, SCIM, CSV, and future sources share this registration surface.
+			</p>
+		</div>
+		<div class="status-panel">
+			<div>
+				<span>Inbound</span>
+				<strong>{inboundCount}</strong>
+			</div>
+			<div>
+				<span>Outbound</span>
+				<strong>{outboundCount}</strong>
+			</div>
+		</div>
+	</div>
+
+	<section class="profiles-panel">
+		<div class="panel-heading">
+			<div class="filter-bar" aria-label="Profile filters">
+				{#each profileKinds as kind (kind)}
+					<button
+						type="button"
+						class:active={activeKind === kind}
+						onclick={() => (activeKind = kind)}
+					>
+						{kind}
+					</button>
+				{/each}
+			</div>
+			<button type="button" onclick={loadProfiles} disabled={loading}>Refresh</button>
+		</div>
+
+		{#if loading}
+			<div class="empty-state">Loading source and destination profiles.</div>
+		{:else if errorMessage}
+			<div class="empty-state">{errorMessage}</div>
+		{:else if visibleProfiles.length === 0}
+			<div class="empty-state">No profiles match this filter.</div>
+		{:else}
+			<div class="profile-grid">
+				{#each visibleProfiles as profile (profile.id)}
+					<article>
+						<div class="profile-heading">
+							<span>{profile.kind}</span>
+							<strong>{profile.lifecycleState}</strong>
+						</div>
+						<h2>{profile.displayName}</h2>
+						<p>{profile.protocol} / {profile.source}</p>
+						<small>{profile.versionLabel}</small>
+					</article>
+				{/each}
+			</div>
+		{/if}
+	</section>
+</div>
+
+<style>
+	.profiles-page {
+		display: grid;
+		gap: 18px;
+	}
+
+	.page-heading,
+	.panel-heading,
+	.profile-heading {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 18px;
+	}
+
+	.back-link {
+		display: inline-flex;
+		margin-bottom: 12px;
+		color: var(--color-primary);
+		font-size: 13px;
+		font-weight: 700;
+		text-decoration: none;
+	}
+
+	.eyebrow,
+	.status-panel span,
+	.profile-heading span,
+	.profile-grid small {
+		margin: 0;
+		color: var(--text-muted);
+		font-size: 12px;
+		font-weight: 800;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+	}
+
+	h1,
+	h2,
+	p {
+		margin: 0;
+	}
+
+	h1 {
+		color: var(--text-primary);
+		font-size: 28px;
+	}
+
+	h2,
+	.status-panel strong,
+	.profile-heading strong {
+		color: var(--text-primary);
+	}
+
+	h2 {
+		font-size: 16px;
+		line-height: 1.35;
+	}
+
+	.summary,
+	.profile-grid p {
+		color: var(--text-secondary);
+		font-size: 13px;
+		line-height: 1.45;
+	}
+
+	.summary {
+		max-width: 780px;
+		margin-top: 8px;
+		font-size: 14px;
+	}
+
+	.status-panel,
+	.profiles-panel,
+	.empty-state,
+	.profile-grid article {
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		background: var(--bg-card);
+	}
+
+	.status-panel {
+		min-width: 260px;
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 12px;
+		padding: 14px;
+	}
+
+	.status-panel strong {
+		display: block;
+		margin-top: 4px;
+		font-size: 22px;
+	}
+
+	.profiles-panel {
+		display: grid;
+		gap: 14px;
+		padding: 16px;
+	}
+
+	.filter-bar {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+	}
+
+	button {
+		min-height: 34px;
+		padding: 0 12px;
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		color: var(--text-secondary);
+		background: var(--bg-card);
+		font-weight: 800;
+		text-transform: capitalize;
+	}
+
+	button.active {
+		color: var(--text-primary);
+		border-color: var(--color-primary);
+		background: var(--bg-hover);
+	}
+
+	button:disabled {
+		cursor: not-allowed;
+		opacity: 0.55;
+	}
+
+	.empty-state {
+		padding: 18px;
+		color: var(--text-secondary);
+	}
+
+	.profile-grid {
+		display: grid;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		gap: 12px;
+	}
+
+	.profile-grid article {
+		display: grid;
+		gap: 8px;
+		padding: 14px;
+	}
+
+	.profile-heading strong {
+		padding: 3px 8px;
+		border-radius: 999px;
+		background: var(--bg-muted);
+		font-size: 12px;
+	}
+
+	@media (max-width: 1100px) {
+		.profile-grid {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+	}
+
+	@media (max-width: 780px) {
+		.page-heading,
+		.panel-heading,
+		.status-panel,
+		.profile-grid {
+			display: grid;
+			grid-template-columns: 1fr;
+		}
+
+		.status-panel {
+			min-width: 0;
+		}
+	}
+</style>

--- a/packages/ar-admin-ui/src/routes/admin/identity-mapping/resolution-center/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/identity-mapping/resolution-center/+page.svelte
@@ -101,8 +101,11 @@
 		isLoading = true;
 		loadError = null;
 		try {
-			const result = await adminIdentityMappingAPI.listReviewTasks({ status: 'open', limit: 100 });
-			reviewTasks = result.reviewTasks;
+			const [openResult, inReviewResult] = await Promise.all([
+				adminIdentityMappingAPI.listReviewTasks({ status: 'open', limit: 100 }),
+				adminIdentityMappingAPI.listReviewTasks({ status: 'in_review', limit: 100 })
+			]);
+			reviewTasks = dedupeReviewTasks([...openResult.reviewTasks, ...inReviewResult.reviewTasks]);
 		} catch (error) {
 			loadError = error instanceof Error ? error.message : 'Failed to load review tasks';
 		} finally {
@@ -186,6 +189,14 @@
 		if (status === 'in_review') return 'needs_approval';
 		if (status === 'open') return 'open';
 		return 'blocked';
+	}
+
+	function dedupeReviewTasks(tasks: IdentityMappingReviewTask[]): IdentityMappingReviewTask[] {
+		const byId: Record<string, IdentityMappingReviewTask> = {};
+		for (const task of tasks) {
+			byId[task.id] = task;
+		}
+		return Object.values(byId).sort((left, right) => right.priority - left.priority);
 	}
 
 	function getPayloadString(payload: Record<string, unknown>, key: string): string | null {

--- a/packages/ar-admin-ui/src/routes/admin/identity-mapping/resolution-center/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/identity-mapping/resolution-center/+page.svelte
@@ -1,0 +1,557 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import {
+		adminIdentityMappingAPI,
+		type IdentityMappingReviewTask
+	} from '$lib/api/admin-identity-mapping';
+
+	type ResolutionCategory =
+		| 'conflicts'
+		| 'missing_mappings'
+		| 'linking_decisions'
+		| 'consent_required'
+		| 'lifecycle_actions'
+		| 'activation_blockers';
+
+	interface ResolutionItem {
+		id: string;
+		category: ResolutionCategory;
+		title: string;
+		source: string;
+		impact: string;
+		severity: 'low' | 'medium' | 'high';
+		status: 'open' | 'blocked' | 'needs_approval';
+	}
+
+	const categories: Array<{ id: ResolutionCategory; label: string; description: string }> = [
+		{
+			id: 'conflicts',
+			label: 'Conflicts',
+			description: 'Multiple trusted sources claim incompatible values for the same target.'
+		},
+		{
+			id: 'missing_mappings',
+			label: 'Missing Mappings',
+			description: 'Imported fields or outbound requirements do not have a safe target yet.'
+		},
+		{
+			id: 'linking_decisions',
+			label: 'Linking Decisions',
+			description: 'Identity candidates need step-up, admin approval, or explicit denial.'
+		},
+		{
+			id: 'consent_required',
+			label: 'Consent Required',
+			description: 'Destination release needs consent, version upgrade, or purpose review.'
+		},
+		{
+			id: 'lifecycle_actions',
+			label: 'Lifecycle Actions',
+			description: 'Provisioning or deprovisioning signals need protected-account review.'
+		},
+		{
+			id: 'activation_blockers',
+			label: 'Activation Blockers',
+			description: 'Policy compile or activation cannot proceed until these items close.'
+		}
+	];
+
+	const fallbackItems: ResolutionItem[] = [
+		{
+			id: 'res-001',
+			category: 'missing_mappings',
+			title: 'SAML User.UserType has no approved release target',
+			source: 'SAML Salesforce columns',
+			impact: 'OIDC destination preview omits the claim until a profile owner confirms the target.',
+			severity: 'medium',
+			status: 'open'
+		},
+		{
+			id: 'res-002',
+			category: 'consent_required',
+			title: 'Academic affiliation bundle requires consent version upgrade',
+			source: 'Destination Profile / SAML assertion',
+			impact: 'Attribute release challenge is required before release to the selected SP.',
+			severity: 'high',
+			status: 'needs_approval'
+		},
+		{
+			id: 'res-003',
+			category: 'linking_decisions',
+			title: 'OIDC iss + sub candidate cannot hard-match existing SAML NameID',
+			source: 'Identity bridge preview',
+			impact: 'Login remains fail-closed unless step-up or admin approval links the candidate.',
+			severity: 'high',
+			status: 'blocked'
+		}
+	];
+
+	let activeCategory = $state<ResolutionCategory>('missing_mappings');
+	let reviewTasks = $state<IdentityMappingReviewTask[]>([]);
+	let isLoading = $state(true);
+	let loadError = $state<string | null>(null);
+	let busyItemId = $state<string | null>(null);
+	let actionState = $state<Record<string, string>>({});
+
+	onMount(() => {
+		void loadReviewTasks();
+	});
+
+	async function loadReviewTasks() {
+		isLoading = true;
+		loadError = null;
+		try {
+			const result = await adminIdentityMappingAPI.listReviewTasks({ status: 'open', limit: 100 });
+			reviewTasks = result.reviewTasks;
+		} catch (error) {
+			loadError = error instanceof Error ? error.message : 'Failed to load review tasks';
+		} finally {
+			isLoading = false;
+		}
+	}
+
+	async function transitionResolutionItem(item: ResolutionItem, status: 'resolved' | 'dismissed') {
+		if (loadError) {
+			actionState = { ...actionState, [item.id]: 'Preview item cannot be changed' };
+			return;
+		}
+		busyItemId = item.id;
+		actionState = {
+			...actionState,
+			[item.id]: status === 'resolved' ? 'Resolving item' : 'Dismissing item'
+		};
+		try {
+			await adminIdentityMappingAPI.transitionReviewTask(item.id, {
+				status,
+				reasonCodes: [status === 'resolved' ? 'operator_resolved' : 'operator_dismissed']
+			});
+			actionState = {
+				...actionState,
+				[item.id]: status === 'resolved' ? 'Resolved' : 'Dismissed'
+			};
+			await loadReviewTasks();
+		} catch (error) {
+			actionState = {
+				...actionState,
+				[item.id]: error instanceof Error ? error.message : 'Action failed'
+			};
+		} finally {
+			busyItemId = null;
+		}
+	}
+
+	const resolutionItems = $derived(loadError ? fallbackItems : reviewTasks.map(reviewTaskToItem));
+	const visibleItems = $derived(resolutionItems.filter((item) => item.category === activeCategory));
+	const categoryCounts = $derived(
+		Object.fromEntries(
+			categories.map((category) => [
+				category.id,
+				resolutionItems.filter((item) => item.category === category.id).length
+			])
+		) as Record<ResolutionCategory, number>
+	);
+
+	function reviewTaskToItem(task: IdentityMappingReviewTask): ResolutionItem {
+		return {
+			id: task.id,
+			category: taskTypeToCategory(task.taskType),
+			title: getPayloadString(task.payload, 'title') ?? humanizeTaskType(task.taskType),
+			source: getPayloadString(task.payload, 'source') ?? task.taskType,
+			impact:
+				getPayloadString(task.payload, 'riskSummary') ??
+				getPayloadString(task.payload, 'impact') ??
+				'Review required before this mapping decision can be closed safely.',
+			severity: priorityToSeverity(task.priority),
+			status: statusToResolutionStatus(task.status)
+		};
+	}
+
+	function taskTypeToCategory(taskType: string): ResolutionCategory {
+		const normalized = taskType.toLowerCase();
+		if (normalized.includes('conflict')) return 'conflicts';
+		if (normalized.includes('consent') || normalized.includes('release')) return 'consent_required';
+		if (normalized.includes('link') || normalized.includes('identity')) return 'linking_decisions';
+		if (normalized.includes('lifecycle') || normalized.includes('provision')) return 'lifecycle_actions';
+		if (normalized.includes('activation') || normalized.includes('compile')) return 'activation_blockers';
+		return 'missing_mappings';
+	}
+
+	function priorityToSeverity(priority: number): ResolutionItem['severity'] {
+		if (priority >= 20) return 'high';
+		if (priority >= 10) return 'medium';
+		return 'low';
+	}
+
+	function statusToResolutionStatus(status: string): ResolutionItem['status'] {
+		if (status === 'in_review') return 'needs_approval';
+		if (status === 'open') return 'open';
+		return 'blocked';
+	}
+
+	function getPayloadString(payload: Record<string, unknown>, key: string): string | null {
+		const value = payload[key];
+		return typeof value === 'string' && value.trim().length > 0 ? value : null;
+	}
+
+	function humanizeTaskType(taskType: string): string {
+		return taskType
+			.split('_')
+			.filter(Boolean)
+			.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+			.join(' ');
+	}
+</script>
+
+<svelte:head>
+	<title>Mapping Resolution Center - Authrim Admin</title>
+</svelte:head>
+
+<div class="resolution-page">
+	<div class="page-heading">
+		<div>
+			<a class="back-link" href="/admin/identity-mapping">Back to Identity Mapping</a>
+			<p class="eyebrow">Identity Mapping</p>
+			<h1>Mapping Resolution Center</h1>
+			<p class="summary">
+				Resolve conflicts, missing mappings, linking decisions, consent blockers, protected
+				lifecycle actions, and activation blockers that automatic mapping cannot close safely.
+			</p>
+		</div>
+		<div class="status-panel">
+			<strong>{loadError ? 'Preview fallback' : 'Review task feed'}</strong>
+			<span>
+				{#if isLoading}
+					Loading unresolved mapping decisions.
+				{:else if loadError}
+					{loadError}. Showing safe preview examples.
+				{:else}
+					{reviewTasks.length} unresolved item{reviewTasks.length === 1 ? '' : 's'} loaded from the
+					resolution feed.
+				{/if}
+			</span>
+		</div>
+	</div>
+
+	<div class="resolution-layout">
+		<nav class="category-list" aria-label="Resolution categories">
+			{#each categories as category (category.id)}
+				<button
+					type="button"
+					class:active={activeCategory === category.id}
+					onclick={() => (activeCategory = category.id)}
+				>
+					<span>{category.label}</span>
+					<strong>{categoryCounts[category.id]}</strong>
+				</button>
+			{/each}
+		</nav>
+
+		<section class="resolution-panel" aria-live="polite">
+			<div class="panel-heading">
+				<div>
+					<p class="eyebrow">
+						{categories.find((category) => category.id === activeCategory)?.label}
+					</p>
+					<h2>{categories.find((category) => category.id === activeCategory)?.description}</h2>
+				</div>
+			</div>
+
+			{#if isLoading}
+				<div class="empty-state">
+					<strong>Loading items</strong>
+					<span>Fetching unresolved conflicts, missing mappings, and approval blockers.</span>
+				</div>
+			{:else if visibleItems.length === 0}
+				<div class="empty-state">
+					<strong>No unresolved items</strong>
+					<span>This category has no open resolution items.</span>
+				</div>
+			{:else}
+				<div class="item-list">
+					{#each visibleItems as item (item.id)}
+						<article class="resolution-item severity-{item.severity}">
+							<div>
+								<p>{item.source}</p>
+								<h3>{item.title}</h3>
+								<span>{item.impact}</span>
+							</div>
+							<div class="item-meta">
+								<strong>{item.severity}</strong>
+								<span>{item.status.replace('_', ' ')}</span>
+								<div class="item-actions">
+									<button
+										type="button"
+										onclick={() => transitionResolutionItem(item, 'resolved')}
+										disabled={busyItemId === item.id}
+									>
+										Resolve
+									</button>
+									<button
+										type="button"
+										onclick={() => transitionResolutionItem(item, 'dismissed')}
+										disabled={busyItemId === item.id}
+									>
+										Dismiss
+									</button>
+								</div>
+								{#if actionState[item.id]}
+									<span class="action-state">{actionState[item.id]}</span>
+								{/if}
+							</div>
+						</article>
+					{/each}
+				</div>
+			{/if}
+		</section>
+	</div>
+</div>
+
+<style>
+	.resolution-page {
+		display: grid;
+		gap: 18px;
+	}
+
+	.page-heading,
+	.panel-heading,
+	.resolution-item {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 18px;
+	}
+
+	.back-link {
+		display: inline-flex;
+		margin-bottom: 12px;
+		color: var(--color-primary);
+		font-size: 13px;
+		font-weight: 700;
+		text-decoration: none;
+	}
+
+	.eyebrow {
+		margin: 0 0 4px;
+		color: var(--text-muted);
+		font-size: 12px;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	h1,
+	h2,
+	h3,
+	p {
+		margin: 0;
+	}
+
+	h1 {
+		color: var(--text-primary);
+		font-size: 28px;
+		line-height: 1.2;
+	}
+
+	h2 {
+		max-width: 760px;
+		color: var(--text-primary);
+		font-size: 17px;
+		line-height: 1.35;
+	}
+
+	h3 {
+		color: var(--text-primary);
+		font-size: 16px;
+		line-height: 1.35;
+	}
+
+	.summary {
+		max-width: 760px;
+		margin-top: 8px;
+		color: var(--text-secondary);
+		font-size: 14px;
+		line-height: 1.5;
+	}
+
+	.status-panel,
+	.category-list,
+	.resolution-panel,
+	.empty-state,
+	.resolution-item {
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		background: var(--bg-card);
+	}
+
+	.status-panel {
+		min-width: 280px;
+		display: grid;
+		gap: 4px;
+		padding: 12px;
+	}
+
+	.status-panel strong,
+	.empty-state strong {
+		color: var(--text-primary);
+		font-size: 13px;
+	}
+
+	.status-panel span,
+	.empty-state span,
+	.resolution-item span {
+		color: var(--text-secondary);
+		font-size: 13px;
+		line-height: 1.45;
+	}
+
+	.resolution-layout {
+		display: grid;
+		grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+		gap: 14px;
+	}
+
+	.category-list {
+		display: grid;
+		align-content: start;
+		overflow: hidden;
+	}
+
+	.category-list button {
+		min-height: 48px;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 10px;
+		padding: 12px;
+		border: 0;
+		border-bottom: 1px solid var(--border-color);
+		color: var(--text-secondary);
+		background: transparent;
+		font-weight: 700;
+		text-align: left;
+	}
+
+	.category-list button:last-child {
+		border-bottom: 0;
+	}
+
+	.category-list button.active {
+		color: var(--text-primary);
+		background: var(--bg-hover);
+	}
+
+	.category-list strong,
+	.item-meta strong {
+		padding: 3px 8px;
+		border-radius: 999px;
+		background: var(--bg-muted);
+		font-size: 12px;
+	}
+
+	.resolution-panel {
+		min-height: 420px;
+		padding: 16px;
+	}
+
+	.empty-state {
+		display: grid;
+		gap: 4px;
+		margin-top: 16px;
+		padding: 18px;
+	}
+
+	.item-list {
+		display: grid;
+		gap: 10px;
+		margin-top: 16px;
+	}
+
+	.resolution-item {
+		padding: 14px;
+		border-left-width: 4px;
+	}
+
+	.resolution-item p {
+		margin-bottom: 4px;
+		color: var(--text-muted);
+		font-size: 12px;
+		font-weight: 700;
+		text-transform: uppercase;
+	}
+
+	.item-meta {
+		min-width: 128px;
+		display: grid;
+		justify-items: end;
+		gap: 6px;
+	}
+
+	.item-meta span {
+		text-transform: capitalize;
+	}
+
+	.item-actions {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: flex-end;
+		gap: 6px;
+	}
+
+	.item-actions button {
+		min-height: 32px;
+		padding: 0 10px;
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		color: var(--text-primary);
+		background: var(--bg-card);
+		font-size: 12px;
+		font-weight: 800;
+	}
+
+	.item-actions button:disabled {
+		cursor: not-allowed;
+		opacity: 0.55;
+	}
+
+	.action-state {
+		max-width: 180px;
+		text-align: right;
+		text-transform: none;
+	}
+
+	.severity-low {
+		border-left-color: #22c55e;
+	}
+
+	.severity-medium {
+		border-left-color: #f59e0b;
+	}
+
+	.severity-high {
+		border-left-color: #ef4444;
+	}
+
+	@media (max-width: 900px) {
+		.page-heading,
+		.resolution-layout,
+		.resolution-item {
+			display: grid;
+		}
+
+		.status-panel {
+			min-width: 0;
+		}
+
+		.item-meta {
+			justify-items: start;
+		}
+
+		.item-actions {
+			justify-content: flex-start;
+		}
+
+		.action-state {
+			text-align: left;
+		}
+	}
+</style>

--- a/packages/ar-admin-ui/src/routes/admin/identity-mapping/schema-readiness/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/identity-mapping/schema-readiness/+page.svelte
@@ -1,80 +1,47 @@
 <script lang="ts">
-	type ReadinessStatus =
-		| 'closed'
-		| 'tested'
-		| 'ui_connected'
-		| 'api_connected'
-		| 'deferred'
-		| 'blocked';
+	import { onMount } from 'svelte';
+	import {
+		adminIdentityMappingAPI,
+		type IdentityMappingSchemaReadinessRow,
+		type IdentityMappingSchemaReadinessSummary
+	} from '$lib/api/admin-identity-mapping';
 
-	interface ReadinessRow {
-		id: string;
-		area: string;
-		status: ReadinessStatus;
-		connection: string;
-		gate: string;
+	type GateFilter = IdentityMappingSchemaReadinessRow['gateState'] | 'all';
+
+	let rows = $state<IdentityMappingSchemaReadinessRow[]>([]);
+	let summary = $state<IdentityMappingSchemaReadinessSummary>({
+		total: 0,
+		pass: 0,
+		attention: 0,
+		blocked: 0,
+		deferred: 0
+	});
+	let activeStatus = $state<GateFilter>('all');
+	let loading = $state(true);
+	let errorMessage = $state<string | null>(null);
+
+	onMount(() => {
+		void loadSchemaReadiness();
+	});
+
+	async function loadSchemaReadiness() {
+		loading = true;
+		errorMessage = null;
+		try {
+			const result = await adminIdentityMappingAPI.getSchemaReadiness();
+			rows = result.rows;
+			summary = result.summary;
+		} catch (error) {
+			errorMessage = error instanceof Error ? error.message : 'Failed to load schema readiness';
+		} finally {
+			loading = false;
+		}
 	}
 
-	const rows: ReadinessRow[] = [
-		{
-			id: 'UIM-SCH-001',
-			area: 'Canonical identity subjects',
-			status: 'closed',
-			connection: 'Tier 1 canonical repository',
-			gate: 'Runtime readers use canonical storage'
-		},
-		{
-			id: 'UIM-SCH-024',
-			area: 'Mapping policy activations',
-			status: 'api_connected',
-			connection: 'PR12 operations view',
-			gate: 'Activation, rollback, and degraded status visible'
-		},
-		{
-			id: 'UIM-SCH-047',
-			area: 'Activation leases',
-			status: 'tested',
-			connection: 'Policy activation API',
-			gate: 'Concurrent activation has negative coverage'
-		},
-		{
-			id: 'UIM-SCH-068',
-			area: 'Lifecycle signal ledger',
-			status: 'tested',
-			connection: 'Implemented lifecycle signals',
-			gate: 'SSF/CAEP/RISC adapters remain deferred'
-		},
-		{
-			id: 'UIM-SCH-072',
-			area: 'Federation trust anchors',
-			status: 'api_connected',
-			connection: 'Federation Trust view',
-			gate: 'SAML trust sources and anchors are inspectable'
-		},
-		{
-			id: 'UIM-SCH-073',
-			area: 'Federation metadata documents',
-			status: 'ui_connected',
-			connection: 'Federation Trust metadata ledger',
-			gate: 'Documents and entity summaries are visible from the trust source detail'
-		},
-		{
-			id: 'UIM-SCH-086',
-			area: 'SSF/CAEP/RISC adapter',
-			status: 'deferred',
-			connection: 'adapter_deferred',
-			gate: 'No runtime endpoint exposure until resume criteria are met'
-		}
-	];
-
-	let activeStatus = $state<ReadinessStatus | 'all'>('all');
-
 	const visibleRows = $derived(
-		activeStatus === 'all' ? rows : rows.filter((row) => row.status === activeStatus)
+		activeStatus === 'all' ? rows : rows.filter((row) => row.gateState === activeStatus)
 	);
-	const blockedCount = $derived(rows.filter((row) => row.status === 'blocked').length);
-	const deferredCount = $derived(rows.filter((row) => row.status === 'deferred').length);
-	const statuses = $derived(['all', ...new Set(rows.map((row) => row.status))] as const);
+	const statuses = $derived(['all', ...new Set(rows.map((row) => row.gateState))] as const);
 </script>
 
 <svelte:head>
@@ -95,11 +62,19 @@
 		<div class="status-panel">
 			<div>
 				<span>Blocked</span>
-				<strong>{blockedCount}</strong>
+				<strong>{summary.blocked}</strong>
 			</div>
 			<div>
 				<span>Deferred</span>
-				<strong>{deferredCount}</strong>
+				<strong>{summary.deferred}</strong>
+			</div>
+			<div>
+				<span>Attention</span>
+				<strong>{summary.attention}</strong>
+			</div>
+			<div>
+				<span>Total</span>
+				<strong>{summary.total}</strong>
 			</div>
 		</div>
 	</div>
@@ -115,32 +90,52 @@
 					{status.replace('_', ' ')}
 				</button>
 			{/each}
+			<button type="button" onclick={loadSchemaReadiness} disabled={loading}>Refresh</button>
 		</div>
 
-		<div class="table-shell">
-			<table>
-				<thead>
-					<tr>
-						<th>Inventory ID</th>
-						<th>Area</th>
-						<th>Status</th>
-						<th>Connection</th>
-						<th>Gate</th>
-					</tr>
-				</thead>
-				<tbody>
-					{#each visibleRows as row (row.id)}
+		{#if loading}
+			<div class="empty-state">Loading schema-readiness inventory from the control plane.</div>
+		{:else if errorMessage}
+			<div class="empty-state">{errorMessage}</div>
+		{:else}
+			<div class="table-shell">
+				<table>
+					<thead>
 						<tr>
-							<td><strong>{row.id}</strong></td>
-							<td>{row.area}</td>
-							<td><span class="status status-{row.status}">{row.status}</span></td>
-							<td>{row.connection}</td>
-							<td>{row.gate}</td>
+							<th>Inventory ID</th>
+							<th>Area</th>
+							<th>Status</th>
+							<th>Gate State</th>
+							<th>Schema Object</th>
+							<th>Connection</th>
+							<th>Gate</th>
 						</tr>
-					{/each}
-				</tbody>
-			</table>
-		</div>
+					</thead>
+					<tbody>
+						{#each visibleRows as row (row.id)}
+							<tr>
+								<td><strong>{row.id}</strong></td>
+								<td>{row.area}</td>
+								<td><span class="status status-{row.status}">{row.status}</span></td>
+								<td>
+									<span class="status status-{row.gateState}">{row.gateState}</span>
+								</td>
+								<td>
+									{#if row.schemaObject}
+										<code>{row.schemaObject}</code>
+										<small>{row.schemaPresent ? 'present' : 'missing'}</small>
+									{:else}
+										<span class="muted">service / adapter</span>
+									{/if}
+								</td>
+								<td>{row.expectedConnectionPr}</td>
+								<td>{row.gate}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{/if}
 	</section>
 </div>
 
@@ -229,6 +224,13 @@
 		padding: 16px;
 	}
 
+	.empty-state {
+		padding: 18px;
+		border: 1px dashed var(--border-color);
+		border-radius: 8px;
+		color: var(--text-secondary);
+	}
+
 	.filter-bar {
 		display: flex;
 		flex-wrap: wrap;
@@ -277,6 +279,22 @@
 		color: var(--text-primary);
 	}
 
+	td small {
+		display: block;
+		margin-top: 4px;
+		color: var(--text-muted);
+		font-size: 12px;
+	}
+
+	code {
+		color: var(--text-primary);
+		font-size: 12px;
+	}
+
+	.muted {
+		color: var(--text-muted);
+	}
+
 	.status {
 		display: inline-flex;
 		padding: 4px 8px;
@@ -288,15 +306,27 @@
 
 	.status-closed,
 	.status-tested,
-	.status-ui_connected,
-	.status-api_connected {
+	.status-api_connected,
+	.status-repo_connected,
+	.status-service_connected,
+	.status-pass {
 		color: #047857;
 		background: rgba(16, 185, 129, 0.14);
 	}
 
-	.status-deferred {
+	.status-deferred,
+	.status-reserved_planned,
+	.status-adapter_deferred {
 		color: #92400e;
 		background: rgba(245, 158, 11, 0.16);
+	}
+
+	.status-attention,
+	.status-schema_added,
+	.status-existing_to_migrate,
+	.status-breaking_planned {
+		color: #9a3412;
+		background: rgba(249, 115, 22, 0.16);
 	}
 
 	.status-blocked {

--- a/packages/ar-admin-ui/src/routes/admin/identity-mapping/schema-readiness/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/identity-mapping/schema-readiness/+page.svelte
@@ -1,0 +1,317 @@
+<script lang="ts">
+	type ReadinessStatus =
+		| 'closed'
+		| 'tested'
+		| 'ui_connected'
+		| 'api_connected'
+		| 'deferred'
+		| 'blocked';
+
+	interface ReadinessRow {
+		id: string;
+		area: string;
+		status: ReadinessStatus;
+		connection: string;
+		gate: string;
+	}
+
+	const rows: ReadinessRow[] = [
+		{
+			id: 'UIM-SCH-001',
+			area: 'Canonical identity subjects',
+			status: 'closed',
+			connection: 'Tier 1 canonical repository',
+			gate: 'Runtime readers use canonical storage'
+		},
+		{
+			id: 'UIM-SCH-024',
+			area: 'Mapping policy activations',
+			status: 'api_connected',
+			connection: 'PR12 operations view',
+			gate: 'Activation, rollback, and degraded status visible'
+		},
+		{
+			id: 'UIM-SCH-047',
+			area: 'Activation leases',
+			status: 'tested',
+			connection: 'Policy activation API',
+			gate: 'Concurrent activation has negative coverage'
+		},
+		{
+			id: 'UIM-SCH-068',
+			area: 'Lifecycle signal ledger',
+			status: 'tested',
+			connection: 'Implemented lifecycle signals',
+			gate: 'SSF/CAEP/RISC adapters remain deferred'
+		},
+		{
+			id: 'UIM-SCH-072',
+			area: 'Federation trust anchors',
+			status: 'api_connected',
+			connection: 'Federation Trust view',
+			gate: 'SAML trust sources and anchors are inspectable'
+		},
+		{
+			id: 'UIM-SCH-073',
+			area: 'Federation metadata documents',
+			status: 'ui_connected',
+			connection: 'Federation Trust metadata ledger',
+			gate: 'Documents and entity summaries are visible from the trust source detail'
+		},
+		{
+			id: 'UIM-SCH-086',
+			area: 'SSF/CAEP/RISC adapter',
+			status: 'deferred',
+			connection: 'adapter_deferred',
+			gate: 'No runtime endpoint exposure until resume criteria are met'
+		}
+	];
+
+	let activeStatus = $state<ReadinessStatus | 'all'>('all');
+
+	const visibleRows = $derived(
+		activeStatus === 'all' ? rows : rows.filter((row) => row.status === activeStatus)
+	);
+	const blockedCount = $derived(rows.filter((row) => row.status === 'blocked').length);
+	const deferredCount = $derived(rows.filter((row) => row.status === 'deferred').length);
+	const statuses = $derived(['all', ...new Set(rows.map((row) => row.status))] as const);
+</script>
+
+<svelte:head>
+	<title>Schema Readiness - Authrim Admin</title>
+</svelte:head>
+
+<div class="readiness-page">
+	<div class="page-heading">
+		<div>
+			<a class="back-link" href="/admin/identity-mapping">Back to Identity Mapping</a>
+			<p class="eyebrow">Identity Mapping</p>
+			<h1>Schema Readiness</h1>
+			<p class="summary">
+				Check inventory IDs, expected connection points, and gate notes before activating Tier 2
+				mapping policies.
+			</p>
+		</div>
+		<div class="status-panel">
+			<div>
+				<span>Blocked</span>
+				<strong>{blockedCount}</strong>
+			</div>
+			<div>
+				<span>Deferred</span>
+				<strong>{deferredCount}</strong>
+			</div>
+		</div>
+	</div>
+
+	<section class="readiness-panel">
+		<div class="filter-bar" aria-label="Schema readiness filters">
+			{#each statuses as status (status)}
+				<button
+					type="button"
+					class:active={activeStatus === status}
+					onclick={() => (activeStatus = status)}
+				>
+					{status.replace('_', ' ')}
+				</button>
+			{/each}
+		</div>
+
+		<div class="table-shell">
+			<table>
+				<thead>
+					<tr>
+						<th>Inventory ID</th>
+						<th>Area</th>
+						<th>Status</th>
+						<th>Connection</th>
+						<th>Gate</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each visibleRows as row (row.id)}
+						<tr>
+							<td><strong>{row.id}</strong></td>
+							<td>{row.area}</td>
+							<td><span class="status status-{row.status}">{row.status}</span></td>
+							<td>{row.connection}</td>
+							<td>{row.gate}</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	</section>
+</div>
+
+<style>
+	.readiness-page {
+		display: grid;
+		gap: 18px;
+	}
+
+	.page-heading {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 18px;
+	}
+
+	.back-link {
+		display: inline-flex;
+		margin-bottom: 12px;
+		color: var(--color-primary);
+		font-size: 13px;
+		font-weight: 700;
+		text-decoration: none;
+	}
+
+	.eyebrow,
+	.status-panel span,
+	th {
+		margin: 0;
+		color: var(--text-muted);
+		font-size: 12px;
+		font-weight: 800;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+	}
+
+	h1,
+	p {
+		margin: 0;
+	}
+
+	h1 {
+		color: var(--text-primary);
+		font-size: 28px;
+	}
+
+	.summary,
+	td {
+		color: var(--text-secondary);
+		font-size: 13px;
+		line-height: 1.45;
+	}
+
+	.summary {
+		max-width: 760px;
+		margin-top: 8px;
+		font-size: 14px;
+	}
+
+	.status-panel,
+	.readiness-panel,
+	.table-shell {
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		background: var(--bg-card);
+	}
+
+	.status-panel {
+		min-width: 260px;
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 12px;
+		padding: 14px;
+	}
+
+	.status-panel strong {
+		display: block;
+		margin-top: 4px;
+		color: var(--text-primary);
+		font-size: 22px;
+	}
+
+	.readiness-panel {
+		display: grid;
+		gap: 14px;
+		padding: 16px;
+	}
+
+	.filter-bar {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+	}
+
+	button {
+		min-height: 34px;
+		padding: 0 12px;
+		border: 1px solid var(--border-color);
+		border-radius: 8px;
+		color: var(--text-secondary);
+		background: var(--bg-card);
+		font-weight: 800;
+		text-transform: capitalize;
+	}
+
+	button.active {
+		color: var(--text-primary);
+		border-color: var(--color-primary);
+		background: var(--bg-hover);
+	}
+
+	.table-shell {
+		overflow: auto;
+	}
+
+	table {
+		width: 100%;
+		border-collapse: collapse;
+	}
+
+	th,
+	td {
+		padding: 12px;
+		border-bottom: 1px solid var(--border-color);
+		text-align: left;
+		vertical-align: top;
+	}
+
+	tr:last-child td {
+		border-bottom: 0;
+	}
+
+	td strong {
+		color: var(--text-primary);
+	}
+
+	.status {
+		display: inline-flex;
+		padding: 4px 8px;
+		border-radius: 999px;
+		background: var(--bg-muted);
+		color: var(--text-primary);
+		font-weight: 800;
+	}
+
+	.status-closed,
+	.status-tested,
+	.status-ui_connected,
+	.status-api_connected {
+		color: #047857;
+		background: rgba(16, 185, 129, 0.14);
+	}
+
+	.status-deferred {
+		color: #92400e;
+		background: rgba(245, 158, 11, 0.16);
+	}
+
+	.status-blocked {
+		color: #b91c1c;
+		background: rgba(239, 68, 68, 0.14);
+	}
+
+	@media (max-width: 900px) {
+		.page-heading,
+		.status-panel {
+			display: grid;
+		}
+
+		.status-panel {
+			min-width: 0;
+		}
+	}
+</style>

--- a/packages/ar-management/src/__tests__/identity-mapping-control-plane.test.ts
+++ b/packages/ar-management/src/__tests__/identity-mapping-control-plane.test.ts
@@ -13,6 +13,7 @@ import {
   adminIdentityMappingPolicyCreateHandler,
   adminIdentityMappingFederationMetadataDocumentsListHandler,
   adminIdentityMappingReviewTasksListHandler,
+  adminIdentityMappingSchemaReadinessHandler,
   IdentityMappingControlPlaneRepository,
 } from '../identity-mapping-control-plane';
 
@@ -1809,6 +1810,68 @@ describe('identity mapping control plane Admin API handlers', () => {
       ],
     });
     expect(adapter.queries[0].params).toEqual(['tenant_a', 'open', 5]);
+  });
+
+  it('lists schema readiness with gate state and schema presence from sqlite metadata', async () => {
+    const adapter = createAdapter({
+      queryRows: [
+        { name: 'mapping_policy_sets' },
+        { name: 'mapping_policy_versions' },
+        { name: 'mapping_rule_edges' },
+        { name: 'review_tasks' },
+        { name: 'attribute_release_consents' },
+      ],
+    });
+    const app = new Hono<{ Bindings: Env }>();
+    app.use('*', async (c, next) => {
+      (c as unknown as { set(key: string, value: string): void }).set('tenantId', 'tenant_a');
+      await next();
+    });
+    app.get(
+      '/api/admin/identity-mapping/schema-readiness',
+      adminIdentityMappingSchemaReadinessHandler
+    );
+
+    const response = await app.request(
+      '/api/admin/identity-mapping/schema-readiness',
+      { headers: { 'X-Tenant-Id': 'tenant_a' } },
+      { DB_ADMIN: adapter } as unknown as Env
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      rows: Array<{
+        id: string;
+        schemaObject?: string;
+        schemaPresent: boolean | null;
+        gateState: string;
+      }>;
+      summary: { blocked: number; deferred: number; total: number };
+    };
+    expect(body.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'UIM-SCH-016',
+          schemaObject: 'mapping_policy_sets',
+          schemaPresent: true,
+          gateState: 'pass',
+        }),
+        expect.objectContaining({
+          id: 'UIM-SCH-071',
+          schemaObject: 'federation_trust_sources',
+          schemaPresent: false,
+          gateState: 'blocked',
+        }),
+        expect.objectContaining({
+          id: 'UIM-SCH-086',
+          schemaPresent: null,
+          gateState: 'deferred',
+        }),
+      ])
+    );
+    expect(body.summary.total).toBeGreaterThan(10);
+    expect(body.summary.blocked).toBeGreaterThan(0);
+    expect(body.summary.deferred).toBeGreaterThan(0);
   });
 
   it('lists federation metadata documents through the Admin API response shape', async () => {

--- a/packages/ar-management/src/__tests__/identity-mapping-control-plane.test.ts
+++ b/packages/ar-management/src/__tests__/identity-mapping-control-plane.test.ts
@@ -11,6 +11,8 @@ import {
   adminIdentityMappingProtocolSchemasListHandler,
   adminIdentityMappingPoliciesListHandler,
   adminIdentityMappingPolicyCreateHandler,
+  adminIdentityMappingFederationMetadataDocumentsListHandler,
+  adminIdentityMappingReviewTasksListHandler,
   IdentityMappingControlPlaneRepository,
 } from '../identity-mapping-control-plane';
 
@@ -19,17 +21,25 @@ interface RecordedExecute {
   params: unknown[];
 }
 
+interface RecordedQuery {
+  sql: string;
+  params: unknown[];
+}
+
 function createAdapter(options: {
   queryRows?: Record<string, unknown>[];
   queryOneRows?: Array<Record<string, unknown> | null>;
-}): DatabaseAdapter & { executes: RecordedExecute[] } {
+}): DatabaseAdapter & { executes: RecordedExecute[]; queries: RecordedQuery[] } {
   const executes: RecordedExecute[] = [];
+  const queries: RecordedQuery[] = [];
   const queryRows = [...(options.queryRows ?? [])];
   const queryOneRows = [...(options.queryOneRows ?? [])];
   const executeResult: ExecuteResult = { rowsAffected: 1, success: true };
   return {
     executes,
-    async query<T>(): Promise<T[]> {
+    queries,
+    async query<T>(sql: string, params: unknown[] = []): Promise<T[]> {
+      queries.push({ sql, params });
       return queryRows as T[];
     },
     async queryOne<T>(): Promise<T | null> {
@@ -458,6 +468,84 @@ describe('IdentityMappingControlPlaneRepository review and notification operatio
       expect.stringContaining('UPDATE review_tasks'),
       expect.stringContaining('INSERT INTO mapping_events'),
     ]);
+  });
+
+  it('lists review tasks with safe filters for the resolution center', async () => {
+    const adapter = createAdapter({
+      queryRows: [
+        {
+          id: 'review-task-1',
+          tenant_id: 'tenant_a',
+          task_type: 'mapping_conflict',
+          subject_id: 'subject-1',
+          account_id: null,
+          status: 'open',
+          priority: 30,
+          assigned_to: 'admin-1',
+          payload_json: JSON.stringify({
+            title: 'Department conflict needs review',
+            source: 'SCIM Directory',
+            riskSummary: 'Two trusted sources disagree on a non-PII department label.',
+          }),
+          due_at: null,
+          created_at: 1000,
+          updated_at: 1000,
+        },
+      ],
+    });
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    const tasks = await repository.listReviewTasks('tenant_a', {
+      status: 'open',
+      taskType: 'mapping_conflict',
+      assignedTo: 'admin-1',
+      limit: 500,
+    });
+
+    expect(tasks).toEqual([
+      expect.objectContaining({
+        id: 'review-task-1',
+        tenantId: 'tenant_a',
+        taskType: 'mapping_conflict',
+        status: 'open',
+        priority: 30,
+        assignedTo: 'admin-1',
+        payload: expect.objectContaining({
+          title: 'Department conflict needs review',
+        }),
+      }),
+    ]);
+    expect(adapter.queries[0]).toEqual({
+      sql: expect.stringContaining('FROM review_tasks'),
+      params: ['tenant_a', 'open', 'mapping_conflict', 'admin-1', 200],
+    });
+  });
+
+  it('fails closed when stored review task payload contains raw identifiers', async () => {
+    const adapter = createAdapter({
+      queryRows: [
+        {
+          id: 'review-task-raw',
+          tenant_id: 'tenant_a',
+          task_type: 'identity_link_review',
+          subject_id: null,
+          account_id: null,
+          status: 'open',
+          priority: 10,
+          assigned_to: null,
+          payload_json: JSON.stringify({ email: 'person@example.test' }),
+          due_at: null,
+          created_at: 1000,
+          updated_at: 1000,
+        },
+      ],
+    });
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    await expect(repository.listReviewTasks('tenant_a')).rejects.toMatchObject({
+      status: 400,
+      code: 'invalid_request',
+    });
   });
 
   it('groups bulk review impact without storing raw values', async () => {
@@ -1323,6 +1411,87 @@ describe('IdentityMappingControlPlaneRepository federation trust and key lifecyc
     expect(String(adapter.executes[2].params[6])).toContain('requestedAttributes');
   });
 
+  it('lists federation metadata documents with normalized entity summaries', async () => {
+    const adapter = createAdapter({
+      queryOneRows: [{ id: 'trust-source-1' }],
+      queryRows: [
+        {
+          id: 'metadata-document-1',
+          trust_source_id: 'trust-source-1',
+          document_type: 'saml_aggregate',
+          source_url: 'https://metadata.example.test/aggregate.xml',
+          document_hash: 'sha256:metadata',
+          document_ref: 'r2://metadata/aggregate.xml',
+          fetched_at: 1000,
+          validated_at: 1100,
+          validation_state: 'valid',
+          created_at: 1000,
+          updated_at: 1100,
+          entity_summary_id: 'entity-summary-1',
+          entity_id: 'https://sp.example.test/sp',
+          entity_role: 'sp',
+          display_name: 'Example SP',
+          summary_json: JSON.stringify({ requestedAttributes: ['mail'] }),
+        },
+        {
+          id: 'metadata-document-1',
+          trust_source_id: 'trust-source-1',
+          document_type: 'saml_aggregate',
+          source_url: 'https://metadata.example.test/aggregate.xml',
+          document_hash: 'sha256:metadata',
+          document_ref: 'r2://metadata/aggregate.xml',
+          fetched_at: 1000,
+          validated_at: 1100,
+          validation_state: 'valid',
+          created_at: 1000,
+          updated_at: 1100,
+          entity_summary_id: 'entity-summary-2',
+          entity_id: 'https://idp.example.test/idp',
+          entity_role: 'idp',
+          display_name: 'Example IdP',
+          summary_json: null,
+        },
+      ],
+    });
+    const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
+
+    await expect(
+      repository.listFederationMetadataDocuments('tenant_a', 'trust-source-1')
+    ).resolves.toEqual([
+      {
+        id: 'metadata-document-1',
+        tenantId: 'tenant_a',
+        trustSourceId: 'trust-source-1',
+        documentType: 'saml_aggregate',
+        sourceUrl: 'https://metadata.example.test/aggregate.xml',
+        documentHash: 'sha256:metadata',
+        documentRef: 'r2://metadata/aggregate.xml',
+        fetchedAt: 1000,
+        validatedAt: 1100,
+        validationState: 'valid',
+        createdAt: 1000,
+        updatedAt: 1100,
+        entitySummaries: [
+          {
+            id: 'entity-summary-1',
+            entityId: 'https://sp.example.test/sp',
+            entityRole: 'sp',
+            displayName: 'Example SP',
+            summary: { requestedAttributes: ['mail'] },
+          },
+          {
+            id: 'entity-summary-2',
+            entityId: 'https://idp.example.test/idp',
+            entityRole: 'idp',
+            displayName: 'Example IdP',
+            summary: null,
+          },
+        ],
+      },
+    ]);
+    expect(adapter.queries[0].sql).toContain('FROM federation_metadata_documents');
+  });
+
   it('rejects federation metadata documents for unknown trust sources', async () => {
     const adapter = createAdapter({ queryOneRows: [null] });
     const repository = new IdentityMappingControlPlaneRepository(adapter, () => 1000);
@@ -1575,6 +1744,129 @@ describe('identity mapping control plane Admin API handlers', () => {
           schemaVersion: '2.0',
           schema: { attributes: [{ name: 'userName' }] },
           lifecycleState: 'active',
+        },
+      ],
+    });
+  });
+
+  it('lists review tasks through the Admin API response shape', async () => {
+    const adapter = createAdapter({
+      queryRows: [
+        {
+          id: 'review-task-1',
+          tenant_id: 'tenant_a',
+          task_type: 'missing_mapping',
+          subject_id: null,
+          account_id: 'account-1',
+          status: 'open',
+          priority: 12,
+          assigned_to: null,
+          payload_json: JSON.stringify({
+            title: 'CSV department needs target',
+            source: 'CSV import profile',
+            impact: 'Activation remains blocked until the target field is selected.',
+          }),
+          due_at: null,
+          created_at: 1000,
+          updated_at: 1100,
+        },
+      ],
+    });
+    const app = new Hono<{ Bindings: Env }>();
+    app.use('*', async (c, next) => {
+      (c as unknown as { set(key: string, value: string): void }).set('tenantId', 'tenant_a');
+      await next();
+    });
+    app.get('/api/admin/identity-mapping/review-tasks', adminIdentityMappingReviewTasksListHandler);
+
+    const response = await app.request(
+      '/api/admin/identity-mapping/review-tasks?status=open&limit=5',
+      { headers: { 'X-Tenant-Id': 'tenant_a' } },
+      { DB_ADMIN: adapter } as unknown as Env
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      reviewTasks: [
+        {
+          id: 'review-task-1',
+          tenantId: 'tenant_a',
+          taskType: 'missing_mapping',
+          subjectId: null,
+          accountId: 'account-1',
+          status: 'open',
+          priority: 12,
+          assignedTo: null,
+          payload: {
+            title: 'CSV department needs target',
+            source: 'CSV import profile',
+            impact: 'Activation remains blocked until the target field is selected.',
+          },
+          dueAt: null,
+          createdAt: 1000,
+          updatedAt: 1100,
+        },
+      ],
+    });
+    expect(adapter.queries[0].params).toEqual(['tenant_a', 'open', 5]);
+  });
+
+  it('lists federation metadata documents through the Admin API response shape', async () => {
+    const adapter = createAdapter({
+      queryOneRows: [{ id: 'trust-source-1' }],
+      queryRows: [
+        {
+          id: 'metadata-document-1',
+          trust_source_id: 'trust-source-1',
+          document_type: 'saml_aggregate',
+          source_url: null,
+          document_hash: 'sha256:metadata',
+          document_ref: null,
+          fetched_at: 1000,
+          validated_at: 1100,
+          validation_state: 'valid',
+          created_at: 1000,
+          updated_at: 1100,
+          entity_summary_id: 'entity-summary-1',
+          entity_id: 'https://sp.example.test/sp',
+          entity_role: 'sp',
+          display_name: 'Example SP',
+          summary_json: '{}',
+        },
+      ],
+    });
+    const app = new Hono<{ Bindings: Env }>();
+    app.use('*', async (c, next) => {
+      (c as unknown as { set(key: string, value: string): void }).set('tenantId', 'tenant_a');
+      await next();
+    });
+    app.get(
+      '/api/admin/identity-mapping/federation-trust-sources/:trustSourceId/metadata-documents',
+      adminIdentityMappingFederationMetadataDocumentsListHandler
+    );
+
+    const response = await app.request(
+      '/api/admin/identity-mapping/federation-trust-sources/trust-source-1/metadata-documents',
+      {},
+      { DB_ADMIN: adapter } as unknown as Env
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      federationMetadataDocuments: [
+        {
+          id: 'metadata-document-1',
+          tenantId: 'tenant_a',
+          trustSourceId: 'trust-source-1',
+          validationState: 'valid',
+          entitySummaries: [
+            {
+              id: 'entity-summary-1',
+              entityId: 'https://sp.example.test/sp',
+              entityRole: 'sp',
+              displayName: 'Example SP',
+            },
+          ],
         },
       ],
     });

--- a/packages/ar-management/src/identity-mapping-control-plane.ts
+++ b/packages/ar-management/src/identity-mapping-control-plane.ts
@@ -315,6 +315,13 @@ interface CreateReviewTaskRequest {
   dueAt?: number;
 }
 
+interface ListReviewTasksOptions {
+  status?: string;
+  taskType?: string;
+  assignedTo?: string;
+  limit?: number;
+}
+
 interface TransitionReviewTaskRequest {
   status: string;
   assignedTo?: string | null;
@@ -477,6 +484,25 @@ interface MigrateSamlFederationTrustProfileRequest {
   profileId: string;
   sourceKey?: string;
   activate?: boolean;
+}
+
+interface FederationMetadataDocumentListRow {
+  id: string;
+  trust_source_id: string;
+  document_type: string;
+  source_url: string | null;
+  document_hash: string;
+  document_ref: string | null;
+  fetched_at: number | null;
+  validated_at: number | null;
+  validation_state: string;
+  created_at: number;
+  updated_at: number;
+  entity_summary_id: string | null;
+  entity_id: string | null;
+  entity_role: string | null;
+  display_name: string | null;
+  summary_json: string | null;
 }
 
 const REVIEW_TASK_STATUSES = new Set([
@@ -1551,6 +1577,69 @@ export class IdentityMappingControlPlaneRepository {
       priority: input.priority ?? 0,
       payload: input.payload,
     };
+  }
+
+  async listReviewTasks(tenantId: string, options: ListReviewTasksOptions = {}) {
+    const where = ['tenant_id = ?'];
+    const params: Array<string | number> = [tenantId];
+
+    if (options.status) {
+      if (!REVIEW_TASK_STATUSES.has(options.status)) {
+        throw badRequest('status is not supported for review task filters');
+      }
+      where.push('status = ?');
+      params.push(options.status);
+    }
+    if (options.taskType) {
+      where.push('task_type = ?');
+      params.push(options.taskType);
+    }
+    if (options.assignedTo) {
+      where.push('assigned_to = ?');
+      params.push(options.assignedTo);
+    }
+
+    const limit = clampListLimit(options.limit, 50, 200);
+    params.push(limit);
+
+    const rows = await this.adapter.query<{
+      id: string;
+      tenant_id: string;
+      task_type: string;
+      subject_id: string | null;
+      account_id: string | null;
+      status: string;
+      priority: number;
+      assigned_to: string | null;
+      payload_json: string;
+      due_at: number | null;
+      created_at: number;
+      updated_at: number;
+    }>(
+      `SELECT
+        id, tenant_id, task_type, subject_id, account_id, status, priority,
+        assigned_to, payload_json, due_at, created_at, updated_at
+      FROM review_tasks
+      WHERE ${where.join(' AND ')}
+      ORDER BY priority DESC, created_at ASC
+      LIMIT ?`,
+      params
+    );
+
+    return rows.map((row) => ({
+      id: row.id,
+      tenantId: row.tenant_id,
+      taskType: row.task_type,
+      subjectId: row.subject_id,
+      accountId: row.account_id,
+      status: row.status,
+      priority: row.priority,
+      assignedTo: row.assigned_to,
+      payload: parseReviewTaskPayload(row.payload_json),
+      dueAt: row.due_at,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
   }
 
   async transitionReviewTask(
@@ -2846,6 +2935,96 @@ export class IdentityMappingControlPlaneRepository {
     };
   }
 
+  async listFederationMetadataDocuments(tenantId: string, trustSourceId: string) {
+    validateRequiredString(trustSourceId, 'trustSourceId');
+    await this.ensureFederationTrustSource(tenantId, trustSourceId);
+
+    const rows = await this.adapter.query<FederationMetadataDocumentListRow>(
+      `SELECT
+        d.id,
+        d.trust_source_id,
+        d.document_type,
+        d.source_url,
+        d.document_hash,
+        d.document_ref,
+        d.fetched_at,
+        d.validated_at,
+        d.validation_state,
+        d.created_at,
+        d.updated_at,
+        e.id AS entity_summary_id,
+        e.entity_id,
+        e.entity_role,
+        e.display_name,
+        e.summary_json
+      FROM federation_metadata_documents d
+      LEFT JOIN federation_metadata_entity_summaries e
+        ON e.tenant_id = d.tenant_id
+       AND e.metadata_document_id = d.id
+      WHERE d.tenant_id = ? AND d.trust_source_id = ?
+      ORDER BY d.fetched_at DESC, d.created_at DESC, e.display_name ASC, e.entity_id ASC`,
+      [tenantId, trustSourceId]
+    );
+
+    const documents = new Map<
+      string,
+      {
+        id: string;
+        tenantId: string;
+        trustSourceId: string;
+        documentType: string;
+        sourceUrl: string | null;
+        documentHash: string;
+        documentRef: string | null;
+        fetchedAt: number | null;
+        validatedAt: number | null;
+        validationState: string;
+        createdAt: number;
+        updatedAt: number;
+        entitySummaries: Array<{
+          id: string;
+          entityId: string;
+          entityRole: string;
+          displayName: string | null;
+          summary: Record<string, unknown> | null;
+        }>;
+      }
+    >();
+
+    for (const row of rows) {
+      let document = documents.get(row.id);
+      if (!document) {
+        document = {
+          id: row.id,
+          tenantId,
+          trustSourceId: row.trust_source_id,
+          documentType: row.document_type,
+          sourceUrl: row.source_url,
+          documentHash: row.document_hash,
+          documentRef: row.document_ref,
+          fetchedAt: row.fetched_at,
+          validatedAt: row.validated_at,
+          validationState: row.validation_state,
+          createdAt: row.created_at,
+          updatedAt: row.updated_at,
+          entitySummaries: [],
+        };
+        documents.set(row.id, document);
+      }
+      if (row.entity_summary_id && row.entity_id && row.entity_role) {
+        document.entitySummaries.push({
+          id: row.entity_summary_id,
+          entityId: row.entity_id,
+          entityRole: row.entity_role,
+          displayName: row.display_name,
+          summary: row.summary_json ? parseJsonObject(row.summary_json, {}) : null,
+        });
+      }
+    }
+
+    return [...documents.values()];
+  }
+
   async migrateSamlFederationTrustProfile(
     tenantId: string,
     input: MigrateSamlFederationTrustProfileRequest
@@ -3699,6 +3878,17 @@ export async function adminIdentityMappingSourceAuthorityEvaluateHandler(c: Admi
   );
 }
 
+export async function adminIdentityMappingReviewTasksListHandler(c: AdminContext) {
+  return handleControlPlane(c, async (repository, tenantId) => ({
+    reviewTasks: await repository.listReviewTasks(tenantId, {
+      status: c.req.query('status'),
+      taskType: c.req.query('taskType'),
+      assignedTo: c.req.query('assignedTo'),
+      limit: parseOptionalInteger(c.req.query('limit')),
+    }),
+  }));
+}
+
 export async function adminIdentityMappingReviewTaskCreateHandler(c: AdminContext) {
   return handleMutation(c, 'review-task.create', async (repository, tenantId, body) =>
     repository.createReviewTask(tenantId, body as CreateReviewTaskRequest)
@@ -3857,6 +4047,15 @@ export async function adminIdentityMappingFederationTrustSourceCreateHandler(c: 
 export async function adminIdentityMappingFederationTrustSourcesListHandler(c: AdminContext) {
   return handleControlPlane(c, async (repository, tenantId) => ({
     federationTrustSources: await repository.listFederationTrustSources(tenantId),
+  }));
+}
+
+export async function adminIdentityMappingFederationMetadataDocumentsListHandler(c: AdminContext) {
+  return handleControlPlane(c, async (repository, tenantId) => ({
+    federationMetadataDocuments: await repository.listFederationMetadataDocuments(
+      tenantId,
+      requiredParam(c, 'trustSourceId')
+    ),
   }));
 }
 
@@ -4068,6 +4267,25 @@ function createId(prefix: string): string {
   return `${prefix}_${crypto.randomUUID()}`;
 }
 
+function parseOptionalInteger(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const normalized = value.trim();
+  if (!/^\d+$/.test(normalized)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(normalized, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function clampListLimit(value: number | undefined, defaultValue: number, maxValue: number): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return defaultValue;
+  }
+  return Math.max(1, Math.min(Math.trunc(value), maxValue));
+}
+
 function parseJsonObject(
   value: string,
   fallback: Record<string, unknown>
@@ -4078,6 +4296,12 @@ function parseJsonObject(
   } catch {
     return fallback;
   }
+}
+
+function parseReviewTaskPayload(value: string): Record<string, unknown> {
+  const payload = parseJsonObject(value, {});
+  assertNoReviewPayloadRawIdentifiers(payload, 'payload');
+  return payload;
 }
 
 function parseProvisioningAssignmentCondition(value: string): ProvisioningAssignmentCondition {

--- a/packages/ar-management/src/identity-mapping-control-plane.ts
+++ b/packages/ar-management/src/identity-mapping-control-plane.ts
@@ -22,6 +22,265 @@ type LifecycleState = 'draft' | 'published' | 'active' | 'scheduled' | 'retired'
 const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
 const ACTIVATION_LEASE_TTL_MS = 60 * 1000;
 
+const SCHEMA_READINESS_INVENTORY: SchemaReadinessInventoryDefinition[] = [
+  {
+    id: 'UIM-SCH-016',
+    objectName: 'mapping_policy_sets',
+    area: 'Mapping policy root',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'PR7 policy foundation',
+    runtimePath: 'policy authoring',
+    status: 'api_connected',
+    gate: 'repo/API/tests; UI in PR12',
+    schemaObject: 'mapping_policy_sets',
+  },
+  {
+    id: 'UIM-SCH-017',
+    objectName: 'mapping_policy_versions',
+    area: 'Draft/published/active versions',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'PR7 policy foundation',
+    runtimePath: 'activation / compile',
+    status: 'api_connected',
+    gate: 'repo/API/tests; hot-path use in later runtime slices',
+    schemaObject: 'mapping_policy_versions',
+  },
+  {
+    id: 'UIM-SCH-019',
+    objectName: 'mapping_rule_edges',
+    area: 'Graph field-to-field edges',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'PR7 policy foundation / PR12 UI',
+    runtimePath: 'Svelte Flow graph',
+    status: 'api_connected',
+    gate: 'API/tests; UI in PR12',
+    schemaObject: 'mapping_rule_edges',
+  },
+  {
+    id: 'UIM-SCH-024',
+    objectName: 'mapping_policy_activations',
+    area: 'Activation / schedule state',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'PR7 policy foundation',
+    runtimePath: 'active snapshot selection',
+    status: 'api_connected',
+    gate: 'activation API/tests; runtime pointer use in later slices',
+    schemaObject: 'mapping_policy_activations',
+  },
+  {
+    id: 'UIM-SCH-025',
+    objectName: 'compiled_mapping_snapshots',
+    area: 'Hot-path compiled policy',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'PR7 policy foundation',
+    runtimePath: 'hot path',
+    status: 'api_connected',
+    gate: 'compile/activate API/tests; runtime hot-path use in later slices',
+    schemaObject: 'compiled_mapping_snapshots',
+  },
+  {
+    id: 'UIM-SCH-030',
+    objectName: 'protocol_schema_catalogs',
+    area: 'Protocol schema catalog',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'PR7 policy foundation',
+    runtimePath: 'adapter validation',
+    status: 'api_connected',
+    gate: 'API/tests',
+    schemaObject: 'protocol_schema_catalogs',
+  },
+  {
+    id: 'UIM-SCH-031',
+    objectName: 'external_schema_catalogs',
+    area: 'Imported external metadata',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'PR7 policy foundation',
+    runtimePath: 'draft suggestions',
+    status: 'api_connected',
+    gate: 'API/tests; import workflow later',
+    schemaObject: 'external_schema_catalogs',
+  },
+  {
+    id: 'UIM-SCH-032',
+    objectName: 'mapping_templates',
+    area: 'Built-in/custom templates',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'PR7 policy foundation',
+    runtimePath: 'policy creation',
+    status: 'api_connected',
+    gate: 'API/tests; UI in PR12',
+    schemaObject: 'mapping_templates',
+  },
+  {
+    id: 'UIM-SCH-044',
+    objectName: 'review_tasks',
+    area: 'Manual review queue',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'PR9 consent / review',
+    runtimePath: 'linking/conflict/release review',
+    status: 'api_connected',
+    gate: 'create/transition API + tests; full Admin UI queue in PR12',
+    schemaObject: 'review_tasks',
+  },
+  {
+    id: 'UIM-SCH-045',
+    objectName: 'review_task_groups',
+    area: 'Grouped bulk review',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'PR9 consent / review',
+    runtimePath: 'bulk import/activation review',
+    status: 'api_connected',
+    gate: 'group API + tests; full Admin UI queue in PR12',
+    schemaObject: 'review_task_groups',
+  },
+  {
+    id: 'UIM-SCH-047',
+    objectName: 'mapping_activation_leases',
+    area: 'Activation concurrency lock',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'PR7 policy foundation',
+    runtimePath: 'publish/activate/schedule',
+    status: 'api_connected',
+    gate: 'API/tests',
+    schemaObject: 'mapping_activation_leases',
+  },
+  {
+    id: 'UIM-SCH-048',
+    objectName: 'idempotency_records',
+    area: 'Mutation retry safety',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'PR7 policy foundation',
+    runtimePath: 'Admin API mutation',
+    status: 'api_connected',
+    gate: 'API/tests',
+    schemaObject: 'idempotency_records',
+  },
+  {
+    id: 'UIM-SCH-068',
+    objectName: 'external_lifecycle_signal_events',
+    area: 'Lifecycle signal ledger',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'PR10 provisioning assignment',
+    runtimePath: 'SCIM / VC / CSV / SAML / OIDC implemented source signal intake',
+    status: 'api_connected',
+    gate: 'implemented lifecycle signals connected; SSF adapter remains deferred',
+    schemaObject: 'external_lifecycle_signal_events',
+  },
+  {
+    id: 'UIM-SCH-071',
+    objectName: 'federation_trust_sources',
+    area: 'Normalized trust source registry',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'federation metadata PR',
+    runtimePath: 'SAML-first trust source; OIDC/VC/SCIM/agent slots reserved',
+    status: 'schema_added',
+    gate: 'SAML repo + runtime + reserved slots disabled',
+    schemaObject: 'federation_trust_sources',
+    requiredForTier2Gate: true,
+  },
+  {
+    id: 'UIM-SCH-072',
+    objectName: 'federation_trust_anchors',
+    area: 'Trust anchors / certificates / issuer roots',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'federation metadata PR',
+    runtimePath: 'SAML aggregate / VC issuer validation; OIDC Fed no runtime in initial slice',
+    status: 'schema_added',
+    gate: 'repo + runtime + tests',
+    schemaObject: 'federation_trust_anchors',
+    requiredForTier2Gate: true,
+  },
+  {
+    id: 'UIM-SCH-073',
+    objectName: 'federation_metadata_documents',
+    area: 'Fetched/imported metadata document ledger',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'federation metadata PR',
+    runtimePath: 'metadata import / refresh / audit',
+    status: 'schema_added',
+    gate: 'jobs + audit + tests',
+    schemaObject: 'federation_metadata_documents',
+    requiredForTier2Gate: true,
+  },
+  {
+    id: 'UIM-SCH-074',
+    objectName: 'federation_entity_statements',
+    area: 'OIDC Federation entity statement storage',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'future OIDC Federation PR',
+    runtimePath: 'reserved only in initial slice',
+    status: 'reserved_planned',
+    gate: 'disabled feature + no runtime exposure + documented readiness',
+    schemaObject: 'federation_entity_statements',
+  },
+  {
+    id: 'UIM-SCH-075',
+    objectName: 'federation_trust_chains',
+    area: 'OIDC Federation trust chain resolution results',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'future OIDC Federation PR',
+    runtimePath: 'reserved only in initial slice',
+    status: 'reserved_planned',
+    gate: 'disabled feature + no runtime exposure + documented readiness',
+    schemaObject: 'federation_trust_chains',
+  },
+  {
+    id: 'UIM-SCH-076',
+    objectName: 'saml_federation_trust_profiles migration',
+    area: 'Legacy SAML aggregate trust profile migration',
+    introducedPr: 'existing',
+    expectedConnectionPr: 'SAML federation migration PR',
+    runtimePath: 'SAML aggregate metadata import / trust validation',
+    status: 'existing_to_migrate',
+    gate: 'migration + adapter + API/UI/tests',
+    schemaObject: 'saml_federation_trust_profiles',
+    requiredForTier2Gate: true,
+  },
+  {
+    id: 'UIM-SCH-083',
+    objectName: 'federation_metadata_entity_summaries',
+    area: 'Aggregate metadata entity summary index',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'federation metadata PR',
+    runtimePath: 'SAML aggregate entity selection / diff',
+    status: 'schema_added',
+    gate: 'import + UI + tests',
+    schemaObject: 'federation_metadata_entity_summaries',
+    requiredForTier2Gate: true,
+  },
+  {
+    id: 'UIM-SCH-086',
+    objectName: 'SSF / CAEP / RISC adapter',
+    area: 'Future shared signal protocol adapter',
+    introducedPr: 'TBD',
+    expectedConnectionPr: 'future lifecycle signal adapter PR',
+    runtimePath: 'no runtime exposure in initial slice',
+    status: 'adapter_deferred',
+    gate: 'disabled feature + no endpoint + resume criteria',
+  },
+  {
+    id: 'UIM-SCH-087',
+    objectName: 'existing consent statement integration',
+    area: 'Existing consent statement/version/user record APIs',
+    introducedPr: 'existing',
+    expectedConnectionPr: 'PR9 consent / review',
+    runtimePath: 'release decision consent gate',
+    status: 'service_connected',
+    gate: 'legal basis gate service + tests; live protocol challenge UI later',
+  },
+  {
+    id: 'UIM-SCH-088',
+    objectName: 'attribute_release_consents',
+    area: 'Destination-specific released attribute set consent',
+    introducedPr: 'schema baseline PR',
+    expectedConnectionPr: 'PR9 consent / review',
+    runtimePath: 'SAML / federation release consent',
+    status: 'repo_connected',
+    gate: 'repository + release challenge tests; user-facing challenge UI later',
+    schemaObject: 'attribute_release_consents',
+  },
+];
+
 interface MappingPolicySetRow {
   id: string;
   tenant_id: string;
@@ -322,6 +581,33 @@ interface ListReviewTasksOptions {
   limit?: number;
 }
 
+type SchemaReadinessStatus =
+  | 'tested'
+  | 'closed'
+  | 'api_connected'
+  | 'repo_connected'
+  | 'service_connected'
+  | 'schema_added'
+  | 'reserved_planned'
+  | 'adapter_deferred'
+  | 'existing_to_migrate'
+  | 'breaking_planned';
+
+type SchemaReadinessGateState = 'pass' | 'attention' | 'blocked' | 'deferred';
+
+interface SchemaReadinessInventoryDefinition {
+  id: string;
+  objectName: string;
+  area: string;
+  introducedPr: string;
+  expectedConnectionPr: string;
+  runtimePath: string;
+  status: SchemaReadinessStatus;
+  gate: string;
+  schemaObject?: string;
+  requiredForTier2Gate?: boolean;
+}
+
 interface TransitionReviewTaskRequest {
   status: string;
   assignedTo?: string | null;
@@ -579,6 +865,33 @@ export class IdentityMappingControlPlaneRepository {
     private readonly adapter: DatabaseAdapter,
     private readonly now: () => number = () => Date.now()
   ) {}
+
+  async listSchemaReadiness() {
+    const schemaRows = await this.adapter.query<{ name: string }>(
+      "SELECT name FROM sqlite_master WHERE type IN ('table', 'index')"
+    );
+    const schemaObjects = new Set(schemaRows.map((row) => row.name));
+    const readiness = SCHEMA_READINESS_INVENTORY.map((item) => {
+      const schemaPresent = item.schemaObject ? schemaObjects.has(item.schemaObject) : null;
+      const gateState = resolveSchemaReadinessGateState(item, schemaPresent);
+      return {
+        ...item,
+        schemaPresent,
+        gateState,
+      };
+    });
+
+    return {
+      rows: readiness,
+      summary: {
+        total: readiness.length,
+        pass: readiness.filter((item) => item.gateState === 'pass').length,
+        attention: readiness.filter((item) => item.gateState === 'attention').length,
+        blocked: readiness.filter((item) => item.gateState === 'blocked').length,
+        deferred: readiness.filter((item) => item.gateState === 'deferred').length,
+      },
+    };
+  }
 
   async createCatalog(tenantId: string, input: CreateCatalogRequest) {
     validateRequiredString(input.catalogKey, 'catalogKey');
@@ -3878,6 +4191,10 @@ export async function adminIdentityMappingSourceAuthorityEvaluateHandler(c: Admi
   );
 }
 
+export async function adminIdentityMappingSchemaReadinessHandler(c: AdminContext) {
+  return handleControlPlane(c, async (repository) => repository.listSchemaReadiness());
+}
+
 export async function adminIdentityMappingReviewTasksListHandler(c: AdminContext) {
   return handleControlPlane(c, async (repository, tenantId) => ({
     reviewTasks: await repository.listReviewTasks(tenantId, {
@@ -4261,6 +4578,26 @@ function assertNoReviewPayloadRawIdentifiers(value: unknown, path: string): void
     }
     assertNoReviewPayloadRawIdentifiers(item, `${path}.${key}`);
   }
+}
+
+function resolveSchemaReadinessGateState(
+  item: SchemaReadinessInventoryDefinition,
+  schemaPresent: boolean | null
+): SchemaReadinessGateState {
+  if (item.status === 'reserved_planned' || item.status === 'adapter_deferred') {
+    return 'deferred';
+  }
+  if (schemaPresent === false) {
+    return 'blocked';
+  }
+  if (
+    item.status === 'schema_added' ||
+    item.status === 'existing_to_migrate' ||
+    item.status === 'breaking_planned'
+  ) {
+    return item.requiredForTier2Gate ? 'blocked' : 'attention';
+  }
+  return 'pass';
 }
 
 function createId(prefix: string): string {

--- a/packages/ar-management/src/index.ts
+++ b/packages/ar-management/src/index.ts
@@ -678,6 +678,7 @@ import {
   adminIdentityMappingReviewTasksListHandler,
   adminIdentityMappingReviewTaskTransitionHandler,
   adminIdentityMappingSamlFederationTrustProfileMigrateHandler,
+  adminIdentityMappingSchemaReadinessHandler,
   adminIdentityMappingSourceAuthorityContractCreateHandler,
   adminIdentityMappingSourceAuthorityContractsListHandler,
   adminIdentityMappingSourceAuthorityEvaluateHandler,
@@ -2312,6 +2313,11 @@ app.post(
   '/api/admin/identity-mapping/source-authority-contracts/evaluate',
   requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
   adminIdentityMappingSourceAuthorityEvaluateHandler
+);
+app.get(
+  '/api/admin/identity-mapping/schema-readiness',
+  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_READ]),
+  adminIdentityMappingSchemaReadinessHandler
 );
 app.get(
   '/api/admin/identity-mapping/review-tasks',

--- a/packages/ar-management/src/index.ts
+++ b/packages/ar-management/src/index.ts
@@ -656,6 +656,7 @@ import {
   adminIdentityMappingPolicyVersionPublishHandler,
   adminIdentityMappingEntitlementGrantHandler,
   adminIdentityMappingFederationMetadataDocumentCreateHandler,
+  adminIdentityMappingFederationMetadataDocumentsListHandler,
   adminIdentityMappingFederationTrustSourceCreateHandler,
   adminIdentityMappingGroupCreateHandler,
   adminIdentityMappingGroupMembershipCreateHandler,
@@ -674,6 +675,7 @@ import {
   adminIdentityMappingProvisioningAssignmentRuleEvaluateHandler,
   adminIdentityMappingReviewTaskCreateHandler,
   adminIdentityMappingReviewTaskGroupCreateHandler,
+  adminIdentityMappingReviewTasksListHandler,
   adminIdentityMappingReviewTaskTransitionHandler,
   adminIdentityMappingSamlFederationTrustProfileMigrateHandler,
   adminIdentityMappingSourceAuthorityContractCreateHandler,
@@ -2311,6 +2313,11 @@ app.post(
   requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
   adminIdentityMappingSourceAuthorityEvaluateHandler
 );
+app.get(
+  '/api/admin/identity-mapping/review-tasks',
+  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_READ]),
+  adminIdentityMappingReviewTasksListHandler
+);
 app.post(
   '/api/admin/identity-mapping/review-tasks',
   requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_WRITE]),
@@ -2417,6 +2424,11 @@ app.get(
   '/api/admin/identity-mapping/federation-trust-sources',
   requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_READ]),
   adminIdentityMappingFederationTrustSourcesListHandler
+);
+app.get(
+  '/api/admin/identity-mapping/federation-trust-sources/:trustSourceId/metadata-documents',
+  requireAdminPermissions([ADMIN_PERMISSIONS.SETTINGS_READ]),
+  adminIdentityMappingFederationMetadataDocumentsListHandler
 );
 app.post(
   '/api/admin/identity-mapping/federation-metadata-documents',

--- a/packages/setup/src/__tests__/keys.test.ts
+++ b/packages/setup/src/__tests__/keys.test.ts
@@ -214,7 +214,7 @@ describe('saveKeysToDirectory with external keys', () => {
     const keysDir = join(testDir, AUTHRIM_DIR, 'dev', 'keys');
     expect(existsSync(join(keysDir, 'private.pem'))).toBe(true);
     expect(existsSync(join(keysDir, 'metadata.json'))).toBe(true);
-  });
+  }, 15_000);
 });
 
 describe('keysExistForEnvironment with external keys', () => {


### PR DESCRIPTION
## Summary
- Add the Tier 2 Identity Mapping Admin UI entry point, flow editor, profile preparation, operations, resolution center, federation trust, and schema-readiness pages.
- Wire Admin UI API client methods for policy operations, review task transitions, federation trust metadata documents, and source/destination profile lists.
- Add management API list endpoints for review tasks and federation metadata documents with coverage for redacted payload handling and entity summary grouping.
- Stabilize the setup key save test timeout for CI coverage runs.

## Validation
- `pnpm --filter @authrim/ar-admin-ui typecheck`
- `pnpm --filter @authrim/ar-admin-ui test`
- `PUBLIC_API_BASE_URL=http://localhost:8786 pnpm --filter @authrim/ar-admin-ui exec vitest run src/lib/api/admin-identity-mapping.test.ts`
- `pnpm --filter @authrim/ar-admin-ui lint`
- `pnpm --filter @authrim/ar-admin-ui build`
- `pnpm --filter @authrim/ar-management exec vitest run src/__tests__/identity-mapping-preview.test.ts src/__tests__/identity-mapping-control-plane.test.ts`
- `pnpm --filter @authrim/ar-management typecheck`
- `pnpm --filter @authrim/setup test -- --coverage`
- `git diff --cached --check`

## Manual check
- Started Admin UI dev server on `127.0.0.1:5177` and confirmed `/admin/identity-mapping` reaches the protected Admin login flow in the local unauthenticated environment.