### PR TITLE
Support JSON settings metadata

### DIFF
--- a/packages/ar-lib-core/src/__tests__/settings-manager.test.ts
+++ b/packages/ar-lib-core/src/__tests__/settings-manager.test.ts
@@ -83,6 +83,15 @@ const TEST_CATEGORY_META: CategoryMeta = {
       enum: ['option1', 'option2', 'option3'],
       visibility: 'public',
     } as SettingMeta,
+    'test.json_setting': {
+      key: 'test.json_setting',
+      type: 'json',
+      default: [],
+      envKey: 'TEST_JSON_SETTING',
+      label: 'JSON Setting',
+      description: 'A test JSON setting',
+      visibility: 'public',
+    } as SettingMeta,
     'test.dependent_setting': {
       key: 'test.dependent_setting',
       type: 'boolean',
@@ -196,6 +205,20 @@ describe('SettingsManager', () => {
       // KV is set for number_setting
       expect(result.values['test.number_setting']).toBe(200);
       expect(result.sources['test.number_setting']).toBe('kv');
+    });
+
+    it('should parse JSON settings from env', async () => {
+      manager = createSettingsManager({
+        env: { TEST_JSON_SETTING: '[{"id":"passkey","enabled":true}]' },
+        kv: mockKV,
+        cacheTTL: 0,
+      });
+      manager.registerCategory(TEST_CATEGORY_META);
+
+      const result = await manager.getAll('test', { type: 'tenant', id: 'tenant_1' });
+
+      expect(result.values['test.json_setting']).toEqual([{ id: 'passkey', enabled: true }]);
+      expect(result.sources['test.json_setting']).toBe('env');
     });
 
     it('should handle DISABLED_MARKER correctly', async () => {
@@ -416,6 +439,28 @@ describe('SettingsManager', () => {
       expect(result.valid).toBe(false);
       const error = result.errors.find((e) => e.key === 'test.boolean_setting');
       expect(error?.reason).toContain('boolean');
+    });
+
+    it('should validate JSON settings', async () => {
+      expect(
+        manager.validate('test', {
+          'test.json_setting': '[{"id":"email_otp","login":true}]',
+        }).valid
+      ).toBe(true);
+
+      expect(
+        manager.validate('test', {
+          'test.json_setting': [{ id: 'passkey', signup: true }],
+        }).valid
+      ).toBe(true);
+
+      const result = manager.validate('test', {
+        'test.json_setting': '[invalid-json',
+      });
+
+      expect(result.valid).toBe(false);
+      const error = result.errors.find((e) => e.key === 'test.json_setting');
+      expect(error?.reason).toContain('valid JSON');
     });
 
     it('should reject invalid enum values', async () => {

--- a/packages/ar-lib-core/src/utils/settings-manager.ts
+++ b/packages/ar-lib-core/src/utils/settings-manager.ts
@@ -52,7 +52,7 @@ export interface SettingMeta {
   /** Key in dot.notation format */
   key: string;
   /** Value type */
-  type: 'number' | 'boolean' | 'string' | 'duration' | 'enum';
+  type: 'number' | 'boolean' | 'string' | 'duration' | 'enum' | 'json';
   /** Default value (from code) */
   default: unknown;
   /** Environment variable key mapping */
@@ -220,6 +220,12 @@ function parseEnvValue(value: string | undefined, type: SettingMeta['type']): un
     case 'string':
     case 'enum':
       return value;
+    case 'json':
+      try {
+        return JSON.parse(value);
+      } catch {
+        return undefined;
+      }
     default:
       return value;
   }
@@ -745,6 +751,22 @@ export class SettingsManager {
           errors.push({ key, reason: `Expected string, got ${typeof value}` });
         } else if (meta.enum && !meta.enum.includes(value)) {
           errors.push({ key, reason: `Value must be one of: ${meta.enum.join(', ')}` });
+        }
+        break;
+
+      case 'json':
+        if (typeof value === 'string') {
+          try {
+            JSON.parse(value);
+          } catch {
+            errors.push({ key, reason: 'Expected valid JSON string' });
+          }
+        } else {
+          try {
+            JSON.stringify(value);
+          } catch {
+            errors.push({ key, reason: 'Expected JSON-serializable value' });
+          }
         }
         break;
     }


### PR DESCRIPTION
## Summary
- Add `json` as a supported settings metadata type.
- Parse JSON-valued environment settings through the settings manager.
- Validate JSON strings and JSON-serializable values.

## Validation
- `pnpm --filter @authrim/ar-lib-core exec vitest run src/__tests__/settings-manager.test.ts`