### PR TITLE
Fix region shard distribution display

### DIFF
--- a/packages/ar-admin-ui/src/lib/api/admin-infrastructure.ts
+++ b/packages/ar-admin-ui/src/lib/api/admin-infrastructure.ts
@@ -40,14 +40,20 @@ export interface ShardUpdateResponse {
 /**
  * Region shard configuration
  */
+export interface RegionShardRange {
+	startShard: number;
+	endShard: number;
+	shardCount: number;
+}
+
 export interface RegionShardConfig {
 	currentGeneration: number;
 	currentTotalShards: number;
-	currentRegions: Record<string, { start: number; end: number; count: number }>;
+	currentRegions: Record<string, RegionShardRange>;
 	previousGenerations: Array<{
 		generation: number;
 		totalShards: number;
-		regions: Record<string, { start: number; end: number; count: number }>;
+		regions: Record<string, RegionShardRange>;
 		deprecatedAt: number;
 	}>;
 	maxPreviousGenerations: number;

--- a/packages/ar-admin-ui/src/routes/admin/scale/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/scale/+page.svelte
@@ -245,7 +245,7 @@
 					selectedRegions = regions;
 					const dist: RegionDistribution = {};
 					for (const [key, data] of Object.entries(region.currentRegions)) {
-						dist[key] = Math.round((data.count / total) * 100);
+						dist[key] = Math.round((data.shardCount / total) * 100);
 					}
 					regionDistribution = dist;
 				}


### PR DESCRIPTION
## Summary
- Align the Admin UI region shard response type with the API payload (`startShard`, `endShard`, `shardCount`).
- Use `shardCount` when calculating the `/admin/scale` region distribution percentages.

## Validation
- `git diff --check HEAD~1..HEAD`
- `pnpm --filter @authrim/ar-admin-ui check`