### PR TITLE
Rename authentication method selector

### DIFF
--- a/packages/ar-login-ui/src/__tests__/ui-url-sinks.test.ts
+++ b/packages/ar-login-ui/src/__tests__/ui-url-sinks.test.ts
@@ -31,7 +31,7 @@ describe('UI URL sink guards', () => {
 
 	it('guards external provider image URLs before using them as img src values', () => {
 		const sources = [
-			source('lib/components/LoginMethodSelector.svelte'),
+			source('lib/components/AuthenticationMethodSelector.svelte'),
 			source('routes/login/+page.svelte'),
 			source('routes/signup/+page.svelte')
 		];

--- a/packages/ar-login-ui/src/lib/components/AuthenticationMethodSelector.svelte
+++ b/packages/ar-login-ui/src/lib/components/AuthenticationMethodSelector.svelte
@@ -81,8 +81,8 @@
 </script>
 
 <!--
-  LoginMethodSelector
-  - Renders available login methods based on server configuration
+  AuthenticationMethodSelector
+  - Renders available authentication methods based on server configuration
   - Delegates authentication actions to parent via callbacks
   - Handles passkey support detection and provider icon resolution
 -->

--- a/packages/ar-login-ui/src/lib/components/index.ts
+++ b/packages/ar-login-ui/src/lib/components/index.ts
@@ -10,4 +10,4 @@ export { default as TestDialog } from './TestDialog.svelte';
 export { default as ToggleSwitch } from './ToggleSwitch.svelte';
 export { default as StatusBadge } from './StatusBadge.svelte';
 export { default as CountdownTimer } from './CountdownTimer.svelte';
-export { default as LoginMethodSelector } from './LoginMethodSelector.svelte';
+export { default as AuthenticationMethodSelector } from './AuthenticationMethodSelector.svelte';


### PR DESCRIPTION
## Summary
- Rename the Login UI selector component to `AuthenticationMethodSelector`.
- Update the component barrel export and URL sink guard test path.

## Validation
- `pnpm --filter @authrim/ar-login-ui typecheck`
- `pnpm --filter @authrim/ar-login-ui lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @authrim/ar-login-ui build`

Note: the Login UI build emitted local web font fetch warnings under restricted network access, but completed successfully with exit code 0.