### PR TITLE
feat: autoscroll identity mapping edge drag

### DIFF
--- a/packages/ar-admin-ui/src/lib/components/identity-mapping/IdentityMappingFlowEditor.svelte
+++ b/packages/ar-admin-ui/src/lib/components/identity-mapping/IdentityMappingFlowEditor.svelte
@@ -2806,6 +2806,11 @@
 		--map-red: #b91c1c;
 		--map-violet: #6d28d9;
 		--map-radius: 4px;
+		--map-target-surface: color-mix(in srgb, var(--map-brand) 2%, var(--map-surface));
+		--map-target-group-surface: color-mix(in srgb, var(--map-brand) 6%, var(--map-surface));
+		--map-target-group-active-surface: color-mix(in srgb, var(--map-brand) 9%, var(--map-surface));
+		--map-target-active-surface: color-mix(in srgb, var(--map-brand) 11%, var(--map-surface));
+		--map-target-related-surface: color-mix(in srgb, var(--map-brand) 7%, var(--map-surface));
 		--map-edge-flow-distance: -24;
 		--map-edge-flow-speed: 720ms;
 		--map-edge-pulse-speed: 1.2s;
@@ -2834,6 +2839,11 @@
 		--map-amber: #fbbf24;
 		--map-red: #f87171;
 		--map-violet: #a78bfa;
+		--map-target-surface: var(--map-surface);
+		--map-target-group-surface: color-mix(in srgb, var(--map-brand) 15%, var(--map-surface));
+		--map-target-group-active-surface: color-mix(in srgb, var(--map-brand) 15%, var(--map-surface));
+		--map-target-active-surface: color-mix(in srgb, var(--map-brand) 42%, var(--map-surface));
+		--map-target-related-surface: color-mix(in srgb, var(--map-brand) 18%, var(--map-surface));
 	}
 
 	.graph-toolbar,
@@ -3141,7 +3151,7 @@
 		border: 1px solid color-mix(in srgb, var(--target-group-accent) 70%, transparent);
 		border-radius: 5px 5px 0 0;
 		color: var(--map-text);
-		background: color-mix(in srgb, var(--target-group-accent) 15%, var(--map-surface));
+		background: var(--map-target-group-surface);
 		box-shadow:
 			0 0 0 1px color-mix(in srgb, var(--target-group-accent) 8%, transparent),
 			0 4px 10px rgb(0 0 0 / 0.2);
@@ -3152,6 +3162,7 @@
 	.target-group-header:focus-visible,
 	.target-group-header.group-hovered {
 		border-color: var(--target-group-accent);
+		background: var(--map-target-group-active-surface);
 		box-shadow:
 			0 0 0 1px color-mix(in srgb, var(--target-group-accent) 70%, transparent),
 			0 0 0 4px color-mix(in srgb, var(--target-group-accent) 14%, transparent),
@@ -3485,10 +3496,12 @@
 	.target-node {
 		padding-bottom: 20px;
 		border-color: rgba(96, 165, 250, 0.64);
+		background: var(--map-target-surface);
 	}
 
 	.target-grouped-node {
 		border-radius: 0;
+		background: var(--map-target-surface);
 		box-shadow: none;
 	}
 
@@ -3660,18 +3673,36 @@
 			0 8px 18px rgba(0, 0, 0, 0.26);
 	}
 
+	.target-node.connection-related,
+	.target-node.selection-related {
+		background: var(--map-target-related-surface);
+	}
+
+	.target-node.active,
+	.target-node.connection-origin,
+	.target-node.selection-origin {
+		background: var(--map-target-active-surface);
+	}
+
 	.target-grouped-node:hover,
 	.target-grouped-node.active,
 	.target-grouped-node.connection-origin,
 	.target-grouped-node.selection-origin,
 	.target-grouped-node.connection-related,
 	.target-grouped-node.selection-related {
+		background: var(--map-target-related-surface);
 		outline: 2px solid color-mix(in srgb, var(--node-accent) 88%, transparent);
 		outline-offset: -2px;
 		box-shadow:
 			inset 0 0 0 1px color-mix(in srgb, var(--node-accent) 42%, transparent),
 			0 0 0 2px color-mix(in srgb, var(--node-accent) 16%, transparent),
 			0 0 18px 1px color-mix(in srgb, var(--node-accent) 28%, transparent);
+	}
+
+	.target-grouped-node.active,
+	.target-grouped-node.connection-origin,
+	.target-grouped-node.selection-origin {
+		background: var(--map-target-active-surface);
 	}
 
 	.target-grouped-node.connection-rejected {

--- a/packages/ar-admin-ui/src/lib/components/identity-mapping/IdentityMappingFlowEditor.svelte
+++ b/packages/ar-admin-ui/src/lib/components/identity-mapping/IdentityMappingFlowEditor.svelte
@@ -257,6 +257,9 @@
 	const targetGroupHeaderHeight = 28;
 	const targetGroupRowStep = targetHeight - 1;
 	const targetGroupGap = 10;
+	const connectionAutoScrollMargin = 72;
+	const connectionAutoScrollMaxSpeed = 24;
+	const connectionAutoScrollMinSpeed = 4;
 
 	let canvas: HTMLDivElement;
 	let canvasWidth = $state(1000);
@@ -298,6 +301,8 @@
 		startClient: Point;
 		from: Point;
 	} | null = null;
+	let connectionDragPointer: Point | null = null;
+	let connectionAutoScrollFrame: number | null = null;
 	let suppressNextNodeClickId: string | null = null;
 
 	interface Point {
@@ -550,6 +555,7 @@
 	}
 
 	function resetDraftFromCurrentSample() {
+		stopConnectionAutoScroll();
 		nodes = [...sample.nodes];
 		edges = [...sample.edges];
 		activeRuleId = sample.activeRuleId;
@@ -563,6 +569,7 @@
 	}
 
 	onDestroy(() => {
+		stopConnectionAutoScroll();
 		window.removeEventListener('pointermove', handlePointerMove);
 		window.removeEventListener('pointerup', handlePointerUp);
 		window.removeEventListener('pointermove', handleEasyConnectionPointerMove);
@@ -1297,20 +1304,149 @@
 		return normalized;
 	}
 
-	function connectionTargetForPointer(event: PointerEvent): MappingNode | undefined {
-		const target = document.elementFromPoint(event.clientX, event.clientY) as HTMLElement | null;
+	function connectionTargetForClientPoint(point: Point): MappingNode | undefined {
+		const target = document.elementFromPoint(point.x, point.y) as HTMLElement | null;
 		const handle = target?.closest?.('.node-handle.input') as HTMLElement | null;
 		const nodeElement = target?.closest?.('.graph-node') as HTMLElement | null;
 		const toNodeId = handle?.dataset.nodeId ?? nodeElement?.dataset.nodeId;
 		return toNodeId ? nodeById(toNodeId) : undefined;
 	}
 
-	function canvasPoint(event: PointerEvent): Point {
+	function connectionTargetForPointer(event: PointerEvent): MappingNode | undefined {
+		return connectionTargetForClientPoint({ x: event.clientX, y: event.clientY });
+	}
+
+	function canvasPointForClientPoint(point: Point): Point {
 		const rect = canvas.getBoundingClientRect();
 		return {
-			x: event.clientX - rect.left,
-			y: event.clientY - rect.top
+			x: point.x - rect.left,
+			y: point.y - rect.top
 		};
+	}
+
+	function canvasPoint(event: PointerEvent): Point {
+		return canvasPointForClientPoint({ x: event.clientX, y: event.clientY });
+	}
+
+	function scrollableCanvasAncestor(): HTMLElement | null {
+		let element = canvas?.parentElement;
+		while (element && element !== document.body && element !== document.documentElement) {
+			const style = getComputedStyle(element);
+			const scrollableY = ['auto', 'scroll', 'overlay'].includes(style.overflowY);
+			if (scrollableY && element.scrollHeight > element.clientHeight) return element;
+			element = element.parentElement;
+		}
+		return null;
+	}
+
+	function edgeDragAutoScrollDelta(pointerY: number, top: number, bottom: number): number {
+		if (pointerY < top + connectionAutoScrollMargin) {
+			const ratio = Math.min(
+				1,
+				(top + connectionAutoScrollMargin - pointerY) / connectionAutoScrollMargin
+			);
+			return -Math.ceil(connectionAutoScrollMinSpeed + ratio * connectionAutoScrollMaxSpeed);
+		}
+		if (pointerY > bottom - connectionAutoScrollMargin) {
+			const ratio = Math.min(
+				1,
+				(pointerY - (bottom - connectionAutoScrollMargin)) / connectionAutoScrollMargin
+			);
+			return Math.ceil(connectionAutoScrollMinSpeed + ratio * connectionAutoScrollMaxSpeed);
+		}
+		return 0;
+	}
+
+	function updateDragStateForClientPoint(clientPoint: Point) {
+		if (!dragState) return;
+		const toNode = connectionTargetForClientPoint(clientPoint);
+		const canvasTargetPoint = canvasPointForClientPoint(clientPoint);
+		if (dragState.reconnectEdgeId && dragState.reconnectSide === 'source') {
+			const fixedToNode = nodeById(dragState.fixedNodeId ?? '');
+			const fixedToLayout = fixedToNode ? layoutNodeById(fixedToNode.id) : undefined;
+			dragState = {
+				...dragState,
+				from: canvasTargetPoint,
+				to: fixedToLayout ? edgePoint(fixedToLayout, 'to') : dragState.to,
+				validTarget: toNode
+					? isValidConnectionForReconnect(toNode, fixedToNode, new Set([dragState.reconnectEdgeId]))
+					: null,
+				targetNodeId: toNode?.id ?? null
+			};
+			return;
+		}
+		if (dragState.reconnectEdgeId && dragState.reconnectSide === 'target') {
+			const fixedFromNode = nodeById(dragState.fixedNodeId ?? '');
+			const fixedFromLayout = fixedFromNode ? layoutNodeById(fixedFromNode.id) : undefined;
+			dragState = {
+				...dragState,
+				from: fixedFromLayout ? edgePoint(fixedFromLayout, 'from') : dragState.from,
+				to: canvasTargetPoint,
+				validTarget: toNode
+					? isValidConnectionForReconnect(
+							fixedFromNode,
+							toNode,
+							new Set([dragState.reconnectEdgeId])
+						)
+					: null,
+				targetNodeId: toNode?.id ?? null
+			};
+			return;
+		}
+		const fromNode = nodeById(dragState.fromNodeId);
+		dragState = {
+			...dragState,
+			to: canvasTargetPoint,
+			validTarget: toNode ? isValidConnection(fromNode, toNode) : null,
+			targetNodeId: toNode?.id ?? null
+		};
+	}
+
+	function runConnectionAutoScroll() {
+		connectionAutoScrollFrame = null;
+		if (!dragState || !connectionDragPointer) return;
+
+		let didScroll = false;
+		const scrollContainer = scrollableCanvasAncestor();
+		if (scrollContainer) {
+			const rect = scrollContainer.getBoundingClientRect();
+			const delta = edgeDragAutoScrollDelta(connectionDragPointer.y, rect.top, rect.bottom);
+			if (delta !== 0) {
+				const before = scrollContainer.scrollTop;
+				scrollContainer.scrollTop += delta;
+				didScroll = scrollContainer.scrollTop !== before;
+			}
+		}
+
+		if (!didScroll) {
+			const maxWindowScroll = document.documentElement.scrollHeight - window.innerHeight;
+			const delta = edgeDragAutoScrollDelta(connectionDragPointer.y, 0, window.innerHeight);
+			if (delta !== 0 && window.scrollY >= 0 && window.scrollY <= maxWindowScroll) {
+				const before = window.scrollY;
+				window.scrollBy({ top: delta, left: 0, behavior: 'instant' });
+				didScroll = window.scrollY !== before;
+			}
+		}
+
+		if (didScroll) updateDragStateForClientPoint(connectionDragPointer);
+		if (dragState && connectionDragPointer) {
+			connectionAutoScrollFrame = requestAnimationFrame(runConnectionAutoScroll);
+		}
+	}
+
+	function updateConnectionAutoScrollPointer(event: PointerEvent) {
+		connectionDragPointer = { x: event.clientX, y: event.clientY };
+		if (connectionAutoScrollFrame === null) {
+			connectionAutoScrollFrame = requestAnimationFrame(runConnectionAutoScroll);
+		}
+	}
+
+	function stopConnectionAutoScroll() {
+		connectionDragPointer = null;
+		if (connectionAutoScrollFrame !== null) {
+			cancelAnimationFrame(connectionAutoScrollFrame);
+			connectionAutoScrollFrame = null;
+		}
 	}
 
 	function startConnectionDrag(event: PointerEvent, node: LayoutNode) {
@@ -1326,6 +1462,7 @@
 			validTarget: null,
 			targetNodeId: null
 		};
+		updateConnectionAutoScrollPointer(event);
 		window.addEventListener('pointermove', handlePointerMove);
 		window.addEventListener('pointerup', handlePointerUp);
 	}
@@ -1380,50 +1517,15 @@
 
 	function handlePointerMove(event: PointerEvent) {
 		if (!dragState) return;
-		const toNode = connectionTargetForPointer(event);
-		if (dragState.reconnectEdgeId && dragState.reconnectSide === 'source') {
-			const fixedToNode = nodeById(dragState.fixedNodeId ?? '');
-			const fixedToLayout = fixedToNode ? layoutNodeById(fixedToNode.id) : undefined;
-			dragState = {
-				...dragState,
-				from: canvasPoint(event),
-				to: fixedToLayout ? edgePoint(fixedToLayout, 'to') : dragState.to,
-				validTarget: toNode
-					? isValidConnectionForReconnect(toNode, fixedToNode, new Set([dragState.reconnectEdgeId]))
-					: null,
-				targetNodeId: toNode?.id ?? null
-			};
-			return;
-		}
-		if (dragState.reconnectEdgeId && dragState.reconnectSide === 'target') {
-			const fixedFromNode = nodeById(dragState.fixedNodeId ?? '');
-			const fixedFromLayout = fixedFromNode ? layoutNodeById(fixedFromNode.id) : undefined;
-			dragState = {
-				...dragState,
-				from: fixedFromLayout ? edgePoint(fixedFromLayout, 'from') : dragState.from,
-				to: canvasPoint(event),
-				validTarget: toNode
-					? isValidConnectionForReconnect(
-							fixedFromNode,
-							toNode,
-							new Set([dragState.reconnectEdgeId])
-						)
-					: null,
-				targetNodeId: toNode?.id ?? null
-			};
-			return;
-		}
-		const fromNode = nodeById(dragState.fromNodeId);
-		dragState = {
-			...dragState,
-			to: canvasPoint(event),
-			validTarget: toNode ? isValidConnection(fromNode, toNode) : null,
-			targetNodeId: toNode?.id ?? null
-		};
+		updateConnectionAutoScrollPointer(event);
+		updateDragStateForClientPoint({ x: event.clientX, y: event.clientY });
 	}
 
 	function handlePointerUp(event: PointerEvent) {
-		if (!dragState) return;
+		if (!dragState) {
+			stopConnectionAutoScroll();
+			return;
+		}
 		const reconnectState = dragState;
 		const fromNode = nodeById(dragState.fromNodeId);
 		const toNode = connectionTargetForPointer(event);
@@ -1433,6 +1535,7 @@
 			addEdge(dragState.fromNodeId, toNode.id);
 		}
 		dragState = null;
+		stopConnectionAutoScroll();
 		window.removeEventListener('pointermove', handlePointerMove);
 		window.removeEventListener('pointerup', handlePointerUp);
 	}
@@ -1475,6 +1578,7 @@
 			reconnectSide: side,
 			fixedNodeId: side === 'source' ? edge.to : edge.from
 		};
+		updateConnectionAutoScrollPointer(event);
 		window.addEventListener('pointermove', handlePointerMove);
 		window.addEventListener('pointerup', handlePointerUp);
 	}


### PR DESCRIPTION
## Summary
- Add automatic vertical scrolling while dragging or reconnecting Identity Mapping edges near the canvas bounds.
- Keep the dragged edge endpoint and target validation in sync while the page scrolls.
- Stop the autoscroll loop on pointer release, draft reset, and component destroy.

## Validation
- `pnpm --filter @authrim/ar-admin-ui typecheck`
- `pnpm --filter @authrim/ar-admin-ui lint`
- `pnpm --filter @authrim/ar-admin-ui exec prettier --check src/lib/components/identity-mapping/IdentityMappingFlowEditor.svelte`
- `pnpm --filter @authrim/ar-admin-ui exec vitest run src/lib/admin/__tests__/identity-mapping-ui-smoke.test.ts src/lib/components/identity-mapping/__tests__/flow-data.test.ts`