### PR TITLE
Add SAML signing certificate SAN and GakuNin endpoint aliases

### DIFF
--- a/packages/ar-admin-ui/src/i18n/en/admin-saml.ts
+++ b/packages/ar-admin-ui/src/i18n/en/admin-saml.ts
@@ -169,6 +169,13 @@ const adminSaml = {
 	admin_saml_local_organization: 'O (Organization)',
 	admin_saml_local_org_unit: 'OU (Organizational Unit)',
 	admin_saml_local_common_name: 'CN (Common Name)',
+	admin_saml_local_dns_san_auto: 'Automatically add DNS SAN from entityID and endpoints',
+	admin_saml_local_dns_san_auto_desc:
+		'Adds the hostnames used by this role, such as metadata, SSO, SLO, or ACS URLs.',
+	admin_saml_local_dns_san_generated: 'Generated DNS SAN',
+	admin_saml_local_dns_san_additional: 'Additional DNS SAN',
+	admin_saml_local_dns_san_additional_desc:
+		'Add scope domains or other owned DNS names explicitly. Separate values with spaces or commas.',
 	admin_saml_local_subject_warning:
 		'The certificate created here is not used for signing immediately. Select it in the stored certificate list and start using it when ready.',
 	admin_saml_local_signing_rollover: 'Certificate Rollover',

--- a/packages/ar-admin-ui/src/i18n/i18n-types.ts
+++ b/packages/ar-admin-ui/src/i18n/i18n-types.ts
@@ -4643,6 +4643,26 @@ type RootTranslation = {
 	 */
 	admin_saml_local_common_name: string;
 	/**
+	 * A​u​t​o​m​a​t​i​c​a​l​l​y​ ​a​d​d​ ​D​N​S​ ​S​A​N​ ​f​r​o​m​ ​e​n​t​i​t​y​I​D​ ​a​n​d​ ​e​n​d​p​o​i​n​t​s
+	 */
+	admin_saml_local_dns_san_auto: string;
+	/**
+	 * A​d​d​s​ ​t​h​e​ ​h​o​s​t​n​a​m​e​s​ ​u​s​e​d​ ​b​y​ ​t​h​i​s​ ​r​o​l​e​,​ ​s​u​c​h​ ​a​s​ ​m​e​t​a​d​a​t​a​,​ ​S​S​O​,​ ​S​L​O​,​ ​o​r​ ​A​C​S​ ​U​R​L​s​.
+	 */
+	admin_saml_local_dns_san_auto_desc: string;
+	/**
+	 * G​e​n​e​r​a​t​e​d​ ​D​N​S​ ​S​A​N
+	 */
+	admin_saml_local_dns_san_generated: string;
+	/**
+	 * A​d​d​i​t​i​o​n​a​l​ ​D​N​S​ ​S​A​N
+	 */
+	admin_saml_local_dns_san_additional: string;
+	/**
+	 * A​d​d​ ​s​c​o​p​e​ ​d​o​m​a​i​n​s​ ​o​r​ ​o​t​h​e​r​ ​o​w​n​e​d​ ​D​N​S​ ​n​a​m​e​s​ ​e​x​p​l​i​c​i​t​l​y​.​ ​S​e​p​a​r​a​t​e​ ​v​a​l​u​e​s​ ​w​i​t​h​ ​s​p​a​c​e​s​,​ ​c​o​m​m​a​s​,​ ​o​r​ ​n​e​w​ ​l​i​n​e​s​.
+	 */
+	admin_saml_local_dns_san_additional_desc: string;
+	/**
 	 * T​h​e​ ​c​e​r​t​i​f​i​c​a​t​e​ ​c​r​e​a​t​e​d​ ​h​e​r​e​ ​i​s​ ​n​o​t​ ​u​s​e​d​ ​f​o​r​ ​s​i​g​n​i​n​g​ ​i​m​m​e​d​i​a​t​e​l​y​.​ ​S​e​l​e​c​t​ ​i​t​ ​i​n​ ​t​h​e​ ​s​t​o​r​e​d​ ​c​e​r​t​i​f​i​c​a​t​e​ ​l​i​s​t​ ​a​n​d​ ​s​t​a​r​t​ ​u​s​i​n​g​ ​i​t​ ​w​h​e​n​ ​r​e​a​d​y​.
 	 */
 	admin_saml_local_subject_warning: string;
@@ -30783,6 +30803,26 @@ export type TranslationFunctions = {
 	 * CN (Common Name)
 	 */
 	admin_saml_local_common_name: () => LocalizedString;
+	/**
+	 * Automatically add DNS SAN from entityID and endpoints
+	 */
+	admin_saml_local_dns_san_auto: () => LocalizedString;
+	/**
+	 * Adds the hostnames used by this role, such as metadata, SSO, SLO, or ACS URLs.
+	 */
+	admin_saml_local_dns_san_auto_desc: () => LocalizedString;
+	/**
+	 * Generated DNS SAN
+	 */
+	admin_saml_local_dns_san_generated: () => LocalizedString;
+	/**
+	 * Additional DNS SAN
+	 */
+	admin_saml_local_dns_san_additional: () => LocalizedString;
+	/**
+	 * Add scope domains or other owned DNS names explicitly. Separate values with spaces, commas, or new lines.
+	 */
+	admin_saml_local_dns_san_additional_desc: () => LocalizedString;
 	/**
 	 * The certificate created here is not used for signing immediately. Select it in the stored certificate list and start using it when ready.
 	 */

--- a/packages/ar-admin-ui/src/i18n/ja/admin-saml.ts
+++ b/packages/ar-admin-ui/src/i18n/ja/admin-saml.ts
@@ -170,6 +170,13 @@ const adminSaml = {
 	admin_saml_local_organization: 'O (Organization)',
 	admin_saml_local_org_unit: 'OU (Organizational Unit)',
 	admin_saml_local_common_name: 'CN (Common Name)',
+	admin_saml_local_dns_san_auto: 'entityID / endpoint のホストを DNS SAN に自動追加',
+	admin_saml_local_dns_san_auto_desc:
+		'このroleで使うmetadata、SSO、SLO、ACS URLなどのホスト名を追加します。',
+	admin_saml_local_dns_san_generated: '自動追加される DNS SAN',
+	admin_saml_local_dns_san_additional: '追加 DNS SAN',
+	admin_saml_local_dns_san_additional_desc:
+		'scope domainなど、所有しているDNS名を明示的に追加します。スペースまたはカンマで区切れます。',
 	admin_saml_local_subject_warning:
 		'ここで作成する証明書は、すぐには署名に使われません。保存済み証明書一覧で選択し、使用開始してください。',
 	admin_saml_local_signing_rollover: '証明書の切り替え',

--- a/packages/ar-admin-ui/src/lib/api/admin-saml.ts
+++ b/packages/ar-admin-ui/src/lib/api/admin-saml.ts
@@ -36,6 +36,9 @@ export interface SAMLSigningKeyReference {
 	validTo?: number;
 	publicKeyAlgorithm?: 'RSA';
 	publicKeySizeBits?: number;
+	subjectAlternativeNames?: {
+		dnsNames: string[];
+	};
 }
 
 export interface SAMLSigningKeyPolicy {
@@ -54,6 +57,11 @@ export interface SAMLSigningCertificateSubject {
 	organizationName: string;
 	organizationalUnitName: string;
 	commonName: string;
+}
+
+export interface SAMLSigningCertificateSubjectAlternativeNames {
+	includeGeneratedDnsNames: boolean;
+	dnsNames: string[];
 }
 
 export interface SAMLCertificateValidationStatus {
@@ -185,12 +193,14 @@ export interface SAMLSettings {
 	entityIdStyle: SAMLEntityIdStyle;
 	interactiveLoginUrlPolicy: SAMLInteractiveLoginUrlPolicy;
 	certificateSubject?: SAMLSigningCertificateSubject;
+	certificateSubjectAlternativeNames?: SAMLSigningCertificateSubjectAlternativeNames;
 	signingKeyPolicies?: {
 		idp?: SAMLSigningKeyPolicy;
 		sp?: SAMLSigningKeyPolicy;
 	};
 	localSigning?: {
 		certificateSubject: SAMLSigningCertificateSubject;
+		certificateSubjectAlternativeNames: SAMLSigningCertificateSubjectAlternativeNames;
 		idpSigningKeyPolicy: SAMLSigningKeyPolicy;
 		spSigningKeyPolicy: SAMLSigningKeyPolicy;
 	};
@@ -545,6 +555,7 @@ export const adminSAMLAPI = {
 		entityIdStyle?: SAMLEntityIdStyle;
 		interactiveLoginUrlPolicy?: SAMLInteractiveLoginUrlPolicy;
 		certificateSubject?: Partial<SAMLSigningCertificateSubject>;
+		certificateSubjectAlternativeNames?: Partial<SAMLSigningCertificateSubjectAlternativeNames>;
 	}): Promise<SAMLSettings> {
 		const response = await adminFetch(`${API_BASE_URL}/api/admin/saml-settings`, {
 			method: 'PUT',
@@ -563,6 +574,7 @@ export const adminSAMLAPI = {
 		role: 'idp' | 'sp';
 		action: 'recreate_active' | 'publish_next' | 'promote_next' | 'retire_backup' | 'delete_next';
 		certificateSubject?: Partial<SAMLSigningCertificateSubject>;
+		certificateSubjectAlternativeNames?: Partial<SAMLSigningCertificateSubjectAlternativeNames>;
 		keepPreviousAsBackup?: boolean;
 		targetKid?: string;
 		targetKeyRef?: string;

--- a/packages/ar-admin-ui/src/lib/server/dev-admin-mock.ts
+++ b/packages/ar-admin-ui/src/lib/server/dev-admin-mock.ts
@@ -655,6 +655,18 @@ async function handleSamlProviders(
 			tenantId: TENANT_ID,
 			entityIdStyle: 'role_url',
 			interactiveLoginUrlPolicy: 'tenant_host',
+			certificateSubject: {
+				countryName: 'JP',
+				stateOrProvinceName: 'Tokyo',
+				localityName: 'Shinagawa',
+				organizationName: 'Authrim',
+				organizationalUnitName: 'Security',
+				commonName: 'localhost'
+			},
+			certificateSubjectAlternativeNames: {
+				includeGeneratedDnsNames: true,
+				dnsNames: ['localhost']
+			},
 			metadata: {
 				signingMode: 'enabled',
 				signingEnabled: true,
@@ -670,6 +682,22 @@ async function handleSamlProviders(
 				spEntityId: 'http://localhost:8787/saml/sp/metadata',
 				idpMetadataUrl: 'http://localhost:8787/saml/idp/metadata',
 				spMetadataUrl: 'http://localhost:8787/saml/sp/metadata'
+			},
+			localSigning: {
+				certificateSubject: {
+					countryName: 'JP',
+					stateOrProvinceName: 'Tokyo',
+					localityName: 'Shinagawa',
+					organizationName: 'Authrim',
+					organizationalUnitName: 'Security',
+					commonName: 'localhost'
+				},
+				certificateSubjectAlternativeNames: {
+					includeGeneratedDnsNames: true,
+					dnsNames: ['localhost']
+				},
+				idpSigningKeyPolicy: {},
+				spSigningKeyPolicy: {}
 			}
 		});
 	}

--- a/packages/ar-admin-ui/src/routes/admin/saml/local/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/saml/local/+page.svelte
@@ -9,12 +9,14 @@
 		type SAMLEntityIdStyle,
 		type SAMLInteractiveLoginUrlPolicy,
 		type SAMLSigningCertificateSubject,
+		type SAMLSigningCertificateSubjectAlternativeNames,
 		type SAMLSigningKeyReference,
 		type SAMLSigningKeyPolicy,
 		type SAMLSettings,
 		type SAMLTrustCertificatePreview
 	} from '$lib/api/admin-saml';
 	import { parseDiscoveryMethods } from '$lib/admin/tenant-discovery-settings';
+	import ToggleSwitch from '$lib/components/ToggleSwitch.svelte';
 	import { settingsContext } from '$lib/stores/settings-context.svelte';
 	import { getLocale, LL } from '$i18n/i18n-svelte';
 
@@ -121,6 +123,12 @@
 		organizationalUnitName: '',
 		commonName: 'Authrim SAML Signing'
 	});
+	let draftCertificateSubjectAlternativeNames =
+		$state<SAMLSigningCertificateSubjectAlternativeNames>({
+			includeGeneratedDnsNames: true,
+			dnsNames: []
+		});
+	let draftCertificateAdditionalDnsNames = $state('');
 
 	const signingRoles: MetadataRole[] = ['idp', 'sp'];
 
@@ -170,6 +178,12 @@
 			draftCertificateSubject = normalizeSubjectForForm(
 				settingsResult.localSigning?.certificateSubject ?? settingsResult.certificateSubject
 			);
+			draftCertificateSubjectAlternativeNames = normalizeSubjectAlternativeNamesForForm(
+				settingsResult.localSigning?.certificateSubjectAlternativeNames ??
+					settingsResult.certificateSubjectAlternativeNames
+			);
+			draftCertificateAdditionalDnsNames =
+				draftCertificateSubjectAlternativeNames.dnsNames.join(', ');
 			metadataDocs = tenantInfoResult.components.saml
 				? await loadMetadataDocuments(tenantInfoResult)
 				: [];
@@ -363,6 +377,92 @@
 			organizationalUnitName: subject?.organizationalUnitName ?? '',
 			commonName: subject?.commonName || 'Authrim SAML Signing'
 		};
+	}
+
+	function normalizeSubjectAlternativeNamesForForm(
+		value: Partial<SAMLSigningCertificateSubjectAlternativeNames> | undefined
+	): SAMLSigningCertificateSubjectAlternativeNames {
+		return {
+			includeGeneratedDnsNames: value?.includeGeneratedDnsNames !== false,
+			dnsNames: normalizeDnsNames(value?.dnsNames ?? [])
+		};
+	}
+
+	function normalizeDnsNames(values: string[]): string[] {
+		const seen = new Set<string>();
+		const names: string[] = [];
+		for (const value of values) {
+			const name = normalizeDnsName(value);
+			if (!name || seen.has(name)) continue;
+			seen.add(name);
+			names.push(name);
+		}
+		return names;
+	}
+
+	function normalizeDnsName(value: string): string {
+		const name = value.trim().toLowerCase();
+		if (!name || name.includes(':') || name.includes('/') || name.includes('*')) return '';
+		if (/^\d{1,3}(\.\d{1,3}){3}$/.test(name)) return '';
+		const labels = name.split('.');
+		if (
+			labels.some(
+				(label) =>
+					label.length === 0 ||
+					label.length > 63 ||
+					!/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label)
+			)
+		) {
+			return '';
+		}
+		return name;
+	}
+
+	function parseAdditionalDnsNamesInput(value: string): string[] {
+		return normalizeDnsNames(value.split(/[\s,]+/).filter(Boolean));
+	}
+
+	function currentCertificateSubjectAlternativeNames(): SAMLSigningCertificateSubjectAlternativeNames {
+		return normalizeSubjectAlternativeNamesForForm(
+			samlSettings?.localSigning?.certificateSubjectAlternativeNames ??
+				samlSettings?.certificateSubjectAlternativeNames
+		);
+	}
+
+	function draftCertificateSubjectAlternativeNamesRequest(): SAMLSigningCertificateSubjectAlternativeNames {
+		return {
+			includeGeneratedDnsNames: draftCertificateSubjectAlternativeNames.includeGeneratedDnsNames,
+			dnsNames: parseAdditionalDnsNamesInput(draftCertificateAdditionalDnsNames)
+		};
+	}
+
+	function generatedDnsNamesPreview(role: MetadataRole): string[] {
+		if (!samlSettings || !draftCertificateSubjectAlternativeNames.includeGeneratedDnsNames)
+			return [];
+		const issuerUrl = samlSettings.generated.issuerUrl;
+		const urls =
+			role === 'idp'
+				? [
+						samlSettings.generated.idpEntityId,
+						samlSettings.generated.idpMetadataUrl,
+						`${issuerUrl}/saml/idp/sso`,
+						`${issuerUrl}/saml/idp/slo`
+					]
+				: [
+						samlSettings.generated.spEntityId,
+						samlSettings.generated.spMetadataUrl,
+						`${issuerUrl}/saml/sp/acs`,
+						`${issuerUrl}/saml/sp/slo`
+					];
+		return normalizeDnsNames(urls.map(extractHostname));
+	}
+
+	function extractHostname(value: string): string {
+		try {
+			return new URL(value).hostname;
+		} catch {
+			return value;
+		}
 	}
 
 	function localSigningPolicy(role: MetadataRole): SAMLSigningKeyPolicy {
@@ -904,6 +1004,7 @@
 				role,
 				action,
 				certificateSubject: draftCertificateSubject,
+				certificateSubjectAlternativeNames: draftCertificateSubjectAlternativeNamesRequest(),
 				keepPreviousAsBackup: true,
 				targetKid: row?.reference?.kid,
 				targetKeyRef: row?.reference?.keyRef,
@@ -913,6 +1014,9 @@
 				publicKeySizeBits: draftCertificatePublicKeySizeBits
 			});
 			draftCertificateSubject = currentCertificateSubject();
+			draftCertificateSubjectAlternativeNames = currentCertificateSubjectAlternativeNames();
+			draftCertificateAdditionalDnsNames =
+				draftCertificateSubjectAlternativeNames.dnsNames.join(', ');
 			actionMessage = $LL.admin_saml_local_certificate_settings_updated();
 			if (tenantInfo?.components.saml) {
 				metadataDocs = await loadMetadataDocuments(tenantInfo);
@@ -1823,6 +1927,41 @@
 					</label>
 				</div>
 
+				<div class="san-settings">
+					<div class="san-toggle-row">
+						<div class="san-toggle-copy">
+							<strong>{$LL.admin_saml_local_dns_san_auto()}</strong>
+							<small>{$LL.admin_saml_local_dns_san_auto_desc()}</small>
+						</div>
+						<ToggleSwitch
+							checked={draftCertificateSubjectAlternativeNames.includeGeneratedDnsNames}
+							disabled={savingSettings}
+							onchange={(checked) =>
+								(draftCertificateSubjectAlternativeNames.includeGeneratedDnsNames = checked)}
+						/>
+					</div>
+					{#if draftCertificateSubjectAlternativeNames.includeGeneratedDnsNames}
+						<div class="san-preview">
+							<span>{$LL.admin_saml_local_dns_san_generated()}</span>
+							<div>
+								{#each generatedDnsNamesPreview(draftCertificateRole) as dnsName (dnsName)}
+									<code>{dnsName}</code>
+								{/each}
+							</div>
+						</div>
+					{/if}
+					<label class="san-extra">
+						<span>{$LL.admin_saml_local_dns_san_additional()}</span>
+						<input
+							class="form-input"
+							bind:value={draftCertificateAdditionalDnsNames}
+							placeholder="authrim.com"
+							disabled={savingSettings}
+						/>
+						<small>{$LL.admin_saml_local_dns_san_additional_desc()}</small>
+					</label>
+				</div>
+
 				<div class="entity-warning">
 					<i class="i-ph-warning-circle"></i>
 					<span>{$LL.admin_saml_local_subject_warning()}</span>
@@ -2430,6 +2569,75 @@
 		color: var(--text-secondary);
 		font-size: 0.75rem;
 		font-weight: 700;
+	}
+
+	.san-settings {
+		display: grid;
+		gap: 10px;
+		margin: 12px 0;
+		padding: 12px;
+		border: 1px solid var(--border-color);
+		border-radius: var(--radius-md);
+		background: var(--surface);
+	}
+
+	.san-toggle-row {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto;
+		gap: 12px;
+		align-items: center;
+	}
+
+	.san-toggle-copy {
+		display: grid;
+		gap: 2px;
+		min-width: 0;
+	}
+
+	.san-toggle-copy strong {
+		color: var(--text-primary);
+		font-size: 0.8125rem;
+	}
+
+	.san-toggle-copy small,
+	.san-extra small {
+		color: var(--text-secondary);
+		font-size: 0.75rem;
+		line-height: 1.4;
+	}
+
+	.san-preview {
+		display: grid;
+		gap: 6px;
+	}
+
+	.san-preview > span,
+	.san-extra > span {
+		color: var(--text-secondary);
+		font-size: 0.75rem;
+		font-weight: 700;
+	}
+
+	.san-preview div {
+		display: flex;
+		flex-wrap: nowrap;
+		gap: 6px;
+		overflow-x: auto;
+		white-space: nowrap;
+	}
+
+	.san-preview code {
+		flex: 0 0 auto;
+		padding: 3px 7px;
+		border-radius: 999px;
+		background: var(--bg-subtle);
+		color: var(--text-primary);
+		font-size: 0.75rem;
+	}
+
+	.san-extra {
+		display: grid;
+		gap: 5px;
 	}
 
 	.local-signing-grid {

--- a/packages/ar-admin-ui/src/routes/admin/saml/local/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/saml/local/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
-	import { SvelteURL } from 'svelte/reactivity';
+	import { SvelteSet, SvelteURL } from 'svelte/reactivity';
 	import { getTenantInfo, type TenantInfo } from '$lib/api/admin-info';
 	import { adminSettingsAPI, type CategorySettings } from '$lib/api/admin-settings';
 	import {
@@ -389,7 +389,7 @@
 	}
 
 	function normalizeDnsNames(values: string[]): string[] {
-		const seen = new Set<string>();
+		const seen = new SvelteSet<string>();
 		const names: string[] = [];
 		for (const value of values) {
 			const name = normalizeDnsName(value);

--- a/packages/ar-lib-core/src/types/saml.ts
+++ b/packages/ar-lib-core/src/types/saml.ts
@@ -376,6 +376,10 @@ export interface SAMLSigningKeyReference {
   publicKeyAlgorithm?: 'RSA';
   /** Public key size in bits */
   publicKeySizeBits?: number;
+  /** DNS subjectAltName values generated into this certificate */
+  subjectAlternativeNames?: {
+    dnsNames: string[];
+  };
 }
 
 export interface SAMLSigningKeyPolicy {

--- a/packages/ar-router/src/__tests__/router.test.ts
+++ b/packages/ar-router/src/__tests__/router.test.ts
@@ -463,6 +463,25 @@ describe('Router Worker', () => {
         expect(mockEnv.OP_SAML.fetch).toHaveBeenCalledTimes(1);
       });
 
+      it.each([
+        '/idp/profile/SAML2/POST/SSO',
+        '/idp/profile/SAML2/Redirect/SSO',
+        '/idp/profile/SAML2/POST/SLO',
+        '/idp/profile/SAML2/Redirect/SLO',
+      ])('should route %s to OP_SAML', async (path) => {
+        const req = new Request(`https://example.com${path}`);
+        await app.fetch(req, mockEnv);
+
+        expect(mockEnv.OP_SAML.fetch).toHaveBeenCalledTimes(1);
+      });
+
+      it('should not route Shibboleth 1.0 SSO profile to OP_SAML', async () => {
+        const req = new Request('https://example.com/idp/profile/Shibboleth/SSO');
+        await app.fetch(req, mockEnv);
+
+        expect(mockEnv.OP_SAML.fetch).not.toHaveBeenCalled();
+      });
+
       it('should route /api/admin/saml-providers to OP_SAML instead of OP_MANAGEMENT', async () => {
         const req = new Request('https://example.com/api/admin/saml-providers', {
           headers: { 'X-Tenant-Id': 'default' },

--- a/packages/ar-router/src/index.ts
+++ b/packages/ar-router/src/index.ts
@@ -113,6 +113,15 @@ function matchesPathGroup(path: string, basePath: string): boolean {
   return path === basePath || path.startsWith(`${basePath}/`);
 }
 
+function isGakuNinShibbolethSAML2IdPPath(path: string): boolean {
+  return (
+    path === '/idp/profile/SAML2/POST/SSO' ||
+    path === '/idp/profile/SAML2/Redirect/SSO' ||
+    path === '/idp/profile/SAML2/POST/SLO' ||
+    path === '/idp/profile/SAML2/Redirect/SLO'
+  );
+}
+
 function bearerTokenTransportError(): Response {
   return Response.json(
     {
@@ -261,6 +270,7 @@ app.use('*', async (c, next) => {
     path.startsWith('/admin-init-setup') ||
     path === '/api/ciba/test' ||
     path.startsWith('/saml/') ||
+    isGakuNinShibbolethSAML2IdPPath(path) ||
     // UI proxy paths - UI Workers handle their own headers
     path.startsWith('/setup') ||
     path.startsWith('/admin') ||
@@ -906,8 +916,20 @@ app.all('/api/internal/*', async (c) => {
  * - /saml/idp/* - IdP endpoints (metadata, SSO, SLO, IdP-initiated)
  * - /saml/sp/* - SP endpoints (metadata, ACS, login, SLO)
  * - /saml/admin/* - Admin API for SAML provider management
+ * - /idp/profile/SAML2/* - GakuNin/Shibboleth SAML2 IdP compatibility aliases
  */
 app.all('/saml/*', async (c) => {
+  if (!c.env.OP_SAML) {
+    return notFoundResponse();
+  }
+  const request = createServiceBindingRequest(c.req.raw);
+  return c.env.OP_SAML.fetch(request);
+});
+
+app.all('/idp/profile/SAML2/*', async (c) => {
+  if (!isGakuNinShibbolethSAML2IdPPath(c.req.path)) {
+    return notFoundResponse();
+  }
   if (!c.env.OP_SAML) {
     return notFoundResponse();
   }

--- a/packages/ar-saml/src/admin/local-signing-dr-bundle.ts
+++ b/packages/ar-saml/src/admin/local-signing-dr-bundle.ts
@@ -8,11 +8,14 @@ import {
   type SAMLSigningCertificateSubject,
 } from '../common/key-utils';
 import {
+  buildSAMLSigningCertificateSubjectAlternativeNames,
   getSAMLLocalEntityIds,
   getSAMLPublicSettings,
+  normalizeCertificateSubjectAlternativeNames,
   normalizeSAMLInteractiveLoginUrlPolicy,
   normalizeSAMLEntityIdStyle,
   putSAMLPublicSettings,
+  type SAMLSigningCertificateSubjectAlternativeNameSettings,
   type SAMLInteractiveLoginUrlPolicy,
   type SAMLEntityIdStyle,
 } from '../common/entity-id';
@@ -68,6 +71,7 @@ export interface SAMLLocalSigningSecretDRBundle {
     entityIdStyle: SAMLEntityIdStyle;
     interactiveLoginUrlPolicy: SAMLInteractiveLoginUrlPolicy;
     certificateSubject: Required<SAMLSigningCertificateSubject>;
+    certificateSubjectAlternativeNames: SAMLSigningCertificateSubjectAlternativeNameSettings;
     signingKeyPolicies: {
       idp?: SAMLSigningKeyPolicy;
       sp?: SAMLSigningKeyPolicy;
@@ -126,6 +130,7 @@ export async function buildSAMLLocalSigningSecretDRBundle(
       entityIdStyle: settings.entityIdStyle,
       interactiveLoginUrlPolicy: settings.interactiveLoginUrlPolicy,
       certificateSubject: settings.certificateSubject,
+      certificateSubjectAlternativeNames: settings.certificateSubjectAlternativeNames,
       signingKeyPolicies: settings.signingKeyPolicies,
     },
     generated,
@@ -179,6 +184,7 @@ export async function restoreSAMLLocalSigningSecretDRBundle(
       entityIdStyle: bundle.settings.entityIdStyle,
       interactiveLoginUrlPolicy: bundle.settings.interactiveLoginUrlPolicy,
       certificateSubject: bundle.settings.certificateSubject,
+      certificateSubjectAlternativeNames: bundle.settings.certificateSubjectAlternativeNames,
       signingKeyPolicies: bundle.settings.signingKeyPolicies,
     })
   );
@@ -333,6 +339,7 @@ async function collectSAMLSigningKeysForDRBundle(
 ): Promise<SAMLLocalSigningSecretDRKey[]> {
   const keys: SAMLLocalSigningSecretDRKey[] = [];
   const seen = new Set<string>();
+  const entityIds = await getSAMLLocalEntityIds(env, tenantId);
   for (const role of ['idp', 'sp'] as const) {
     const policy = settings.signingKeyPolicies[role] ?? {};
     const nextRefs = [policy.next, ...(policy.nextCandidates ?? [])]
@@ -372,6 +379,13 @@ async function collectSAMLSigningKeysForDRBundle(
       const exported = await exportSigningKeyWithPrivateMaterial(env, tenantId, {
         keyRef: ref.keyRef,
         certificateSubject: settings.certificateSubject,
+        certificateOptions: {
+          subjectAlternativeNames: buildSAMLSigningCertificateSubjectAlternativeNames(
+            entityIds,
+            ref.role,
+            settings.certificateSubjectAlternativeNames
+          ),
+        },
       });
       keys.push({
         role: ref.role,
@@ -490,6 +504,9 @@ function normalizeSAMLLocalSigningSecretDRBundle(input: unknown): SAMLLocalSigni
       entityIdStyle,
       interactiveLoginUrlPolicy,
       certificateSubject: normalizeCertificateSubject(settings.certificateSubject),
+      certificateSubjectAlternativeNames: normalizeCertificateSubjectAlternativeNames(
+        settings.certificateSubjectAlternativeNames
+      ),
       signingKeyPolicies: normalizeSigningKeyPolicies(settings.signingKeyPolicies),
     },
     generated: (typeof source.generated === 'object' && source.generated !== null

--- a/packages/ar-saml/src/admin/providers.ts
+++ b/packages/ar-saml/src/admin/providers.ts
@@ -96,8 +96,10 @@ import {
 } from './local-signing-dr-bundle';
 import { previewTrustCertificate } from './certificate-preview';
 import {
+  buildSAMLSigningCertificateSubjectAlternativeNames,
   getSAMLLocalEntityIds,
   getSAMLPublicSettings,
+  normalizeCertificateSubjectAlternativeNames,
   normalizeSAMLInteractiveLoginUrlPolicy,
   normalizeSAMLEntityIdStyle,
   putSAMLLocalSigningSettings,
@@ -499,6 +501,7 @@ export async function handleGetSAMLSettings(c: AdminSAMLContext): Promise<Respon
       metadata: buildSAMLMetadataPublicationSettings(c.env),
       localSigning: {
         certificateSubject: settings.certificateSubject,
+        certificateSubjectAlternativeNames: settings.certificateSubjectAlternativeNames,
         idpSigningKeyPolicy: settings.signingKeyPolicies.idp ?? {},
         spSigningKeyPolicy: settings.signingKeyPolicies.sp ?? {},
       },
@@ -529,6 +532,7 @@ export async function handleUpdateSAMLSettings(c: AdminSAMLContext): Promise<Res
       entityIdStyle?: unknown;
       interactiveLoginUrlPolicy?: unknown;
       certificateSubject?: unknown;
+      certificateSubjectAlternativeNames?: unknown;
     };
     const tenantId = resolveSAMLTenantIdFromContext(c);
     const before = await getSAMLPublicSettings(c.env, tenantId);
@@ -555,11 +559,16 @@ export async function handleUpdateSAMLSettings(c: AdminSAMLContext): Promise<Res
       body.certificateSubject === undefined
         ? before.certificateSubject
         : normalizeSAMLSigningCertificateSubject(body.certificateSubject);
+    const certificateSubjectAlternativeNames =
+      body.certificateSubjectAlternativeNames === undefined
+        ? before.certificateSubjectAlternativeNames
+        : normalizeCertificateSubjectAlternativeNames(body.certificateSubjectAlternativeNames);
 
     await putSAMLPublicSettings(c.env, tenantId, {
       entityIdStyle,
       interactiveLoginUrlPolicy,
       certificateSubject,
+      certificateSubjectAlternativeNames,
       signingKeyPolicies: before.signingKeyPolicies,
     });
 
@@ -575,6 +584,9 @@ export async function handleUpdateSAMLSettings(c: AdminSAMLContext): Promise<Res
         interactive_login_url_policy: interactiveLoginUrlPolicy,
         certificate_subject_changed:
           JSON.stringify(before.certificateSubject) !== JSON.stringify(certificateSubject),
+        certificate_subject_alternative_names_changed:
+          JSON.stringify(before.certificateSubjectAlternativeNames) !==
+          JSON.stringify(certificateSubjectAlternativeNames),
       },
     });
 
@@ -584,10 +596,12 @@ export async function handleUpdateSAMLSettings(c: AdminSAMLContext): Promise<Res
       entityIdStyle,
       interactiveLoginUrlPolicy,
       certificateSubject,
+      certificateSubjectAlternativeNames,
       signingKeyPolicies: before.signingKeyPolicies,
       metadata: buildSAMLMetadataPublicationSettings(c.env),
       localSigning: {
         certificateSubject,
+        certificateSubjectAlternativeNames,
         idpSigningKeyPolicy: before.signingKeyPolicies.idp ?? {},
         spSigningKeyPolicy: before.signingKeyPolicies.sp ?? {},
       },
@@ -618,6 +632,7 @@ export async function handleUpdateSAMLLocalSigning(c: AdminSAMLContext): Promise
       role?: unknown;
       action?: unknown;
       certificateSubject?: unknown;
+      certificateSubjectAlternativeNames?: unknown;
       keepPreviousAsBackup?: unknown;
       targetKid?: unknown;
       targetKeyRef?: unknown;
@@ -652,6 +667,10 @@ export async function handleUpdateSAMLLocalSigning(c: AdminSAMLContext): Promise
       body.certificateSubject === undefined
         ? settings.certificateSubject
         : normalizeSAMLSigningCertificateSubject(body.certificateSubject);
+    const certificateSubjectAlternativeNames =
+      body.certificateSubjectAlternativeNames === undefined
+        ? settings.certificateSubjectAlternativeNames
+        : normalizeCertificateSubjectAlternativeNames(body.certificateSubjectAlternativeNames);
     const targetKid = typeof body.targetKid === 'string' ? body.targetKid : undefined;
     const targetKeyRef = typeof body.targetKeyRef === 'string' ? body.targetKeyRef : undefined;
     const validFrom = normalizeOptionalTimestamp(body.validFrom);
@@ -666,6 +685,12 @@ export async function handleUpdateSAMLLocalSigning(c: AdminSAMLContext): Promise
     const signingKeyPolicies = { ...settings.signingKeyPolicies };
     const currentPolicy = signingKeyPolicies[role] ?? {};
     const baseContext = { tenantId, role };
+    const entityIds = await getSAMLLocalEntityIds(c.env, tenantId);
+    const subjectAlternativeNames = buildSAMLSigningCertificateSubjectAlternativeNames(
+      entityIds,
+      role,
+      certificateSubjectAlternativeNames
+    );
     let nextPolicy = currentPolicy;
     let generated: { keyRef?: string; kid?: string; certificate?: string } = {};
 
@@ -685,6 +710,7 @@ export async function handleUpdateSAMLLocalSigning(c: AdminSAMLContext): Promise
           validTo,
           publicKeyAlgorithm,
           publicKeySizeBits,
+          subjectAlternativeNames,
         },
       });
       nextPolicy = {
@@ -700,6 +726,7 @@ export async function handleUpdateSAMLLocalSigning(c: AdminSAMLContext): Promise
           validTo,
           publicKeyAlgorithm,
           publicKeySizeBits,
+          subjectAlternativeNames,
         },
         metadataCertificatePublication: getSAMLNextSigningCertificates(currentPolicy).length
           ? currentPolicy.backup
@@ -721,6 +748,7 @@ export async function handleUpdateSAMLLocalSigning(c: AdminSAMLContext): Promise
           validTo,
           publicKeyAlgorithm,
           publicKeySizeBits,
+          subjectAlternativeNames,
         },
       });
       nextPolicy = publishSAMLNextSigningCertificate(currentPolicy, {
@@ -733,6 +761,7 @@ export async function handleUpdateSAMLLocalSigning(c: AdminSAMLContext): Promise
         validTo,
         publicKeyAlgorithm,
         publicKeySizeBits,
+        subjectAlternativeNames,
         metadataCertificatePublication: currentPolicy.backup ? 'active_next_backup' : 'active_next',
       });
     } else if (action === 'promote_next') {
@@ -751,6 +780,7 @@ export async function handleUpdateSAMLLocalSigning(c: AdminSAMLContext): Promise
     signingKeyPolicies[role] = nextPolicy;
     const nextSettings = await putSAMLLocalSigningSettings(c.env, tenantId, {
       certificateSubject,
+      certificateSubjectAlternativeNames,
       signingKeyPolicies,
     });
 
@@ -769,13 +799,13 @@ export async function handleUpdateSAMLLocalSigning(c: AdminSAMLContext): Promise
       },
     });
 
-    const entityIds = await getSAMLLocalEntityIds(c.env, tenantId);
     return c.json({
       tenantId,
       ...nextSettings,
       metadata: buildSAMLMetadataPublicationSettings(c.env),
       localSigning: {
         certificateSubject: nextSettings.certificateSubject,
+        certificateSubjectAlternativeNames: nextSettings.certificateSubjectAlternativeNames,
         idpSigningKeyPolicy: nextSettings.signingKeyPolicies.idp ?? {},
         spSigningKeyPolicy: nextSettings.signingKeyPolicies.sp ?? {},
       },
@@ -899,6 +929,7 @@ export async function handleImportSAMLLocalSigningDRBundle(c: AdminSAMLContext):
       metadata: buildSAMLMetadataPublicationSettings(c.env),
       localSigning: {
         certificateSubject: settings.certificateSubject,
+        certificateSubjectAlternativeNames: settings.certificateSubjectAlternativeNames,
         idpSigningKeyPolicy: settings.signingKeyPolicies.idp ?? {},
         spSigningKeyPolicy: settings.signingKeyPolicies.sp ?? {},
       },

--- a/packages/ar-saml/src/admin/signing-rollover.ts
+++ b/packages/ar-saml/src/admin/signing-rollover.ts
@@ -23,6 +23,9 @@ export interface PublishSAMLNextSigningCertificateInput extends SAMLSigningRollo
   validTo?: number;
   publicKeyAlgorithm?: 'RSA';
   publicKeySizeBits?: number;
+  subjectAlternativeNames?: {
+    dnsNames: string[];
+  };
   metadataCertificatePublication?: Extract<
     SAMLMetadataCertificatePublication,
     'active_next' | 'active_next_backup'
@@ -64,6 +67,7 @@ export function publishSAMLNextSigningCertificate(
     validTo: input.validTo,
     publicKeyAlgorithm: input.publicKeyAlgorithm,
     publicKeySizeBits: input.publicKeySizeBits,
+    subjectAlternativeNames: input.subjectAlternativeNames,
   };
 
   return {

--- a/packages/ar-saml/src/common/__tests__/entity-id.test.ts
+++ b/packages/ar-saml/src/common/__tests__/entity-id.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildSAMLEntityIdFromIssuerUrl,
+  buildSAMLSigningCertificateSubjectAlternativeNames,
   DEFAULT_SAML_ENTITY_ID_STYLE,
   DEFAULT_SAML_INTERACTIVE_LOGIN_URL_POLICY,
   getSAMLPublicSettings,
@@ -72,7 +73,31 @@ describe('SAML local entityID helpers', () => {
         organizationalUnitName: '',
         commonName: 'Authrim SAML Signing',
       },
+      certificateSubjectAlternativeNames: {
+        includeGeneratedDnsNames: true,
+        dnsNames: [],
+      },
       signingKeyPolicies: {},
     });
+  });
+
+  it('builds DNS SAN names from entity IDs, endpoints, and explicit DNS settings', () => {
+    const subjectAlternativeNames = buildSAMLSigningCertificateSubjectAlternativeNames(
+      {
+        issuerUrl: 'https://conformance.authrim.com',
+        entityIdStyle: 'metadata_url',
+        idpEntityId: 'https://conformance.authrim.com/saml/idp/metadata',
+        spEntityId: 'https://conformance.authrim.com/saml/sp/metadata',
+        idpMetadataUrl: 'https://conformance.authrim.com/saml/idp/metadata',
+        spMetadataUrl: 'https://conformance.authrim.com/saml/sp/metadata',
+      },
+      'idp',
+      {
+        includeGeneratedDnsNames: true,
+        dnsNames: ['authrim.com', 'CONFORMANCE.authrim.com', 'https://invalid.example'],
+      }
+    );
+
+    expect(subjectAlternativeNames.dnsNames).toEqual(['conformance.authrim.com', 'authrim.com']);
   });
 });

--- a/packages/ar-saml/src/common/__tests__/key-utils.test.ts
+++ b/packages/ar-saml/src/common/__tests__/key-utils.test.ts
@@ -69,6 +69,38 @@ describe('SAML key utilities', () => {
     expect(certificate.issuer).toBe(certificate.subject);
   });
 
+  it('generates a self-signed certificate with DNS subject alternative names', async () => {
+    const keyPair = await crypto.subtle.generateKey(
+      {
+        name: 'RSASSA-PKCS1-v1_5',
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+        hash: 'SHA-256',
+      },
+      true,
+      ['sign', 'verify']
+    );
+    const [publicJwk, privateKeyPkcs8] = await Promise.all([
+      crypto.subtle.exportKey('jwk', keyPair.publicKey),
+      crypto.subtle.exportKey('pkcs8', keyPair.privateKey),
+    ]);
+
+    const certificatePem = await generateSelfSignedCertificate(
+      publicJwk,
+      formatPem('PRIVATE KEY', arrayBufferToBase64(new Uint8Array(privateKeyPkcs8))),
+      { commonName: 'conformance.authrim.com' },
+      {
+        subjectAlternativeNames: {
+          dnsNames: ['conformance.authrim.com', 'authrim.com', 'conformance.authrim.com'],
+        },
+      }
+    );
+    const certificate = new X509Certificate(certificatePem);
+
+    expect(certificate.subjectAltName).toContain('DNS:conformance.authrim.com');
+    expect(certificate.subjectAltName).toContain('DNS:authrim.com');
+  });
+
   it('stores a generated certificate in KeyManager when a key has no certificate yet', async () => {
     const keyPair = await crypto.subtle.generateKey(
       {

--- a/packages/ar-saml/src/common/entity-id.ts
+++ b/packages/ar-saml/src/common/entity-id.ts
@@ -2,6 +2,7 @@ import type { Env, SAMLSigningKeyPolicy } from '@authrim/ar-lib-core';
 import { buildIssuerUrl } from '@authrim/ar-lib-core';
 import {
   DEFAULT_SAML_SIGNING_CERTIFICATE_SUBJECT,
+  type SAMLSigningCertificateSubjectAlternativeNames,
   type SAMLSigningCertificateSubject,
 } from './key-utils';
 
@@ -13,10 +14,16 @@ export interface SAMLPublicSettings {
   entityIdStyle: SAMLEntityIdStyle;
   interactiveLoginUrlPolicy: SAMLInteractiveLoginUrlPolicy;
   certificateSubject: Required<SAMLSigningCertificateSubject>;
+  certificateSubjectAlternativeNames: SAMLSigningCertificateSubjectAlternativeNameSettings;
   signingKeyPolicies: {
     idp?: SAMLSigningKeyPolicy;
     sp?: SAMLSigningKeyPolicy;
   };
+}
+
+export interface SAMLSigningCertificateSubjectAlternativeNameSettings {
+  includeGeneratedDnsNames: boolean;
+  dnsNames: string[];
 }
 
 export interface SAMLLocalEntityIds {
@@ -95,6 +102,7 @@ export async function getSAMLPublicSettings(
       normalizeSAMLInteractiveLoginUrlPolicy(env.SAML_INTERACTIVE_LOGIN_URL_POLICY) ??
       storedSettings.interactiveLoginUrlPolicy,
     certificateSubject: storedSettings.certificateSubject,
+    certificateSubjectAlternativeNames: storedSettings.certificateSubjectAlternativeNames,
     signingKeyPolicies: storedSettings.signingKeyPolicies,
   };
 }
@@ -116,6 +124,8 @@ export async function putSAMLPublicSettings(
       entityIdStyle: settings.entityIdStyle,
       interactiveLoginUrlPolicy: settings.interactiveLoginUrlPolicy,
       certificateSubject: settings.certificateSubject ?? before.certificateSubject,
+      certificateSubjectAlternativeNames:
+        settings.certificateSubjectAlternativeNames ?? before.certificateSubjectAlternativeNames,
       signingKeyPolicies: settings.signingKeyPolicies ?? before.signingKeyPolicies,
       updatedAt: Date.now(),
     })
@@ -125,7 +135,10 @@ export async function putSAMLPublicSettings(
 export async function putSAMLLocalSigningSettings(
   env: Env,
   tenantId: string,
-  settings: Pick<SAMLPublicSettings, 'certificateSubject' | 'signingKeyPolicies'>
+  settings: Pick<
+    SAMLPublicSettings,
+    'certificateSubject' | 'certificateSubjectAlternativeNames' | 'signingKeyPolicies'
+  >
 ): Promise<SAMLPublicSettings> {
   if (!env.SETTINGS) {
     throw new Error('SETTINGS KV binding is required to update SAML signing settings');
@@ -134,6 +147,7 @@ export async function putSAMLLocalSigningSettings(
   const next: SAMLPublicSettings = {
     ...before,
     certificateSubject: settings.certificateSubject,
+    certificateSubjectAlternativeNames: settings.certificateSubjectAlternativeNames,
     signingKeyPolicies: settings.signingKeyPolicies,
   };
   await env.SETTINGS.put(
@@ -162,11 +176,42 @@ export async function getSAMLLocalEntityIds(
   };
 }
 
+export function buildSAMLSigningCertificateSubjectAlternativeNames(
+  entityIds: SAMLLocalEntityIds,
+  role: SAMLLocalRole,
+  settings: SAMLSigningCertificateSubjectAlternativeNameSettings
+): SAMLSigningCertificateSubjectAlternativeNames {
+  const generatedUrls =
+    role === 'idp'
+      ? [
+          entityIds.idpEntityId,
+          entityIds.idpMetadataUrl,
+          `${entityIds.issuerUrl}/saml/idp/sso`,
+          `${entityIds.issuerUrl}/saml/idp/slo`,
+        ]
+      : [
+          entityIds.spEntityId,
+          entityIds.spMetadataUrl,
+          `${entityIds.issuerUrl}/saml/sp/acs`,
+          `${entityIds.issuerUrl}/saml/sp/slo`,
+        ];
+  const generatedNames = settings.includeGeneratedDnsNames
+    ? generatedUrls.map(extractDnsNameFromUrl).filter((name): name is string => Boolean(name))
+    : [];
+  return {
+    dnsNames: uniqueDnsNames([...generatedNames, ...settings.dnsNames]),
+  };
+}
+
 async function readStoredSAMLSettings(env: Env, tenantId: string): Promise<SAMLPublicSettings> {
   const defaults = {
     entityIdStyle: DEFAULT_SAML_ENTITY_ID_STYLE,
     interactiveLoginUrlPolicy: DEFAULT_SAML_INTERACTIVE_LOGIN_URL_POLICY,
     certificateSubject: DEFAULT_SAML_SIGNING_CERTIFICATE_SUBJECT,
+    certificateSubjectAlternativeNames: {
+      includeGeneratedDnsNames: true,
+      dnsNames: [],
+    },
     signingKeyPolicies: {},
   };
 
@@ -186,6 +231,8 @@ async function readStoredSAMLSettings(env: Env, tenantId: string): Promise<SAMLP
       interactiveLoginUrlPolicy?: unknown;
       interactive_login_url_policy?: unknown;
       certificateSubject?: unknown;
+      certificateSubjectAlternativeNames?: unknown;
+      certificate_subject_alternative_names?: unknown;
       signingKeyPolicies?: unknown;
     };
     return {
@@ -198,6 +245,9 @@ async function readStoredSAMLSettings(env: Env, tenantId: string): Promise<SAMLP
         normalizeSAMLInteractiveLoginUrlPolicy(parsed.interactive_login_url_policy) ??
         DEFAULT_SAML_INTERACTIVE_LOGIN_URL_POLICY,
       certificateSubject: normalizeCertificateSubject(parsed.certificateSubject),
+      certificateSubjectAlternativeNames: normalizeCertificateSubjectAlternativeNames(
+        parsed.certificateSubjectAlternativeNames ?? parsed.certificate_subject_alternative_names
+      ),
       signingKeyPolicies: normalizeSigningKeyPolicies(parsed.signingKeyPolicies),
     };
   } catch {
@@ -228,6 +278,59 @@ function readString(value: unknown, maxLength: number): string {
         .trim()
         .slice(0, maxLength)
     : '';
+}
+
+export function normalizeCertificateSubjectAlternativeNames(
+  value: unknown
+): SAMLSigningCertificateSubjectAlternativeNameSettings {
+  const source =
+    typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {};
+  const includeGeneratedDnsNames =
+    typeof source.includeGeneratedDnsNames === 'boolean' ? source.includeGeneratedDnsNames : true;
+  return {
+    includeGeneratedDnsNames,
+    dnsNames: uniqueDnsNames(Array.isArray(source.dnsNames) ? source.dnsNames : []),
+  };
+}
+
+function uniqueDnsNames(values: unknown[]): string[] {
+  const seen = new Set<string>();
+  const names: string[] = [];
+  for (const value of values) {
+    const name = readDnsName(value);
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    names.push(name);
+  }
+  return names.slice(0, 20);
+}
+
+function readDnsName(value: unknown): string {
+  const normalized = readString(value, 253).toLowerCase();
+  if (!normalized || normalized.includes(':') || normalized.includes('/')) {
+    return '';
+  }
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(normalized) || normalized.includes('*')) {
+    return '';
+  }
+  const labels = normalized.split('.');
+  if (
+    labels.some(
+      (label) =>
+        label.length === 0 || label.length > 63 || !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label)
+    )
+  ) {
+    return '';
+  }
+  return normalized;
+}
+
+function extractDnsNameFromUrl(value: string): string {
+  try {
+    return readDnsName(new URL(value).hostname);
+  } catch {
+    return readDnsName(value);
+  }
 }
 
 function normalizeSigningKeyPolicies(value: unknown): SAMLPublicSettings['signingKeyPolicies'] {

--- a/packages/ar-saml/src/common/key-utils.ts
+++ b/packages/ar-saml/src/common/key-utils.ts
@@ -52,11 +52,16 @@ export interface SAMLSigningCertificateSubject {
   commonName?: string;
 }
 
+export interface SAMLSigningCertificateSubjectAlternativeNames {
+  dnsNames: string[];
+}
+
 export interface SAMLSigningCertificateCreationOptions {
   validFrom?: number;
   validTo?: number;
   publicKeyAlgorithm?: 'RSA';
   publicKeySizeBits?: 2048 | 3072 | 4096;
+  subjectAlternativeNames?: SAMLSigningCertificateSubjectAlternativeNames;
 }
 
 export const DEFAULT_SAML_SIGNING_CERTIFICATE_SUBJECT: Required<SAMLSigningCertificateSubject> = {
@@ -75,6 +80,7 @@ const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 export interface SigningKeyLookupOptions {
   keyRef?: string;
   certificateSubject?: SAMLSigningCertificateSubject;
+  certificateOptions?: SAMLSigningCertificateCreationOptions;
 }
 
 export interface SecretLookupOptions {
@@ -155,6 +161,7 @@ export async function getSigningKey(
       const certificate = await getOrPersistSigningCertificate(keyManager, env.KEY_MANAGER_SECRET, {
         keyData: rotateData.key,
         certificateSubject: options.certificateSubject,
+        certificateOptions: options.certificateOptions,
       });
 
       // Update cache
@@ -181,6 +188,7 @@ export async function getSigningKey(
   const certificate = await getOrPersistSigningCertificate(keyManager, env.KEY_MANAGER_SECRET, {
     keyData,
     certificateSubject: options.certificateSubject,
+    certificateOptions: options.certificateOptions,
   });
 
   // Update cache
@@ -356,6 +364,7 @@ export async function exportSigningKeyWithPrivateMaterial(
   options: {
     keyRef: string;
     certificateSubject?: SAMLSigningCertificateSubject;
+    certificateOptions?: SAMLSigningCertificateCreationOptions;
   }
 ): Promise<SAMLExportedSigningKey> {
   const resolvedTenantId = requireSAMLTenantId(tenantId, 'SAML signing key tenant');
@@ -363,10 +372,12 @@ export async function exportSigningKeyWithPrivateMaterial(
   const keyManager = env.KEY_MANAGER.get(keyManagerId);
   const keyData = await getOrCreateKeyManagerSigningKey(keyManager, env.KEY_MANAGER_SECRET, {
     certificateSubject: options.certificateSubject,
+    certificateOptions: options.certificateOptions,
   });
   const certificate = await getOrPersistSigningCertificate(keyManager, env.KEY_MANAGER_SECRET, {
     keyData,
     certificateSubject: options.certificateSubject,
+    certificateOptions: options.certificateOptions,
   });
 
   signingKeyCache.set(buildSigningKeyCacheKey(resolvedTenantId, options.keyRef), {
@@ -431,6 +442,7 @@ async function getOrCreateKeyManagerSigningKey(
   keyManagerSecret: string | undefined,
   options: {
     certificateSubject?: SAMLSigningCertificateSubject;
+    certificateOptions?: SAMLSigningCertificateCreationOptions;
   }
 ): Promise<KeyManagerSigningKey> {
   if (!keyManagerSecret) {
@@ -467,6 +479,7 @@ async function getOrCreateKeyManagerSigningKey(
   await getOrPersistSigningCertificate(keyManager, keyManagerSecret, {
     keyData: rotateData.key,
     certificateSubject: options.certificateSubject,
+    certificateOptions: options.certificateOptions,
   });
   return rotateData.key;
 }
@@ -576,7 +589,7 @@ function buildSelfSignedCertificateTbs(
     derSequence(derUtcTime(notBefore), derUtcTime(notAfter)),
     buildCertificateName(subject),
     subjectPublicKeyInfo,
-    derExplicit(3, buildCertificateExtensions())
+    derExplicit(3, buildCertificateExtensions(options))
   );
 }
 
@@ -646,7 +659,7 @@ function buildCertificateName(subject: Required<SAMLSigningCertificateSubject>):
   return derSequence(...attributes);
 }
 
-function buildCertificateExtensions(): Uint8Array {
+function buildCertificateExtensions(options: SAMLSigningCertificateCreationOptions): Uint8Array {
   const basicConstraints = derSequence(
     derObjectIdentifier('2.5.29.19'),
     derBoolean(true),
@@ -657,8 +670,64 @@ function buildCertificateExtensions(): Uint8Array {
     derBoolean(true),
     derOctetString(derBitString(new Uint8Array([0x80]), 7))
   );
+  const subjectAlternativeNames = normalizeCertificateSubjectAlternativeNames(
+    options.subjectAlternativeNames
+  );
 
-  return derSequence(basicConstraints, keyUsage);
+  return derSequence(
+    basicConstraints,
+    keyUsage,
+    ...(subjectAlternativeNames.dnsNames.length
+      ? [buildSubjectAlternativeNameExtension(subjectAlternativeNames)]
+      : [])
+  );
+}
+
+function normalizeCertificateSubjectAlternativeNames(
+  value: SAMLSigningCertificateSubjectAlternativeNames | undefined
+): { dnsNames: string[] } {
+  const seen = new Set<string>();
+  const dnsNames = Array.isArray(value?.dnsNames)
+    ? value.dnsNames
+        .map((name) => sanitizeDnsName(name))
+        .filter((name): name is string => {
+          if (!name || seen.has(name)) return false;
+          seen.add(name);
+          return true;
+        })
+    : [];
+  return { dnsNames };
+}
+
+function sanitizeDnsName(value: string | undefined): string {
+  const normalized = String(value || '')
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .trim()
+    .toLowerCase()
+    .slice(0, 253);
+  if (!normalized || normalized.includes(':') || normalized.includes('/')) {
+    return '';
+  }
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(normalized) || normalized.includes('*')) {
+    return '';
+  }
+  const labels = normalized.split('.');
+  if (
+    labels.some(
+      (label) =>
+        label.length === 0 || label.length > 63 || !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label)
+    )
+  ) {
+    return '';
+  }
+  return normalized;
+}
+
+function buildSubjectAlternativeNameExtension(input: { dnsNames: string[] }): Uint8Array {
+  const generalNames = derSequence(
+    ...input.dnsNames.map((dnsName) => derTag(0x82, new TextEncoder().encode(dnsName)))
+  );
+  return derSequence(derObjectIdentifier('2.5.29.17'), derOctetString(generalNames));
 }
 
 function buildSha256WithRsaAlgorithmIdentifier(): Uint8Array {

--- a/packages/ar-saml/src/common/saml-signing-keys.ts
+++ b/packages/ar-saml/src/common/saml-signing-keys.ts
@@ -10,8 +10,15 @@ import type {
 import {
   getSigningCertificate,
   getSigningKey,
+  type SAMLSigningCertificateCreationOptions,
+  type SAMLSigningCertificateSubjectAlternativeNames,
   type SAMLSigningCertificateSubject,
 } from './key-utils';
+import {
+  buildSAMLSigningCertificateSubjectAlternativeNames,
+  getSAMLLocalEntityIds,
+  getSAMLPublicSettings,
+} from './entity-id';
 import { requireSAMLTenantId } from './tenant';
 
 export interface SAMLSigningKeyContext {
@@ -20,6 +27,7 @@ export interface SAMLSigningKeyContext {
   counterpartyEntityId?: string;
   policy?: SAMLSigningKeyPolicy;
   certificateSubject?: SAMLSigningCertificateSubject;
+  certificateSubjectAlternativeNames?: SAMLSigningCertificateSubjectAlternativeNames;
 }
 
 export interface SAMLSigningMaterial {
@@ -63,11 +71,16 @@ export async function getSAMLSigningMaterial(
   context: SAMLSigningKeyContext
 ): Promise<SAMLSigningMaterial> {
   const keyRef = resolveSAMLSigningKeyRef(context);
+  const certificateOptions = await resolveSAMLSigningCertificateOptions(env, context);
   const [key, certificate] = await Promise.all([
-    getSigningKey(env, context.tenantId, { keyRef }),
+    getSigningKey(env, context.tenantId, {
+      keyRef,
+      certificateOptions,
+    }),
     getSigningCertificate(env, context.tenantId, {
       keyRef,
       certificateSubject: context.certificateSubject,
+      certificateOptions,
     }),
   ]);
 
@@ -149,6 +162,7 @@ async function resolvePublishedCertificate(
   const certificate = await getSigningCertificate(env, context.tenantId, {
     keyRef: reference.keyRef,
     certificateSubject: context.certificateSubject,
+    certificateOptions: await resolveSAMLSigningCertificateOptions(env, context),
   });
 
   return {
@@ -156,6 +170,28 @@ async function resolvePublishedCertificate(
     keyRef: reference.keyRef,
     kid: reference.kid,
     certificate,
+  };
+}
+
+async function resolveSAMLSigningCertificateOptions(
+  env: Env,
+  context: SAMLSigningKeyContext
+): Promise<SAMLSigningCertificateCreationOptions> {
+  if (context.certificateSubjectAlternativeNames) {
+    return {
+      subjectAlternativeNames: context.certificateSubjectAlternativeNames,
+    };
+  }
+  const [entityIds, settings] = await Promise.all([
+    getSAMLLocalEntityIds(env, context.tenantId),
+    getSAMLPublicSettings(env, context.tenantId),
+  ]);
+  return {
+    subjectAlternativeNames: buildSAMLSigningCertificateSubjectAlternativeNames(
+      entityIds,
+      context.role,
+      settings.certificateSubjectAlternativeNames
+    ),
   };
 }
 

--- a/packages/ar-saml/src/idp/__tests__/shibboleth-compat.test.ts
+++ b/packages/ar-saml/src/idp/__tests__/shibboleth-compat.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildIdPSLODestinationUrls,
+  buildIdPSSODestinationUrls,
+  GAKUNIN_SHIBBOLETH_SAML2_IDP_SLO_POST_PATH,
+  GAKUNIN_SHIBBOLETH_SAML2_IDP_SLO_REDIRECT_PATH,
+  GAKUNIN_SHIBBOLETH_SAML2_IDP_SSO_POST_PATH,
+  GAKUNIN_SHIBBOLETH_SAML2_IDP_SSO_REDIRECT_PATH,
+  isAllowedIdPSLODestination,
+  isAllowedIdPSSODestination,
+} from '../shibboleth-compat';
+
+describe('GakuNin/Shibboleth SAML2 IdP compatibility endpoints', () => {
+  const issuerUrl = 'https://conformance.authrim.com';
+
+  it('allows canonical and Shibboleth-style SAML2 SSO destinations', () => {
+    expect(buildIdPSSODestinationUrls(`${issuerUrl}/`)).toEqual([
+      `${issuerUrl}/saml/idp/sso`,
+      `${issuerUrl}${GAKUNIN_SHIBBOLETH_SAML2_IDP_SSO_POST_PATH}`,
+      `${issuerUrl}${GAKUNIN_SHIBBOLETH_SAML2_IDP_SSO_REDIRECT_PATH}`,
+    ]);
+
+    expect(isAllowedIdPSSODestination(`${issuerUrl}/saml/idp/sso`, issuerUrl)).toBe(true);
+    expect(
+      isAllowedIdPSSODestination(
+        `${issuerUrl}${GAKUNIN_SHIBBOLETH_SAML2_IDP_SSO_POST_PATH}`,
+        issuerUrl
+      )
+    ).toBe(true);
+    expect(
+      isAllowedIdPSSODestination(
+        `${issuerUrl}${GAKUNIN_SHIBBOLETH_SAML2_IDP_SSO_REDIRECT_PATH}`,
+        issuerUrl
+      )
+    ).toBe(true);
+  });
+
+  it('allows canonical and Shibboleth-style SAML2 SLO destinations', () => {
+    expect(buildIdPSLODestinationUrls(`${issuerUrl}/`)).toEqual([
+      `${issuerUrl}/saml/idp/slo`,
+      `${issuerUrl}${GAKUNIN_SHIBBOLETH_SAML2_IDP_SLO_POST_PATH}`,
+      `${issuerUrl}${GAKUNIN_SHIBBOLETH_SAML2_IDP_SLO_REDIRECT_PATH}`,
+    ]);
+
+    expect(isAllowedIdPSLODestination(`${issuerUrl}/saml/idp/slo`, issuerUrl)).toBe(true);
+    expect(
+      isAllowedIdPSLODestination(
+        `${issuerUrl}${GAKUNIN_SHIBBOLETH_SAML2_IDP_SLO_POST_PATH}`,
+        issuerUrl
+      )
+    ).toBe(true);
+    expect(
+      isAllowedIdPSLODestination(
+        `${issuerUrl}${GAKUNIN_SHIBBOLETH_SAML2_IDP_SLO_REDIRECT_PATH}`,
+        issuerUrl
+      )
+    ).toBe(true);
+  });
+
+  it('does not allow Shibboleth 1.0 profile destinations', () => {
+    expect(isAllowedIdPSSODestination(`${issuerUrl}/idp/profile/Shibboleth/SSO`, issuerUrl)).toBe(
+      false
+    );
+  });
+});

--- a/packages/ar-saml/src/idp/metadata.ts
+++ b/packages/ar-saml/src/idp/metadata.ts
@@ -40,7 +40,11 @@ import {
   shouldSignSAMLMetadata,
   signSAMLMetadata,
 } from '../common/metadata-signing';
-import { getSAMLLocalEntityIds, getSAMLPublicSettings } from '../common/entity-id';
+import {
+  buildSAMLSigningCertificateSubjectAlternativeNames,
+  getSAMLLocalEntityIds,
+  getSAMLPublicSettings,
+} from '../common/entity-id';
 
 /**
  * Handle IdP metadata request
@@ -50,10 +54,16 @@ export async function handleIdPMetadata(c: Context<{ Bindings: Env }>): Promise<
   const log = getLogger(c).module('SAML-IDP');
   const tenantId = resolveSAMLTenantIdFromContext(c);
 
-  const [{ issuerUrl, idpEntityId: entityId }, settings] = await Promise.all([
+  const [entityIds, settings] = await Promise.all([
     getSAMLLocalEntityIds(env, tenantId),
     getSAMLPublicSettings(env, tenantId),
   ]);
+  const { issuerUrl, idpEntityId: entityId } = entityIds;
+  const certificateSubjectAlternativeNames = buildSAMLSigningCertificateSubjectAlternativeNames(
+    entityIds,
+    'idp',
+    settings.certificateSubjectAlternativeNames
+  );
 
   // Get signing certificates from KeyManager / SAML rollover policy.
   let signingCertificates: SAMLMetadataSigningCertificate[];
@@ -63,6 +73,7 @@ export async function handleIdPMetadata(c: Context<{ Bindings: Env }>): Promise<
       role: 'idp',
       policy: settings.signingKeyPolicies.idp,
       certificateSubject: settings.certificateSubject,
+      certificateSubjectAlternativeNames,
     });
   } catch (error) {
     log.error('Failed to get signing certificate', {}, error as Error);
@@ -83,6 +94,7 @@ export async function handleIdPMetadata(c: Context<{ Bindings: Env }>): Promise<
         role: 'idp',
         policy: settings.signingKeyPolicies.idp,
         certificateSubject: settings.certificateSubject,
+        certificateSubjectAlternativeNames,
       });
       metadataXml = signSAMLMetadata(metadataXml, signingMaterial);
     } catch (error) {

--- a/packages/ar-saml/src/idp/shibboleth-compat.ts
+++ b/packages/ar-saml/src/idp/shibboleth-compat.ts
@@ -1,0 +1,33 @@
+export const GAKUNIN_SHIBBOLETH_SAML2_IDP_SSO_POST_PATH = '/idp/profile/SAML2/POST/SSO';
+export const GAKUNIN_SHIBBOLETH_SAML2_IDP_SSO_REDIRECT_PATH = '/idp/profile/SAML2/Redirect/SSO';
+export const GAKUNIN_SHIBBOLETH_SAML2_IDP_SLO_POST_PATH = '/idp/profile/SAML2/POST/SLO';
+export const GAKUNIN_SHIBBOLETH_SAML2_IDP_SLO_REDIRECT_PATH = '/idp/profile/SAML2/Redirect/SLO';
+
+export function buildIdPSSODestinationUrls(issuerUrl: string): string[] {
+  return buildDestinationUrls(issuerUrl, [
+    '/saml/idp/sso',
+    GAKUNIN_SHIBBOLETH_SAML2_IDP_SSO_POST_PATH,
+    GAKUNIN_SHIBBOLETH_SAML2_IDP_SSO_REDIRECT_PATH,
+  ]);
+}
+
+export function buildIdPSLODestinationUrls(issuerUrl: string): string[] {
+  return buildDestinationUrls(issuerUrl, [
+    '/saml/idp/slo',
+    GAKUNIN_SHIBBOLETH_SAML2_IDP_SLO_POST_PATH,
+    GAKUNIN_SHIBBOLETH_SAML2_IDP_SLO_REDIRECT_PATH,
+  ]);
+}
+
+export function isAllowedIdPSSODestination(destination: string, issuerUrl: string): boolean {
+  return buildIdPSSODestinationUrls(issuerUrl).includes(destination);
+}
+
+export function isAllowedIdPSLODestination(destination: string, issuerUrl: string): boolean {
+  return buildIdPSLODestinationUrls(issuerUrl).includes(destination);
+}
+
+function buildDestinationUrls(issuerUrl: string, paths: string[]): string[] {
+  const base = issuerUrl.endsWith('/') ? issuerUrl.slice(0, -1) : issuerUrl;
+  return paths.map((path) => `${base}${path}`);
+}

--- a/packages/ar-saml/src/idp/slo.ts
+++ b/packages/ar-saml/src/idp/slo.ts
@@ -77,6 +77,7 @@ import {
 } from './slo-state';
 import { getSAMLLocalEntityIds } from '../common/entity-id';
 import { assertSAMLRelayStateSize } from '../common/relay-state';
+import { buildIdPSLODestinationUrls, isAllowedIdPSLODestination } from './shibboleth-compat';
 
 interface ParsedLogoutRequestInput {
   logoutRequest: ParsedLogoutRequest;
@@ -527,11 +528,10 @@ function validateLogoutResponseDestination(
     return;
   }
 
-  const expectedDestination = `${issuerUrl}/saml/idp/slo`;
-  if (logoutResponse.destination !== expectedDestination) {
+  if (!isAllowedIdPSLODestination(logoutResponse.destination, issuerUrl)) {
     throw new SAMLLogoutResponseCorrelationError('Invalid Destination in SAML LogoutResponse', {
       destination: logoutResponse.destination,
-      expected_destination: expectedDestination,
+      expected_destinations: buildIdPSLODestinationUrls(issuerUrl),
     });
   }
 }
@@ -564,8 +564,7 @@ function validateLogoutRequest(logoutRequest: ParsedLogoutRequest, issuerUrl: st
 
   // Validate Destination if present
   if (logoutRequest.destination) {
-    const expectedDestination = `${issuerUrl}/saml/idp/slo`;
-    if (logoutRequest.destination !== expectedDestination) {
+    if (!isAllowedIdPSLODestination(logoutRequest.destination, issuerUrl)) {
       // SECURITY: Do not expose endpoint URLs in error message
       throw new Error('Invalid Destination in SAML LogoutRequest');
     }

--- a/packages/ar-saml/src/idp/sso.ts
+++ b/packages/ar-saml/src/idp/sso.ts
@@ -102,6 +102,7 @@ import { buildSAMLAssertionTiming } from './assertion-timing';
 import { buildSAMLPostBindingResponse } from '../common/post-binding-form';
 import { getSAMLLocalEntityIds } from '../common/entity-id';
 import { assertSAMLRelayStateSize } from '../common/relay-state';
+import { isAllowedIdPSSODestination } from './shibboleth-compat';
 
 interface AuthenticatedSAMLSession {
   userId: string;
@@ -993,8 +994,7 @@ async function validateAuthnRequest(
 
   // Validate Destination if present
   if (authnRequest.destination) {
-    const expectedDestination = `${issuerUrl}/saml/idp/sso`;
-    if (authnRequest.destination !== expectedDestination) {
+    if (!isAllowedIdPSSODestination(authnRequest.destination, issuerUrl)) {
       // SECURITY: Do not expose endpoint URLs in error message
       throw new Error('Invalid Destination in SAML AuthnRequest');
     }

--- a/packages/ar-saml/src/index.ts
+++ b/packages/ar-saml/src/index.ts
@@ -7,8 +7,12 @@
  * - GET  /saml/idp/metadata - IdP metadata
  * - GET  /saml/idp/sso      - SSO (HTTP-Redirect Binding)
  * - POST /saml/idp/sso      - SSO (HTTP-POST Binding)
+ * - GET  /idp/profile/SAML2/Redirect/SSO - GakuNin/Shibboleth SAML2 SSO alias
+ * - POST /idp/profile/SAML2/POST/SSO     - GakuNin/Shibboleth SAML2 SSO alias
  * - GET  /saml/idp/init     - IdP-initiated SSO
  * - POST /saml/idp/slo      - Single Logout
+ * - GET  /idp/profile/SAML2/Redirect/SLO - GakuNin/Shibboleth SAML2 SLO alias
+ * - POST /idp/profile/SAML2/POST/SLO     - GakuNin/Shibboleth SAML2 SLO alias
  *
  * SP Endpoints:
  * - GET  /saml/sp/metadata  - SP metadata
@@ -81,6 +85,12 @@ import {
   handleRetireSigningBackup,
 } from './admin/providers';
 import { handleScheduled } from './scheduled';
+import {
+  GAKUNIN_SHIBBOLETH_SAML2_IDP_SLO_POST_PATH,
+  GAKUNIN_SHIBBOLETH_SAML2_IDP_SLO_REDIRECT_PATH,
+  GAKUNIN_SHIBBOLETH_SAML2_IDP_SSO_POST_PATH,
+  GAKUNIN_SHIBBOLETH_SAML2_IDP_SSO_REDIRECT_PATH,
+} from './idp/shibboleth-compat';
 
 // Create Hono app with Cloudflare Workers bindings
 const app = new Hono<{ Bindings: Env }>();
@@ -130,12 +140,14 @@ app.get('/saml/idp/metadata', handleIdPMetadata);
  * Receives SAML AuthnRequest via URL parameters
  */
 app.get('/saml/idp/sso', handleIdPSSO);
+app.get(GAKUNIN_SHIBBOLETH_SAML2_IDP_SSO_REDIRECT_PATH, handleIdPSSO);
 
 /**
  * SSO Endpoint (HTTP-POST Binding)
  * Receives SAML AuthnRequest via POST body
  */
 app.post('/saml/idp/sso', handleIdPSSO);
+app.post(GAKUNIN_SHIBBOLETH_SAML2_IDP_SSO_POST_PATH, handleIdPSSO);
 
 /**
  * Attribute release consent callback
@@ -153,11 +165,13 @@ app.get('/saml/idp/init', handleIdPInitiated);
  * Single Logout (IdP) - POST Binding
  */
 app.post('/saml/idp/slo', handleIdPSLO);
+app.post(GAKUNIN_SHIBBOLETH_SAML2_IDP_SLO_POST_PATH, handleIdPSLO);
 
 /**
  * Single Logout (IdP) - Redirect Binding
  */
 app.get('/saml/idp/slo', handleIdPSLO);
+app.get(GAKUNIN_SHIBBOLETH_SAML2_IDP_SLO_REDIRECT_PATH, handleIdPSLO);
 
 // ============================================================================
 // SP Endpoints

--- a/packages/ar-saml/src/sp/metadata.ts
+++ b/packages/ar-saml/src/sp/metadata.ts
@@ -35,7 +35,11 @@ import {
   shouldSignSAMLMetadata,
   signSAMLMetadata,
 } from '../common/metadata-signing';
-import { getSAMLLocalEntityIds, getSAMLPublicSettings } from '../common/entity-id';
+import {
+  buildSAMLSigningCertificateSubjectAlternativeNames,
+  getSAMLLocalEntityIds,
+  getSAMLPublicSettings,
+} from '../common/entity-id';
 
 /**
  * Handle SP metadata request
@@ -45,10 +49,16 @@ export async function handleSPMetadata(c: Context<{ Bindings: Env }>): Promise<R
   const log = getLogger(c).module('SAML-SP');
   const tenantId = resolveSAMLTenantIdFromContext(c);
 
-  const [{ issuerUrl, spEntityId: entityId }, settings] = await Promise.all([
+  const [entityIds, settings] = await Promise.all([
     getSAMLLocalEntityIds(env, tenantId),
     getSAMLPublicSettings(env, tenantId),
   ]);
+  const { issuerUrl, spEntityId: entityId } = entityIds;
+  const certificateSubjectAlternativeNames = buildSAMLSigningCertificateSubjectAlternativeNames(
+    entityIds,
+    'sp',
+    settings.certificateSubjectAlternativeNames
+  );
 
   // Get signing certificates from KeyManager / SAML rollover policy.
   let signingCertificates: SAMLMetadataSigningCertificate[];
@@ -58,6 +68,7 @@ export async function handleSPMetadata(c: Context<{ Bindings: Env }>): Promise<R
       role: 'sp',
       policy: settings.signingKeyPolicies.sp,
       certificateSubject: settings.certificateSubject,
+      certificateSubjectAlternativeNames,
     });
   } catch (error) {
     log.error('Failed to get signing certificate', {}, error as Error);
@@ -78,6 +89,7 @@ export async function handleSPMetadata(c: Context<{ Bindings: Env }>): Promise<R
         role: 'sp',
         policy: settings.signingKeyPolicies.sp,
         certificateSubject: settings.certificateSubject,
+        certificateSubjectAlternativeNames,
       });
       metadataXml = signSAMLMetadata(metadataXml, signingMaterial);
     } catch (error) {

--- a/packages/setup/src/__tests__/wrangler-routes.test.ts
+++ b/packages/setup/src/__tests__/wrangler-routes.test.ts
@@ -27,6 +27,35 @@ describe('generateRoutes', () => {
     );
   });
 
+  it('exposes SAML and GakuNin/Shibboleth SAML2 compatibility routes on ar-saml', () => {
+    const routes = generateRoutes('ar-saml', 'conformance.authrim.com', 'authrim.com');
+
+    expect(routes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          pattern: 'conformance.authrim.com/saml/*',
+          zone_name: 'authrim.com',
+        }),
+        expect.objectContaining({
+          pattern: 'conformance.authrim.com/idp/profile/SAML2/POST/SSO',
+          zone_name: 'authrim.com',
+        }),
+        expect.objectContaining({
+          pattern: 'conformance.authrim.com/idp/profile/SAML2/Redirect/SSO',
+          zone_name: 'authrim.com',
+        }),
+        expect.objectContaining({
+          pattern: 'conformance.authrim.com/idp/profile/SAML2/POST/SLO',
+          zone_name: 'authrim.com',
+        }),
+        expect.objectContaining({
+          pattern: 'conformance.authrim.com/idp/profile/SAML2/Redirect/SLO',
+          zone_name: 'authrim.com',
+        }),
+      ])
+    );
+  });
+
   it('adds Cloudflare Email Service bindings only to ar-auth and ar-management', () => {
     const config = {
       version: '1.0.0',

--- a/packages/setup/src/core/wrangler.ts
+++ b/packages/setup/src/core/wrangler.ts
@@ -1486,6 +1486,15 @@ export function generateRoutes(
     case 'ar-management':
       routes.push({ pattern: `${domain}/register`, zone_name: zoneName });
       break;
+    case 'ar-saml':
+      routes.push(
+        { pattern: `${domain}/saml/*`, zone_name: zoneName },
+        { pattern: `${domain}/idp/profile/SAML2/POST/SSO`, zone_name: zoneName },
+        { pattern: `${domain}/idp/profile/SAML2/Redirect/SSO`, zone_name: zoneName },
+        { pattern: `${domain}/idp/profile/SAML2/POST/SLO`, zone_name: zoneName },
+        { pattern: `${domain}/idp/profile/SAML2/Redirect/SLO`, zone_name: zoneName }
+      );
+      break;
   }
 
   return routes;

--- a/scripts/setup-remote-wrangler.sh
+++ b/scripts/setup-remote-wrangler.sh
@@ -542,6 +542,22 @@ zone_name = \"$ZONE_NAME\""
             routes="
 [[routes]]
 pattern = \"$DOMAIN_ONLY/saml/*\"
+zone_name = \"$ZONE_NAME\"
+
+[[routes]]
+pattern = \"$DOMAIN_ONLY/idp/profile/SAML2/POST/SSO\"
+zone_name = \"$ZONE_NAME\"
+
+[[routes]]
+pattern = \"$DOMAIN_ONLY/idp/profile/SAML2/Redirect/SSO\"
+zone_name = \"$ZONE_NAME\"
+
+[[routes]]
+pattern = \"$DOMAIN_ONLY/idp/profile/SAML2/POST/SLO\"
+zone_name = \"$ZONE_NAME\"
+
+[[routes]]
+pattern = \"$DOMAIN_ONLY/idp/profile/SAML2/Redirect/SLO\"
 zone_name = \"$ZONE_NAME\""
             ;;
         ar-bridge)


### PR DESCRIPTION
## Summary
- Add DNS Subject Alternative Name support for SAML signing certificate generation and rollover settings.
- Add Admin UI controls for generated and explicit DNS SAN entries.
- Add GakuNin/Shibboleth-style SAML2 IdP SSO/SLO endpoint aliases and route them through ar-router/setup generated routes.

## Validation
- pnpm --filter @authrim/ar-saml typecheck
- pnpm --filter @authrim/ar-saml test -- --run src/idp/__tests__/shibboleth-compat.test.ts src/common/__tests__/slo-security.test.ts src/__tests__/saml-integration.test.ts
- pnpm --filter @authrim/ar-router typecheck
- pnpm --filter @authrim/ar-router test -- --run src/__tests__/router.test.ts
- pnpm --filter @authrim/setup typecheck
- pnpm --filter @authrim/setup test -- --run src/__tests__/wrangler-routes.test.ts
- pnpm --filter @authrim/ar-admin-ui typecheck
- pnpm --dir packages/ar-admin-ui exec prettier --check src/routes/admin/saml/local/+page.svelte src/i18n/en/admin-saml.ts src/i18n/ja/admin-saml.ts