### PR TITLE
Avoid duplicate signup base fields

### DIFF
--- a/packages/ar-login-ui/src/lib/api/registration-fields.test.ts
+++ b/packages/ar-login-ui/src/lib/api/registration-fields.test.ts
@@ -52,6 +52,53 @@ describe('registration-fields API', () => {
 		]);
 	});
 
+	it('filters signup base fields from custom registration fields', async () => {
+		const fetchMock = vi.fn<typeof fetch>().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				fields: [
+					{
+						field_key: 'name',
+						display_label: 'Full Name',
+						field_type: 'string',
+						required: true,
+						placeholder: null,
+						validation_rules: null
+					},
+					{
+						field_key: 'field.canonical.email',
+						display_label: 'Email',
+						field_type: 'email',
+						required: true,
+						placeholder: null,
+						validation_rules: null
+					},
+					{
+						field_key: 'locale',
+						display_label: 'Locale',
+						field_type: 'string',
+						required: false,
+						placeholder: 'ja-JP',
+						validation_rules: null
+					}
+				]
+			})
+		} as Response);
+
+		const result = await fetchRegistrationFields(fetchMock, 'https://auth.example.com');
+
+		expect(result).toEqual([
+			{
+				field_key: 'locale',
+				display_label: 'Locale',
+				field_type: 'string',
+				required: false,
+				placeholder: 'ja-JP',
+				validation_rules: null
+			}
+		]);
+	});
+
 	it('returns an empty array when the request fails', async () => {
 		const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(new Error('network error'));
 

--- a/packages/ar-login-ui/src/lib/api/registration-fields.ts
+++ b/packages/ar-login-ui/src/lib/api/registration-fields.ts
@@ -10,6 +10,23 @@ export interface RegistrationField {
 	order?: number;
 }
 
+const SIGNUP_BASE_FIELD_KEYS = new Set([
+	'email',
+	'field.canonical.email',
+	'name',
+	'field.canonical.name',
+	'email_verified',
+	'field.canonical.email_verified'
+]);
+
+export function isSignupBaseField(field: RegistrationField): boolean {
+	return SIGNUP_BASE_FIELD_KEYS.has(field.field_key.trim().toLowerCase());
+}
+
+export function filterCustomRegistrationFields(fields: RegistrationField[]): RegistrationField[] {
+	return fields.filter((field) => !isSignupBaseField(field));
+}
+
 export function resolveRegistrationFieldsUrl(apiBaseUrl = API_BASE_URL): string {
 	const base = apiBaseUrl.trim();
 	if (!base) {
@@ -34,7 +51,7 @@ export async function fetchRegistrationFields(
 		}
 
 		const data = (await response.json()) as { fields?: RegistrationField[] };
-		return Array.isArray(data.fields) ? data.fields : [];
+		return Array.isArray(data.fields) ? filterCustomRegistrationFields(data.fields) : [];
 	} catch {
 		return [];
 	}


### PR DESCRIPTION
## Summary
- Filter signup base fields such as email, name, and email_verified out of custom registration fields in the Login UI.
- Add a regression test to keep canonical name/email fields from rendering as duplicate custom fields on signup.

## Verification
- pnpm --filter @authrim/ar-login-ui test -- src/lib/api/registration-fields.test.ts
- pnpm --filter @authrim/ar-login-ui typecheck
- pnpm format:check
- pnpm lint
- pnpm typecheck

Note: package-local ar-login-ui format:check still reports existing generated i18n files with no local diff; the root format:check used by CI passes.