### PR TITLE
Keep passkey signup email unverified

### DIFF
--- a/packages/ar-auth/src/__tests__/direct-auth-flows.test.ts
+++ b/packages/ar-auth/src/__tests__/direct-auth-flows.test.ts
@@ -719,9 +719,9 @@ describe('Direct Auth primary passkey and email-code flows', () => {
         device_name: 'Direct Auth Passkey',
       })
     );
-    expect(mocks.coreAdapter.execute).toHaveBeenCalledWith(
-      'UPDATE users_core SET email_verified = 1, updated_at = ? WHERE id = ? AND tenant_id = ?',
-      [expect.any(Number), 'user_new', 'tenant_test']
+    expect(mocks.coreAdapter.execute).not.toHaveBeenCalledWith(
+      expect.stringContaining('email_verified = 1'),
+      expect.any(Array)
     );
     expect(mocks.persistRegistrationFieldValuesFromEnv).toHaveBeenCalledWith(
       expect.any(Object),

--- a/packages/ar-auth/src/__tests__/passkey.test.ts
+++ b/packages/ar-auth/src/__tests__/passkey.test.ts
@@ -852,7 +852,7 @@ describe('Passkey Handlers', () => {
       mockUserCoreRepository.findById.mockResolvedValue({
         id: 'user-123',
         is_active: true,
-        email_verified: true,
+        email_verified: false,
         created_at: Date.now(),
         updated_at: Date.now(),
         last_login_at: Date.now(),
@@ -894,6 +894,7 @@ describe('Passkey Handlers', () => {
       expect(db.prepare).toHaveBeenCalledWith(
         expect.stringContaining('INSERT INTO user_custom_fields')
       );
+      expect(mockCoreAdapter.execute).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/ar-auth/src/direct-auth.ts
+++ b/packages/ar-auth/src/direct-auth.ts
@@ -1398,10 +1398,8 @@ export async function directPasskeySignupFinishHandler(c: Context<{ Bindings: En
       device_name: 'Direct Auth Passkey',
     });
 
-    // Update email_verified
     const now = Date.now();
     const runtimeUsers = createCanonicalRuntimeUserStore(c, tenantId);
-    await runtimeUsers.markEmailVerified(userId);
 
     // Check if this is a new user (created in this flow)
     const runtimeUser = await runtimeUsers.findById(userId, { includeInactive: true });

--- a/packages/ar-auth/src/passkey.ts
+++ b/packages/ar-auth/src/passkey.ts
@@ -533,10 +533,8 @@ export async function passkeyRegisterVerifyHandler(c: Context<{ Bindings: Env }>
       device_name: deviceName || 'Unknown Device',
     });
 
-    // Step 3: Update user's email_verified status in canonical contact points.
-    await runtimeUsers.markEmailVerified(userId);
-
-    // Get updated user details via canonical projection.
+    // Registering a passkey proves possession of the authenticator, not the email address.
+    // Keep email verification tied to email-code or explicit verification flows.
     const updatedUser = await runtimeUsers.findById(userId, { includeInactive: true });
 
     const customFields = challengeData.metadata?.custom_fields;


### PR DESCRIPTION
## Summary
- Stop marking end-user email as verified when a passkey registration completes
- Keep email verification tied to email-code or explicit email verification flows
- Add regression coverage for Direct Auth and legacy passkey registration handlers

## Verification
- pnpm format:check
- pnpm --filter @authrim/ar-auth test -- src/__tests__/direct-auth-flows.test.ts
- pnpm --filter @authrim/ar-auth test -- src/__tests__/passkey.test.ts
- pnpm --filter @authrim/ar-auth test
- pnpm lint
- pnpm typecheck