### PR TITLE
Rename authentication methods admin client

### DIFF
--- a/packages/ar-admin-ui/src/lib/api/admin-authentication-methods.ts
+++ b/packages/ar-admin-ui/src/lib/api/admin-authentication-methods.ts
@@ -4,17 +4,17 @@ import {
 	type CategorySettings
 } from '$lib/api/admin-settings';
 
-const CATEGORY = 'login-methods';
+const SETTINGS_CATEGORY = 'login-methods';
 const EXTERNAL_PROVIDERS_KEY = 'login-methods.external_providers';
 
-export type LoginMethodProviderType = 'oidc' | 'oauth2' | 'saml' | 'vc' | 'custom';
-export type LoginMethodProviderStartMode = 'oauth_redirect' | 'saml_sp' | 'direct';
+export type AuthenticationMethodProviderType = 'oidc' | 'oauth2' | 'saml' | 'vc' | 'custom';
+export type AuthenticationMethodProviderStartMode = 'oauth_redirect' | 'saml_sp' | 'direct';
 
-export interface LoginMethodExternalProvider {
+export interface AuthenticationMethodExternalProvider {
 	id: string;
 	name: string;
-	type: LoginMethodProviderType;
-	startMode: LoginMethodProviderStartMode;
+	type: AuthenticationMethodProviderType;
+	startMode: AuthenticationMethodProviderStartMode;
 	startUrl: string;
 	enabled: boolean;
 	slug?: string;
@@ -24,12 +24,12 @@ export interface LoginMethodExternalProvider {
 	buttonText?: string;
 }
 
-export interface LoginMethodSettingsResponse {
+export interface AuthenticationMethodSettingsResponse {
 	settings: CategorySettings;
-	providers: LoginMethodExternalProvider[];
+	providers: AuthenticationMethodExternalProvider[];
 }
 
-function parseProviders(value: unknown): LoginMethodExternalProvider[] {
+function parseProviders(value: unknown): AuthenticationMethodExternalProvider[] {
 	if (Array.isArray(value)) {
 		return value.filter(isProviderLike).map(normalizeProvider);
 	}
@@ -43,13 +43,13 @@ function parseProviders(value: unknown): LoginMethodExternalProvider[] {
 	}
 }
 
-function isProviderLike(value: unknown): value is Partial<LoginMethodExternalProvider> {
+function isProviderLike(value: unknown): value is Partial<AuthenticationMethodExternalProvider> {
 	return typeof value === 'object' && value !== null;
 }
 
 function normalizeProvider(
-	provider: Partial<LoginMethodExternalProvider>
-): LoginMethodExternalProvider {
+	provider: Partial<AuthenticationMethodExternalProvider>
+): AuthenticationMethodExternalProvider {
 	const type = normalizeType(provider.type);
 	return {
 		id: String(provider.id || ''),
@@ -66,22 +66,22 @@ function normalizeProvider(
 	};
 }
 
-function normalizeType(value: unknown): LoginMethodProviderType {
+function normalizeType(value: unknown): AuthenticationMethodProviderType {
 	if (value === 'oidc' || value === 'oauth2' || value === 'saml' || value === 'vc') return value;
 	return 'custom';
 }
 
 function normalizeStartMode(
 	value: unknown,
-	type: LoginMethodProviderType
-): LoginMethodProviderStartMode {
+	type: AuthenticationMethodProviderType
+): AuthenticationMethodProviderStartMode {
 	if (value === 'oauth_redirect' || value === 'saml_sp' || value === 'direct') return value;
 	if (type === 'saml') return 'saml_sp';
 	if (type === 'oidc' || type === 'oauth2') return 'oauth_redirect';
 	return 'direct';
 }
 
-function serializeProviders(providers: LoginMethodExternalProvider[]): string {
+function serializeProviders(providers: AuthenticationMethodExternalProvider[]): string {
 	return JSON.stringify(
 		providers.map((provider) => ({
 			id: provider.id.trim(),
@@ -99,9 +99,9 @@ function serializeProviders(providers: LoginMethodExternalProvider[]): string {
 	);
 }
 
-export const adminLoginMethodsAPI = {
-	async get(tenantId?: string): Promise<LoginMethodSettingsResponse> {
-		const settings = await adminSettingsAPI.getSettings(CATEGORY, tenantId);
+export const adminAuthenticationMethodsAPI = {
+	async get(tenantId?: string): Promise<AuthenticationMethodSettingsResponse> {
+		const settings = await adminSettingsAPI.getSettings(SETTINGS_CATEGORY, tenantId);
 		return {
 			settings,
 			providers: parseProviders(settings.values[EXTERNAL_PROVIDERS_KEY])
@@ -110,12 +110,12 @@ export const adminLoginMethodsAPI = {
 
 	async updateProviders(
 		settings: CategorySettings,
-		providers: LoginMethodExternalProvider[],
+		providers: AuthenticationMethodExternalProvider[],
 		tenantId?: string
 	) {
 		try {
 			return await adminSettingsAPI.updateSettings(
-				CATEGORY,
+				SETTINGS_CATEGORY,
 				{
 					ifMatch: settings.version,
 					set: {

--- a/packages/ar-admin-ui/src/routes/admin/authentication-methods/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/authentication-methods/+page.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import {
-		adminLoginMethodsAPI,
-		type LoginMethodExternalProvider,
-		type LoginMethodProviderType
-	} from '$lib/api/admin-login-methods';
+		adminAuthenticationMethodsAPI,
+		type AuthenticationMethodExternalProvider,
+		type AuthenticationMethodProviderType
+	} from '$lib/api/admin-authentication-methods';
 	import type { CategorySettings } from '$lib/api/admin-settings';
 	import { settingsContext } from '$lib/stores/settings-context.svelte';
 	import { LL } from '$i18n/i18n-svelte';
 
-	const EMPTY_FORM: LoginMethodExternalProvider = {
+	const EMPTY_FORM: AuthenticationMethodExternalProvider = {
 		id: '',
 		name: '',
 		type: 'vc',
@@ -27,9 +27,9 @@
 	let error = $state('');
 	let successMessage = $state('');
 	let settings = $state<CategorySettings | null>(null);
-	let providers = $state<LoginMethodExternalProvider[]>([]);
+	let providers = $state<AuthenticationMethodExternalProvider[]>([]);
 	let initialProvidersJson = $state('[]');
-	let form = $state<LoginMethodExternalProvider>({ ...EMPTY_FORM });
+	let form = $state<AuthenticationMethodExternalProvider>({ ...EMPTY_FORM });
 	let editingIndex = $state<number | null>(null);
 	let formError = $state('');
 
@@ -58,7 +58,7 @@
 		successMessage = '';
 		formError = '';
 		try {
-			const response = await adminLoginMethodsAPI.get(currentTenantId);
+			const response = await adminAuthenticationMethodsAPI.get(currentTenantId);
 			settings = response.settings;
 			providers = response.providers;
 			initialProvidersJson = JSON.stringify(response.providers);
@@ -100,7 +100,7 @@
 		providers = [...providers.slice(0, index + 1), copy, ...providers.slice(index + 1)];
 	}
 
-	function setProviderType(type: LoginMethodProviderType) {
+	function setProviderType(type: AuthenticationMethodProviderType) {
 		form.type = type;
 		if (type === 'saml') {
 			form.startMode = 'saml_sp';
@@ -111,7 +111,7 @@
 		}
 	}
 
-	function validateProvider(provider: LoginMethodExternalProvider): string {
+	function validateProvider(provider: AuthenticationMethodExternalProvider): string {
 		if (!provider.id.trim()) return $LL.admin_login_methods_validation_id_required();
 		if (!/^[a-zA-Z0-9:_-]+$/.test(provider.id.trim())) {
 			return $LL.admin_login_methods_validation_id_format();
@@ -141,7 +141,7 @@
 	}
 
 	function upsertProvider() {
-		const normalized: LoginMethodExternalProvider = {
+		const normalized: AuthenticationMethodExternalProvider = {
 			...form,
 			id: form.id.trim(),
 			name: form.name.trim(),
@@ -173,7 +173,7 @@
 		successMessage = '';
 		saving = true;
 		try {
-			const result = await adminLoginMethodsAPI.updateProviders(
+			const result = await adminAuthenticationMethodsAPI.updateProviders(
 				settings,
 				providers,
 				currentTenantId
@@ -314,7 +314,7 @@
 						value={form.type}
 						disabled={!canEdit}
 						onchange={(event) =>
-							setProviderType(event.currentTarget.value as LoginMethodProviderType)}
+							setProviderType(event.currentTarget.value as AuthenticationMethodProviderType)}
 					>
 						<option value="vc">VC</option>
 						<option value="custom">Custom</option>


### PR DESCRIPTION
## Summary
- Rename the Admin UI API client module from admin-login-methods to admin-authentication-methods.
- Rename page-local API and provider types to authentication-methods terminology.
- Keep the persisted settings category and keys unchanged in this small PR.

## Validation
- pnpm --filter @authrim/ar-admin-ui format:check
- pnpm --filter @authrim/ar-admin-ui typecheck
- pnpm --filter @authrim/ar-admin-ui lint
- pnpm format:check
- pnpm typecheck
- pnpm lint
- pnpm --filter @authrim/ar-admin-ui build