### PR TITLE
Rename authentication methods public API

### DIFF
--- a/packages/ar-lib-core/src/utils/__tests__/tenant-context.test.ts
+++ b/packages/ar-lib-core/src/utils/__tests__/tenant-context.test.ts
@@ -82,7 +82,7 @@ describe('resolveTenantFromRequest', () => {
 
     it('should reject forwarded naked domain when tenant omission is disabled', () => {
       const request = new Request(
-        'https://test-ar-router.sgrastar.workers.dev/api/auth/login-methods',
+        'https://test-ar-router.sgrastar.workers.dev/api/auth/authentication-methods',
         {
           headers: {
             Host: 'test-ar-router.sgrastar.workers.dev',
@@ -98,7 +98,7 @@ describe('resolveTenantFromRequest', () => {
 
     it('should reject generic X-Forwarded-Host when Host is workers.dev', () => {
       const request = new Request(
-        'https://test-ar-router.sgrastar.workers.dev/api/auth/login-methods',
+        'https://test-ar-router.sgrastar.workers.dev/api/auth/authentication-methods',
         {
           headers: {
             Host: 'test-ar-router.sgrastar.workers.dev',
@@ -114,7 +114,7 @@ describe('resolveTenantFromRequest', () => {
 
     it('should not let forwarded tenant host override an unrecognized Host', () => {
       const request = new Request(
-        'https://test-ar-router.sgrastar.workers.dev/api/auth/login-methods',
+        'https://test-ar-router.sgrastar.workers.dev/api/auth/authentication-methods',
         {
           headers: {
             Host: 'test-ar-router.sgrastar.workers.dev',
@@ -131,7 +131,7 @@ describe('resolveTenantFromRequest', () => {
 
     it('should not let forwarded naked domain override an unrecognized Host', () => {
       const request = new Request(
-        'https://test-ar-router.sgrastar.workers.dev/api/auth/login-methods',
+        'https://test-ar-router.sgrastar.workers.dev/api/auth/authentication-methods',
         {
           headers: {
             Host: 'test-ar-router.sgrastar.workers.dev',
@@ -149,7 +149,7 @@ describe('resolveTenantFromRequest', () => {
     });
 
     it('should prefer Host when it already resolves to a tenant', () => {
-      const request = new Request('https://acme.test.authrim.com/api/auth/login-methods', {
+      const request = new Request('https://acme.test.authrim.com/api/auth/authentication-methods', {
         headers: {
           Host: 'acme.test.authrim.com',
           'X-Forwarded-Host': 'test.authrim.com',

--- a/packages/ar-login-ui/src/lib/api/authentication-methods.ts
+++ b/packages/ar-login-ui/src/lib/api/authentication-methods.ts
@@ -109,7 +109,7 @@ export async function fetchAuthenticationMethods(): Promise<{
 	const timeoutId = setTimeout(() => controller.abort(), 15000);
 
 	try {
-		const response = await authrimFetch('/api/auth/login-methods', {
+		const response = await authrimFetch('/api/auth/authentication-methods', {
 			method: 'GET',
 			headers: buildDiagnosticHeaders({ Accept: 'application/json' }),
 			signal: controller.signal

--- a/packages/ar-login-ui/src/lib/authrim/fetch.test.ts
+++ b/packages/ar-login-ui/src/lib/authrim/fetch.test.ts
@@ -10,12 +10,12 @@ import {
 
 describe('Authrim LoginUI fetch profile', () => {
 	it('resolves relative requests against the configured API base URL', () => {
-		expect(resolveAuthrimRequestUrl('/api/auth/login-methods', 'https://auth.example.com')).toBe(
-			'https://auth.example.com/api/auth/login-methods'
-		);
-		expect(resolveAuthrimRequestUrl('api/auth/login-methods', 'https://auth.example.com/')).toBe(
-			'https://auth.example.com/api/auth/login-methods'
-		);
+		expect(
+			resolveAuthrimRequestUrl('/api/auth/authentication-methods', 'https://auth.example.com')
+		).toBe('https://auth.example.com/api/auth/authentication-methods');
+		expect(
+			resolveAuthrimRequestUrl('api/auth/authentication-methods', 'https://auth.example.com/')
+		).toBe('https://auth.example.com/api/auth/authentication-methods');
 		expect(
 			resolveAuthrimRequestUrl('https://issuer.example.com/userinfo', 'https://auth.example.com')
 		).toBe('https://issuer.example.com/userinfo');

--- a/packages/ar-management/src/__tests__/authentication-methods.test.ts
+++ b/packages/ar-management/src/__tests__/authentication-methods.test.ts
@@ -1,8 +1,8 @@
 /**
- * Login Methods API Tests
+ * Authentication Methods API Tests
  *
- * Tests for the public login methods endpoint:
- * - GET /api/auth/login-methods
+ * Tests for the public authentication methods endpoint:
+ * - GET /api/auth/authentication-methods
  *
  * Verifies:
  * - All methods enabled/disabled combinations
@@ -42,7 +42,7 @@ vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
 
 import { Hono } from 'hono';
 import type { Env } from '@authrim/ar-lib-core';
-import { getLoginMethodsHandler } from '../login-methods';
+import { getAuthenticationMethodsHandler } from '../authentication-methods';
 
 // =============================================================================
 // Mock helpers
@@ -109,7 +109,7 @@ function createTestApp(options: CreateTestAppOptions = {}) {
   const externalIdp = options.externalIdp !== undefined ? options.externalIdp : null;
 
   const app = new Hono<{ Bindings: Env }>();
-  app.get('/api/auth/login-methods', getLoginMethodsHandler);
+  app.get('/api/auth/authentication-methods', getAuthenticationMethodsHandler);
 
   const mockEnv = {
     SETTINGS: settingsKV,
@@ -124,7 +124,7 @@ function createTestApp(options: CreateTestAppOptions = {}) {
 // Tests
 // =============================================================================
 
-describe('Login Methods API', () => {
+describe('Authentication Methods API', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockResolveAuthCorePersistenceAdapterFromEnv.mockResolvedValue({
@@ -136,11 +136,11 @@ describe('Login Methods API', () => {
   // Default behavior
   // ===========================================================================
 
-  describe('GET /api/auth/login-methods (defaults)', () => {
+  describe('GET /api/auth/authentication-methods (defaults)', () => {
     it('should return passkey + emailCode enabled by default', async () => {
       const { app, mockEnv } = createTestApp();
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
@@ -161,7 +161,7 @@ describe('Login Methods API', () => {
     it('should return default UI config', async () => {
       const { app, mockEnv } = createTestApp();
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
       const body = (await res.json()) as any;
 
       expect(body.ui.theme).toBe('light');
@@ -175,7 +175,7 @@ describe('Login Methods API', () => {
     it('should return default appearance config', async () => {
       const { app, mockEnv } = createTestApp();
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
       const body = (await res.json()) as any;
 
       expect(body.ui.appearance.backgroundImageUrl).toBeNull();
@@ -189,7 +189,7 @@ describe('Login Methods API', () => {
     it('should include meta with cacheTTL and revision', async () => {
       const { app, mockEnv } = createTestApp();
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
       const body = (await res.json()) as any;
 
       expect(body.meta.cacheTTL).toBe(300);
@@ -201,7 +201,7 @@ describe('Login Methods API', () => {
     it('should set Cache-Control header', async () => {
       const { app, mockEnv } = createTestApp();
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
 
       expect(res.headers.get('Cache-Control')).toBe('public, max-age=300');
     });
@@ -220,7 +220,7 @@ describe('Login Methods API', () => {
       });
       const { app, mockEnv } = createTestApp({ settingsKV });
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
       const body = (await res.json()) as any;
 
       expect(body.methods.passkey.enabled).toBe(false);
@@ -236,7 +236,7 @@ describe('Login Methods API', () => {
       });
       const { app, mockEnv } = createTestApp({ settingsKV });
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
       const body = (await res.json()) as any;
 
       expect(body.methods.passkey.enabled).toBe(true);
@@ -256,7 +256,7 @@ describe('Login Methods API', () => {
       });
       const { app, mockEnv } = createTestApp({ settingsKV, externalIdp: null });
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
       const body = (await res.json()) as any;
 
       expect(res.status).toBe(200);
@@ -294,7 +294,7 @@ describe('Login Methods API', () => {
       });
       const { app, mockEnv } = createTestApp({ externalIdp });
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
       const body = (await res.json()) as any;
 
       expect(body.methods.external.enabled).toBe(true);
@@ -329,7 +329,7 @@ describe('Login Methods API', () => {
       });
       const { app, mockEnv } = createTestApp();
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
       const body = (await res.json()) as any;
 
       expect(body.methods.external.enabled).toBe(true);
@@ -364,7 +364,7 @@ describe('Login Methods API', () => {
       });
       const { app, mockEnv } = createTestApp({ settingsKV });
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
       const body = (await res.json()) as any;
 
       expect(body.methods.external.enabled).toBe(true);
@@ -389,7 +389,7 @@ describe('Login Methods API', () => {
       });
       const { app, mockEnv } = createTestApp({ externalIdp });
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
       const body = (await res.json()) as any;
 
       expect(body.methods.external.providers).toHaveLength(1);
@@ -400,7 +400,7 @@ describe('Login Methods API', () => {
       const externalIdp = createMockExternalIdp({ shouldFail: true });
       const { app, mockEnv } = createTestApp({ externalIdp });
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
       const body = (await res.json()) as any;
 
       expect(body.methods.external.enabled).toBe(false);
@@ -413,7 +413,7 @@ describe('Login Methods API', () => {
       });
       const { app, mockEnv } = createTestApp({ externalIdp });
 
-      await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
 
       expect(externalIdp.fetch).toHaveBeenCalledWith(
         'https://external-idp/api/external/providers',
@@ -427,7 +427,7 @@ describe('Login Methods API', () => {
       });
       const { app, mockEnv } = createTestApp({ externalIdp });
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
       const body = (await res.json()) as any;
 
       expect(body.methods.external.enabled).toBe(true);
@@ -449,7 +449,7 @@ describe('Login Methods API', () => {
       // No EXTERNAL_IDP → no external login
       const { app, mockEnv } = createTestApp({ settingsKV, externalIdp: null });
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
 
       expect(res.status).toBe(503);
       const body = (await res.json()) as any;
@@ -466,7 +466,7 @@ describe('Login Methods API', () => {
       });
       const { app, mockEnv } = createTestApp({ settingsKV });
 
-      await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
 
       expect(mockLogger.warn).toHaveBeenCalledWith('No login method available', {});
     });
@@ -500,7 +500,7 @@ describe('Login Methods API', () => {
       });
       const { app, mockEnv } = createTestApp({ settingsKV });
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
       const body = (await res.json()) as any;
 
       expect(body.ui.theme).toBe('dark');
@@ -531,7 +531,7 @@ describe('Login Methods API', () => {
       // Empty configKV → no settings-v2
       const { app, mockEnv } = createTestApp({ settingsKV });
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
       const body = (await res.json()) as any;
 
       expect(body.ui.theme).toBe('dark');
@@ -563,7 +563,7 @@ describe('Login Methods API', () => {
       });
       const { app, mockEnv } = createTestApp({ settingsKV });
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
       const body = (await res.json()) as any;
 
       expect(body.ui.theme).toBe('dark');
@@ -587,7 +587,7 @@ describe('Login Methods API', () => {
       } as unknown as KVNamespace;
       const { app, mockEnv } = createTestApp({ settingsKV });
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
 
       // Handler is resilient — KV failure falls back to defaults
       expect(res.status).toBe(200);
@@ -603,7 +603,7 @@ describe('Login Methods API', () => {
       });
       const { app, mockEnv } = createTestApp({ settingsKV });
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
 
       // Should not crash — falls back to empty settings → defaults
       expect(res.status).toBe(200);
@@ -619,7 +619,7 @@ describe('Login Methods API', () => {
       });
       const { app, mockEnv } = createTestApp({ settingsKV });
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
 
       // Should fall through to legacy → defaults
       expect(res.status).toBe(200);
@@ -641,7 +641,7 @@ describe('Login Methods API', () => {
       });
       const { app, mockEnv } = createTestApp({ settingsKV });
 
-      const res = await app.request('/api/auth/login-methods', { method: 'GET' }, mockEnv);
+      const res = await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;

--- a/packages/ar-management/src/authentication-methods.ts
+++ b/packages/ar-management/src/authentication-methods.ts
@@ -1,13 +1,13 @@
 /**
- * Login Methods API
+ * Authentication Methods API
  *
- * Public endpoint to retrieve available login methods and UI configuration.
+ * Public endpoint to retrieve available authentication methods and UI configuration.
  * Used by Login UI to dynamically render authentication options.
  *
- * GET /api/auth/login-methods
+ * GET /api/auth/authentication-methods
  *   - No authentication required (public endpoint)
  *   - Rate limited with lenient profile
- *   - Returns enabled login methods + UI config
+ *   - Returns enabled authentication methods + UI config
  *
  * Data sources:
  *   - SETTINGS KV ("system_settings") → passkeyEnabled, magicLinkEnabled, UI theme
@@ -63,16 +63,16 @@ interface ExternalLoginProvider {
   startUrl?: string;
 }
 
-interface ExternalLoginMethod {
+interface ExternalAuthenticationMethod {
   enabled: boolean;
   providers: ExternalLoginProvider[];
 }
 
-interface LoginMethods {
+interface AuthenticationMethods {
   passkey: PasskeyMethod;
   emailCode: EmailCodeMethod;
   directoryPassword: DirectoryPasswordMethod;
-  external: ExternalLoginMethod;
+  external: ExternalAuthenticationMethod;
 }
 
 interface UIConfig {
@@ -100,18 +100,18 @@ interface UIConfig {
   supportedLocales: string[];
 }
 
-interface LoginMethodsMeta {
+interface AuthenticationMethodsMeta {
   cacheTTL: number;
   revision: string;
 }
 
-interface LoginMethodsResponse {
-  methods: LoginMethods;
+interface AuthenticationMethodsResponse {
+  methods: AuthenticationMethods;
   ui: UIConfig;
-  meta: LoginMethodsMeta;
+  meta: AuthenticationMethodsMeta;
 }
 
-interface LoginMethodsErrorResponse {
+interface AuthenticationMethodsErrorResponse {
   error: {
     code: string;
     message: string;
@@ -244,7 +244,7 @@ interface LoginUIKVSettings {
   'login-ui.custom_blocks'?: string;
 }
 
-interface LoginMethodKVSettings {
+interface AuthenticationMethodKVSettings {
   'login-methods.cache_ttl'?: number;
   'login-methods.external_providers'?: string | ExternalLoginProviderConfig[];
   'login-methods.directory_password.enabled'?: boolean | string;
@@ -603,7 +603,7 @@ async function fetchConfiguredExternalLoginProviders(
     const kvJson = await env.SETTINGS?.get(`settings:tenant:${tenantId}:login-methods`);
     if (!kvJson) return [];
 
-    const kvSettings = JSON.parse(kvJson) as LoginMethodKVSettings;
+    const kvSettings = JSON.parse(kvJson) as AuthenticationMethodKVSettings;
     const rawProviders = kvSettings['login-methods.external_providers'];
     const providers =
       typeof rawProviders === 'string'
@@ -659,7 +659,7 @@ async function resolveDirectoryPasswordMethod(
     const kvJson = await env.SETTINGS?.get(`settings:tenant:${tenantId}:login-methods`);
     if (!kvJson) return defaults;
 
-    const kvSettings = JSON.parse(kvJson) as LoginMethodKVSettings;
+    const kvSettings = JSON.parse(kvJson) as AuthenticationMethodKVSettings;
     return {
       enabled: normalizeBoolean(
         kvSettings['login-methods.directory_password.enabled'],
@@ -728,7 +728,7 @@ async function resolveCacheTTL(env: Env, tenantId: string): Promise<number> {
   try {
     const kvJson = await env.SETTINGS?.get(`settings:tenant:${tenantId}:login-methods`);
     if (kvJson) {
-      const kvSettings = JSON.parse(kvJson) as LoginMethodKVSettings;
+      const kvSettings = JSON.parse(kvJson) as AuthenticationMethodKVSettings;
       const kvTTL = kvSettings['login-methods.cache_ttl'];
       if (typeof kvTTL === 'number' && kvTTL >= 0 && kvTTL <= 3600) {
         return kvTTL;
@@ -756,11 +756,11 @@ async function resolveCacheTTL(env: Env, tenantId: string): Promise<number> {
 // =============================================================================
 
 /**
- * GET /api/auth/login-methods
+ * GET /api/auth/authentication-methods
  *
- * Public endpoint — returns available login methods and UI configuration.
+ * Public endpoint — returns available authentication methods and UI configuration.
  */
-export async function getLoginMethodsHandler(c: Context<{ Bindings: Env }>) {
+export async function getAuthenticationMethodsHandler(c: Context<{ Bindings: Env }>) {
   const log = getLogger(c).module('LOGIN-METHODS');
 
   try {
@@ -790,7 +790,7 @@ export async function getLoginMethodsHandler(c: Context<{ Bindings: Env }>) {
     // Check if at least one method is available
     if (!passkeyEnabled && !emailCodeEnabled && !directoryPasswordEnabled && !externalEnabled) {
       log.warn('No login method available', {});
-      const errorResponse: LoginMethodsErrorResponse = {
+      const errorResponse: AuthenticationMethodsErrorResponse = {
         error: {
           code: 'NO_LOGIN_METHOD_AVAILABLE',
           message: 'No login method is enabled for this tenant',
@@ -800,7 +800,7 @@ export async function getLoginMethodsHandler(c: Context<{ Bindings: Env }>) {
       return c.json(errorResponse, 503);
     }
 
-    const methods: LoginMethods = {
+    const methods: AuthenticationMethods = {
       passkey: {
         enabled: passkeyEnabled,
         capabilities: passkeyEnabled ? ['conditional', 'discoverable'] : [],
@@ -827,7 +827,7 @@ export async function getLoginMethodsHandler(c: Context<{ Bindings: Env }>) {
     ]);
     const ui = buildUIConfig(loginUISettings);
 
-    const response: LoginMethodsResponse = {
+    const response: AuthenticationMethodsResponse = {
       methods,
       ui,
       meta: {
@@ -841,12 +841,12 @@ export async function getLoginMethodsHandler(c: Context<{ Bindings: Env }>) {
 
     return c.json(response);
   } catch (error) {
-    log.error('Failed to get login methods', {}, error as Error);
+    log.error('Failed to get authentication methods', {}, error as Error);
     c.header('Cache-Control', 'no-store');
     return c.json(
       {
         error: 'server_error',
-        error_description: 'Failed to retrieve login methods',
+        error_description: 'Failed to retrieve authentication methods',
       },
       500
     );

--- a/packages/ar-management/src/index.ts
+++ b/packages/ar-management/src/index.ts
@@ -360,7 +360,7 @@ import {
 import { requireSupportedTenantParam } from './single-tenant-guard';
 import { adminTenantPolicyMiddleware } from './admin-tenant-policy';
 import { userConsentsListHandler, userConsentRevokeHandler } from './user-consents';
-import { getLoginMethodsHandler } from './login-methods';
+import { getAuthenticationMethodsHandler } from './authentication-methods';
 import {
   getDiscoveryConfigHandler,
   postDiscoveryGrantHandler,
@@ -1024,16 +1024,16 @@ const healthHandlers = createHealthCheckHandlers({
 app.get('/health/live', healthHandlers.liveness);
 app.get('/health/ready', healthHandlers.readiness);
 
-// Login Methods API - public endpoint for Login UI
-// Returns enabled login methods (passkey, emailCode, external providers) and UI config
-app.use('/api/auth/login-methods', async (c, next) => {
+// Authentication Methods API - public endpoint for Login UI
+// Returns enabled authentication methods (passkey, emailCode, external providers) and UI config
+app.use('/api/auth/authentication-methods', async (c, next) => {
   const profile = await getRateLimitProfileAsync(c.env, 'lenient');
   return rateLimitMiddleware({
     ...profile,
-    endpoints: ['/api/auth/login-methods'],
+    endpoints: ['/api/auth/authentication-methods'],
   })(c, next);
 });
-app.get('/api/auth/login-methods', getLoginMethodsHandler);
+app.get('/api/auth/authentication-methods', getAuthenticationMethodsHandler);
 app.use('/api/auth/discovery', async (c, next) => {
   const profile = await getRateLimitProfileAsync(c.env, 'lenient');
   return rateLimitMiddleware({

--- a/test/environment-validation/README.md
+++ b/test/environment-validation/README.md
@@ -86,7 +86,7 @@ Main checks:
 - `GET /.well-known/openid-configuration`
 - `GET /.well-known/jwks.json`
 - `GET /api/auth/health`
-- `GET /api/auth/login-methods`
+- `GET /api/auth/authentication-methods`
 - `GET /authorize` expects OP_AUTH `invalid_request`, not router 404
 - `GET /auth/login-challenge?challenge_id=...` expects OP_AUTH `invalid_request`, not router 404
 - when Login UI is enabled, the same OIDC browser-helper probes are also run against the Login UI

--- a/test/setup-portability/README.md
+++ b/test/setup-portability/README.md
@@ -80,7 +80,7 @@ Main checks:
 - `GET /.well-known/openid-configuration`
 - `GET /.well-known/jwks.json`
 - `GET /api/auth/health`
-- `GET /api/auth/login-methods`
+- `GET /api/auth/authentication-methods`
 
 ## Admin API smoke
 


### PR DESCRIPTION
## Summary
- Rename the public Login UI endpoint from `/api/auth/login-methods` to `/api/auth/authentication-methods`.
- Rename the ar-management handler and tests to authentication methods terminology.
- Update Login UI fetch usage, tenant URL tests, and environment validation docs.

## Notes
- This intentionally leaves the persisted settings category and keys as `login-methods` for a separate, smaller follow-up.
- No backward-compatible public route is added, following the current no-compatibility migration direction.

## Validation
- `pnpm --filter @authrim/ar-management test -- authentication-methods`
- `pnpm --filter @authrim/ar-lib-core test -- tenant-context`
- `pnpm --filter @authrim/ar-login-ui test`
- `pnpm --filter @authrim/ar-login-ui typecheck`
- `pnpm --filter @authrim/ar-login-ui lint`
- `pnpm --filter @authrim/ar-management typecheck`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

Note: local Login UI tests/builds emit web font fetch warnings under restricted network access, but the commands completed successfully.