### PR TITLE
Fail setup deploy when migrations fail

### DIFF
--- a/packages/setup/src/cli/commands/deploy.ts
+++ b/packages/setup/src/cli/commands/deploy.ts
@@ -1510,6 +1510,11 @@ export async function deployCommand(options: DeployCommandOptions): Promise<void
   }
 
   await cleanupEphemeralSetupMachineAccess();
+
+  if (!migrationsSuccess) {
+    // Let CI fail at the deploy step while still giving cleanup a chance to run.
+    process.exitCode = 1;
+  }
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Fail the setup deploy command when D1 migrations fail instead of allowing later smoke tests to surface the problem as runtime 500s.
- Preserve cleanup behavior by setting `process.exitCode` after temporary setup machine access cleanup runs.

## Verification
- `pnpm exec prettier --check packages/setup/src/cli/commands/deploy.ts`
- `pnpm --filter @authrim/setup typecheck`
- Re-ran `test/environment-validation/smoke-generated-approvals.ts --env test` after applying the missing test D1 migration; result OK.