### PR TITLE
Redirect active sessions away from login

### DIFF
--- a/packages/ar-login-ui/src/__tests__/entry-routing.test.ts
+++ b/packages/ar-login-ui/src/__tests__/entry-routing.test.ts
@@ -683,6 +683,47 @@ describe('common-entry routing', () => {
 		expect(result).toEqual({});
 	});
 
+	it('redirects direct /login visits to root when the browser has an active session', async () => {
+		const fetch = vi.fn().mockResolvedValueOnce(
+			jsonResponse({
+				active: true,
+				user_id: 'user-123'
+			})
+		);
+
+		await expect(
+			loginLoad({
+				cookies: createCookies({ authrim_session: '0_session_active' }),
+				fetch,
+				request: new Request('https://auth.example.com/login'),
+				url: new URL('https://auth.example.com/login')
+			} as never)
+		).rejects.toMatchObject({
+			status: 303,
+			location: '/'
+		});
+
+		expect(fetch).toHaveBeenCalledWith('/api/sessions/status', {
+			headers: { 'x-authrim-original-host': 'auth.example.com' }
+		});
+	});
+
+	it('keeps protocol login requests on /login even when a session cookie is present', async () => {
+		const fetch = vi.fn().mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+		const result = await loginLoad({
+			cookies: createCookies({ authrim_session: '0_session_active' }),
+			fetch,
+			request: new Request('https://auth.example.com/login?challenge_id=login_challenge'),
+			url: new URL('https://auth.example.com/login?challenge_id=login_challenge')
+		} as never);
+
+		expect(result).toEqual({});
+		expect(fetch).toHaveBeenCalledWith('/auth/login-challenge?challenge_id=login_challenge', {
+			headers: { 'x-authrim-original-host': 'auth.example.com' }
+		});
+	});
+
 	it('does not redirect single-tenant signup pages', async () => {
 		const fetch = vi.fn().mockResolvedValueOnce(
 			jsonResponse({

--- a/packages/ar-login-ui/src/routes/login/+page.server.ts
+++ b/packages/ar-login-ui/src/routes/login/+page.server.ts
@@ -3,6 +3,7 @@ import type { Actions, PageServerLoad } from './$types';
 import {
 	fetchDiscoveryConfig,
 	getDiscoveryRequestHeaders,
+	isCurrentSessionActive,
 	verifyLoginChallengeForCurrentTenant,
 	verifyDiscoveryGrant
 } from '../../lib/discovery-entry';
@@ -55,6 +56,10 @@ function consumeVerifiedGrantCookie(
 export const load: PageServerLoad = async (event) => {
 	const challengeId = event.url.searchParams.get('challenge_id');
 	const discoveryHeaders = getDiscoveryRequestHeaders(event);
+	const hasProtocolLoginContext =
+		!!challengeId ||
+		event.url.searchParams.has('saml_request_id') ||
+		event.url.searchParams.get('return_to') === 'saml_sso';
 
 	if (challengeId) {
 		const challengeBelongsToCurrentTenant = await verifyLoginChallengeForCurrentTenant(
@@ -64,6 +69,15 @@ export const load: PageServerLoad = async (event) => {
 		).catch(() => false);
 		if (challengeBelongsToCurrentTenant) {
 			return {};
+		}
+	}
+
+	if (!hasProtocolLoginContext && event.cookies.get('authrim_session')) {
+		const sessionActive = await isCurrentSessionActive(event.fetch, discoveryHeaders).catch(
+			() => false
+		);
+		if (sessionActive) {
+			throw redirect(303, '/');
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Redirect direct /login visits back to / when the browser already has an active managed session.
- Keep protocol login requests, including challenge-based login, on /login so OIDC/SAML flows are not interrupted.
- Add routing regression tests for both cases.

## Verification
- pnpm --filter @authrim/ar-login-ui test -- src/__tests__/entry-routing.test.ts
- pnpm --filter @authrim/ar-login-ui typecheck
- pnpm format:check
- pnpm lint
- pnpm typecheck