### PR TITLE
Fix sensitive logging key version query

### DIFF
--- a/packages/ar-lib-core/src/repositories/admin/admin-logging-control.ts
+++ b/packages/ar-lib-core/src/repositories/admin/admin-logging-control.ts
@@ -399,11 +399,12 @@ export class AdminLoggingControlRepository {
        LIMIT 100`
     );
     const keyVersions = await this.adapter.query<LoggingKeyVersionStatusRow>(
-      `SELECT status, COUNT(*) AS total
-       FROM logging_key_versions
-       WHERE plane = 'sensitive_detail'
-       GROUP BY status
-       ORDER BY status ASC`
+      `SELECT kv.status, COUNT(*) AS total
+       FROM logging_key_versions kv
+       INNER JOIN logging_key_registry kr ON kr.id = kv.key_registry_id
+       WHERE kr.plane = 'sensitive_detail'
+       GROUP BY kv.status
+       ORDER BY kv.status ASC`
     );
     const staleKeyCount = keyVersions
       .filter((row) => ['rewrap_required', 'compromised', 'retiring'].includes(row.status))

--- a/packages/ar-management/src/__tests__/logging-control-router.test.ts
+++ b/packages/ar-management/src/__tests__/logging-control-router.test.ts
@@ -5443,6 +5443,9 @@ describe('logging control routers', () => {
       encrypted: true,
       indexed_object_class_count: 1,
     });
+    expect(mockAdapter.query).toHaveBeenCalledWith(
+      expect.stringContaining('INNER JOIN logging_key_registry kr ON kr.id = kv.key_registry_id')
+    );
 
     mockAdapter.queryOne
       .mockResolvedValueOnce(


### PR DESCRIPTION
## Summary
- Load sensitive detail key version status through the logging key registry relationship.
- Keep the admin logging sensitive detail policy response aligned with the current database schema.
- Add a router test assertion for the registry join.

## Validation
- `git diff --check HEAD~1..HEAD`
- `pnpm --filter @authrim/ar-management exec vitest run src/__tests__/logging-control-router.test.ts`