### PR TITLE
Persist passkey signup custom fields

### DIFF
--- a/migrations/003_core_policy_identity_tables.sql
+++ b/migrations/003_core_policy_identity_tables.sql
@@ -77,7 +77,7 @@ CREATE TABLE organizations (
 CREATE TABLE "passkeys" (
   id TEXT PRIMARY KEY,
   user_id TEXT NOT NULL,
-  credential_id TEXT UNIQUE NOT NULL,
+  credential_id TEXT NOT NULL,
   public_key TEXT NOT NULL,
   counter INTEGER DEFAULT 0,
   transports TEXT,
@@ -85,7 +85,7 @@ CREATE TABLE "passkeys" (
   created_at INTEGER NOT NULL,
   last_used_at INTEGER,
   tenant_id TEXT NOT NULL DEFAULT 'default',
-  FOREIGN KEY (user_id) REFERENCES users_core(id) ON DELETE CASCADE
+  UNIQUE(tenant_id, credential_id)
 );
 
 CREATE TABLE "password_reset_tokens" (

--- a/migrations/013_passkeys_canonical_user_binding.sql
+++ b/migrations/013_passkeys_canonical_user_binding.sql
@@ -1,0 +1,52 @@
+-- Migration: 013_passkeys_canonical_user_binding
+-- Description: Align end-user passkeys with canonical runtime users.
+--
+-- Runtime users are now stored in the canonical identity graph, not users_core.
+-- Passkeys still belong to an Authrim runtime user id, but that id is no longer
+-- guaranteed to exist in users_core. Keep deletion explicit in application code.
+
+CREATE TABLE IF NOT EXISTS passkeys_canonical (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  credential_id TEXT NOT NULL,
+  public_key TEXT NOT NULL,
+  counter INTEGER DEFAULT 0,
+  transports TEXT,
+  device_name TEXT,
+  created_at INTEGER NOT NULL,
+  last_used_at INTEGER,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  UNIQUE(tenant_id, credential_id)
+);
+
+INSERT INTO passkeys_canonical (
+  id,
+  user_id,
+  credential_id,
+  public_key,
+  counter,
+  transports,
+  device_name,
+  created_at,
+  last_used_at,
+  tenant_id
+)
+SELECT
+  id,
+  user_id,
+  credential_id,
+  public_key,
+  counter,
+  transports,
+  device_name,
+  created_at,
+  last_used_at,
+  tenant_id
+FROM passkeys;
+
+DROP TABLE passkeys;
+ALTER TABLE passkeys_canonical RENAME TO passkeys;
+
+CREATE INDEX IF NOT EXISTS idx_passkeys_tenant ON passkeys(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_passkeys_user ON passkeys(tenant_id, user_id);
+CREATE INDEX IF NOT EXISTS idx_passkeys_credential ON passkeys(tenant_id, credential_id);

--- a/migrations/external/postgres/001_external_durable_core.sql
+++ b/migrations/external/postgres/001_external_durable_core.sql
@@ -308,8 +308,7 @@ CREATE TABLE IF NOT EXISTS passkeys (
   device_name TEXT,
   created_at BIGINT NOT NULL,
   last_used_at BIGINT,
-  CONSTRAINT passkeys_unique_credential UNIQUE(tenant_id, credential_id),
-  CONSTRAINT passkeys_user_fk FOREIGN KEY (user_id) REFERENCES users_core(id) ON DELETE CASCADE
+  CONSTRAINT passkeys_unique_credential UNIQUE(tenant_id, credential_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_passkeys_user

--- a/packages/ar-auth/src/__tests__/direct-auth-flows.test.ts
+++ b/packages/ar-auth/src/__tests__/direct-auth-flows.test.ts
@@ -536,6 +536,10 @@ describe('Direct Auth primary passkey and email-code flows', () => {
   });
 
   it('starts passkey signup by creating a new user and storing challenge mapping', async () => {
+    mocks.validateRegistrationFieldSubmissionFromEnv.mockResolvedValueOnce({
+      ok: true,
+      values: { affiliation: 'Faculty' },
+    });
     const { directPasskeySignupStartHandler } = await import('../direct-auth');
 
     const response = await directPasskeySignupStartHandler(
@@ -549,6 +553,7 @@ describe('Direct Auth primary passkey and email-code flows', () => {
           channel: 'browser',
           scope: 'openid email',
           authenticator_type: 'platform',
+          custom_fields: { affiliation: 'Faculty' },
         },
         webHeaders()
       ) as never
@@ -586,6 +591,7 @@ describe('Direct Auth primary passkey and email-code flows', () => {
           channel: 'browser',
           code_challenge: 'signup-pkce-challenge',
           origin: 'https://app.example.com',
+          custom_fields: { affiliation: 'Faculty' },
         }),
       })
     );
@@ -672,6 +678,7 @@ describe('Direct Auth primary passkey and email-code flows', () => {
         scope: 'openid email',
         origin: 'https://app.example.com',
         rpID: 'app.example.com',
+        custom_fields: { affiliation: 'Faculty' },
       },
     });
     mocks.userCore.findById.mockResolvedValue({
@@ -715,6 +722,12 @@ describe('Direct Auth primary passkey and email-code flows', () => {
     expect(mocks.coreAdapter.execute).toHaveBeenCalledWith(
       'UPDATE users_core SET email_verified = 1, updated_at = ? WHERE id = ? AND tenant_id = ?',
       [expect.any(Number), 'user_new', 'tenant_test']
+    );
+    expect(mocks.persistRegistrationFieldValuesFromEnv).toHaveBeenCalledWith(
+      expect.any(Object),
+      'tenant_test',
+      'user_new',
+      { affiliation: 'Faculty' }
     );
     expect(mocks.authCodeStore.storeCodeRpc).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/ar-auth/src/direct-auth.ts
+++ b/packages/ar-auth/src/direct-auth.ts
@@ -1026,6 +1026,7 @@ export async function directPasskeySignupStartHandler(c: Context<{ Bindings: Env
       authenticator_type?: 'platform' | 'cross-platform' | 'any';
       resident_key?: 'required' | 'preferred' | 'discouraged';
       user_verification?: 'required' | 'preferred' | 'discouraged';
+      custom_fields?: Record<string, unknown>;
     }>();
 
     const {
@@ -1039,6 +1040,7 @@ export async function directPasskeySignupStartHandler(c: Context<{ Bindings: Env
       authenticator_type = 'any',
       resident_key = 'required',
       user_verification = 'required',
+      custom_fields,
     } = body;
 
     if (!client_id || !email || !code_challenge || code_challenge_method !== 'S256' || !channel) {
@@ -1077,6 +1079,26 @@ export async function directPasskeySignupStartHandler(c: Context<{ Bindings: Env
     const existingUser = await runtimeUsers.findByEmail(email.toLowerCase());
     if (existingUser) {
       return createErrorResponse(c, AR_ERROR_CODES.ADMIN_CONFLICT);
+    }
+
+    const customFieldValidation = await validateRegistrationFieldSubmissionFromEnv(
+      c.env,
+      tenantId,
+      custom_fields
+    );
+    if (!customFieldValidation.ok) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_FORMAT, {
+        variables: { field: 'custom_fields', reason: customFieldValidation.error },
+        extensions: customFieldValidation.missingRequiredFields
+          ? {
+              missing_required_fields: customFieldValidation.missingRequiredFields.map((field) => ({
+                field_key: field.fieldKey,
+                label: field.label,
+                field_type: field.fieldType,
+              })),
+            }
+          : undefined,
+      });
     }
 
     if (!user) {
@@ -1180,6 +1202,9 @@ export async function directPasskeySignupStartHandler(c: Context<{ Bindings: Env
         origin: originHeader,
         rpID,
         challenge_id: challengeId,
+        ...(Object.keys(customFieldValidation.values).length > 0
+          ? { custom_fields: customFieldValidation.values }
+          : {}),
       },
     });
 
@@ -1295,6 +1320,7 @@ export async function directPasskeySignupFinishHandler(c: Context<{ Bindings: En
         scope?: string;
         origin: string;
         rpID: string;
+        custom_fields?: Record<string, unknown>;
       };
     };
 
@@ -1380,6 +1406,19 @@ export async function directPasskeySignupFinishHandler(c: Context<{ Bindings: En
     // Check if this is a new user (created in this flow)
     const runtimeUser = await runtimeUsers.findById(userId, { includeInactive: true });
     const isNewUser = runtimeUser ? now - Date.parse(runtimeUser.created_at) < 60000 : false;
+
+    const customFields = challengeData.metadata?.custom_fields;
+    if (customFields) {
+      try {
+        await persistRegistrationFieldValuesFromEnv(c.env, tenantId, userId, customFields);
+      } catch (persistError) {
+        log.warn(
+          'Failed to persist registration field values',
+          { action: 'registration_fields_persist' },
+          persistError as Error
+        );
+      }
+    }
 
     // Generate auth_code
     const authCode = await generateAuthCode(

--- a/packages/ar-lib-core/src/migrations/__tests__/external-durable-schema.test.ts
+++ b/packages/ar-lib-core/src/migrations/__tests__/external-durable-schema.test.ts
@@ -100,4 +100,15 @@ describe('external durable postgres schema', () => {
     expect(combinedSql).not.toMatch(/\bjson_valid\s*\(/i);
     expect(combinedSql).not.toMatch(/\bINTEGER PRIMARY KEY AUTOINCREMENT\b/i);
   });
+
+  it('keeps passkeys bound to canonical runtime user ids instead of users_core rows', () => {
+    const coreSql = readMigration('migrations/external/postgres/001_external_durable_core.sql');
+    const passkeysBlock = extractCreateTableBlock(coreSql, 'passkeys');
+
+    expect(passkeysBlock).toContain('user_id TEXT NOT NULL');
+    expect(passkeysBlock).toContain(
+      'CONSTRAINT passkeys_unique_credential UNIQUE(tenant_id, credential_id)'
+    );
+    expect(passkeysBlock).not.toMatch(/\bREFERENCES\s+users_core\b/i);
+  });
 });

--- a/packages/ar-lib-core/src/migrations/__tests__/passkeys-canonical-binding.test.ts
+++ b/packages/ar-lib-core/src/migrations/__tests__/passkeys-canonical-binding.test.ts
@@ -1,0 +1,46 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+
+function findWorkspaceRoot(start: string): string {
+  let current = start;
+
+  while (current !== dirname(current)) {
+    if (existsSync(join(current, 'pnpm-workspace.yaml'))) {
+      return current;
+    }
+    current = dirname(current);
+  }
+
+  throw new Error('workspace_root_not_found');
+}
+
+const workspaceRoot = findWorkspaceRoot(testDir);
+
+function readMigration(relativePath: string): string {
+  return readFileSync(join(workspaceRoot, relativePath), 'utf8');
+}
+
+describe('passkeys canonical runtime user binding migrations', () => {
+  it('creates new core passkeys without a users_core foreign key', () => {
+    const sql = readMigration('migrations/003_core_policy_identity_tables.sql');
+    const passkeysBlock = sql.match(/CREATE TABLE "passkeys" \([\s\S]*?\n\);/u)?.[0] ?? '';
+
+    expect(passkeysBlock).toContain('user_id TEXT NOT NULL');
+    expect(passkeysBlock).toContain('UNIQUE(tenant_id, credential_id)');
+    expect(passkeysBlock).not.toMatch(/\bREFERENCES\s+users_core\b/iu);
+  });
+
+  it('rebuilds existing passkeys without preserving the users_core foreign key', () => {
+    const sql = readMigration('migrations/013_passkeys_canonical_user_binding.sql');
+
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS passkeys_canonical');
+    expect(sql).toContain('UNIQUE(tenant_id, credential_id)');
+    expect(sql).toContain('DROP TABLE passkeys');
+    expect(sql).toContain('ALTER TABLE passkeys_canonical RENAME TO passkeys');
+    expect(sql).not.toMatch(/\bREFERENCES\s+users_core\b/iu);
+  });
+});


### PR DESCRIPTION
## Summary
- Validate Direct Auth passkey signup custom fields before creating the registration challenge
- Carry validated custom fields through the passkey signup challenge and persist them after successful registration
- Remove the users_core foreign key from passkeys for canonical runtime user storage and add a migration for existing D1 databases

## Verification
- pnpm format:check
- pnpm --filter @authrim/ar-auth test -- src/__tests__/direct-auth-flows.test.ts
- pnpm --filter @authrim/ar-auth test
- pnpm --filter @authrim/ar-lib-core exec vitest run src/migrations/__tests__/passkeys-canonical-binding.test.ts src/migrations/__tests__/external-durable-schema.test.ts
- pnpm --filter @authrim/ar-lib-core test
- pnpm lint
- pnpm typecheck