### PR TITLE
Read directory password authentication settings

### DIFF
--- a/packages/ar-auth/src/__tests__/directory-password-live-wordwarden.test.ts
+++ b/packages/ar-auth/src/__tests__/directory-password-live-wordwarden.test.ts
@@ -58,10 +58,10 @@ function createContext() {
   const headers = new Headers();
   const env = {
     AUTHRIM_CONFIG: createKV({
-      'settings:tenant:tenant-a:login-methods': {
-        'login-methods.directory_password.enabled': true,
-        'login-methods.directory_password.connector_id': 'campus',
-        'login-methods.directory_password.auto_provision': true,
+      'settings:tenant:tenant-a:authentication-methods': {
+        'authentication-methods.directory_password.enabled': true,
+        'authentication-methods.directory_password.connector_id': 'campus',
+        'authentication-methods.directory_password.auto_provision': true,
       },
       'settings:tenant:tenant-a:directory-connectors': {
         'directory-connectors.campus.endpoint_url': 'http://127.0.0.1:8080',

--- a/packages/ar-auth/src/__tests__/directory-password-login.test.ts
+++ b/packages/ar-auth/src/__tests__/directory-password-login.test.ts
@@ -64,9 +64,9 @@ function createContext(body: Record<string, unknown>, settings?: Record<string, 
   const headers = new Headers();
   const env = {
     AUTHRIM_CONFIG: createKV({
-      'settings:tenant:tenant-a:login-methods': {
-        'login-methods.directory_password.enabled': true,
-        'login-methods.directory_password.connector_id': 'campus',
+      'settings:tenant:tenant-a:authentication-methods': {
+        'authentication-methods.directory_password.enabled': true,
+        'authentication-methods.directory_password.connector_id': 'campus',
       },
       'settings:tenant:tenant-a:directory-connectors': {
         'directory-connectors.campus.endpoint_url': 'https://wordwarden.example.com',
@@ -165,10 +165,10 @@ describe('directory password login handler', () => {
       createContext(
         { username: 'alice', password: 'correct' },
         {
-          'settings:tenant:tenant-a:login-methods': {
-            'login-methods.directory_password.enabled': true,
-            'login-methods.directory_password.connector_id': 'campus',
-            'login-methods.directory_password.auto_provision': true,
+          'settings:tenant:tenant-a:authentication-methods': {
+            'authentication-methods.directory_password.enabled': true,
+            'authentication-methods.directory_password.connector_id': 'campus',
+            'authentication-methods.directory_password.auto_provision': true,
           },
         }
       ) as never
@@ -482,8 +482,8 @@ describe('directory password login handler', () => {
       createContext(
         { username: 'alice', password: 'correct' },
         {
-          'settings:tenant:tenant-a:login-methods': {
-            'login-methods.directory_password.enabled': false,
+          'settings:tenant:tenant-a:authentication-methods': {
+            'authentication-methods.directory_password.enabled': false,
           },
         }
       ) as never

--- a/packages/ar-auth/src/directory-password-login.ts
+++ b/packages/ar-auth/src/directory-password-login.ts
@@ -376,14 +376,17 @@ async function resolveDirectoryConnector(
   env: Env,
   tenantId: string
 ): Promise<ResolvedDirectoryConnector | null> {
-  const loginMethods = await readTenantSettings(env, tenantId, 'login-methods');
-  if (!normalizeBoolean(loginMethods?.['login-methods.directory_password.enabled'])) {
+  const authenticationMethods = await readTenantSettings(env, tenantId, 'authentication-methods');
+  if (
+    !normalizeBoolean(authenticationMethods?.['authentication-methods.directory_password.enabled'])
+  ) {
     return null;
   }
 
   const connectorId =
-    stringSetting(loginMethods?.['login-methods.directory_password.connector_id']) ||
-    DEFAULT_DIRECTORY_PASSWORD_CONNECTOR_ID;
+    stringSetting(
+      authenticationMethods?.['authentication-methods.directory_password.connector_id']
+    ) || DEFAULT_DIRECTORY_PASSWORD_CONNECTOR_ID;
   const connectorSettings = await readTenantSettings(env, tenantId, 'directory-connectors');
   const prefix = `directory-connectors.${connectorId}.`;
   const endpoint =
@@ -417,7 +420,7 @@ async function resolveDirectoryConnector(
       stringArraySetting(connectorSettings?.[`${prefix}attribute_names`]) ??
       DEFAULT_DIRECTORY_PASSWORD_ATTRIBUTES,
     autoProvision: normalizeBoolean(
-      loginMethods?.['login-methods.directory_password.auto_provision']
+      authenticationMethods?.['authentication-methods.directory_password.auto_provision']
     ),
   };
 }


### PR DESCRIPTION
## Summary
- Read directory password configuration from the renamed authentication-methods tenant settings category.
- Update directory password tests to use authentication-methods.directory_password.* keys.

## Validation
- pnpm --filter @authrim/ar-auth test -- directory-password-login
- pnpm --filter @authrim/ar-auth typecheck
- pnpm format:check