### PR TITLE
Use authentication methods wording in UI

### DIFF
--- a/packages/ar-admin-ui/src/i18n/en/admin-tenant-discovery.ts
+++ b/packages/ar-admin-ui/src/i18n/en/admin-tenant-discovery.ts
@@ -30,7 +30,7 @@ const adminTenantDiscovery = {
 	admin_tenant_discovery_entry_mode_discovery_optional_sample:
 		'Good default for gradual multi-tenant rollout.',
 	admin_tenant_discovery_entry_mode_discovery_required_description:
-		'Users must resolve a tenant before login methods are shown.',
+		'Users must resolve a tenant before authentication methods are shown.',
 	admin_tenant_discovery_entry_mode_discovery_required_sample:
 		'Use when the shared login entry should always choose a tenant first.',
 	admin_tenant_discovery_example: 'Example: {sample:string}',

--- a/packages/ar-admin-ui/src/lib/components/flow-designer/NodeConfigModal.svelte
+++ b/packages/ar-admin-ui/src/lib/components/flow-designer/NodeConfigModal.svelte
@@ -28,8 +28,8 @@
 	// Auth Method Select config (v1 selection node)
 	let authMethodSelectMethods = $state<string[]>(['password', 'passkey']);
 
-	// Login Method Select config (v1 selection node)
-	let loginMethodSelectMethods = $state<string[]>(['email', 'social']);
+	// Authentication Method Select config (v1 selection node)
+	let authenticationMethodSelectMethods = $state<string[]>(['email', 'social']);
 
 	// Check Session config (v1 declarative)
 	let sessionFact = $state('session.authenticated');
@@ -39,7 +39,7 @@
 	let errorAllowRetry = $state(false);
 
 	// Login config
-	let loginMethods = $state<string[]>(['password']);
+	let authenticationMethods = $state<string[]>(['password']);
 	let loginRememberMe = $state(true);
 
 	// Register config
@@ -178,7 +178,10 @@
 			} else if (node.type === 'auth_method_select') {
 				authMethodSelectMethods = (config.available_methods as string[]) || ['password', 'passkey'];
 			} else if (node.type === 'login_method_select') {
-				loginMethodSelectMethods = (config.available_methods as string[]) || ['email', 'social'];
+				authenticationMethodSelectMethods = (config.available_methods as string[]) || [
+					'email',
+					'social'
+				];
 			} else if (node.type === 'redirect') {
 				// Support new `to` semantic destination
 				redirectTo = (config.to as string) || 'post_login';
@@ -190,9 +193,9 @@
 				errorAllowRetry = config.allow_retry === true;
 			} else if (node.type === 'login') {
 				if (Array.isArray(config.methods)) {
-					loginMethods = config.methods as string[];
+					authenticationMethods = config.methods as string[];
 				} else {
-					loginMethods = ['password'];
+					authenticationMethods = ['password'];
 				}
 				loginRememberMe = config.remember_me !== false;
 			} else if (node.type === 'register') {
@@ -230,7 +233,7 @@
 				config = { available_methods: authMethodSelectMethods };
 				break;
 			case 'login_method_select':
-				config = { available_methods: loginMethodSelectMethods };
+				config = { available_methods: authenticationMethodSelectMethods };
 				break;
 			case 'mfa':
 				config = { factors: mfaFactors };
@@ -245,7 +248,7 @@
 				config = { reason: errorReason, allow_retry: errorAllowRetry };
 				break;
 			case 'login':
-				config = { methods: loginMethods, remember_me: loginRememberMe };
+				config = { methods: authenticationMethods, remember_me: loginRememberMe };
 				break;
 			case 'register':
 				config = {
@@ -341,7 +344,7 @@
 			check_risk: 'Check Risk',
 			// 3. Selection Nodes
 			auth_method_select: 'Auth Method Select',
-			login_method_select: 'Login Method Select',
+			login_method_select: 'Authentication Method Select',
 			identifier: 'Identifier',
 			profile_input: 'Profile Input',
 			custom_form: 'Custom Form',
@@ -411,7 +414,7 @@
 			// 3. Selection Nodes
 			auth_method_select:
 				'Let user choose their preferred authentication method (password, passkey, etc.).',
-			login_method_select: 'Let user choose how to login (email, social provider, etc.).',
+			login_method_select: 'Let user choose how to authenticate (email, social provider, etc.).',
 			identifier: 'Collect user identifier such as email address, phone number, or username.',
 			profile_input: 'Collect user profile information like display name or avatar.',
 			custom_form: 'Display a custom form with configurable fields.',
@@ -499,22 +502,25 @@
 		updateConfigFromForm();
 	}
 
-	function toggleLoginMethodSelect(method: string) {
-		if (loginMethodSelectMethods.includes(method)) {
-			loginMethodSelectMethods = loginMethodSelectMethods.filter((m) => m !== method);
-			if (loginMethodSelectMethods.length === 0) loginMethodSelectMethods = [method]; // At least one
+	function toggleAuthenticationMethodSelect(method: string) {
+		if (authenticationMethodSelectMethods.includes(method)) {
+			authenticationMethodSelectMethods = authenticationMethodSelectMethods.filter(
+				(m) => m !== method
+			);
+			if (authenticationMethodSelectMethods.length === 0)
+				authenticationMethodSelectMethods = [method]; // At least one
 		} else {
-			loginMethodSelectMethods = [...loginMethodSelectMethods, method];
+			authenticationMethodSelectMethods = [...authenticationMethodSelectMethods, method];
 		}
 		updateConfigFromForm();
 	}
 
-	function toggleLoginMethod(method: string) {
-		if (loginMethods.includes(method)) {
-			loginMethods = loginMethods.filter((m) => m !== method);
-			if (loginMethods.length === 0) loginMethods = [method];
+	function toggleAuthenticationMethod(method: string) {
+		if (authenticationMethods.includes(method)) {
+			authenticationMethods = authenticationMethods.filter((m) => m !== method);
+			if (authenticationMethods.length === 0) authenticationMethods = [method];
 		} else {
-			loginMethods = [...loginMethods, method];
+			authenticationMethods = [...authenticationMethods, method];
 		}
 		updateConfigFromForm();
 	}
@@ -862,7 +868,7 @@
 			</div>
 		{/if}
 
-		<!-- Login Method Select: Checkboxes (login options for user to choose) -->
+		<!-- Authentication Method Select: Checkboxes (login options for user to choose) -->
 		{#if node.type === 'login_method_select'}
 			<div class="form-group">
 				<!-- svelte-ignore a11y_label_has_associated_control -->
@@ -874,8 +880,8 @@
 						<label class="checkbox-label">
 							<input
 								type="checkbox"
-								checked={loginMethodSelectMethods.includes(option.value)}
-								onchange={() => toggleLoginMethodSelect(option.value)}
+								checked={authenticationMethodSelectMethods.includes(option.value)}
+								onchange={() => toggleAuthenticationMethodSelect(option.value)}
 							/>
 							<span>{option.label}</span>
 						</label>
@@ -962,18 +968,18 @@
 			</div>
 		{/if}
 
-		<!-- Login Methods: Checkboxes + Remember Me -->
+		<!-- Authentication Methods: Checkboxes + Remember Me -->
 		{#if node.type === 'login'}
 			<div class="form-group">
 				<!-- svelte-ignore a11y_label_has_associated_control -->
-				<label>Login Methods <span class="hint">(select one or more)</span></label>
+				<label>Authentication Methods <span class="hint">(select one or more)</span></label>
 				<div class="checkbox-group">
 					{#each [{ value: 'password', label: 'Password' }, { value: 'passkey', label: 'Passkey' }, { value: 'social', label: 'Social Login' }, { value: 'magic_link', label: 'Magic Link' }] as option (option.value)}
 						<label class="checkbox-label">
 							<input
 								type="checkbox"
-								checked={loginMethods.includes(option.value)}
-								onchange={() => toggleLoginMethod(option.value)}
+								checked={authenticationMethods.includes(option.value)}
+								onchange={() => toggleAuthenticationMethod(option.value)}
 							/>
 							<span>{option.label}</span>
 						</label>

--- a/packages/ar-admin-ui/src/lib/components/flow-designer/PropertiesPanel.svelte
+++ b/packages/ar-admin-ui/src/lib/components/flow-designer/PropertiesPanel.svelte
@@ -66,7 +66,7 @@
 			check_risk: 'Check Risk',
 			// 3. Selection Nodes
 			auth_method_select: 'Auth Method Select',
-			login_method_select: 'Login Method Select',
+			login_method_select: 'Authentication Method Select',
 			identifier: 'Identifier Input',
 			profile_input: 'Profile Input',
 			custom_form: 'Custom Form',

--- a/packages/ar-admin-ui/src/routes/admin/flows/[id]/edit/+page.svelte
+++ b/packages/ar-admin-ui/src/routes/admin/flows/[id]/edit/+page.svelte
@@ -140,7 +140,7 @@
 			check_risk: 'Check Risk',
 			// 3. Selection Nodes
 			auth_method_select: 'Auth Method Select',
-			login_method_select: 'Login Method Select',
+			login_method_select: 'Authentication Method Select',
 			identifier: 'Identifier Input',
 			profile_input: 'Profile Input',
 			custom_form: 'Custom Form',

--- a/packages/ar-login-ui/src/routes/login/+page.svelte
+++ b/packages/ar-login-ui/src/routes/login/+page.svelte
@@ -168,7 +168,7 @@
 			window.history.replaceState({}, '', newUrl.toString());
 		}
 
-		// Fetch login methods + challenge data in parallel
+		// Fetch authentication methods + challenge data in parallel
 		const urlChallengeId = $page.url.searchParams.get('challenge_id');
 		authorizationChallengeId = urlChallengeId || '';
 		samlRequestId = $page.url.searchParams.get('saml_request_id') || '';
@@ -207,7 +207,7 @@
 				externalProviders = data.methods.external.providers;
 			}
 		} catch {
-			methodsError = 'Failed to load login methods';
+			methodsError = 'Failed to load authentication methods';
 		} finally {
 			methodsLoading = false;
 		}


### PR DESCRIPTION
## Summary
- Replace remaining UI copy that referred to login methods with authentication methods wording.
- Rename local flow designer state/helpers while keeping existing flow node type identifiers unchanged.
- Update Login UI loading error copy for authentication methods.

## Validation
- pnpm --filter @authrim/ar-admin-ui format:check
- pnpm --filter @authrim/ar-admin-ui typecheck
- pnpm --filter @authrim/ar-login-ui typecheck
- pnpm format:check
- pnpm typecheck