### PR TITLE
Try tenant API candidates for Login UI client provisioning

### DIFF
--- a/packages/setup/src/__tests__/login-ui-client.test.ts
+++ b/packages/setup/src/__tests__/login-ui-client.test.ts
@@ -226,6 +226,105 @@ describe('ensureLoginUiClient', () => {
     );
   });
 
+  it('falls back to a tenant-scoped API candidate for setup machine provisioning', async () => {
+    const secrets = generateAllSecrets('login-ui-test-key');
+    await saveKeysToDirectory(secrets, { targetDir: tempDir });
+
+    fetchMock
+      .mockResolvedValueOnce(
+        textResponse(
+          JSON.stringify({
+            error: 'not_found',
+            error_description: 'Tenant not found',
+          }),
+          404
+        )
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          access_token: 'tenant-machine-admin-token',
+          token_type: 'Bearer',
+          expires_in: 600,
+          scope: 'admin:clients:*',
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ clients: [], pagination: { total: 0 } }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          client: {
+            client_id: 'tenant-login-ui-client',
+            client_name: 'Login UI',
+          },
+        })
+      );
+
+    const result = await ensureLoginUiClient({
+      apiBaseUrl: 'https://base.example.test',
+      apiBaseUrls: ['https://first.example.test', 'https://base.example.test'],
+      loginUiUrl: 'https://login.example.test',
+      adminApiSecretPath,
+      tenantId: 'first',
+      maxRetries: 1,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      clientId: 'tenant-login-ui-client',
+      alreadyExists: false,
+    });
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('https://base.example.test/token');
+    expect(String(fetchMock.mock.calls[1]?.[0])).toBe('https://first.example.test/token');
+    expect(String(fetchMock.mock.calls[2]?.[0])).toBe(
+      'https://first.example.test/api/admin/clients?search=Login%20UI&limit=10'
+    );
+    const listHeaders = fetchMock.mock.calls[2]?.[1]?.headers as Record<string, string>;
+    expect(listHeaders.Authorization).toBe('Bearer tenant-machine-admin-token');
+    expect(listHeaders['X-Tenant-Id']).toBe('first');
+  });
+
+  it('falls back to a tenant-scoped API candidate when legacy admin calls hit the wrong host', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        textResponse(
+          JSON.stringify({
+            error: 'not_found',
+            error_description: 'Tenant not found',
+          }),
+          404
+        )
+      )
+      .mockResolvedValueOnce(jsonResponse({ clients: [], pagination: { total: 0 } }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          client: {
+            client_id: 'tenant-login-ui-client',
+            client_name: 'Login UI',
+          },
+        })
+      );
+
+    const result = await ensureLoginUiClient({
+      apiBaseUrl: 'https://base.example.test',
+      apiBaseUrls: ['https://first.example.test'],
+      loginUiUrl: 'https://login.example.test',
+      adminApiSecretPath,
+      tenantId: 'first',
+      maxRetries: 1,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      clientId: 'tenant-login-ui-client',
+      alreadyExists: false,
+    });
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      'https://base.example.test/api/admin/clients?search=Login%20UI&limit=10'
+    );
+    expect(String(fetchMock.mock.calls[1]?.[0])).toBe(
+      'https://first.example.test/api/admin/clients?search=Login%20UI&limit=10'
+    );
+  });
+
   it('creates the built-in Login UI client with browser refresh tokens disabled', async () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse({ clients: [], pagination: { total: 0 } }))

--- a/packages/setup/src/cli/commands/deploy.ts
+++ b/packages/setup/src/cli/commands/deploy.ts
@@ -1291,6 +1291,10 @@ export async function deployCommand(options: DeployCommandOptions): Promise<void
 
       const clientResult = await ensureLoginUiClient({
         apiBaseUrl,
+        apiBaseUrls: resolveApiBaseUrlCandidates(config, {
+          env,
+          purpose: 'tenant-scoped-admin',
+        }),
         loginUiUrl,
         adminApiSecretPath,
         keysDir,

--- a/packages/setup/src/core/login-ui-client.ts
+++ b/packages/setup/src/core/login-ui-client.ts
@@ -34,6 +34,12 @@ import {
 export interface LoginUiClientConfig {
   /** API base URL (e.g., https://prod-ar-router.workers.dev) */
   apiBaseUrl: string;
+  /**
+   * Candidate API base URLs for tenant-scoped setup/admin calls.
+   * The first reachable candidate that can issue a setup machine token and
+   * serve Admin API requests is used for this provisioning operation.
+   */
+  apiBaseUrls?: string[];
   /** Login UI URL (e.g., https://prod-ar-login-ui.workers.dev) */
   loginUiUrl: string;
   /**
@@ -128,6 +134,30 @@ interface AdminClientCreateResponse {
     client_name: string;
     client_secret?: string;
   };
+}
+
+function normalizeApiBaseUrl(url: string): string | null {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+
+  try {
+    return new URL(trimmed).origin;
+  } catch {
+    return trimmed.replace(/\/+$/, '');
+  }
+}
+
+function buildApiBaseUrlCandidates(primary: string, candidates?: string[]): string[] {
+  const seen = new Set<string>();
+  return [primary, ...(candidates ?? [])].reduce<string[]>((list, candidate) => {
+    const normalized = normalizeApiBaseUrl(candidate);
+    if (!normalized || seen.has(normalized)) {
+      return list;
+    }
+    seen.add(normalized);
+    list.push(normalized);
+    return list;
+  }, []);
 }
 
 // =============================================================================
@@ -332,6 +362,7 @@ export async function ensureLoginUiClient(
 ): Promise<LoginUiClientResult> {
   const {
     apiBaseUrl,
+    apiBaseUrls,
     loginUiUrl,
     adminApiSecretPath,
     keysDir,
@@ -340,73 +371,98 @@ export async function ensureLoginUiClient(
     retryDelayMs = LOGIN_UI_CLIENT_RETRY_BASE_DELAY_MS,
     maxRetries = LOGIN_UI_CLIENT_MAX_RETRIES,
   } = config;
+  const apiCandidates = buildApiBaseUrlCandidates(apiBaseUrl, apiBaseUrls);
 
   try {
-    let adminBearerToken: string | null = null;
+    const adminBearerTokens = new Map<string, string>();
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
-      try {
-        if (!adminBearerToken) {
-          adminBearerToken = await resolveAdminBearerToken({
-            apiBaseUrl,
-            adminApiSecretPath,
-            keysDir,
-            tenantId,
-            onProgress,
-          });
-        }
+      let retryableError: string | null = null;
+      let lastError: string | null = null;
 
-        onProgress?.('Checking for existing Login UI client...');
-        const existingClient = await findExistingClient(apiBaseUrl, adminBearerToken, tenantId);
-
-        if (existingClient) {
-          if (existingClient.needsMigration) {
-            onProgress?.(`Migrating Login UI client to public client: ${existingClient.clientId}`);
-            await updateClientToPublic(
-              apiBaseUrl,
-              adminBearerToken,
-              existingClient.clientId,
-              tenantId
-            );
-            onProgress?.(
-              'Login UI client migrated to public client (token_endpoint_auth_method=none, require_pkce=true)'
-            );
-          } else {
-            onProgress?.(`Login UI client already exists: ${existingClient.clientId}`);
+      for (const candidateApiBaseUrl of apiCandidates) {
+        try {
+          let adminBearerToken = adminBearerTokens.get(candidateApiBaseUrl);
+          if (!adminBearerToken) {
+            adminBearerToken = await resolveAdminBearerToken({
+              apiBaseUrl: candidateApiBaseUrl,
+              adminApiSecretPath,
+              keysDir,
+              tenantId,
+              onProgress,
+            });
+            adminBearerTokens.set(candidateApiBaseUrl, adminBearerToken);
           }
+
+          onProgress?.('Checking for existing Login UI client...');
+          const existingClient = await findExistingClient(
+            candidateApiBaseUrl,
+            adminBearerToken,
+            tenantId
+          );
+
+          if (existingClient) {
+            if (existingClient.needsMigration) {
+              onProgress?.(
+                `Migrating Login UI client to public client: ${existingClient.clientId}`
+              );
+              await updateClientToPublic(
+                candidateApiBaseUrl,
+                adminBearerToken,
+                existingClient.clientId,
+                tenantId
+              );
+              onProgress?.(
+                'Login UI client migrated to public client (token_endpoint_auth_method=none, require_pkce=true)'
+              );
+            } else {
+              onProgress?.(`Login UI client already exists: ${existingClient.clientId}`);
+            }
+            return {
+              success: true,
+              clientId: existingClient.clientId,
+              alreadyExists: true,
+            };
+          }
+
+          onProgress?.('Creating Login UI OAuth client...');
+          const clientId = await createClient(
+            candidateApiBaseUrl,
+            adminBearerToken,
+            loginUiUrl,
+            tenantId
+          );
+
+          onProgress?.(`Login UI client created: ${clientId}`);
           return {
             success: true,
-            clientId: existingClient.clientId,
-            alreadyExists: true,
+            clientId,
+            alreadyExists: false,
           };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          lastError = apiCandidates.length > 1 ? `${candidateApiBaseUrl}: ${message}` : message;
+          adminBearerTokens.delete(candidateApiBaseUrl);
+
+          if (isRetryableLoginUiClientError(message)) {
+            retryableError = lastError;
+          }
         }
-
-        onProgress?.('Creating Login UI OAuth client...');
-        const clientId = await createClient(apiBaseUrl, adminBearerToken, loginUiUrl, tenantId);
-
-        onProgress?.(`Login UI client created: ${clientId}`);
-        return {
-          success: true,
-          clientId,
-          alreadyExists: false,
-        };
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        const shouldRetry = attempt < maxRetries && isRetryableLoginUiClientError(message);
-
-        if (!shouldRetry) {
-          return {
-            success: false,
-            error: message,
-          };
-        }
-
-        const delayMs = Math.min(retryDelayMs * attempt, 10000);
-        onProgress?.(
-          `Login UI client request hit a temporary router readiness error. Retrying in ${Math.ceil(delayMs / 1000)}s...`
-        );
-        await sleep(delayMs);
       }
+
+      const shouldRetry = attempt < maxRetries && retryableError !== null;
+      if (!shouldRetry) {
+        return {
+          success: false,
+          error: lastError || 'Login UI client creation failed',
+        };
+      }
+
+      const delayMs = Math.min(retryDelayMs * attempt, 10000);
+      onProgress?.(
+        `Login UI client request hit a temporary router readiness error. Retrying in ${Math.ceil(delayMs / 1000)}s...`
+      );
+      await sleep(delayMs);
     }
 
     return {

--- a/packages/setup/src/index.ts
+++ b/packages/setup/src/index.ts
@@ -31,7 +31,7 @@ import { tenantDatabasePoolStatusCommand } from './cli/commands/tenant-db-pool-s
 import { tenantDatabaseSlotResetCommand } from './cli/commands/tenant-db-slot-reset.js';
 import { tenantDatabaseMigrateAllCommand } from './cli/commands/tenant-db-migrate-all.js';
 import { r2ProvisionCommand } from './cli/commands/r2-provision.js';
-import { resolveIssuerUrl } from './core/url-config.js';
+import { resolveApiBaseUrlCandidates, resolveIssuerUrl } from './core/url-config.js';
 
 // Read version from package.json
 const require = createRequire(import.meta.url);
@@ -338,6 +338,10 @@ program
             const { ensureLoginUiClient } = await import('./core/login-ui-client.js');
             const clientResult = await ensureLoginUiClient({
               apiBaseUrl,
+              apiBaseUrls: resolveApiBaseUrlCandidates(cfg as AuthrimConfig, {
+                env,
+                purpose: 'tenant-scoped-admin',
+              }),
               loginUiUrl,
               adminApiSecretPath,
               keysDir,

--- a/scripts/deploy-ui.ts
+++ b/scripts/deploy-ui.ts
@@ -18,6 +18,7 @@ import {
 } from '../packages/setup/src/core/deploy.js';
 import { ensureLoginUiClient } from '../packages/setup/src/core/login-ui-client.js';
 import { resolveUiDeploymentSettings } from '../packages/setup/src/core/ui-deployment.js';
+import { resolveApiBaseUrlCandidates } from '../packages/setup/src/core/url-config.js';
 
 interface CliOptions {
   env: string;
@@ -120,11 +121,17 @@ async function resolveLoginUiClientId(
   const adminApiSecretPath = foundKeys
     ? join(foundKeys.path, 'admin_api_secret.txt')
     : (resolved.paths as EnvironmentPaths).keyFiles.adminApiSecret;
+  const keysDir = foundKeys ? foundKeys.path : (resolved.paths as EnvironmentPaths).keys;
 
   const clientResult = await ensureLoginUiClient({
     apiBaseUrl,
+    apiBaseUrls: resolveApiBaseUrlCandidates(config, {
+      env,
+      purpose: 'tenant-scoped-admin',
+    }),
     loginUiUrl,
     adminApiSecretPath,
+    keysDir,
     tenantId: config.tenant?.name,
     onProgress: (message) => console.log(message),
   });


### PR DESCRIPTION
## Summary
- Add optional `apiBaseUrls` support to `ensureLoginUiClient`.
- Retry Login UI client lookup/creation across normalized API base URL candidates.
- Pass tenant-scoped API candidates from setup deploy flows and the UI deploy helper.
- Add tests for tenant-scoped API fallback during setup machine provisioning and legacy admin calls.

## Validation
- `git diff --check`
- `pnpm --filter @authrim/setup exec vitest run src/__tests__/login-ui-client.test.ts`
- `pnpm --filter @authrim/setup exec vitest run src/__tests__/login-ui-client.test.ts src/__tests__/deploy.test.ts`
- `pnpm exec tsx scripts/deploy-ui.ts --help`