### PR TITLE
Smoke authentication methods endpoint in setup

### DIFF
--- a/packages/setup/src/__tests__/generated-api-smoke.test.ts
+++ b/packages/setup/src/__tests__/generated-api-smoke.test.ts
@@ -8,7 +8,7 @@ import {
   validateDiscoveryPayload,
   validateInvalidRequestPayload,
   validateJwksPayload,
-  validateLoginMethodsPayload,
+  validateAuthenticationMethodsPayload,
 } from '../core/generated-api-smoke.js';
 
 describe('generated api smoke helpers', () => {
@@ -40,7 +40,7 @@ describe('generated api smoke helpers', () => {
       'oidc-discovery',
       'jwks',
       'auth-health',
-      'login-methods',
+      'authentication-methods',
       'oidc-authorize-invalid-request',
       'oidc-login-challenge-invalid-request',
       'login-ui-oidc-authorize-proxy',
@@ -101,9 +101,9 @@ describe('generated api smoke helpers', () => {
     expect(validateJwksPayload({ keys: [] })).toEqual(['keys is empty']);
   });
 
-  it('accepts a valid login-methods payload', () => {
+  it('accepts a valid authentication-methods payload', () => {
     expect(
-      validateLoginMethodsPayload({
+      validateAuthenticationMethodsPayload({
         methods: {
           passkey: { enabled: true, capabilities: [] },
           emailCode: { enabled: true, steps: [] },

--- a/packages/setup/src/__tests__/ui-workers-deployment-smoke.test.ts
+++ b/packages/setup/src/__tests__/ui-workers-deployment-smoke.test.ts
@@ -47,7 +47,7 @@ describe('UI Workers deployment smoke tests', () => {
 
     for (const path of [
       '/callback',
-      '/api/auth/login-methods',
+      '/api/auth/authentication-methods',
       '/api/v1/auth/direct/session',
       '/handoff/finalize',
       '/logout',

--- a/packages/setup/src/core/generated-api-smoke.ts
+++ b/packages/setup/src/core/generated-api-smoke.ts
@@ -178,7 +178,7 @@ export function validateJwksPayload(payload: unknown): string[] {
   return failures;
 }
 
-export function validateLoginMethodsPayload(payload: unknown): string[] {
+export function validateAuthenticationMethodsPayload(payload: unknown): string[] {
   if (!isRecord(payload)) {
     return ['payload is not an object'];
   }
@@ -325,10 +325,10 @@ export function buildApiSmokeTargets(config: AuthrimConfig): ApiSmokeTarget[] {
       validate: (payload) => validateAuthHealthPayload(payload),
     },
     {
-      id: 'login-methods',
-      title: 'login methods endpoint',
-      path: '/api/auth/login-methods',
-      validate: (payload) => validateLoginMethodsPayload(payload),
+      id: 'authentication-methods',
+      title: 'authentication methods endpoint',
+      path: '/api/auth/authentication-methods',
+      validate: (payload) => validateAuthenticationMethodsPayload(payload),
     },
     ...buildBrowserOidcTargets(config),
   ];


### PR DESCRIPTION
## Summary
- Rename the generated API smoke target from login-methods to authentication-methods.
- Validate /api/auth/authentication-methods in setup smoke helpers and UI worker routing tests.

## Validation
- pnpm --filter @authrim/setup test -- generated-api-smoke ui-workers-deployment-smoke
- pnpm --filter @authrim/setup typecheck
- pnpm format:check