### PR TITLE
Harden Admin API route authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,15 @@ Authrim is still under active development, and breaking changes, including datab
 ### Security Hardening Status
 
 Recent internal security review work has remediated several pre-1.0 findings across
-selected management API authorization paths, CIBA client authentication, admin setup-token recovery,
+management API authorization, CIBA client authentication, admin setup-token recovery,
 Admin WebAuthn origin/RP ID validation, OTP HMAC secret handling, VCI holder binding,
-device-flow token issuance, and SCIM filter handling. These fixes include negative
-regression coverage in the affected packages.
+device-flow token issuance, and SCIM filter handling. The Admin API now uses a
+declarative, fail-closed route access table with CI coverage that fails undeclared
+admin routes, plus UI-side permission awareness for core user-management actions.
+These fixes include negative regression coverage in the affected packages.
 
-Security validation remains active. The main remaining authorization hardening task is
-a declarative, fail-closed Admin API permission table with CI coverage for undeclared
-routes. Low/Info hardening items and an external audit/penetration test are still pending.
+Security validation remains active. Low/Info hardening items and an external
+audit/penetration test are still pending.
 
 ### For Organizations Considering Adoption
 
@@ -211,7 +212,7 @@ Authrim is currently pre-1.0. Core protocol and platform capabilities are implem
 | JavaScript SDKs | Implemented |
 | Setup tooling | Implemented; production deployment docs in progress |
 | UI consolidation | Active; Admin/Login/setup flows are being polished against the current Workers deployment model |
-| Security, QA, and validation | Active; internal review remediation landed for selected management authorization, CIBA, setup-token, WebAuthn, OTP, VCI, device-flow, and SCIM findings |
+| Security, QA, and validation | Active; internal review remediation landed for management authorization, CIBA, setup-token, WebAuthn, OTP, VCI, device-flow, and SCIM findings; Admin API route access is now declarative fail-closed with CI coverage |
 | Storage portability | Implementation baseline complete; validation active |
 | Multi-tenant isolation | Implementation baseline complete; validation active |
 | Operational logging and evidence | Implementation baseline complete; validation active |

--- a/packages/ar-admin-ui/src/lib/stores/admin-auth.svelte.ts
+++ b/packages/ar-admin-ui/src/lib/stores/admin-auth.svelte.ts
@@ -33,6 +33,17 @@ interface AdminAuthState {
 	error: string | null;
 }
 
+function permissionMatches(permissions: string[], required: string): boolean {
+	if (permissions.includes('*') || permissions.includes(required)) return true;
+	const parts = required.split(':');
+	for (let i = parts.length - 1; i >= 0; i -= 1) {
+		if (permissions.includes([...parts.slice(0, i), '*'].join(':'))) {
+			return true;
+		}
+	}
+	return false;
+}
+
 /**
  * Create admin authentication store
  */
@@ -79,6 +90,22 @@ function createAdminAuthStore() {
 		 */
 		get error(): string | null {
 			return state.error;
+		},
+
+		hasPermission(permission: string): boolean {
+			return permissionMatches(state.user?.permissions ?? [], permission);
+		},
+
+		hasAnyPermission(permissions: string[]): boolean {
+			return permissions.some((permission) =>
+				permissionMatches(state.user?.permissions ?? [], permission)
+			);
+		},
+
+		hasAllPermissions(permissions: string[]): boolean {
+			return permissions.every((permission) =>
+				permissionMatches(state.user?.permissions ?? [], permission)
+			);
 		},
 
 		/**

--- a/packages/ar-admin-ui/src/routes/admin/admin-logging/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/admin-logging/+page.svelte
@@ -69,38 +69,27 @@
 	const PERM_LOGGING_SENSITIVE_DETAIL_EXPORT = 'admin:logging:sensitive_detail:export';
 	const isPlatformAdmin = $derived(Boolean(adminAuth.user?.isPlatformAdmin));
 	const canViewCoverage = $derived(
-		isPlatformAdmin && hasAdminPermission(PERM_ADMIN_LOGGING_COVERAGE_READ)
+		isPlatformAdmin && adminAuth.hasPermission(PERM_ADMIN_LOGGING_COVERAGE_READ)
 	);
 	const canCheckCoverage = $derived(
-		isPlatformAdmin && hasAdminPermission(PERM_ADMIN_LOGGING_COVERAGE_UPDATE)
+		isPlatformAdmin && adminAuth.hasPermission(PERM_ADMIN_LOGGING_COVERAGE_UPDATE)
 	);
 	const canReadCatalogRepair = $derived(
-		isPlatformAdmin && hasAdminPermission(PERM_ADMIN_LOGGING_REPAIR_READ)
+		isPlatformAdmin && adminAuth.hasPermission(PERM_ADMIN_LOGGING_REPAIR_READ)
 	);
 	const canViewCriticalPolicy = $derived(
-		isPlatformAdmin && hasAdminPermission(PERM_ADMIN_LOGGING_OVERVIEW_READ)
+		isPlatformAdmin && adminAuth.hasPermission(PERM_ADMIN_LOGGING_OVERVIEW_READ)
 	);
 	const canRunCatalogRepair = $derived(
-		isPlatformAdmin && hasAdminPermission(PERM_ADMIN_LOGGING_REPAIR_RUN)
+		isPlatformAdmin && adminAuth.hasPermission(PERM_ADMIN_LOGGING_REPAIR_RUN)
 	);
 	const canViewSensitiveDetailPolicy = $derived(
-		isPlatformAdmin && hasAdminPermission(PERM_ADMIN_LOGGING_SENSITIVE_DETAIL_POLICY_READ)
+		isPlatformAdmin && adminAuth.hasPermission(PERM_ADMIN_LOGGING_SENSITIVE_DETAIL_POLICY_READ)
 	);
 	const canProbeSensitiveDetail = $derived(
-		isPlatformAdmin && hasAdminPermission(PERM_LOGGING_SENSITIVE_DETAIL_EXPORT)
+		isPlatformAdmin && adminAuth.hasPermission(PERM_LOGGING_SENSITIVE_DETAIL_EXPORT)
 	);
-	const canReadMessageJobs = $derived(hasAdminPermission(PERM_LOGGING_DELIVERY_EVENTS_READ));
-	function hasAdminPermission(permission: string): boolean {
-		const permissions = adminAuth.user?.permissions ?? [];
-		if (permissions.includes('*') || permissions.includes(permission)) return true;
-		const parts = permission.split(':');
-		for (let i = parts.length - 1; i >= 0; i -= 1) {
-			if (permissions.includes([...parts.slice(0, i), '*'].join(':'))) {
-				return true;
-			}
-		}
-		return false;
-	}
+	const canReadMessageJobs = $derived(adminAuth.hasPermission(PERM_LOGGING_DELIVERY_EVENTS_READ));
 
 	function requestDangerConfirmation(input: Omit<DangerConfirmationRequest, 'resolve'>) {
 		return new Promise<string | null>((resolve) => {

--- a/packages/ar-admin-ui/src/routes/admin/logging-policies/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/logging-policies/+page.svelte
@@ -115,33 +115,23 @@
 	const isPlatformAdmin = $derived(Boolean(adminAuth.user?.isPlatformAdmin));
 	const canFilterByTenant = $derived(isPlatformAdmin);
 	const canManagePlatformLogging = $derived(
-		isPlatformAdmin && hasAdminPermission(PERM_LOGGING_PLATFORM_DEFAULTS_UPDATE)
+		isPlatformAdmin && adminAuth.hasPermission(PERM_LOGGING_PLATFORM_DEFAULTS_UPDATE)
 	);
-	const canReadDeliveryEvents = $derived(hasAdminPermission(PERM_LOGGING_DELIVERY_EVENTS_READ));
-	const canRetryDelivery = $derived(hasAdminPermission(PERM_LOGGING_DELIVERY_RETRY));
-	const canCreateExport = $derived(hasAdminPermission(PERM_LOGGING_EXPORT_CREATE));
+	const canReadDeliveryEvents = $derived(
+		adminAuth.hasPermission(PERM_LOGGING_DELIVERY_EVENTS_READ)
+	);
+	const canRetryDelivery = $derived(adminAuth.hasPermission(PERM_LOGGING_DELIVERY_RETRY));
+	const canCreateExport = $derived(adminAuth.hasPermission(PERM_LOGGING_EXPORT_CREATE));
 	const canExportSensitiveDetail = $derived(
-		hasAdminPermission(PERM_LOGGING_SENSITIVE_DETAIL_EXPORT)
+		adminAuth.hasPermission(PERM_LOGGING_SENSITIVE_DETAIL_EXPORT)
 	);
-	const canDeleteDlq = $derived(hasAdminPermission(PERM_LOGGING_DLQ_DELETE));
-	const canPurgeDlq = $derived(isPlatformAdmin && hasAdminPermission(PERM_LOGGING_DLQ_PURGE));
-	const canPublishSnapshots = $derived(hasAdminPermission(PERM_LOGGING_SNAPSHOTS_PUBLISH));
-	const canReadMessageRepair = $derived(hasAdminPermission(PERM_ADMIN_LOGGING_REPAIR_READ));
-	const canRunMessageRepair = $derived(hasAdminPermission(PERM_ADMIN_LOGGING_REPAIR_RUN));
-	const canReadDatabaseRouting = $derived(hasAdminPermission(PERM_DATABASE_ROUTING_READ));
-	const canWriteDatabaseRouting = $derived(hasAdminPermission(PERM_DATABASE_ROUTING_WRITE));
-
-	function hasAdminPermission(permission: string): boolean {
-		const permissions = adminAuth.user?.permissions ?? [];
-		if (permissions.includes('*') || permissions.includes(permission)) return true;
-		const parts = permission.split(':');
-		for (let i = parts.length - 1; i >= 0; i -= 1) {
-			if (permissions.includes([...parts.slice(0, i), '*'].join(':'))) {
-				return true;
-			}
-		}
-		return false;
-	}
+	const canDeleteDlq = $derived(adminAuth.hasPermission(PERM_LOGGING_DLQ_DELETE));
+	const canPurgeDlq = $derived(isPlatformAdmin && adminAuth.hasPermission(PERM_LOGGING_DLQ_PURGE));
+	const canPublishSnapshots = $derived(adminAuth.hasPermission(PERM_LOGGING_SNAPSHOTS_PUBLISH));
+	const canReadMessageRepair = $derived(adminAuth.hasPermission(PERM_ADMIN_LOGGING_REPAIR_READ));
+	const canRunMessageRepair = $derived(adminAuth.hasPermission(PERM_ADMIN_LOGGING_REPAIR_RUN));
+	const canReadDatabaseRouting = $derived(adminAuth.hasPermission(PERM_DATABASE_ROUTING_READ));
+	const canWriteDatabaseRouting = $derived(adminAuth.hasPermission(PERM_DATABASE_ROUTING_WRITE));
 
 	function requestDangerConfirmation(input: Omit<DangerConfirmationRequest, 'resolve'>) {
 		return new Promise<string | null>((resolve) => {

--- a/packages/ar-admin-ui/src/routes/admin/users/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/users/+page.svelte
@@ -9,6 +9,7 @@
 		type Pagination,
 		type UserListParams
 	} from '$lib/api/admin-users';
+	import { adminAuth } from '$lib/stores/admin-auth.svelte';
 	import { Modal } from '$lib/components';
 	import { getLocale, LL } from '$i18n/i18n-svelte';
 
@@ -28,6 +29,8 @@
 	let selectedIds = new SvelteSet<string>();
 	let isAllSelected = $derived(users.length > 0 && selectedIds.size === users.length);
 	let hasSelection = $derived(selectedIds.size > 0);
+	const canCreateUsers = $derived(adminAuth.hasPermission('admin:users:write'));
+	const canDeleteUsers = $derived(adminAuth.hasPermission('admin:users:delete'));
 
 	// Bulk delete dialog state
 	let showBulkDeleteDialog = $state(false);
@@ -146,6 +149,7 @@
 
 	// Selection functions
 	function toggleSelectAll() {
+		if (!canDeleteUsers) return;
 		if (isAllSelected) {
 			selectedIds.clear();
 		} else {
@@ -156,6 +160,7 @@
 
 	function toggleSelect(id: string, event: Event) {
 		event.stopPropagation();
+		if (!canDeleteUsers) return;
 		if (selectedIds.has(id)) {
 			selectedIds.delete(id);
 		} else {
@@ -164,6 +169,7 @@
 	}
 
 	function openBulkDeleteDialog() {
+		if (!canDeleteUsers) return;
 		bulkDeleteError = '';
 		bulkDeleteProgress = { current: 0, total: selectedIds.size, failed: 0 };
 		showBulkDeleteDialog = true;
@@ -228,16 +234,18 @@
 			<p class="page-description">{$LL.admin_users_description()}</p>
 		</div>
 		<div class="page-actions">
-			{#if hasSelection}
+			{#if canDeleteUsers && hasSelection}
 				<button class="btn btn-danger" onclick={openBulkDeleteDialog}>
 					<i class="i-ph-trash"></i>
 					{$LL.admin_users_delete_selected({ count: selectedIds.size })}
 				</button>
 			{/if}
-			<a href="/admin/users/new" class="btn btn-primary">
-				<i class="i-ph-plus"></i>
-				{$LL.admin_users_create()}
-			</a>
+			{#if canCreateUsers}
+				<a href="/admin/users/new" class="btn btn-primary">
+					<i class="i-ph-plus"></i>
+					{$LL.admin_users_create()}
+				</a>
+			{/if}
 		</div>
 	</div>
 
@@ -307,6 +315,7 @@
 								class="checkbox"
 								checked={isAllSelected}
 								onchange={toggleSelectAll}
+								disabled={!canDeleteUsers}
 								aria-label={$LL.admin_users_select_all()}
 							/>
 						</th>
@@ -333,6 +342,7 @@
 									class="checkbox"
 									checked={selectedIds.has(user.id)}
 									onchange={(e) => toggleSelect(user.id, e)}
+									disabled={!canDeleteUsers}
 									aria-label={$LL.admin_users_select_user({ user: user.email || user.id })}
 								/>
 							</td>

--- a/packages/ar-admin-ui/src/routes/admin/users/[id]/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/users/[id]/+page.svelte
@@ -19,6 +19,7 @@
 	import OrganizationSelectDialog from '$lib/components/OrganizationSelectDialog.svelte';
 	import { Modal, ToggleSwitch } from '$lib/components';
 	import type { OrganizationNode } from '$lib/api/admin-organizations';
+	import { adminAuth } from '$lib/stores/admin-auth.svelte';
 	import { settingsContext } from '$lib/stores/settings-context.svelte';
 	import { sanitizeText, isValidUUID } from '$lib/utils';
 
@@ -86,6 +87,10 @@
 	let loadedTenantId = $state('');
 
 	const userId = $derived($page.params.id ?? '');
+	const canWriteUsers = $derived(adminAuth.hasPermission('admin:users:write'));
+	const canDeleteUsers = $derived(adminAuth.hasPermission('admin:users:delete'));
+	const canManageRoles = $derived(adminAuth.hasPermission('admin:roles:write'));
+	const canRevokeSessions = $derived(adminAuth.hasPermission('admin:sessions:revoke'));
 
 	async function loadUser() {
 		loading = true;
@@ -169,6 +174,7 @@
 	}
 
 	function openAssignRoleDialog() {
+		if (!canManageRoles) return;
 		selectedRoleId = '';
 		selectedScope = 'global';
 		selectedOrgId = null;
@@ -203,7 +209,7 @@
 	}
 
 	async function assignRole() {
-		if (!selectedRoleId) return;
+		if (!canManageRoles || !selectedRoleId) return;
 		if (selectedScope === 'org' && !selectedOrgId) {
 			rolesError = $LL.admin_user_detail_error_select_org();
 			return;
@@ -233,6 +239,7 @@
 	}
 
 	function confirmRemoveRole(role: RoleAssignment) {
+		if (!canManageRoles) return;
 		roleToRemove = role;
 		showRemoveRoleDialog = true;
 	}
@@ -243,7 +250,7 @@
 	}
 
 	async function removeRole() {
-		if (!roleToRemove) return;
+		if (!canManageRoles || !roleToRemove) return;
 
 		removeRoleLoading = true;
 		rolesError = '';
@@ -274,6 +281,7 @@
 	}
 
 	function startEditing() {
+		if (!canWriteUsers) return;
 		resetEditForm();
 		isEditing = true;
 		actionError = '';
@@ -286,7 +294,7 @@
 	}
 
 	async function saveChanges() {
-		if (!user) return;
+		if (!user || !canWriteUsers) return;
 
 		saving = true;
 		actionError = '';
@@ -305,6 +313,13 @@
 	function openConfirmDialog(
 		action: 'suspend' | 'lock' | 'delete' | 'activate' | 'revoke-sessions'
 	) {
+		if (
+			((action === 'suspend' || action === 'lock' || action === 'activate') && !canWriteUsers) ||
+			(action === 'delete' && !canDeleteUsers) ||
+			(action === 'revoke-sessions' && !canRevokeSessions)
+		) {
+			return;
+		}
 		confirmAction = action;
 		showConfirmDialog = true;
 		actionError = '';
@@ -417,7 +432,7 @@
 
 	// Withdraw consent
 	async function handleWithdrawConsent() {
-		if (!statementToWithdraw) return;
+		if (!canWriteUsers || !statementToWithdraw) return;
 
 		withdrawLoading = true;
 		consentError = '';
@@ -622,7 +637,7 @@
 			<div class="panel">
 				<div class="panel-header">
 					<h2 class="panel-title">{$LL.admin_user_detail_user_information()}</h2>
-					{#if !isEditing}
+					{#if !isEditing && canWriteUsers}
 						<button class="btn btn-primary btn-sm" onclick={startEditing}
 							>{$LL.admin_users_edit()}</button
 						>
@@ -859,9 +874,11 @@
 			<div class="panel">
 				<div class="panel-header">
 					<h2 class="panel-title">{$LL.admin_user_detail_role_assignments()}</h2>
-					<button class="btn btn-primary btn-sm" onclick={openAssignRoleDialog}
-						>{$LL.admin_user_detail_assign_role()}</button
-					>
+					{#if canManageRoles}
+						<button class="btn btn-primary btn-sm" onclick={openAssignRoleDialog}
+							>{$LL.admin_user_detail_assign_role()}</button
+						>
+					{/if}
 				</div>
 
 				{#if rolesError}
@@ -907,9 +924,14 @@
 												: $LL.admin_user_detail_never()}</td
 										>
 										<td class="text-right">
-											<button class="btn btn-danger btn-sm" onclick={() => confirmRemoveRole(role)}>
-												{$LL.admin_user_detail_remove()}
-											</button>
+											{#if canManageRoles}
+												<button
+													class="btn btn-danger btn-sm"
+													onclick={() => confirmRemoveRole(role)}
+												>
+													{$LL.admin_user_detail_remove()}
+												</button>
+											{/if}
 										</td>
 									</tr>
 								{/each}
@@ -975,7 +997,7 @@
 											>
 												{$LL.admin_user_detail_history()}
 											</button>
-											{#if record.status === 'granted'}
+											{#if canWriteUsers && record.status === 'granted'}
 												<button
 													class="btn btn-danger btn-sm"
 													onclick={() => {
@@ -1008,24 +1030,28 @@
 			<div class="panel">
 				<h2 class="panel-title">{$LL.admin_user_detail_tab_actions()}</h2>
 				<div class="action-buttons">
-					{#if user.status === 'active'}
+					{#if canWriteUsers && user.status === 'active'}
 						<button class="btn btn-warning" onclick={() => openConfirmDialog('suspend')}>
 							{$LL.admin_user_detail_suspend_user()}
 						</button>
 						<button class="btn btn-danger" onclick={() => openConfirmDialog('lock')}>
 							{$LL.admin_user_detail_lock_account()}
 						</button>
-					{:else if user.status === 'suspended' || user.status === 'locked'}
+					{:else if canWriteUsers && (user.status === 'suspended' || user.status === 'locked')}
 						<button class="btn btn-success" onclick={() => openConfirmDialog('activate')}>
 							{$LL.admin_user_detail_activate_user()}
 						</button>
 					{/if}
-					<button class="btn btn-purple" onclick={() => openConfirmDialog('revoke-sessions')}>
-						{$LL.admin_user_detail_revoke_all_sessions()}
-					</button>
-					<button class="btn btn-danger" onclick={() => openConfirmDialog('delete')}>
-						{$LL.admin_user_detail_deleteUser()}
-					</button>
+					{#if canRevokeSessions}
+						<button class="btn btn-purple" onclick={() => openConfirmDialog('revoke-sessions')}>
+							{$LL.admin_user_detail_revoke_all_sessions()}
+						</button>
+					{/if}
+					{#if canDeleteUsers}
+						<button class="btn btn-danger" onclick={() => openConfirmDialog('delete')}>
+							{$LL.admin_user_detail_deleteUser()}
+						</button>
+					{/if}
 				</div>
 			</div>
 		{/if}
@@ -1308,11 +1334,15 @@
 				showWithdrawModal = false;
 				statementToWithdraw = null;
 			}}
-			disabled={withdrawLoading}
+			disabled={withdrawLoading || !canWriteUsers}
 		>
 			{$LL.dialog_cancel()}
 		</button>
-		<button class="btn btn-danger" onclick={handleWithdrawConsent} disabled={withdrawLoading}>
+		<button
+			class="btn btn-danger"
+			onclick={handleWithdrawConsent}
+			disabled={withdrawLoading || !canWriteUsers}
+		>
 			{withdrawLoading
 				? $LL.admin_user_detail_withdrawing()
 				: $LL.admin_user_detail_withdraw_consent_title()}

--- a/packages/ar-admin-ui/src/routes/admin/users/new/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/users/new/+page.svelte
@@ -3,6 +3,7 @@
 	import { onMount } from 'svelte';
 	import { adminUsersAPI, type CreateUserInput } from '$lib/api/admin-users';
 	import { ToggleSwitch } from '$lib/components';
+	import { adminAuth } from '$lib/stores/admin-auth.svelte';
 	import { settingsContext } from '$lib/stores/settings-context.svelte';
 	import { LL } from '$i18n/i18n-svelte';
 
@@ -17,8 +18,10 @@
 		family_name: '',
 		email_verified: false
 	});
+	const canCreateUsers = $derived(adminAuth.hasPermission('admin:users:write'));
 
 	async function handleSubmit() {
+		if (!canCreateUsers) return;
 		if (!form.email?.trim()) {
 			error = $LL.admin_users_email_required();
 			return;
@@ -194,14 +197,14 @@
 			<div style="display: flex; gap: 12px; margin-top: 24px;">
 				<button
 					type="submit"
-					disabled={saving}
+					disabled={saving || !canCreateUsers}
 					style="
 						padding: 10px 24px;
-						background-color: {saving ? '#9ca3af' : '#3b82f6'};
+						background-color: {saving || !canCreateUsers ? '#9ca3af' : '#3b82f6'};
 						color: white;
 						border: none;
 						border-radius: 6px;
-						cursor: {saving ? 'not-allowed' : 'pointer'};
+						cursor: {saving || !canCreateUsers ? 'not-allowed' : 'pointer'};
 						font-size: 14px;
 						font-weight: 500;
 					"

--- a/packages/ar-management/src/__tests__/admin-route-access.test.ts
+++ b/packages/ar-management/src/__tests__/admin-route-access.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import type { AdminAuthContext, Env } from '@authrim/ar-lib-core';
+import { ADMIN_PERMISSIONS } from '@authrim/ar-lib-core';
+import { app as managementApp } from '../index';
+import {
+  ADMIN_ROUTE_ACCESS_RULES,
+  enforceDeclaredAdminRouteAccess,
+  findAdminRouteAccessRule,
+  registerDeclaredAdminRouteAccessMiddleware,
+} from '../admin-route-access';
+
+const ROUTE_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']);
+
+function createHarness(permissions: string[]) {
+  const app = new Hono<{
+    Bindings: Env;
+    Variables: { adminAuth?: AdminAuthContext };
+  }>();
+
+  app.use('*', async (c, next) => {
+    c.set('adminAuth', {
+      userId: 'admin-1',
+      authMethod: 'machine_access_token',
+      actorType: 'machine',
+      tenantId: 'tenant-a',
+      roles: [],
+      permissions,
+      hierarchyLevel: 0,
+      mfaVerified: false,
+    });
+    await next();
+  });
+
+  registerDeclaredAdminRouteAccessMiddleware(app);
+
+  app.get('/api/admin/users', (c) => c.json({ ok: true }));
+  app.delete('/api/admin/users/user-1', (c) => c.json({ ok: true }));
+  app.delete('/api/admin/users/user-1/roles/assignment-1', (c) => c.json({ ok: true }));
+  app.put('/api/admin/settings', (c) => c.json({ ok: true }));
+  app.post('/api/admin/undocumented', (c) => c.json({ ok: true }));
+
+  return app;
+}
+
+describe('declared admin route access', () => {
+  it('fails closed when an admin route has no declaration', async () => {
+    const app = createHarness([ADMIN_PERMISSIONS.ALL]);
+    const response = await app.request('/api/admin/undocumented', { method: 'POST' });
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe('insufficient_permissions');
+  });
+
+  it('enforces declared read/write/delete permissions before the handler runs', async () => {
+    const reader = createHarness([ADMIN_PERMISSIONS.USERS_READ, ADMIN_PERMISSIONS.SETTINGS_READ]);
+    const userWriter = createHarness([ADMIN_PERMISSIONS.USERS_DELETE]);
+    const settingsWriter = createHarness([ADMIN_PERMISSIONS.SETTINGS_WRITE]);
+
+    const readUsers = await reader.request('/api/admin/users');
+    const deniedDeleteUser = await reader.request('/api/admin/users/user-1', {
+      method: 'DELETE',
+    });
+    const allowedDeleteUser = await userWriter.request('/api/admin/users/user-1', {
+      method: 'DELETE',
+    });
+    const deniedUpdateSettings = await reader.request('/api/admin/settings', {
+      method: 'PUT',
+    });
+    const allowedUpdateSettings = await settingsWriter.request('/api/admin/settings', {
+      method: 'PUT',
+    });
+
+    expect(readUsers.status).toBe(200);
+    expect(deniedDeleteUser.status).toBe(403);
+    expect(allowedDeleteUser.status).toBe(200);
+    expect(deniedUpdateSettings.status).toBe(403);
+    expect(allowedUpdateSettings.status).toBe(200);
+  });
+
+  it('keeps role assignment removal on roles write permission for existing admins', async () => {
+    const app = createHarness([ADMIN_PERMISSIONS.ROLES_WRITE]);
+    const response = await app.request('/api/admin/users/user-1/roles/assignment-1', {
+      method: 'DELETE',
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it('keeps the production admin route table covered by declared access rules', () => {
+    const routes = managementApp.routes
+      .filter((route) => ROUTE_METHODS.has(route.method))
+      .filter((route) => route.path.startsWith('/api/admin'));
+
+    const uncoveredRoutes = routes
+      .filter((route) => !findAdminRouteAccessRule(route.method, route.path))
+      .map((route) => `${route.method} ${route.path}`)
+      .sort();
+
+    expect(routes.length).toBeGreaterThan(300);
+    expect(uncoveredRoutes).toEqual([]);
+  });
+
+  it('does not rely on a blanket /api/admin/* declaration', async () => {
+    const hasBlanketRule = ADMIN_ROUTE_ACCESS_RULES.some((rule) => rule.pattern === '/api/admin/*');
+    expect(hasBlanketRule).toBe(false);
+
+    const app = new Hono<{ Bindings: Env; Variables: { adminAuth?: AdminAuthContext } }>();
+    app.use('*', async (c, next) => {
+      c.set('adminAuth', {
+        userId: 'admin-1',
+        authMethod: 'machine_access_token',
+        actorType: 'machine',
+        tenantId: 'tenant-a',
+        roles: [],
+        permissions: [ADMIN_PERMISSIONS.ALL],
+        hierarchyLevel: 0,
+        mfaVerified: false,
+      });
+      await next();
+    });
+    app.use('/api/admin/*', enforceDeclaredAdminRouteAccess());
+    app.get('/api/admin/new-control-plane', (c) => c.json({ ok: true }));
+
+    const response = await app.request('/api/admin/new-control-plane');
+    expect(response.status).toBe(403);
+  });
+});

--- a/packages/ar-management/src/admin-route-access.ts
+++ b/packages/ar-management/src/admin-route-access.ts
@@ -1,0 +1,1284 @@
+import type { Context, Hono, Next } from 'hono';
+import type { Env } from '@authrim/ar-lib-core';
+import { ADMIN_PERMISSIONS, hasAdminPermission, type AdminAuthContext } from '@authrim/ar-lib-core';
+
+export type AdminRouteMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+export interface AdminRouteAccessRule {
+  pattern: string;
+  methods: AdminRouteMethod[];
+  permissions?: string[];
+  anyPermissions?: string[];
+  roles?: string[];
+  authenticated?: boolean;
+  description: string;
+}
+
+type RuleInput = Omit<AdminRouteAccessRule, 'methods'> & {
+  methods?: AdminRouteMethod[];
+};
+
+const READ_METHODS: AdminRouteMethod[] = ['GET'];
+const WRITE_METHODS: AdminRouteMethod[] = ['POST', 'PUT', 'PATCH'];
+const DELETE_METHODS: AdminRouteMethod[] = ['DELETE'];
+const ALL_METHODS: AdminRouteMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
+const TENANT_ADMIN_ROLES = ['system_admin', 'distributor_admin', 'tenant_admin', 'admin'];
+const PLATFORM_ADMIN_ROLES = ['super_admin', 'system_admin'];
+
+function rule(input: RuleInput): AdminRouteAccessRule {
+  return {
+    ...input,
+    methods: input.methods ?? ALL_METHODS,
+  };
+}
+
+function authenticated(pattern: string, description: string): AdminRouteAccessRule {
+  return rule({
+    pattern,
+    authenticated: true,
+    description,
+  });
+}
+
+function byMethod(
+  pattern: string,
+  readPermission: string,
+  writePermission: string,
+  deletePermission: string = writePermission,
+  description: string,
+  roles?: string[]
+): AdminRouteAccessRule[] {
+  return [
+    rule({
+      pattern,
+      methods: READ_METHODS,
+      permissions: [readPermission],
+      roles,
+      description: `${description} read`,
+    }),
+    rule({
+      pattern,
+      methods: WRITE_METHODS,
+      permissions: [writePermission],
+      roles,
+      description: `${description} write`,
+    }),
+    rule({
+      pattern,
+      methods: DELETE_METHODS,
+      permissions: [deletePermission],
+      roles,
+      description: `${description} delete`,
+    }),
+  ];
+}
+
+function readOnly(pattern: string, permission: string, description: string): AdminRouteAccessRule {
+  return rule({
+    pattern,
+    methods: READ_METHODS,
+    permissions: [permission],
+    description,
+  });
+}
+
+function writeOnly(pattern: string, permission: string, description: string): AdminRouteAccessRule {
+  return rule({
+    pattern,
+    methods: [...WRITE_METHODS, ...DELETE_METHODS],
+    permissions: [permission],
+    description,
+  });
+}
+
+export const ADMIN_ROUTE_ACCESS_RULES: AdminRouteAccessRule[] = [
+  authenticated('/api/admin/me/session', 'current admin session'),
+  authenticated('/api/admin/logout', 'current admin logout'),
+  authenticated('/api/admin/sessions/me', 'removed legacy session endpoint'),
+  authenticated('/api/admin/me/passkeys', 'current admin passkey management'),
+  authenticated('/api/admin/me/passkeys/*', 'current admin passkey management'),
+
+  rule({
+    pattern: '/api/admin/test/*',
+    permissions: [ADMIN_PERMISSIONS.SECURITY_WRITE],
+    roles: PLATFORM_ADMIN_ROLES,
+    description: 'gated admin test endpoints',
+  }),
+
+  ...byMethod(
+    '/api/admin/users/:id/roles',
+    ADMIN_PERMISSIONS.ROLES_READ,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    'end-user role assignments'
+  ),
+  ...byMethod(
+    '/api/admin/users/:id/roles/*',
+    ADMIN_PERMISSIONS.ROLES_READ,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    'end-user role assignments'
+  ),
+  ...byMethod(
+    '/api/admin/users/:id/relationships',
+    ADMIN_PERMISSIONS.ROLES_READ,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    'end-user access graph relationships'
+  ),
+  ...byMethod(
+    '/api/admin/users/:id/relationships/*',
+    ADMIN_PERMISSIONS.ROLES_READ,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    'end-user access graph relationships'
+  ),
+  readOnly(
+    '/api/admin/users/:id/effective-permissions',
+    ADMIN_PERMISSIONS.ROLES_READ,
+    'end-user effective permissions'
+  ),
+  ...byMethod(
+    '/api/admin/roles',
+    ADMIN_PERMISSIONS.ROLES_READ,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    ADMIN_PERMISSIONS.ROLES_DELETE,
+    'end-user roles'
+  ),
+  ...byMethod(
+    '/api/admin/roles/*',
+    ADMIN_PERMISSIONS.ROLES_READ,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    ADMIN_PERMISSIONS.ROLES_DELETE,
+    'end-user roles'
+  ),
+  ...byMethod(
+    '/api/admin/organizations',
+    ADMIN_PERMISSIONS.ROLES_READ,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    'organizations and access graph'
+  ),
+  ...byMethod(
+    '/api/admin/organizations/*',
+    ADMIN_PERMISSIONS.ROLES_READ,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    'organizations and access graph'
+  ),
+  ...byMethod(
+    '/api/admin/policies',
+    ADMIN_PERMISSIONS.ROLES_READ,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    'authorization policies'
+  ),
+  ...byMethod(
+    '/api/admin/policies/*',
+    ADMIN_PERMISSIONS.ROLES_READ,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    'authorization policies'
+  ),
+  ...byMethod(
+    '/api/admin/role-assignment-rules',
+    ADMIN_PERMISSIONS.ROLES_READ,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    'role assignment rules'
+  ),
+  ...byMethod(
+    '/api/admin/role-assignment-rules/*',
+    ADMIN_PERMISSIONS.ROLES_READ,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    'role assignment rules'
+  ),
+  ...byMethod(
+    '/api/admin/resource-permissions',
+    ADMIN_PERMISSIONS.ROLES_READ,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    'resource permissions'
+  ),
+  ...byMethod(
+    '/api/admin/resource-permissions/*',
+    ADMIN_PERMISSIONS.ROLES_READ,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    'resource permissions'
+  ),
+
+  ...byMethod(
+    '/api/admin/users/:id/sessions',
+    ADMIN_PERMISSIONS.SESSIONS_READ,
+    ADMIN_PERMISSIONS.SESSIONS_REVOKE,
+    ADMIN_PERMISSIONS.SESSIONS_REVOKE,
+    'user session management'
+  ),
+  ...byMethod(
+    '/api/admin/users/:id/refresh-tokens',
+    ADMIN_PERMISSIONS.SESSIONS_READ,
+    ADMIN_PERMISSIONS.SESSIONS_REVOKE,
+    ADMIN_PERMISSIONS.SESSIONS_REVOKE,
+    'user refresh-token revocation'
+  ),
+  ...byMethod(
+    '/api/admin/users/:userId/device-secrets',
+    ADMIN_PERMISSIONS.SESSIONS_READ,
+    ADMIN_PERMISSIONS.SESSIONS_REVOKE,
+    ADMIN_PERMISSIONS.SESSIONS_REVOKE,
+    'native SSO user device secrets'
+  ),
+  ...byMethod(
+    '/api/admin/users/:userId/device-secrets/*',
+    ADMIN_PERMISSIONS.SESSIONS_READ,
+    ADMIN_PERMISSIONS.SESSIONS_REVOKE,
+    ADMIN_PERMISSIONS.SESSIONS_REVOKE,
+    'native SSO user device secrets'
+  ),
+  ...byMethod(
+    '/api/admin/sessions',
+    ADMIN_PERMISSIONS.SESSIONS_READ,
+    ADMIN_PERMISSIONS.SESSIONS_REVOKE,
+    ADMIN_PERMISSIONS.SESSIONS_REVOKE,
+    'admin-visible sessions'
+  ),
+  ...byMethod(
+    '/api/admin/sessions/*',
+    ADMIN_PERMISSIONS.SESSIONS_READ,
+    ADMIN_PERMISSIONS.SESSIONS_REVOKE,
+    ADMIN_PERMISSIONS.SESSIONS_REVOKE,
+    'admin-visible sessions'
+  ),
+  ...byMethod(
+    '/api/admin/device-secrets',
+    ADMIN_PERMISSIONS.SESSIONS_READ,
+    ADMIN_PERMISSIONS.SESSIONS_REVOKE,
+    ADMIN_PERMISSIONS.SESSIONS_REVOKE,
+    'native SSO device secrets'
+  ),
+  ...byMethod(
+    '/api/admin/device-secrets/*',
+    ADMIN_PERMISSIONS.SESSIONS_READ,
+    ADMIN_PERMISSIONS.SESSIONS_REVOKE,
+    ADMIN_PERMISSIONS.SESSIONS_REVOKE,
+    'native SSO device secrets'
+  ),
+
+  ...byMethod(
+    '/api/admin/users',
+    ADMIN_PERMISSIONS.USERS_READ,
+    ADMIN_PERMISSIONS.USERS_WRITE,
+    ADMIN_PERMISSIONS.USERS_DELETE,
+    'end users'
+  ),
+  ...byMethod(
+    '/api/admin/users/*',
+    ADMIN_PERMISSIONS.USERS_READ,
+    ADMIN_PERMISSIONS.USERS_WRITE,
+    ADMIN_PERMISSIONS.USERS_DELETE,
+    'end users'
+  ),
+  readOnly('/api/admin/avatars/*', ADMIN_PERMISSIONS.USERS_READ, 'user avatars'),
+  ...byMethod(
+    '/api/admin/anonymous-users',
+    ADMIN_PERMISSIONS.USERS_READ,
+    ADMIN_PERMISSIONS.USERS_WRITE,
+    ADMIN_PERMISSIONS.USERS_DELETE,
+    'anonymous users'
+  ),
+  ...byMethod(
+    '/api/admin/anonymous-users/*',
+    ADMIN_PERMISSIONS.USERS_READ,
+    ADMIN_PERMISSIONS.USERS_WRITE,
+    ADMIN_PERMISSIONS.USERS_DELETE,
+    'anonymous users'
+  ),
+
+  ...byMethod(
+    '/api/admin/clients',
+    ADMIN_PERMISSIONS.CLIENTS_READ,
+    ADMIN_PERMISSIONS.CLIENTS_WRITE,
+    ADMIN_PERMISSIONS.CLIENTS_DELETE,
+    'OAuth clients'
+  ),
+  ...byMethod(
+    '/api/admin/clients/*',
+    ADMIN_PERMISSIONS.CLIENTS_READ,
+    ADMIN_PERMISSIONS.CLIENTS_WRITE,
+    ADMIN_PERMISSIONS.CLIENTS_DELETE,
+    'OAuth clients'
+  ),
+  ...byMethod(
+    '/api/admin/iat-tokens',
+    ADMIN_PERMISSIONS.CLIENTS_READ,
+    ADMIN_PERMISSIONS.CLIENTS_WRITE,
+    ADMIN_PERMISSIONS.CLIENTS_WRITE,
+    'initial access tokens'
+  ),
+  ...byMethod(
+    '/api/admin/iat-tokens/*',
+    ADMIN_PERMISSIONS.CLIENTS_READ,
+    ADMIN_PERMISSIONS.CLIENTS_WRITE,
+    ADMIN_PERMISSIONS.CLIENTS_WRITE,
+    'initial access tokens'
+  ),
+
+  ...byMethod(
+    '/api/admin/settings',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'tenant settings'
+  ),
+  ...byMethod(
+    '/api/admin/settings/*',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'tenant settings'
+  ),
+  ...byMethod(
+    '/api/admin/platform/settings/*',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'platform settings',
+    PLATFORM_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/tenants/:tenantId/settings/*',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'scoped tenant settings'
+  ),
+  ...byMethod(
+    '/api/admin/tenants/:tenantId/email-settings',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'tenant email settings'
+  ),
+  ...byMethod(
+    '/api/admin/tenants/:tenantId/audit/*',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'tenant audit settings'
+  ),
+  ...byMethod(
+    '/api/admin/tenants',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'tenant administration',
+    PLATFORM_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/tenants/*',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'tenant administration',
+    PLATFORM_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/runtime-profiles',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'runtime profiles',
+    PLATFORM_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/runtime-profiles/*',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'runtime profiles',
+    PLATFORM_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/tenant-policy',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'contract tenant policy',
+    ['system_admin', 'org_admin', 'admin']
+  ),
+  ...byMethod(
+    '/api/admin/tenant-policy/*',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'contract tenant policy',
+    ['system_admin', 'org_admin', 'admin']
+  ),
+  ...byMethod(
+    '/api/admin/client-profile-presets',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'client profile presets'
+  ),
+  readOnly('/api/admin/effective-policy', ADMIN_PERMISSIONS.SETTINGS_READ, 'effective policy'),
+  readOnly('/api/admin/effective-policy/*', ADMIN_PERMISSIONS.SETTINGS_READ, 'effective policy'),
+
+  ...byMethod(
+    '/api/admin/tenant-vanity-domains',
+    ADMIN_PERMISSIONS.TENANT_DOMAINS_READ,
+    ADMIN_PERMISSIONS.TENANT_DOMAINS_WRITE,
+    ADMIN_PERMISSIONS.TENANT_DOMAINS_DELETE,
+    'tenant vanity domains'
+  ),
+  ...byMethod(
+    '/api/admin/tenant-vanity-domains/*',
+    ADMIN_PERMISSIONS.TENANT_DOMAINS_READ,
+    ADMIN_PERMISSIONS.TENANT_DOMAINS_WRITE,
+    ADMIN_PERMISSIONS.TENANT_DOMAINS_DELETE,
+    'tenant vanity domains'
+  ),
+  ...byMethod(
+    '/api/admin/platform/tenant-domain-mappings',
+    ADMIN_PERMISSIONS.TENANT_DOMAINS_READ,
+    ADMIN_PERMISSIONS.TENANT_DOMAINS_WRITE,
+    ADMIN_PERMISSIONS.TENANT_DOMAINS_DELETE,
+    'platform tenant domain mappings',
+    PLATFORM_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/platform/tenant-domain-mappings/*',
+    ADMIN_PERMISSIONS.TENANT_DOMAINS_READ,
+    ADMIN_PERMISSIONS.TENANT_DOMAINS_WRITE,
+    ADMIN_PERMISSIONS.TENANT_DOMAINS_DELETE,
+    'platform tenant domain mappings',
+    PLATFORM_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/platform/tenant-vanity-domains',
+    ADMIN_PERMISSIONS.TENANT_DOMAINS_READ,
+    ADMIN_PERMISSIONS.TENANT_DOMAINS_WRITE,
+    ADMIN_PERMISSIONS.TENANT_DOMAINS_DELETE,
+    'platform tenant vanity domains',
+    PLATFORM_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/platform/tenant-vanity-domains/*',
+    ADMIN_PERMISSIONS.TENANT_DOMAINS_READ,
+    ADMIN_PERMISSIONS.TENANT_DOMAINS_WRITE,
+    ADMIN_PERMISSIONS.TENANT_DOMAINS_DELETE,
+    'platform tenant vanity domains',
+    PLATFORM_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/org-domain-mappings',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'organization domain mappings'
+  ),
+  ...byMethod(
+    '/api/admin/org-domain-mappings/*',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'organization domain mappings'
+  ),
+
+  ...byMethod(
+    '/api/admin/attributes',
+    ADMIN_PERMISSIONS.USERS_READ,
+    ADMIN_PERMISSIONS.USERS_WRITE,
+    ADMIN_PERMISSIONS.USERS_WRITE,
+    'ABAC attributes',
+    TENANT_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/attributes/*',
+    ADMIN_PERMISSIONS.USERS_READ,
+    ADMIN_PERMISSIONS.USERS_WRITE,
+    ADMIN_PERMISSIONS.USERS_WRITE,
+    'ABAC attributes',
+    TENANT_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/custom-claims',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'custom claims',
+    TENANT_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/custom-claims/*',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'custom claims',
+    TENANT_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/token-claim-rules',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'token claim rules'
+  ),
+  ...byMethod(
+    '/api/admin/token-claim-rules/*',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'token claim rules'
+  ),
+  ...byMethod(
+    '/api/admin/field-mapping',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'identity field mapping'
+  ),
+  ...byMethod(
+    '/api/admin/field-mapping/*',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'identity field mapping'
+  ),
+  ...byMethod(
+    '/api/admin/flows',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'flow definitions',
+    TENANT_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/flows/*',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'flow definitions',
+    TENANT_ADMIN_ROLES
+  ),
+
+  ...byMethod(
+    '/api/admin/signing-keys',
+    ADMIN_PERMISSIONS.SECURITY_READ,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    'signing keys'
+  ),
+  ...byMethod(
+    '/api/admin/signing-keys/*',
+    ADMIN_PERMISSIONS.SECURITY_READ,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    'signing keys'
+  ),
+  ...byMethod(
+    '/api/admin/scim-tokens',
+    ADMIN_PERMISSIONS.SECURITY_READ,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    'SCIM bearer tokens'
+  ),
+  ...byMethod(
+    '/api/admin/scim-tokens/*',
+    ADMIN_PERMISSIONS.SECURITY_READ,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    'SCIM bearer tokens'
+  ),
+  ...byMethod(
+    '/api/admin/check-api-keys',
+    ADMIN_PERMISSIONS.SECURITY_READ,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    'check API keys'
+  ),
+  ...byMethod(
+    '/api/admin/check-api-keys/*',
+    ADMIN_PERMISSIONS.SECURITY_READ,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    'check API keys'
+  ),
+  ...byMethod(
+    '/api/admin/security',
+    ADMIN_PERMISSIONS.SECURITY_READ,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    'security monitoring',
+    TENANT_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/security/*',
+    ADMIN_PERMISSIONS.SECURITY_READ,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    'security monitoring',
+    TENANT_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/vc',
+    ADMIN_PERMISSIONS.SECURITY_READ,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    'verifiable credential status'
+  ),
+  ...byMethod(
+    '/api/admin/vc/*',
+    ADMIN_PERMISSIONS.SECURITY_READ,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    ADMIN_PERMISSIONS.SECURITY_WRITE,
+    'verifiable credential status'
+  ),
+
+  ...byMethod(
+    '/api/admin/external-providers',
+    ADMIN_PERMISSIONS.EXTERNAL_PROVIDERS_READ,
+    ADMIN_PERMISSIONS.EXTERNAL_PROVIDERS_WRITE,
+    ADMIN_PERMISSIONS.EXTERNAL_PROVIDERS_DELETE,
+    'external identity providers'
+  ),
+  ...byMethod(
+    '/api/admin/external-providers/*',
+    ADMIN_PERMISSIONS.EXTERNAL_PROVIDERS_READ,
+    ADMIN_PERMISSIONS.EXTERNAL_PROVIDERS_WRITE,
+    ADMIN_PERMISSIONS.EXTERNAL_PROVIDERS_DELETE,
+    'external identity providers'
+  ),
+  ...byMethod(
+    '/api/admin/external-token-refresh',
+    ADMIN_PERMISSIONS.EXTERNAL_TOKEN_REFRESH_READ,
+    ADMIN_PERMISSIONS.EXTERNAL_TOKEN_REFRESH_WRITE,
+    ADMIN_PERMISSIONS.EXTERNAL_TOKEN_REFRESH_WRITE,
+    'external token refresh'
+  ),
+  rule({
+    pattern: '/api/admin/external-token-refresh/run',
+    methods: WRITE_METHODS,
+    permissions: [ADMIN_PERMISSIONS.EXTERNAL_TOKEN_REFRESH_RUN],
+    description: 'external token refresh manual run',
+  }),
+  ...byMethod(
+    '/api/admin/external-token-refresh/*',
+    ADMIN_PERMISSIONS.EXTERNAL_TOKEN_REFRESH_READ,
+    ADMIN_PERMISSIONS.EXTERNAL_TOKEN_REFRESH_WRITE,
+    ADMIN_PERMISSIONS.EXTERNAL_TOKEN_REFRESH_WRITE,
+    'external token refresh'
+  ),
+
+  ...byMethod(
+    '/api/admin/admins',
+    ADMIN_PERMISSIONS.ADMIN_USERS_READ,
+    ADMIN_PERMISSIONS.ADMIN_USERS_WRITE,
+    ADMIN_PERMISSIONS.ADMIN_USERS_DELETE,
+    'admin users'
+  ),
+  ...byMethod(
+    '/api/admin/admins/*',
+    ADMIN_PERMISSIONS.ADMIN_USERS_READ,
+    ADMIN_PERMISSIONS.ADMIN_USERS_WRITE,
+    ADMIN_PERMISSIONS.ADMIN_USERS_DELETE,
+    'admin users'
+  ),
+  ...byMethod(
+    '/api/admin/admin-roles',
+    ADMIN_PERMISSIONS.ADMIN_ROLES_READ,
+    ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE,
+    ADMIN_PERMISSIONS.ADMIN_ROLES_DELETE,
+    'admin roles'
+  ),
+  ...byMethod(
+    '/api/admin/admin-roles/*',
+    ADMIN_PERMISSIONS.ADMIN_ROLES_READ,
+    ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE,
+    ADMIN_PERMISSIONS.ADMIN_ROLES_DELETE,
+    'admin roles'
+  ),
+  ...byMethod(
+    '/api/admin/ip-allowlist',
+    ADMIN_PERMISSIONS.IP_ALLOWLIST_READ,
+    ADMIN_PERMISSIONS.IP_ALLOWLIST_WRITE,
+    ADMIN_PERMISSIONS.IP_ALLOWLIST_DELETE,
+    'admin IP allowlist'
+  ),
+  ...byMethod(
+    '/api/admin/ip-allowlist/*',
+    ADMIN_PERMISSIONS.IP_ALLOWLIST_READ,
+    ADMIN_PERMISSIONS.IP_ALLOWLIST_WRITE,
+    ADMIN_PERMISSIONS.IP_ALLOWLIST_DELETE,
+    'admin IP allowlist'
+  ),
+  ...byMethod(
+    '/api/admin/admin-audit-log',
+    ADMIN_PERMISSIONS.ADMIN_AUDIT_READ,
+    ADMIN_PERMISSIONS.ADMIN_AUDIT_READ,
+    ADMIN_PERMISSIONS.ADMIN_AUDIT_READ,
+    'admin audit log'
+  ),
+  ...byMethod(
+    '/api/admin/admin-audit-log/*',
+    ADMIN_PERMISSIONS.ADMIN_AUDIT_READ,
+    ADMIN_PERMISSIONS.ADMIN_AUDIT_DETAIL_READ,
+    ADMIN_PERMISSIONS.ADMIN_AUDIT_DETAIL_READ,
+    'admin audit log'
+  ),
+  ...byMethod(
+    '/api/admin/admin-attributes',
+    ADMIN_PERMISSIONS.ADMIN_USERS_READ,
+    ADMIN_PERMISSIONS.ADMIN_USERS_WRITE,
+    ADMIN_PERMISSIONS.ADMIN_USERS_DELETE,
+    'admin ABAC attributes'
+  ),
+  ...byMethod(
+    '/api/admin/admin-attributes/*',
+    ADMIN_PERMISSIONS.ADMIN_USERS_READ,
+    ADMIN_PERMISSIONS.ADMIN_USERS_WRITE,
+    ADMIN_PERMISSIONS.ADMIN_USERS_DELETE,
+    'admin ABAC attributes'
+  ),
+  ...byMethod(
+    '/api/admin/admin-relationships',
+    ADMIN_PERMISSIONS.ADMIN_ROLES_READ,
+    ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE,
+    ADMIN_PERMISSIONS.ADMIN_ROLES_DELETE,
+    'admin ReBAC relationships'
+  ),
+  ...byMethod(
+    '/api/admin/admin-relationships/*',
+    ADMIN_PERMISSIONS.ADMIN_ROLES_READ,
+    ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE,
+    ADMIN_PERMISSIONS.ADMIN_ROLES_DELETE,
+    'admin ReBAC relationships'
+  ),
+  ...byMethod(
+    '/api/admin/admin-rebac-definitions',
+    ADMIN_PERMISSIONS.ADMIN_ROLES_READ,
+    ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE,
+    ADMIN_PERMISSIONS.ADMIN_ROLES_DELETE,
+    'admin ReBAC definitions'
+  ),
+  ...byMethod(
+    '/api/admin/admin-rebac-definitions/*',
+    ADMIN_PERMISSIONS.ADMIN_ROLES_READ,
+    ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE,
+    ADMIN_PERMISSIONS.ADMIN_ROLES_DELETE,
+    'admin ReBAC definitions'
+  ),
+  ...byMethod(
+    '/api/admin/admin-policies',
+    ADMIN_PERMISSIONS.ADMIN_ROLES_READ,
+    ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE,
+    ADMIN_PERMISSIONS.ADMIN_ROLES_DELETE,
+    'admin access policies'
+  ),
+  ...byMethod(
+    '/api/admin/admin-policies/*',
+    ADMIN_PERMISSIONS.ADMIN_ROLES_READ,
+    ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE,
+    ADMIN_PERMISSIONS.ADMIN_ROLES_DELETE,
+    'admin access policies'
+  ),
+  readOnly(
+    '/api/admin/admin-access-control',
+    ADMIN_PERMISSIONS.ADMIN_ROLES_READ,
+    'admin access control hub'
+  ),
+  readOnly(
+    '/api/admin/admin-access-control/*',
+    ADMIN_PERMISSIONS.ADMIN_ROLES_READ,
+    'admin access control hub'
+  ),
+  ...byMethod(
+    '/api/admin/approvals',
+    ADMIN_PERMISSIONS.APPROVALS_READ,
+    ADMIN_PERMISSIONS.APPROVALS_WRITE,
+    ADMIN_PERMISSIONS.APPROVALS_WRITE,
+    'admin approvals'
+  ),
+  ...byMethod(
+    '/api/admin/approvals/*',
+    ADMIN_PERMISSIONS.APPROVALS_READ,
+    ADMIN_PERMISSIONS.APPROVALS_WRITE,
+    ADMIN_PERMISSIONS.APPROVALS_WRITE,
+    'admin approvals'
+  ),
+  ...byMethod(
+    '/api/admin/operational-logs',
+    ADMIN_PERMISSIONS.OPERATIONAL_LOGS_READ,
+    ADMIN_PERMISSIONS.OPERATIONAL_LOGS_DETAIL_READ,
+    ADMIN_PERMISSIONS.OPERATIONAL_LOGS_DETAIL_READ,
+    'operational logs'
+  ),
+  ...byMethod(
+    '/api/admin/operational-logs/*',
+    ADMIN_PERMISSIONS.OPERATIONAL_LOGS_READ,
+    ADMIN_PERMISSIONS.OPERATIONAL_LOGS_DETAIL_READ,
+    ADMIN_PERMISSIONS.OPERATIONAL_LOGS_DETAIL_READ,
+    'operational logs'
+  ),
+  ...byMethod(
+    '/api/admin/storage-destinations',
+    ADMIN_PERMISSIONS.STORAGE_DESTINATIONS_LIST,
+    ADMIN_PERMISSIONS.STORAGE_DESTINATIONS_CREATE,
+    ADMIN_PERMISSIONS.STORAGE_DESTINATIONS_DELETE,
+    'storage destinations'
+  ),
+  ...byMethod(
+    '/api/admin/storage-destinations/*',
+    ADMIN_PERMISSIONS.STORAGE_DESTINATIONS_READ,
+    ADMIN_PERMISSIONS.STORAGE_DESTINATIONS_UPDATE,
+    ADMIN_PERMISSIONS.STORAGE_DESTINATIONS_DELETE,
+    'storage destinations'
+  ),
+  ...byMethod(
+    '/api/admin/database-connections',
+    ADMIN_PERMISSIONS.DATABASE_CONNECTIONS_LIST,
+    ADMIN_PERMISSIONS.DATABASE_CONNECTIONS_CREATE,
+    ADMIN_PERMISSIONS.DATABASE_CONNECTIONS_DELETE,
+    'database connections'
+  ),
+  ...byMethod(
+    '/api/admin/database-connections/*',
+    ADMIN_PERMISSIONS.DATABASE_CONNECTIONS_READ,
+    ADMIN_PERMISSIONS.DATABASE_CONNECTIONS_UPDATE,
+    ADMIN_PERMISSIONS.DATABASE_CONNECTIONS_DELETE,
+    'database connections'
+  ),
+  ...byMethod(
+    '/api/admin/machine-access',
+    ADMIN_PERMISSIONS.ADMIN_MACHINE_ACCESS_READ,
+    ADMIN_PERMISSIONS.ADMIN_MACHINE_ACCESS_WRITE,
+    ADMIN_PERMISSIONS.ADMIN_MACHINE_ACCESS_DELETE,
+    'admin machine access'
+  ),
+  ...byMethod(
+    '/api/admin/machine-access/*',
+    ADMIN_PERMISSIONS.ADMIN_MACHINE_ACCESS_READ,
+    ADMIN_PERMISSIONS.ADMIN_MACHINE_ACCESS_WRITE,
+    ADMIN_PERMISSIONS.ADMIN_MACHINE_ACCESS_DELETE,
+    'admin machine access'
+  ),
+
+  ...byMethod(
+    '/api/admin/destinations',
+    ADMIN_PERMISSIONS.STORAGE_DESTINATIONS_LIST,
+    ADMIN_PERMISSIONS.STORAGE_DESTINATIONS_CREATE,
+    ADMIN_PERMISSIONS.STORAGE_DESTINATIONS_DELETE,
+    'logging destinations'
+  ),
+  ...byMethod(
+    '/api/admin/destinations/*',
+    ADMIN_PERMISSIONS.STORAGE_DESTINATIONS_READ,
+    ADMIN_PERMISSIONS.STORAGE_DESTINATIONS_UPDATE,
+    ADMIN_PERMISSIONS.STORAGE_DESTINATIONS_DELETE,
+    'logging destinations'
+  ),
+  ...byMethod(
+    '/api/admin/logging-policies',
+    ADMIN_PERMISSIONS.LOGGING_OVERVIEW_READ,
+    ADMIN_PERMISSIONS.LOGGING_PLATFORM_DEFAULTS_UPDATE,
+    ADMIN_PERMISSIONS.LOGGING_PLATFORM_DEFAULTS_UPDATE,
+    'logging policies'
+  ),
+  ...byMethod(
+    '/api/admin/logging-policies/*',
+    ADMIN_PERMISSIONS.LOGGING_OVERVIEW_READ,
+    ADMIN_PERMISSIONS.LOGGING_PLATFORM_DEFAULTS_UPDATE,
+    ADMIN_PERMISSIONS.LOGGING_PLATFORM_DEFAULTS_UPDATE,
+    'logging policies'
+  ),
+  ...byMethod(
+    '/api/admin/admin-logging',
+    ADMIN_PERMISSIONS.ADMIN_LOGGING_OVERVIEW_READ,
+    ADMIN_PERMISSIONS.ADMIN_LOGGING_REPAIR_RUN,
+    ADMIN_PERMISSIONS.ADMIN_LOGGING_REPAIR_RUN,
+    'admin logging operations'
+  ),
+  ...byMethod(
+    '/api/admin/admin-logging/*',
+    ADMIN_PERMISSIONS.ADMIN_LOGGING_OVERVIEW_READ,
+    ADMIN_PERMISSIONS.ADMIN_LOGGING_REPAIR_RUN,
+    ADMIN_PERMISSIONS.ADMIN_LOGGING_REPAIR_RUN,
+    'admin logging operations'
+  ),
+  ...byMethod(
+    '/api/admin/notifications',
+    ADMIN_PERMISSIONS.LOGGING_DELIVERY_EVENTS_READ,
+    ADMIN_PERMISSIONS.LOGGING_PLATFORM_DEFAULTS_UPDATE,
+    ADMIN_PERMISSIONS.LOGGING_PLATFORM_DEFAULTS_UPDATE,
+    'logging notifications'
+  ),
+  ...byMethod(
+    '/api/admin/notifications/*',
+    ADMIN_PERMISSIONS.LOGGING_DELIVERY_EVENTS_READ,
+    ADMIN_PERMISSIONS.LOGGING_PLATFORM_DEFAULTS_UPDATE,
+    ADMIN_PERMISSIONS.LOGGING_PLATFORM_DEFAULTS_UPDATE,
+    'logging notifications'
+  ),
+  ...byMethod(
+    '/api/admin/diagnostic-logging',
+    ADMIN_PERMISSIONS.LOGGING_OVERVIEW_READ,
+    ADMIN_PERMISSIONS.LOGGING_EXPORT_CREATE,
+    ADMIN_PERMISSIONS.LOGGING_EXPORT_CREATE,
+    'diagnostic logging'
+  ),
+  ...byMethod(
+    '/api/admin/diagnostic-logging/*',
+    ADMIN_PERMISSIONS.LOGGING_OVERVIEW_READ,
+    ADMIN_PERMISSIONS.LOGGING_EXPORT_CREATE,
+    ADMIN_PERMISSIONS.LOGGING_EXPORT_CREATE,
+    'diagnostic logging'
+  ),
+
+  ...byMethod(
+    '/api/admin/webhooks',
+    ADMIN_PERMISSIONS.WEBHOOKS_READ,
+    ADMIN_PERMISSIONS.WEBHOOKS_WRITE,
+    ADMIN_PERMISSIONS.WEBHOOKS_DELETE,
+    'webhooks'
+  ),
+  ...byMethod(
+    '/api/admin/webhooks/*',
+    ADMIN_PERMISSIONS.WEBHOOKS_READ,
+    ADMIN_PERMISSIONS.WEBHOOKS_WRITE,
+    ADMIN_PERMISSIONS.WEBHOOKS_DELETE,
+    'webhooks'
+  ),
+
+  ...byMethod(
+    '/api/admin/jobs',
+    ADMIN_PERMISSIONS.JOBS_READ,
+    ADMIN_PERMISSIONS.JOBS_WRITE,
+    ADMIN_PERMISSIONS.JOBS_WRITE,
+    'admin jobs',
+    TENANT_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/jobs/*',
+    ADMIN_PERMISSIONS.JOBS_READ,
+    ADMIN_PERMISSIONS.JOBS_WRITE,
+    ADMIN_PERMISSIONS.JOBS_WRITE,
+    'admin jobs',
+    TENANT_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/support-ops',
+    ADMIN_PERMISSIONS.SUPPORT_OPS_REGISTRY_READ,
+    ADMIN_PERMISSIONS.SUPPORT_OPS_ACTIONS_REQUEST,
+    ADMIN_PERMISSIONS.SUPPORT_OPS_ACTIONS_REQUEST,
+    'privacy-preserving support operations'
+  ),
+  ...byMethod(
+    '/api/admin/support-ops/*',
+    ADMIN_PERMISSIONS.SUPPORT_OPS_REGISTRY_READ,
+    ADMIN_PERMISSIONS.SUPPORT_OPS_ACTIONS_REQUEST,
+    ADMIN_PERMISSIONS.SUPPORT_OPS_ACTIONS_REQUEST,
+    'privacy-preserving support operations'
+  ),
+
+  rule({
+    pattern: '/api/admin/stats',
+    methods: READ_METHODS,
+    anyPermissions: [
+      ADMIN_PERMISSIONS.USERS_READ,
+      ADMIN_PERMISSIONS.CLIENTS_READ,
+      ADMIN_PERMISSIONS.AUDIT_READ,
+    ],
+    description: 'admin dashboard stats',
+  }),
+  rule({
+    pattern: '/api/admin/stats/*',
+    methods: READ_METHODS,
+    anyPermissions: [
+      ADMIN_PERMISSIONS.USERS_READ,
+      ADMIN_PERMISSIONS.CLIENTS_READ,
+      ADMIN_PERMISSIONS.AUDIT_READ,
+    ],
+    roles: TENANT_ADMIN_ROLES,
+    description: 'admin dashboard stats',
+  }),
+  ...byMethod(
+    '/api/admin/access-trace',
+    ADMIN_PERMISSIONS.AUDIT_READ,
+    ADMIN_PERMISSIONS.AUDIT_READ,
+    ADMIN_PERMISSIONS.AUDIT_READ,
+    'access trace',
+    TENANT_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/access-trace/*',
+    ADMIN_PERMISSIONS.AUDIT_READ,
+    ADMIN_PERMISSIONS.AUDIT_READ,
+    ADMIN_PERMISSIONS.AUDIT_READ,
+    'access trace',
+    TENANT_ADMIN_ROLES
+  ),
+  readOnly(
+    '/api/admin/access-control/*',
+    ADMIN_PERMISSIONS.ROLES_READ,
+    'access control aggregate stats'
+  ),
+  ...byMethod(
+    '/api/admin/ai-grants',
+    ADMIN_PERMISSIONS.AI_GRANTS_READ,
+    ADMIN_PERMISSIONS.AI_GRANTS_CREATE,
+    ADMIN_PERMISSIONS.AI_GRANTS_REVOKE,
+    'AI grants'
+  ),
+  ...byMethod(
+    '/api/admin/ai-grants/*',
+    ADMIN_PERMISSIONS.AI_GRANTS_READ,
+    ADMIN_PERMISSIONS.AI_GRANTS_UPDATE,
+    ADMIN_PERMISSIONS.AI_GRANTS_REVOKE,
+    'AI grants'
+  ),
+  ...byMethod(
+    '/api/admin/rebac',
+    ADMIN_PERMISSIONS.ROLES_READ,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    ADMIN_PERMISSIONS.ROLES_DELETE,
+    'ReBAC definitions',
+    PLATFORM_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/rebac/*',
+    ADMIN_PERMISSIONS.ROLES_READ,
+    ADMIN_PERMISSIONS.ROLES_WRITE,
+    ADMIN_PERMISSIONS.ROLES_DELETE,
+    'ReBAC definitions',
+    PLATFORM_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/compliance',
+    ADMIN_PERMISSIONS.AUDIT_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'compliance operations',
+    TENANT_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/compliance/*',
+    ADMIN_PERMISSIONS.AUDIT_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'compliance operations',
+    TENANT_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/data-retention',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'data retention'
+  ),
+  ...byMethod(
+    '/api/admin/data-retention/*',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'data retention'
+  ),
+  readOnly('/api/admin/audit-logs', ADMIN_PERMISSIONS.AUDIT_READ, 'end-user audit logs'),
+  readOnly('/api/admin/audit-logs/*', ADMIN_PERMISSIONS.AUDIT_READ, 'end-user audit logs'),
+  ...byMethod(
+    '/api/admin/consent-statements',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'consent statements'
+  ),
+  ...byMethod(
+    '/api/admin/consent-statements/*',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'consent statements'
+  ),
+  ...byMethod(
+    '/api/admin/consent-requirements',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'consent requirements'
+  ),
+  ...byMethod(
+    '/api/admin/consent-requirements/*',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'consent requirements'
+  ),
+  ...byMethod(
+    '/api/admin/plugins',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'tenant plugins'
+  ),
+  ...byMethod(
+    '/api/admin/plugins/*',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'tenant plugins'
+  ),
+  ...byMethod(
+    '/api/admin/platform/plugins',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'platform plugins',
+    PLATFORM_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/platform/plugins/*',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'platform plugins',
+    PLATFORM_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/tombstones',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'tombstones'
+  ),
+  ...byMethod(
+    '/api/admin/tombstones/*',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'tombstones'
+  ),
+  ...byMethod(
+    '/api/admin/platform/tombstones',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'platform tombstones',
+    PLATFORM_ADMIN_ROLES
+  ),
+  ...byMethod(
+    '/api/admin/platform/tombstones/*',
+    ADMIN_PERMISSIONS.SETTINGS_READ,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    ADMIN_PERMISSIONS.SETTINGS_WRITE,
+    'platform tombstones',
+    PLATFORM_ADMIN_ROLES
+  ),
+];
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function patternToRegExp(pattern: string): RegExp {
+  const segments = pattern.split('/').map((segment) => {
+    if (segment === '*') return '.*';
+    if (segment.startsWith(':')) return '[^/]+';
+    return escapeRegExp(segment);
+  });
+
+  return new RegExp(`^${segments.join('/')}$`);
+}
+
+const compiledRules = ADMIN_ROUTE_ACCESS_RULES.map((accessRule) => ({
+  accessRule,
+  regex: patternToRegExp(accessRule.pattern),
+}));
+
+export function findAdminRouteAccessRule(
+  method: string,
+  pathname: string
+): AdminRouteAccessRule | null {
+  const normalizedMethod = method.toUpperCase();
+  return (
+    compiledRules.find(
+      ({ accessRule, regex }) =>
+        accessRule.methods.includes(normalizedMethod as AdminRouteMethod) && regex.test(pathname)
+    )?.accessRule ?? null
+  );
+}
+
+function hasAnyPermission(permissions: string[], required: string[]): boolean {
+  return required.some((permission) => hasAdminPermission(permissions, permission));
+}
+
+function hasAnyRole(roles: string[], required: string[]): boolean {
+  return required.some((role) => roles.includes(role));
+}
+
+function isAllowedByRule(authContext: AdminAuthContext, accessRule: AdminRouteAccessRule): boolean {
+  if (accessRule.authenticated) {
+    return true;
+  }
+
+  const permissions = authContext.permissions || [];
+  const roles = authContext.roles || [];
+
+  if (accessRule.permissions?.every((permission) => hasAdminPermission(permissions, permission))) {
+    return true;
+  }
+
+  if (accessRule.anyPermissions && hasAnyPermission(permissions, accessRule.anyPermissions)) {
+    return true;
+  }
+
+  if (accessRule.roles && hasAnyRole(roles, accessRule.roles)) {
+    return true;
+  }
+
+  return false;
+}
+
+function insufficientPermissionsResponse(c: Context<{ Bindings: Env }>): Response {
+  return c.json(
+    {
+      error: 'insufficient_permissions',
+      error_description: 'You do not have the required permissions for this operation.',
+    },
+    403
+  );
+}
+
+export function enforceDeclaredAdminRouteAccess() {
+  return async (c: Context<{ Bindings: Env }>, next: Next) => {
+    const authContext = (c as unknown as { get: (key: string) => unknown }).get('adminAuth') as
+      | AdminAuthContext
+      | undefined;
+
+    if (!authContext) {
+      return c.json(
+        {
+          error: 'invalid_token',
+          error_description: 'Admin authentication required.',
+        },
+        401
+      );
+    }
+
+    const pathname = new URL(c.req.url).pathname;
+    const accessRule = findAdminRouteAccessRule(c.req.method, pathname);
+    if (!accessRule) {
+      return insufficientPermissionsResponse(c);
+    }
+
+    if (!isAllowedByRule(authContext, accessRule)) {
+      return insufficientPermissionsResponse(c);
+    }
+
+    return next();
+  };
+}
+
+export function registerDeclaredAdminRouteAccessMiddleware(app: Hono<any, any, any>): void {
+  app.use('/api/admin/*', enforceDeclaredAdminRouteAccess());
+}

--- a/packages/ar-management/src/index.ts
+++ b/packages/ar-management/src/index.ts
@@ -183,6 +183,7 @@ import {
 } from './admin-rbac';
 import { registerAdminRbacPermissionMiddleware } from './admin-rbac-permissions';
 import { registerAdminResourcePermissionMiddleware } from './admin-resource-permissions';
+import { registerDeclaredAdminRouteAccessMiddleware } from './admin-route-access';
 import {
   adminRelationDefinitionsListHandler,
   adminRelationDefinitionGetHandler,
@@ -802,7 +803,7 @@ function requireClientManagementPermission() {
 }
 
 // Create Hono app with Cloudflare Workers types
-const app = new Hono<{ Bindings: Env }>();
+export const app = new Hono<{ Bindings: Env }>();
 
 const loadPlugins = createPluginLoader([
   {
@@ -1138,6 +1139,7 @@ app.use('/api/admin/*', async (c, next) => {
 });
 
 // Admin API endpoints
+registerDeclaredAdminRouteAccessMiddleware(app);
 registerAdminResourcePermissionMiddleware(app);
 
 app.get('/api/admin/stats', adminStatsHandler);


### PR DESCRIPTION
## Summary

- Add a declarative fail-closed access table for every Admin API route.
- Register the route access gate immediately after Admin authentication and before Admin route handlers.
- Add route coverage tests that fail when a new Admin route has no explicit access rule.
- Make core Admin UI user-management and logging controls permission-aware.
- Update the README security hardening status.

## Why

The security review identified broad BFLA risk outside the RBAC-specific routes. The previous model relied on per-route opt-in checks, so new or overlooked Admin API handlers could be exposed after authentication without a function-level permission requirement.

## Impact

Admin API requests now require an explicit declared access rule. Undeclared Admin routes fail closed with `403 insufficient_permissions`, and UI controls for core user-management actions are hidden or disabled when the current admin lacks the required permission. Existing wildcard permissions such as `*` and `admin:<resource>:*` continue to work.

## Validation

- `pnpm --filter @authrim/ar-management typecheck`
- `pnpm --filter @authrim/ar-management exec vitest run src/__tests__/admin-route-access.test.ts src/__tests__/admin-rbac-permissions.test.ts src/__tests__/admin-resource-permissions.test.ts`
- `pnpm --filter @authrim/ar-management test`
- `pnpm --filter @authrim/ar-admin-ui typecheck`
- `pnpm --filter @authrim/ar-admin-ui test`
- `pnpm --filter @authrim/ar-admin-ui format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `git diff --check`