### PR TITLE
test(admin-ui): update field mapping smoke expectation

### DIFF
--- a/packages/ar-admin-ui/src/lib/admin/__tests__/identity-mapping-ui-smoke.test.ts
+++ b/packages/ar-admin-ui/src/lib/admin/__tests__/identity-mapping-ui-smoke.test.ts
@@ -203,7 +203,7 @@ describe('field mapping Admin UI smoke checks', () => {
 		expect(pageShell).toContain('profile-mode-control');
 		expect(pageShell).toContain('selectedEditorProfileId');
 		expect(pageShell).toContain('routePolicyOptionId');
-		expect(pageShell).toContain('initialPolicyOptionId={selectedPolicyOptionId}');
+		expect(pageShell).toContain('initialPolicyOptionId={selectedFieldMappingOptionId}');
 		expect(pageShell).toContain('admin_identity_mapping_editor_policy_version');
 		expect(pageShell).toContain('toggleSelectedPolicyActivation');
 		expect(pageShell).toContain('publishSelectedFieldMappingVersion');


### PR DESCRIPTION
## Summary
- update the Admin UI field mapping smoke test expectation after the field mapping rename

## Verification
- pnpm --filter @authrim/ar-admin-ui test -- --run src/lib/admin/__tests__/identity-mapping-ui-smoke.test.ts
- pnpm --filter @authrim/ar-admin-ui typecheck
- pnpm --filter @authrim/ar-admin-ui test