### PR TITLE
Rename Login UI authentication methods client

### DIFF
--- a/packages/ar-login-ui/src/lib/api/authentication-methods.ts
+++ b/packages/ar-login-ui/src/lib/api/authentication-methods.ts
@@ -1,7 +1,7 @@
 /**
- * Login Methods API Client
+ * Authentication Methods API Client
  *
- * Fetches available login methods and UI configuration from the backend.
+ * Fetches available authentication methods and UI configuration from the backend.
  * Used to dynamically render authentication options on the login page.
  */
 
@@ -50,7 +50,7 @@ export interface ExternalMethod {
 	providers: ExternalProvider[];
 }
 
-export interface LoginMethods {
+export interface AuthenticationMethods {
 	passkey: PasskeyMethod;
 	emailCode: EmailCodeMethod;
 	directoryPassword: DirectoryPasswordMethod;
@@ -67,18 +67,18 @@ export interface LoginUIConfig {
 	supportedLocales: string[];
 }
 
-export interface LoginMethodsMeta {
+export interface AuthenticationMethodsMeta {
 	cacheTTL: number;
 	revision: string;
 }
 
-export interface LoginMethodsResponse {
-	methods: LoginMethods;
+export interface AuthenticationMethodsResponse {
+	methods: AuthenticationMethods;
 	ui: LoginUIConfig;
-	meta: LoginMethodsMeta;
+	meta: AuthenticationMethodsMeta;
 }
 
-export interface LoginMethodsError {
+export interface AuthenticationMethodsError {
 	error: {
 		code: string;
 		message: string;
@@ -89,16 +89,16 @@ export interface LoginMethodsError {
 // API Client
 // =============================================================================
 
-let cachedResponse: LoginMethodsResponse | null = null;
+let cachedResponse: AuthenticationMethodsResponse | null = null;
 let cacheExpiry = 0;
 
 /**
- * Fetch available login methods from the backend.
+ * Fetch available authentication methods from the backend.
  * Results are cached per the server-provided TTL.
  */
-export async function fetchLoginMethods(): Promise<{
-	data?: LoginMethodsResponse;
-	error?: LoginMethodsError;
+export async function fetchAuthenticationMethods(): Promise<{
+	data?: AuthenticationMethodsResponse;
+	error?: AuthenticationMethodsError;
 }> {
 	// Return cached response if still valid
 	if (cachedResponse && Date.now() < cacheExpiry) {
@@ -118,10 +118,10 @@ export async function fetchLoginMethods(): Promise<{
 		const data = await response.json();
 
 		if (!response.ok) {
-			return { error: data as LoginMethodsError };
+			return { error: data as AuthenticationMethodsError };
 		}
 
-		const result = data as LoginMethodsResponse;
+		const result = data as AuthenticationMethodsResponse;
 
 		// Cache the response
 		cachedResponse = result;
@@ -137,7 +137,7 @@ export async function fetchLoginMethods(): Promise<{
 			error: {
 				error: {
 					code: 'NETWORK_ERROR',
-					message: 'Failed to fetch login methods'
+					message: 'Failed to fetch authentication methods'
 				}
 			}
 		};
@@ -147,9 +147,9 @@ export async function fetchLoginMethods(): Promise<{
 }
 
 /**
- * Clear the cached login methods response
+ * Clear the cached authentication methods response
  */
-export function clearLoginMethodsCache(): void {
+export function clearAuthenticationMethodsCache(): void {
 	cachedResponse = null;
 	cacheExpiry = 0;
 }

--- a/packages/ar-login-ui/src/lib/components/LoginMethodSelector.svelte
+++ b/packages/ar-login-ui/src/lib/components/LoginMethodSelector.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Button, Input, Alert } from '$lib/components';
 	import { LL } from '$i18n/i18n-svelte';
-	import type { ExternalProvider } from '$lib/api/login-methods';
+	import type { ExternalProvider } from '$lib/api/authentication-methods';
 	import { getExternalProviderIconClass } from '$lib/login-provider-icons';
 	import { isValidImageUrl, sanitizeColor } from '$lib/utils/url-validation';
 

--- a/packages/ar-login-ui/src/lib/login-provider-icons.test.ts
+++ b/packages/ar-login-ui/src/lib/login-provider-icons.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { ExternalProvider } from '$lib/api/login-methods';
+import type { ExternalProvider } from '$lib/api/authentication-methods';
 import { getExternalProviderIconClass } from '$lib/login-provider-icons';
 
 function provider(overrides: Partial<ExternalProvider>): ExternalProvider {

--- a/packages/ar-login-ui/src/lib/login-provider-icons.ts
+++ b/packages/ar-login-ui/src/lib/login-provider-icons.ts
@@ -1,4 +1,4 @@
-import type { ExternalProvider } from '$lib/api/login-methods';
+import type { ExternalProvider } from '$lib/api/authentication-methods';
 
 const SELECTABLE_ICON_NAMES = new Set([
 	'buildings',

--- a/packages/ar-login-ui/src/lib/stores/branding.svelte.ts
+++ b/packages/ar-login-ui/src/lib/stores/branding.svelte.ts
@@ -1,10 +1,10 @@
 /**
  * Branding Store - Manages tenant branding state
  *
- * Provides brand name and logo URL from the login-methods API
+ * Provides brand name and logo URL from the authentication methods API
  * to all pages via a shared reactive store.
  *
- * Populated in +layout.svelte from fetchLoginMethods() response.
+ * Populated in +layout.svelte from fetchAuthenticationMethods() response.
  */
 
 function createBrandingStore() {

--- a/packages/ar-login-ui/src/lib/stores/theme.svelte.ts
+++ b/packages/ar-login-ui/src/lib/stores/theme.svelte.ts
@@ -6,11 +6,11 @@
  * - 6 variant options (3 light, 3 dark)
  * - localStorage persistence
  * - SSR-safe initialization
- * - Tenant theme defaults (from login-methods API)
+ * - Tenant theme defaults (from authentication methods API)
  *
  * Theme Resolution Order:
  * 1. User local preference (localStorage)
- * 2. Tenant theme (login-methods API → ui.theme/ui.variant)
+ * 2. Tenant theme (authentication methods API -> ui.theme/ui.variant)
  * 3. System preference (prefers-color-scheme)
  * 4. Default: light / beige
  */
@@ -79,7 +79,7 @@ function createThemeStore() {
 	// Get the current variant based on mode
 	const currentVariant = $derived(mode === 'light' ? lightVariant : darkVariant);
 
-	// Tenant defaults (set from login-methods API)
+	// Tenant defaults (set from authentication methods API)
 	let tenantMode: ThemeMode | null = null;
 	let tenantLightVariant: LightVariant | null = null;
 	let tenantDarkVariant: DarkVariant | null = null;
@@ -119,7 +119,7 @@ function createThemeStore() {
 	}
 
 	/**
-	 * Set tenant theme defaults from the login-methods API response.
+	 * Set tenant theme defaults from the authentication methods API response.
 	 * These are used as fallback when the user has no localStorage preference.
 	 * Call this before init() for correct resolution order.
 	 */

--- a/packages/ar-login-ui/src/routes/+layout.svelte
+++ b/packages/ar-login-ui/src/routes/+layout.svelte
@@ -5,7 +5,7 @@
 	import { setLocale, getLocale } from '$i18n/i18n-svelte';
 	import { themeStore } from '$lib/stores/theme.svelte';
 	import { brandingStore } from '$lib/stores/branding.svelte';
-	import { fetchLoginMethods } from '$lib/api/login-methods';
+	import { fetchAuthenticationMethods } from '$lib/api/authentication-methods';
 	import { onMount } from 'svelte';
 	import type { LayoutData } from './$types';
 	import type { Snippet } from 'svelte';
@@ -33,12 +33,15 @@
 		if (data.shouldLoadTenantBranding) {
 			// Fetch tenant theme defaults (non-blocking for theme init)
 			try {
-				const { data: loginMethods } = await fetchLoginMethods();
-				if (loginMethods?.ui) {
-					themeStore.setTenantDefaults(loginMethods.ui.theme, loginMethods.ui.variant);
+				const { data: authenticationMethods } = await fetchAuthenticationMethods();
+				if (authenticationMethods?.ui) {
+					themeStore.setTenantDefaults(
+						authenticationMethods.ui.theme,
+						authenticationMethods.ui.variant
+					);
 					brandingStore.set(
-						loginMethods.ui.branding.brandName || '',
-						loginMethods.ui.branding.logoUrl || null
+						authenticationMethods.ui.branding.brandName || '',
+						authenticationMethods.ui.branding.logoUrl || null
 					);
 					document.documentElement.setAttribute('data-branding-loaded', '');
 				}

--- a/packages/ar-login-ui/src/routes/login/+page.svelte
+++ b/packages/ar-login-ui/src/routes/login/+page.svelte
@@ -16,7 +16,10 @@
 		isValidLinkUrl,
 		sanitizeColor
 	} from '$lib/utils/url-validation';
-	import { fetchLoginMethods, type ExternalProvider } from '$lib/api/login-methods';
+	import {
+		fetchAuthenticationMethods,
+		type ExternalProvider
+	} from '$lib/api/authentication-methods';
 	import { getExternalProviderIconClass } from '$lib/login-provider-icons';
 	import { startAuthentication } from '@simplewebauthn/browser';
 	import { auth } from '$lib/stores/auth';
@@ -176,7 +179,7 @@
 			email = urlLoginHint;
 		}
 
-		const tasks: Promise<void>[] = [loadLoginMethods()];
+		const tasks: Promise<void>[] = [loadAuthenticationMethods()];
 		if (urlChallengeId) {
 			tasks.push(loadChallengeData(urlChallengeId));
 		}
@@ -186,11 +189,11 @@
 	// ---------------------------------------------------------------------------
 	// Data fetchers
 	// ---------------------------------------------------------------------------
-	async function loadLoginMethods() {
+	async function loadAuthenticationMethods() {
 		methodsLoading = true;
 		methodsError = '';
 		try {
-			const { data, error: apiError } = await fetchLoginMethods();
+			const { data, error: apiError } = await fetchAuthenticationMethods();
 			if (apiError) {
 				methodsError = apiError.error.message;
 				return;

--- a/packages/ar-login-ui/src/routes/reauth/+page.svelte
+++ b/packages/ar-login-ui/src/routes/reauth/+page.svelte
@@ -7,7 +7,7 @@
 	import { LL } from '$i18n/i18n-svelte';
 	import { passkeyAPI, emailCodeAPI, loginChallengeAPI } from '$lib/api/client';
 	import { isValidRedirectUrl, isValidImageUrl } from '$lib/utils/url-validation';
-	import { fetchLoginMethods } from '$lib/api/login-methods';
+	import { fetchAuthenticationMethods } from '$lib/api/authentication-methods';
 	import { startAuthentication } from '@simplewebauthn/browser';
 
 	// ---------------------------------------------------------------------------
@@ -61,7 +61,7 @@
 			return;
 		}
 
-		await Promise.all([loadChallengeData(), loadLoginMethods()]);
+		await Promise.all([loadChallengeData(), loadAuthenticationMethods()]);
 		loading = false;
 	});
 
@@ -83,9 +83,9 @@
 		}
 	}
 
-	async function loadLoginMethods() {
+	async function loadAuthenticationMethods() {
 		try {
-			const { data } = await fetchLoginMethods();
+			const { data } = await fetchAuthenticationMethods();
 			if (data) {
 				passkeyEnabled = data.methods.passkey.enabled;
 				emailCodeEnabled = data.methods.emailCode.enabled;

--- a/packages/ar-login-ui/src/routes/signup/+page.svelte
+++ b/packages/ar-login-ui/src/routes/signup/+page.svelte
@@ -7,7 +7,10 @@
 	import { fetchRegistrationFields, type RegistrationField } from '$lib/api/registration-fields';
 	import { brandingStore } from '$lib/stores/branding.svelte';
 	import { isValidImageUrl, isValidRedirectUrl, sanitizeColor } from '$lib/utils/url-validation';
-	import { fetchLoginMethods, type ExternalProvider } from '$lib/api/login-methods';
+	import {
+		fetchAuthenticationMethods,
+		type ExternalProvider
+	} from '$lib/api/authentication-methods';
 	import { getExternalProviderIconClass } from '$lib/login-provider-icons';
 	import { startRegistration } from '@simplewebauthn/browser';
 	import { auth } from '$lib/stores/auth';
@@ -109,13 +112,13 @@
 			inviteTenantName = tenant;
 		}
 
-		await Promise.all([loadLoginMethods(), loadRegistrationFields()]);
+		await Promise.all([loadAuthenticationMethods(), loadRegistrationFields()]);
 	});
 
-	async function loadLoginMethods() {
+	async function loadAuthenticationMethods() {
 		methodsLoading = true;
 		try {
-			const { data } = await fetchLoginMethods();
+			const { data } = await fetchAuthenticationMethods();
 			if (data) {
 				passkeyEnabled = data.methods.passkey.enabled;
 				emailCodeEnabled = data.methods.emailCode.enabled;


### PR DESCRIPTION
## Summary
- Rename the Login UI API client module from login-methods to authentication-methods.
- Rename client-side functions and response types to AuthenticationMethods terminology.
- Keep the current backend endpoint path unchanged in this small PR.

## Validation
- pnpm --filter @authrim/ar-login-ui typecheck
- pnpm --filter @authrim/ar-login-ui lint
- pnpm format:check
- pnpm typecheck
- pnpm lint
- pnpm --filter @authrim/ar-login-ui build

Note: package-local ar-login-ui format:check still reports existing generated i18n formatting files unrelated to this change.