### PR TITLE
Fix Login UI root routing on shared domains

### DIFF
--- a/packages/ar-login-ui/src/__tests__/entry-routing.test.ts
+++ b/packages/ar-login-ui/src/__tests__/entry-routing.test.ts
@@ -226,6 +226,28 @@ describe('common-entry routing', () => {
 		});
 	});
 
+	it('does not redirect tenant-host root to /login when the browser has an active session', async () => {
+		const fetch = vi.fn().mockResolvedValueOnce(
+			jsonResponse({
+				active: true,
+				user_id: 'user-123'
+			})
+		);
+
+		const result = await rootLoad({
+			cookies: createCookies({ authrim_session: '0_session_active' }),
+			fetch,
+			request: new Request('https://first.multi-tenant.authrim.com/'),
+			url: new URL('https://first.multi-tenant.authrim.com/')
+		} as never);
+
+		expect(result).toEqual({});
+		expect(fetch).toHaveBeenCalledTimes(1);
+		expect(fetch).toHaveBeenCalledWith('/api/sessions/status', {
+			headers: { 'x-authrim-original-host': 'first.multi-tenant.authrim.com' }
+		});
+	});
+
 	it('allows a tenant-host login challenge only when it resolves for the current tenant', async () => {
 		const fetch = vi
 			.fn()

--- a/packages/ar-login-ui/src/__tests__/entry-routing.test.ts
+++ b/packages/ar-login-ui/src/__tests__/entry-routing.test.ts
@@ -88,6 +88,64 @@ describe('common-entry routing', () => {
 		});
 	});
 
+	it('does not redirect the common-entry root page when the browser has an active session', async () => {
+		const fetch = vi.fn().mockResolvedValueOnce(
+			jsonResponse({
+				active: true,
+				user_id: 'user-123'
+			})
+		);
+
+		const result = await rootLoad({
+			cookies: createCookies({ authrim_session: '0_session_active' }),
+			fetch,
+			request: new Request('https://multi-tenant.authrim.com/'),
+			url: new URL('https://multi-tenant.authrim.com/')
+		} as never);
+
+		expect(result).toEqual({});
+		expect(fetch).toHaveBeenCalledTimes(1);
+		expect(fetch).toHaveBeenCalledWith('/api/sessions/status', {
+			headers: { 'x-authrim-original-host': 'multi-tenant.authrim.com' }
+		});
+	});
+
+	it('continues root entry routing when the session cookie is inactive', async () => {
+		const fetch = vi
+			.fn()
+			.mockResolvedValueOnce(jsonResponse({ active: false }))
+			.mockResolvedValueOnce(
+				jsonResponse({
+					config: {
+						tenant_id: 'default',
+						mode: 'discovery_optional',
+						discovery_methods: ['email_domain', 'tenant_code', 'tenant_slug'],
+						selection_policy: 'select_if_multiple',
+						allow_manual_tenant_entry: true,
+						remember_last_tenant: true,
+						redirect_default_login_to_discovery: false,
+						require_common_discovery_before_login: true,
+						redirect_tenant_discover_to_common_entry: true
+					},
+					single_tenant_mode: false,
+					is_common_entry_host: true,
+					common_discover_url: 'https://multi-tenant.authrim.com/discover'
+				})
+			);
+
+		await expect(
+			rootLoad({
+				cookies: createCookies({ authrim_session: '0_session_expired' }),
+				fetch,
+				request: new Request('https://multi-tenant.authrim.com/'),
+				url: new URL('https://multi-tenant.authrim.com/')
+			} as never)
+		).rejects.toMatchObject({
+			status: 303,
+			location: '/discover'
+		});
+	});
+
 	it('redirects misplaced root resolve actions to /discover', async () => {
 		await expect(rootActions.resolve({} as never)).rejects.toMatchObject({
 			status: 303,

--- a/packages/ar-login-ui/src/lib/discovery-entry.ts
+++ b/packages/ar-login-ui/src/lib/discovery-entry.ts
@@ -57,6 +57,11 @@ export interface DiscoveryGrantVerifyResponse {
 	target_url: string;
 }
 
+export interface SessionStatusResponse {
+	active: boolean;
+	user_id?: string;
+}
+
 interface DiscoveryRequestEventLike {
 	request: Request;
 	url: URL;
@@ -80,6 +85,19 @@ export async function fetchDiscoveryConfig(
 		throw new Error('Failed to load discovery config');
 	}
 	return (await response.json()) as DiscoveryConfigResponse;
+}
+
+export async function isCurrentSessionActive(
+	fetchFn: typeof fetch,
+	headers?: HeadersInit
+): Promise<boolean> {
+	const response = await fetchFn('/api/sessions/status', headers ? { headers } : undefined);
+	if (!response.ok) {
+		return false;
+	}
+
+	const data = (await response.json()) as SessionStatusResponse;
+	return data.active === true && typeof data.user_id === 'string' && data.user_id.length > 0;
 }
 
 export async function verifyLoginChallengeForCurrentTenant(

--- a/packages/ar-login-ui/src/routes/+page.server.ts
+++ b/packages/ar-login-ui/src/routes/+page.server.ts
@@ -3,6 +3,7 @@ import type { Actions, PageServerLoad } from './$types';
 import {
 	fetchDiscoveryConfig,
 	getDiscoveryRequestHeaders,
+	isCurrentSessionActive,
 	verifyLoginChallengeForCurrentTenant
 } from '../lib/discovery-entry';
 
@@ -17,6 +18,15 @@ export const load: PageServerLoad = async (event) => {
 			discoveryHeaders
 		).catch(() => false);
 		if (challengeBelongsToCurrentTenant) {
+			return {};
+		}
+	}
+
+	if (event.cookies.get('authrim_session')) {
+		const sessionActive = await isCurrentSessionActive(event.fetch, discoveryHeaders).catch(
+			() => false
+		);
+		if (sessionActive) {
 			return {};
 		}
 	}

--- a/packages/ar-router/src/__tests__/router.test.ts
+++ b/packages/ar-router/src/__tests__/router.test.ts
@@ -1089,6 +1089,34 @@ describe('Router Worker', () => {
       expect(proxiedRequest.headers.get('X-Authrim-Original-Host')).toBe('first.example.com');
     });
 
+    it('should proxy naked-domain root requests to Login UI when Login UI shares the API host', async () => {
+      const loginUiWorker = createMockFetcher('LOGIN_UI_WORKER');
+      const adminUiWorker = createMockFetcher('ADMIN_UI_WORKER');
+      const envWithLoginUiOnApiHost = {
+        ...mockEnv,
+        BASE_DOMAIN: 'example.com',
+        ADMIN_UI_URL: 'https://admin.example.com',
+        LOGIN_UI_URL: 'https://example.com',
+        ENABLE_LOGIN_UI_PROXY: 'true',
+        AR_LOGIN_UI_URL: 'https://phase9-ar-login-ui.example.workers.dev',
+        LOGIN_UI_WORKER: loginUiWorker,
+        ENABLE_ADMIN_UI_PROXY: 'true',
+        AR_ADMIN_UI_URL: 'https://phase9-ar-admin-ui.example.workers.dev',
+        ADMIN_UI_WORKER: adminUiWorker,
+      };
+
+      const req = new Request('https://example.com/');
+      const res = await app.fetch(req, envWithLoginUiOnApiHost);
+
+      expect(res.status).toBe(200);
+      expect(loginUiWorker.fetch).toHaveBeenCalledTimes(1);
+      expect(adminUiWorker.fetch).not.toHaveBeenCalled();
+
+      const proxiedRequest = loginUiWorker.fetch.mock.calls[0][0];
+      expect(new URL(proxiedRequest.url).pathname).toBe('/');
+      expect(proxiedRequest.headers.get('X-Authrim-Original-Host')).toBe('example.com');
+    });
+
     it('should proxy admin UI through service binding when configured', async () => {
       const adminUiWorker = createMockFetcher('ADMIN_UI_WORKER');
       const envWithAdminUi = {

--- a/packages/ar-router/src/__tests__/router.test.ts
+++ b/packages/ar-router/src/__tests__/router.test.ts
@@ -1245,6 +1245,7 @@ describe('Router Worker', () => {
         ...mockEnv,
         BASE_DOMAIN: 'example.com',
         ADMIN_UI_URL: 'https://admin.example.com',
+        LOGIN_UI_URL: 'https://example.com',
         ENABLE_LOGIN_UI_PROXY: 'true',
         AR_LOGIN_UI_URL: 'https://phase9-ar-login-ui.example.workers.dev',
         LOGIN_UI_WORKER: loginUiWorker,
@@ -1263,6 +1264,34 @@ describe('Router Worker', () => {
       const proxiedRequest = adminUiWorker.fetch.mock.calls[0][0];
       expect(new URL(proxiedRequest.url).pathname).toBe('/');
       expect(proxiedRequest.headers.get('X-Authrim-Original-Host')).toBe('admin.example.com');
+    });
+
+    it('should prefer Login UI at root when API, Admin UI, and Login UI share one host', async () => {
+      const loginUiWorker = createMockFetcher('LOGIN_UI_WORKER');
+      const adminUiWorker = createMockFetcher('ADMIN_UI_WORKER');
+      const envWithSharedHostUis = {
+        ...mockEnv,
+        BASE_DOMAIN: 'example.com',
+        ADMIN_UI_URL: 'https://example.com',
+        LOGIN_UI_URL: 'https://example.com',
+        ENABLE_LOGIN_UI_PROXY: 'true',
+        AR_LOGIN_UI_URL: 'https://phase9-ar-login-ui.example.workers.dev',
+        LOGIN_UI_WORKER: loginUiWorker,
+        ENABLE_ADMIN_UI_PROXY: 'true',
+        AR_ADMIN_UI_URL: 'https://phase9-ar-admin-ui.example.workers.dev',
+        ADMIN_UI_WORKER: adminUiWorker,
+      };
+
+      const req = new Request('https://example.com/');
+      const res = await app.fetch(req, envWithSharedHostUis);
+
+      expect(res.status).toBe(200);
+      expect(loginUiWorker.fetch).toHaveBeenCalledTimes(1);
+      expect(adminUiWorker.fetch).not.toHaveBeenCalled();
+
+      const proxiedRequest = loginUiWorker.fetch.mock.calls[0][0];
+      expect(new URL(proxiedRequest.url).pathname).toBe('/');
+      expect(proxiedRequest.headers.get('X-Authrim-Original-Host')).toBe('example.com');
     });
 
     it('should return API metadata at root when no UI proxy is enabled', async () => {

--- a/packages/ar-router/src/index.ts
+++ b/packages/ar-router/src/index.ts
@@ -49,6 +49,8 @@ interface Env {
   AR_ADMIN_UI_URL?: string;
   /** Public Admin UI URL (e.g., https://admin.example.com) */
   ADMIN_UI_URL?: string;
+  /** Public Login UI URL (e.g., https://login.example.com) */
+  LOGIN_UI_URL?: string;
   /** Login UI Worker service binding */
   LOGIN_UI_WORKER?: Fetcher;
   /** Admin UI Worker service binding */
@@ -1156,20 +1158,24 @@ app.all('/_app/*', async (c) => {
 // Root Admin UI custom domains are covered by the wildcard host route without a path suffix.
 app.get('/', async (c) => {
   const requestHost = new URL(c.req.url).hostname.toLowerCase();
+  const loginUiHost = getConfiguredUrlHostname(c.env.LOGIN_UI_URL);
   const adminUiHost =
     getConfiguredUrlHostname(c.env.ADMIN_UI_URL) ||
     (c.env.BASE_DOMAIN ? `admin.${c.env.BASE_DOMAIN.toLowerCase()}` : null);
+  const loginEnabled = c.env.ENABLE_LOGIN_UI_PROXY === 'true' && !!c.env.AR_LOGIN_UI_URL;
+  const requestIsLoginUiHost = loginEnabled && loginUiHost !== null && requestHost === loginUiHost;
   if (
     adminUiHost &&
     requestHost === adminUiHost &&
+    !requestIsLoginUiHost &&
     c.env.ENABLE_ADMIN_UI_PROXY === 'true' &&
     c.env.AR_ADMIN_UI_URL
   ) {
     return proxyToUiWorker(c.req.raw, c.env.AR_ADMIN_UI_URL, '/', c.env.ADMIN_UI_WORKER);
   }
 
-  if (c.env.ENABLE_LOGIN_UI_PROXY === 'true' && c.env.AR_LOGIN_UI_URL) {
-    return proxyToUiWorker(c.req.raw, c.env.AR_LOGIN_UI_URL, '/', c.env.LOGIN_UI_WORKER);
+  if (loginEnabled) {
+    return proxyToUiWorker(c.req.raw, c.env.AR_LOGIN_UI_URL!, '/', c.env.LOGIN_UI_WORKER);
   }
 
   // Return basic API info when Login UI proxy is not enabled.

--- a/packages/setup/src/__tests__/wrangler-url.test.ts
+++ b/packages/setup/src/__tests__/wrangler-url.test.ts
@@ -264,6 +264,12 @@ describe('generateEnvVars - ar-router', () => {
 
     expect(vars['ENABLE_ADMIN_UI_PROXY']).toBe(adminProxyEnabled ? 'true' : 'false');
     expect(vars['ENABLE_LOGIN_UI_PROXY']).toBe(loginProxyEnabled ? 'true' : 'false');
+    const apiUrl = config.urls?.api?.custom || config.urls?.api?.auto;
+    const expectedLoginUiUrl =
+      scenario.config.loginUiSameAsApi || !!scenario.config.baseDomain
+        ? apiUrl
+        : config.urls?.loginUi?.custom || config.urls?.loginUi?.auto || apiUrl;
+    expect(vars['LOGIN_UI_URL']).toBe(expectedLoginUiUrl);
 
     // AR_ADMIN_UI_URL is set when ar-router owns Admin UI paths.
     if (adminProxyEnabled) {

--- a/packages/setup/src/core/wrangler.ts
+++ b/packages/setup/src/core/wrangler.ts
@@ -927,6 +927,9 @@ export function generateEnvVars(
 
     const loginProxyEnabled = config.urls?.loginUi?.sameAsApi === true || multiTenantEnabled;
     vars['ENABLE_LOGIN_UI_PROXY'] = loginProxyEnabled ? 'true' : 'false';
+    if (uiUrl) {
+      vars['LOGIN_UI_URL'] = uiUrl;
+    }
     if (loginProxyEnabled) {
       const loginUiWorkerUrl = normalizeWorkersDevUrl(
         config.urls?.loginUi?.auto || config.urls?.loginUi?.custom || '',


### PR DESCRIPTION
## Summary
- Route `/` to Login UI when API, Admin UI, and Login UI share the same public host
- Keep authenticated users on `/` by checking the current session before entry routing redirects
- Emit `LOGIN_UI_URL` for router UI host selection
- Add regression coverage for shared-host root routing and authenticated common-entry root access

## Validation
- `pnpm --filter @authrim/ar-router test -- --run src/__tests__/router.test.ts`
- `pnpm --filter @authrim/ar-login-ui test -- --run src/__tests__/entry-routing.test.ts`
- `pnpm --filter @authrim/setup test -- --run src/__tests__/wrangler-url.test.ts`
- `pnpm exec prettier --check packages/ar-router/src/index.ts packages/ar-router/src/__tests__/router.test.ts packages/ar-login-ui/src/routes/+page.server.ts packages/ar-login-ui/src/lib/discovery-entry.ts packages/ar-login-ui/src/__tests__/entry-routing.test.ts packages/setup/src/core/wrangler.ts`
- `pnpm lint`
- `pnpm --filter @authrim/ar-router typecheck`
- `pnpm --filter @authrim/ar-login-ui typecheck`
- `pnpm --filter @authrim/setup typecheck`

Note: the Login UI unit test prints a local UnoCSS web-font fetch warning when network access is unavailable, but the test exits successfully.