### PR TITLE
Stabilize refresh token rotator test teardown

### DIFF
--- a/packages/ar-lib-core/src/durable-objects/__tests__/RefreshTokenRotator.test.ts
+++ b/packages/ar-lib-core/src/durable-objects/__tests__/RefreshTokenRotator.test.ts
@@ -5,7 +5,7 @@
  * V2 uses rtv (Refresh Token Version) for theft detection instead of token string comparison.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { RefreshTokenRotator } from '../RefreshTokenRotator';
 import type { Env } from '../../types/env';
 
@@ -111,9 +111,15 @@ describe('RefreshTokenRotator V2', () => {
   let mockEnv: Env;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     mockState = new MockDurableObjectState();
     mockEnv = createMockEnv();
     rotator = new RefreshTokenRotator(mockState as unknown as DurableObjectState, mockEnv);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   describe('Token Family Creation', () => {


### PR DESCRIPTION
## Summary
- Use Vitest fake timers in the RefreshTokenRotator test suite
- Clear pending audit flush timers after each test to avoid teardown-time unhandled rejections

## Verification
- pnpm --filter @authrim/ar-lib-core exec vitest run src/durable-objects/__tests__/RefreshTokenRotator.test.ts
- pnpm --filter @authrim/ar-lib-core test
- pnpm format:check
- pnpm lint
- pnpm test