### PR TITLE
Harden setup worker update wrangler sync

### DIFF
--- a/packages/setup/src/__tests__/deploy.test.ts
+++ b/packages/setup/src/__tests__/deploy.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execa } from 'execa';
 import {
+  buildApiPackages,
   buildUiWorkerBuildEnv,
   deployAll,
   deployUiWorkerComponent,
@@ -97,6 +98,28 @@ describe('buildUiWorkerBuildEnv', () => {
 
     expect(result.PUBLIC_API_BASE_URL).toBeUndefined();
     expect(result.PUBLIC_LOGIN_UI_CLIENT_ID).toBeUndefined();
+  });
+});
+
+describe('buildApiPackages', () => {
+  it('builds only the requested worker component when components are specified', async () => {
+    const rootDir = createTempRoot();
+    mkdirSync(join(rootDir, 'node_modules'), { recursive: true });
+
+    const progressMessages: string[] = [];
+    const result = await buildApiPackages({
+      rootDir,
+      components: ['ar-auth'],
+      onProgress: (message) => progressMessages.push(message),
+    });
+
+    expect(result.success).toBe(true);
+    expect(progressMessages).toContain('Building ar-auth...');
+    expect(vi.mocked(execa)).toHaveBeenCalledWith(
+      'pnpm',
+      ['exec', 'turbo', 'run', 'build', '--filter=@authrim/ar-auth'],
+      expect.objectContaining({ cwd: rootDir })
+    );
   });
 });
 

--- a/packages/setup/src/__tests__/environment-cleanup.test.ts
+++ b/packages/setup/src/__tests__/environment-cleanup.test.ts
@@ -5,6 +5,7 @@ import { existsSync } from 'node:fs';
 import { afterEach, describe, expect, it } from 'vitest';
 import { cleanupLocalEnvironmentArtifacts } from '../core/environment-cleanup.js';
 import {
+  extractEnvironmentSectionFromToml,
   mergeEnvironmentSectionIntoToml,
   removeEnvironmentSectionFromToml,
 } from '../core/wrangler-sync.js';
@@ -60,6 +61,41 @@ name = "prod-new"
     expect(merged).not.toContain('name = "prod-old"');
     expect(merged).toContain('[env.staging]');
     expect(merged).toContain('name = "staging-current"');
+  });
+
+  it('does not inject generated top-level wrangler keys into an env section', () => {
+    const deployContent = `main = "src/index.ts"
+compatibility_date = "2024-09-23"
+compatibility_flags = ["nodejs_compat"]
+
+# Environment: conformance
+[env.conformance]
+name = "conformance-old"
+
+# Environment: test
+[env.test]
+name = "test-current"
+`;
+    const masterContent = `main = "src/index.ts"
+compatibility_date = "2024-09-23"
+compatibility_flags = ["nodejs_compat"]
+
+# Environment: conformance
+[env.conformance]
+name = "conformance-new"
+
+[env.conformance.vars]
+FOO = "bar"
+`;
+
+    const merged = mergeEnvironmentSectionIntoToml(deployContent, masterContent, 'conformance');
+    const conformanceSection = extractEnvironmentSectionFromToml(merged, 'conformance');
+
+    expect(conformanceSection).toContain('name = "conformance-new"');
+    expect(conformanceSection).toContain('[env.conformance.vars]');
+    expect(conformanceSection).not.toContain('main = "src/index.ts"');
+    expect(conformanceSection).not.toContain('compatibility_date = "2024-09-23"');
+    expect(merged.match(/^main = "src\/index\.ts"$/gm) ?? []).toHaveLength(1);
   });
 });
 

--- a/packages/setup/src/__tests__/wrangler-routes.test.ts
+++ b/packages/setup/src/__tests__/wrangler-routes.test.ts
@@ -157,6 +157,94 @@ describe('generateRoutes', () => {
     expect(authConfig.vars.EMAIL_FROM_NAME).toBe('Authrim');
   });
 
+  it('omits ar-lib-core Durable Object migrations for existing environment worker updates', () => {
+    const config = {
+      version: '1.0.0',
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:00.000Z',
+      environment: { prefix: 'existing' },
+      urls: {
+        api: {
+          custom: null,
+          auto: 'https://existing-ar-router.example.workers.dev',
+        },
+        loginUi: {
+          custom: null,
+          auto: 'https://existing-ar-login-ui.workers.dev',
+          sameAsApi: false,
+        },
+        adminUi: {
+          custom: null,
+          auto: 'https://existing-ar-admin-ui.workers.dev',
+          sameAsApi: false,
+        },
+      },
+      tenant: {
+        name: 'default',
+        displayName: 'Default Tenant',
+        multiTenant: false,
+        userIdFormat: 'nanoid',
+      },
+      components: {
+        api: true,
+        loginUi: true,
+        adminUi: true,
+        saml: false,
+        async: false,
+        vc: false,
+        bridge: true,
+        policy: true,
+      },
+      oidc: {
+        accessTokenTtl: 3600,
+        refreshTokenTtl: 604800,
+        authCodeTtl: 600,
+        pkceRequired: true,
+        responseTypes: ['code'],
+        grantTypes: ['authorization_code', 'refresh_token'],
+      },
+      sharding: {
+        authCodeShards: 4,
+        refreshTokenShards: 4,
+        sessionShards: 4,
+        challengeShards: 4,
+      },
+      features: {
+        queue: { enabled: false },
+        r2: { enabled: false },
+        email: { configured: false },
+      },
+      keys: {
+        secretsPath: './keys/',
+        includeSecrets: false,
+        storageType: 'external',
+      },
+      cloudflare: {},
+      database: {
+        core: { location: 'auto', jurisdiction: 'none' },
+        pii: { location: 'auto', jurisdiction: 'none' },
+      },
+      security: {
+        piiEncryptionEnabled: true,
+        domainHashEnabled: true,
+      },
+      profile: 'basic-op',
+    } satisfies AuthrimConfig;
+
+    const resourceIds = { d1: {}, kv: {} };
+    const initialConfig = generateWranglerConfig('ar-lib-core', config, resourceIds);
+    const updateConfig = generateWranglerConfig('ar-lib-core', config, resourceIds, undefined, {
+      includeDurableObjectMigrations: false,
+    });
+
+    expect(initialConfig.migrations?.[0]?.new_sqlite_classes).toContain('SessionStore');
+    expect(updateConfig.durable_objects?.bindings).toEqual(
+      expect.arrayContaining([expect.objectContaining({ class_name: 'SessionStore' })])
+    );
+    expect(updateConfig.migrations).toBeUndefined();
+    expect(toToml(updateConfig, 'existing')).not.toContain('new_sqlite_classes');
+  });
+
   it('serializes send_email bindings in env-scoped wrangler.toml output', () => {
     const config = {
       main: 'src/index.ts',

--- a/packages/setup/src/core/deploy.ts
+++ b/packages/setup/src/core/deploy.ts
@@ -95,6 +95,7 @@ export interface DeploymentSummary {
 
 export interface BuildOptions {
   rootDir: string;
+  components?: WorkerComponent[];
   onProgress?: (message: string) => void;
 }
 
@@ -151,7 +152,7 @@ export function buildUiWorkerBuildEnv(
  * 3. Uses pnpm exec turbo (works even if turbo isn't globally installed)
  */
 export async function buildApiPackages(options: BuildOptions): Promise<BuildResult> {
-  const { rootDir, onProgress } = options;
+  const { rootDir, components, onProgress } = options;
 
   try {
     // Check if node_modules exists
@@ -172,17 +173,21 @@ export async function buildApiPackages(options: BuildOptions): Promise<BuildResu
       reject: false, // Don't fail if directories don't exist
     });
 
-    // Use pnpm exec turbo instead of relying on global turbo
-    // This works because turbo is in devDependencies
-    onProgress?.('Building packages...');
-    await execa(
-      'pnpm',
-      ['exec', 'turbo', 'run', 'build', '--filter=!@authrim/ui-*', '--filter=!@authrim/setup'],
-      {
-        cwd: rootDir,
-        stdio: 'pipe',
-      }
+    const filters =
+      components && components.length > 0
+        ? components.map((component) => `--filter=@authrim/${component}`)
+        : ['--filter=!@authrim/ui-*', '--filter=!@authrim/setup'];
+
+    // Use pnpm exec turbo instead of relying on global turbo.
+    onProgress?.(
+      components && components.length > 0
+        ? `Building ${components.join(', ')}...`
+        : 'Building packages...'
     );
+    await execa('pnpm', ['exec', 'turbo', 'run', 'build', ...filters], {
+      cwd: rootDir,
+      stdio: 'pipe',
+    });
 
     return { success: true };
   } catch (error) {

--- a/packages/setup/src/core/wrangler-sync.ts
+++ b/packages/setup/src/core/wrangler-sync.ts
@@ -37,6 +37,8 @@ export interface WranglerSyncOptions {
   dryRun?: boolean;
   /** Progress callback */
   onProgress?: (msg: string) => void;
+  /** Optional component subset to sync */
+  components?: WorkerComponent[];
 }
 
 export interface WranglerSyncResult {
@@ -166,7 +168,7 @@ export function mergeEnvironmentSectionIntoToml(
   env: string
 ): string {
   const withoutTargetEnv = removeEnvironmentSectionFromToml(deployContent, env).content.trimEnd();
-  const targetSection = masterContent.trim();
+  const targetSection = extractEnvironmentSectionFromToml(masterContent, env).trim();
   return [withoutTargetEnv, targetSection].filter(Boolean).join('\n\n') + '\n';
 }
 
@@ -222,8 +224,10 @@ export async function checkWranglerStatus(
     if (masterExists && deployExists) {
       const masterContent = await readFile(masterPath, 'utf-8');
       const deployContent = await readFile(deployPath, 'utf-8');
-      // Compare the relevant [env.xxx] section content
-      inSync = normalizeToml(masterContent) === normalizeToml(deployContent);
+      // Compare only the relevant [env.xxx] section content.
+      inSync =
+        normalizeToml(extractEnvironmentSectionFromToml(masterContent, env)) ===
+        normalizeToml(extractEnvironmentSectionFromToml(deployContent, env));
     } else if (masterExists !== deployExists) {
       inSync = false;
     }
@@ -251,9 +255,12 @@ export async function checkWranglerStatus(
 export async function saveMasterWranglerConfigs(
   config: AuthrimConfig,
   resourceIds: ResourceIds,
-  options: Pick<WranglerSyncOptions, 'baseDir' | 'env' | 'dryRun' | 'onProgress'>
+  options: Pick<WranglerSyncOptions, 'baseDir' | 'env' | 'dryRun' | 'onProgress'> & {
+    includeDurableObjectMigrations?: boolean;
+    components?: WorkerComponent[];
+  }
 ): Promise<{ success: boolean; files: string[]; errors: string[] }> {
-  const { baseDir, env, dryRun, onProgress } = options;
+  const { baseDir, env, dryRun, onProgress, includeDurableObjectMigrations } = options;
   const envPaths = getEnvironmentPaths({ baseDir, env });
   const files: string[] = [];
   const errors: string[] = [];
@@ -267,13 +274,19 @@ export async function saveMasterWranglerConfigs(
   // Workers.dev URLs must be in format: {name}.{subdomain}.workers.dev
   const workersSubdomain = await getWorkersSubdomain();
 
-  for (const component of getWranglerComponentsForConfig(config)) {
+  const configuredComponents = getWranglerComponentsForConfig(config);
+  const components = options.components
+    ? options.components.filter((component) => configuredComponents.includes(component))
+    : configuredComponents;
+
+  for (const component of components) {
     try {
       const wranglerConfig = generateWranglerConfig(
         component,
         config,
         resourceIds,
-        workersSubdomain ?? undefined
+        workersSubdomain ?? undefined,
+        { includeDurableObjectMigrations }
       );
       // Generate TOML with [env.{env}] section format
       const tomlContent = toToml(wranglerConfig, env);
@@ -329,7 +342,8 @@ export async function syncWranglerConfigs(
     return result;
   }
 
-  for (const component of WORKER_COMPONENTS) {
+  const components = options.components ?? WORKER_COMPONENTS;
+  for (const component of components) {
     const masterPath = getMasterWranglerPath(envPaths, component);
     const deployPath = getDeployWranglerPath(packagesDir, component);
     const componentDir = join(packagesDir, component);

--- a/packages/setup/src/core/wrangler.ts
+++ b/packages/setup/src/core/wrangler.ts
@@ -90,6 +90,10 @@ export interface WranglerConfig {
   }>;
 }
 
+export interface GenerateWranglerConfigOptions {
+  includeDurableObjectMigrations?: boolean;
+}
+
 const LOGGING_DELIVERY_QUEUE_DEFINITIONS = [
   {
     binding: 'LOGGING_DELIVERY_CRITICAL_QUEUE',
@@ -430,7 +434,8 @@ export function generateWranglerConfig(
   component: WorkerComponent,
   config: AuthrimConfig,
   resourceIds: ResourceIds,
-  workersSubdomain?: string
+  workersSubdomain?: string,
+  options: GenerateWranglerConfigOptions = {}
 ): WranglerConfig {
   const env = config.environment.prefix;
   const multiTenantBaseDomain =
@@ -497,8 +502,11 @@ export function generateWranglerConfig(
       })),
     };
 
-    // Migrations for ar-lib-core
-    wranglerConfig.migrations = generateDOMigrations();
+    if (options.includeDurableObjectMigrations !== false) {
+      // Migrations for ar-lib-core. Existing environment updates must not resend
+      // initial new_sqlite_classes migrations for already-created Durable Objects.
+      wranglerConfig.migrations = generateDOMigrations();
+    }
   } else {
     // Other components reference DOs from ar-lib-core
     const doBindings = COMPONENT_DO_BINDINGS[component];
@@ -690,7 +698,7 @@ export function generateWranglerConfig(
 
   // Custom-domain routing is terminated at ar-router.
   // Non-router workers are reached through service bindings, otherwise ar-router's
-  // special-case routing (e.g. /api/auth/login-methods, /api/admin/setup-token/*)
+  // special-case routing (e.g. /api/auth/authentication-methods, /api/admin/setup-token/*)
   // is bypassed by Cloudflare route precedence.
 
   return wranglerConfig;

--- a/packages/setup/src/web/api.ts
+++ b/packages/setup/src/web/api.ts
@@ -3144,6 +3144,8 @@ export function createApiRoutes(): Hono {
           baseDir: rootDir,
           env,
           dryRun: false,
+          includeDurableObjectMigrations: false,
+          components: componentsToUpdate,
           onProgress: addProgress,
         });
 
@@ -3160,6 +3162,7 @@ export function createApiRoutes(): Hono {
           packagesDir: join(rootDir, 'packages'),
           force: true,
           dryRun: false,
+          components: componentsToUpdate,
           onProgress: addProgress,
         });
 
@@ -3613,6 +3616,8 @@ export function createApiRoutes(): Hono {
                 baseDir: rootDir,
                 env,
                 dryRun: false,
+                includeDurableObjectMigrations: false,
+                components: [componentName as WorkerComponent],
                 onProgress: addProgress,
               });
 
@@ -3629,6 +3634,7 @@ export function createApiRoutes(): Hono {
                 packagesDir: join(rootDir, 'packages'),
                 force: true,
                 dryRun: false,
+                components: [componentName as WorkerComponent],
                 onProgress: addProgress,
               });
 

--- a/packages/setup/src/web/api.ts
+++ b/packages/setup/src/web/api.ts
@@ -3654,6 +3654,7 @@ export function createApiRoutes(): Hono {
             addProgress('Building packages...');
             const buildResult = await buildApiPackages({
               rootDir,
+              components: [componentName as WorkerComponent],
               onProgress: addProgress,
             });
 


### PR DESCRIPTION
## Summary
- Add a wrangler config generation option to omit Durable Object migrations for existing environment updates.
- Merge and compare only the target `[env.*]` section when syncing wrangler configs.
- Limit wrangler sync to the worker components being updated.
- Allow setup worker builds to target selected components and use that for single worker updates.

## Validation
- `git diff --check`
- `pnpm --filter @authrim/setup exec vitest run src/__tests__/wrangler-routes.test.ts src/__tests__/environment-cleanup.test.ts`
- `pnpm --filter @authrim/setup exec vitest run src/__tests__/deploy.test.ts src/__tests__/wrangler-routes.test.ts src/__tests__/environment-cleanup.test.ts`
- `pnpm --filter @authrim/setup typecheck`