### PR TITLE
Clean authentication methods wording in docs

### DIFF
--- a/docs/saml-production-readiness.md
+++ b/docs/saml-production-readiness.md
@@ -30,7 +30,7 @@ Authrim includes SAML 2.0 IdP and SP support for tenant-scoped deployments. The 
 - Configurable default signing-certificate subject fields for newly generated local SAML certificates, including country, state/province, locality, organization, organizational unit, and common name.
 - SP metadata import for ACS, SLO, signing certificates, encryption certificates, and RequestedAttribute data.
 - Aggregate metadata import with search, lazy loading, `mdui:Keywords` filtering, `mdui:Logo` display, and selected provider creation.
-- Provider Login UI logo URL and curated login-button icon selection for SAML/OIDC login methods.
+- Provider Login UI logo URL and curated login-button icon selection for SAML/OIDC authentication methods.
 - Metadata refresh diffing for entityID, `validUntil`, signing/encryption certificates, and SSO/SLO/ACS endpoints.
 - Built-in attribute preset catalog for common academic, federation, and enterprise SaaS profiles.
 - Response/assertion signing policy, AuthnRequest signature policy, SLO signature policy, and algorithm allow-list behavior.

--- a/docs/specification/authrim-specification.md
+++ b/docs/specification/authrim-specification.md
@@ -1788,7 +1788,7 @@ Defaults:
 LoginUI Worker route policy:
 
 - Core OAuth/OIDC endpoints such as `/authorize`, `/token`, `/userinfo`, `/introspect`, `/revoke`, `/register`, and `/.well-known/*` remain core Authrim endpoints.
-- LoginUI keeps UI-owned routes such as callback/handoff finalize, login methods proxy, Direct Auth session support, logout UI behavior, and local UI language route where applicable.
+- LoginUI keeps UI-owned routes such as callback/handoff finalize, authentication methods proxy, Direct Auth session support, logout UI behavior, and local UI language route where applicable.
 
 ## 17. Compatibility and Legacy Behavior
 

--- a/packages/ar-admin-ui/src/i18n/i18n-types.ts
+++ b/packages/ar-admin-ui/src/i18n/i18n-types.ts
@@ -27026,7 +27026,7 @@ export type TranslationFunctions = {
 	 */
 	admin_nav_resolution_center: () => LocalizedString;
 	/**
-	 * Login Methods
+	 * Authentication Methods
 	 */
 	admin_nav_login_methods: () => LocalizedString;
 	/**
@@ -37036,7 +37036,7 @@ Actual results vary by authentication flow, token TTL, and usage patterns.
 	 */
 	admin_tenant_discovery_entry_mode_discovery_optional_sample: () => LocalizedString;
 	/**
-	 * Users must resolve a tenant before login methods are shown.
+	 * Users must resolve a tenant before authentication methods are shown.
 	 */
 	admin_tenant_discovery_entry_mode_discovery_required_description: () => LocalizedString;
 	/**
@@ -51104,11 +51104,11 @@ Remove this role from {email}?
 	 */
 	admin_policy_embedding_info_desc: () => LocalizedString;
 	/**
-	 * Login Methods - Authrim Admin
+	 * Authentication Methods - Authrim Admin
 	 */
 	admin_authentication_methods_page_title: () => LocalizedString;
 	/**
-	 * Login Methods
+	 * Authentication Methods
 	 */
 	admin_authentication_methods_title: () => LocalizedString;
 	/**
@@ -51116,7 +51116,7 @@ Remove this role from {email}?
 	 */
 	admin_authentication_methods_description: (arg: { tenantId: string }) => LocalizedString;
 	/**
-	 * Failed to load login method settings
+	 * Failed to load authentication method settings
 	 */
 	admin_authentication_methods_error_load: () => LocalizedString;
 	/**

--- a/packages/ar-admin-ui/src/lib/components/flow-designer/NodeConfigModal.svelte.bak
+++ b/packages/ar-admin-ui/src/lib/components/flow-designer/NodeConfigModal.svelte.bak
@@ -27,8 +27,8 @@
 	// Auth Method Select config (v1 selection node)
 	let authMethodSelectMethods = $state<string[]>(['password', 'passkey']);
 
-	// Login Method Select config (v1 selection node)
-	let loginMethodSelectMethods = $state<string[]>(['email', 'social']);
+	// Authentication Method Select config (v1 selection node)
+	let authenticationMethodSelectMethods = $state<string[]>(['email', 'social']);
 
 	// Check Session config (v1 declarative)
 	let sessionFact = $state('session.authenticated');
@@ -38,7 +38,7 @@
 	let errorAllowRetry = $state(false);
 
 	// Login config
-	let loginMethods = $state<string[]>(['password']);
+	let authenticationMethods = $state<string[]>(['password']);
 	let loginRememberMe = $state(true);
 
 	// Register config
@@ -111,7 +111,7 @@
 			} else if (node.type === 'auth_method_select') {
 				authMethodSelectMethods = (config.available_methods as string[]) || ['password', 'passkey'];
 			} else if (node.type === 'login_method_select') {
-				loginMethodSelectMethods = (config.available_methods as string[]) || ['email', 'social'];
+				authenticationMethodSelectMethods = (config.available_methods as string[]) || ['email', 'social'];
 			} else if (node.type === 'redirect') {
 				// Support new `to` semantic destination
 				redirectTo = (config.to as string) || 'post_login';
@@ -123,9 +123,9 @@
 				errorAllowRetry = config.allow_retry === true;
 			} else if (node.type === 'login') {
 				if (Array.isArray(config.methods)) {
-					loginMethods = config.methods as string[];
+					authenticationMethods = config.methods as string[];
 				} else {
-					loginMethods = ['password'];
+					authenticationMethods = ['password'];
 				}
 				loginRememberMe = config.remember_me !== false;
 			} else if (node.type === 'register') {
@@ -163,7 +163,7 @@
 				config = { available_methods: authMethodSelectMethods };
 				break;
 			case 'login_method_select':
-				config = { available_methods: loginMethodSelectMethods };
+				config = { available_methods: authenticationMethodSelectMethods };
 				break;
 			case 'mfa':
 				config = { factors: mfaFactors };
@@ -178,7 +178,7 @@
 				config = { reason: errorReason, allow_retry: errorAllowRetry };
 				break;
 			case 'login':
-				config = { methods: loginMethods, remember_me: loginRememberMe };
+				config = { methods: authenticationMethods, remember_me: loginRememberMe };
 				break;
 			case 'register':
 				config = {
@@ -255,7 +255,7 @@
 			check_risk: 'Check Risk',
 			// 3. Selection Nodes
 			auth_method_select: 'Auth Method Select',
-			login_method_select: 'Login Method Select',
+			login_method_select: 'Authentication Method Select',
 			identifier: 'Identifier',
 			profile_input: 'Profile Input',
 			custom_form: 'Custom Form',
@@ -323,7 +323,7 @@
 			check_risk: 'Evaluate risk score based on user behavior and context signals.',
 			// 3. Selection Nodes
 			auth_method_select: 'Let user choose their preferred authentication method (password, passkey, etc.).',
-			login_method_select: 'Let user choose how to login (email, social provider, etc.).',
+			login_method_select: 'Let user choose how to authenticate (email, social provider, etc.).',
 			identifier: 'Collect user identifier such as email address, phone number, or username.',
 			profile_input: 'Collect user profile information like display name or avatar.',
 			custom_form: 'Display a custom form with configurable fields.',
@@ -423,22 +423,22 @@
 		updateConfigFromForm();
 	}
 
-	function toggleLoginMethodSelect(method: string) {
-		if (loginMethodSelectMethods.includes(method)) {
-			loginMethodSelectMethods = loginMethodSelectMethods.filter((m) => m !== method);
-			if (loginMethodSelectMethods.length === 0) loginMethodSelectMethods = [method]; // At least one
+	function toggleAuthenticationMethodSelect(method: string) {
+		if (authenticationMethodSelectMethods.includes(method)) {
+			authenticationMethodSelectMethods = authenticationMethodSelectMethods.filter((m) => m !== method);
+			if (authenticationMethodSelectMethods.length === 0) authenticationMethodSelectMethods = [method]; // At least one
 		} else {
-			loginMethodSelectMethods = [...loginMethodSelectMethods, method];
+			authenticationMethodSelectMethods = [...authenticationMethodSelectMethods, method];
 		}
 		updateConfigFromForm();
 	}
 
-	function toggleLoginMethod(method: string) {
-		if (loginMethods.includes(method)) {
-			loginMethods = loginMethods.filter((m) => m !== method);
-			if (loginMethods.length === 0) loginMethods = [method];
+	function toggleAuthenticationMethod(method: string) {
+		if (authenticationMethods.includes(method)) {
+			authenticationMethods = authenticationMethods.filter((m) => m !== method);
+			if (authenticationMethods.length === 0) authenticationMethods = [method];
 		} else {
-			loginMethods = [...loginMethods, method];
+			authenticationMethods = [...authenticationMethods, method];
 		}
 		updateConfigFromForm();
 	}
@@ -785,7 +785,7 @@
 					</div>
 				{/if}
 
-				<!-- Login Method Select: Checkboxes (login options for user to choose) -->
+				<!-- Authentication Method Select: Checkboxes (login options for user to choose) -->
 				{#if node.type === 'login_method_select'}
 					<div class="form-group">
 						<label>Available Methods <span class="hint">(login options user can select from)</span></label>
@@ -794,8 +794,8 @@
 								<label class="checkbox-label">
 									<input
 										type="checkbox"
-										checked={loginMethodSelectMethods.includes(option.value)}
-										onchange={() => toggleLoginMethodSelect(option.value)}
+										checked={authenticationMethodSelectMethods.includes(option.value)}
+										onchange={() => toggleAuthenticationMethodSelect(option.value)}
 									/>
 									<span>{option.label}</span>
 								</label>
@@ -879,17 +879,17 @@
 					</div>
 				{/if}
 
-				<!-- Login Methods: Checkboxes + Remember Me -->
+				<!-- Authentication Methods: Checkboxes + Remember Me -->
 				{#if node.type === 'login'}
 					<div class="form-group">
-						<label>Login Methods <span class="hint">(select one or more)</span></label>
+						<label>Authentication Methods <span class="hint">(select one or more)</span></label>
 						<div class="checkbox-group">
 							{#each [{ value: 'password', label: 'Password' }, { value: 'passkey', label: 'Passkey' }, { value: 'social', label: 'Social Login' }, { value: 'magic_link', label: 'Magic Link' }] as option (option.value)}
 								<label class="checkbox-label">
 									<input
 										type="checkbox"
-										checked={loginMethods.includes(option.value)}
-										onchange={() => toggleLoginMethod(option.value)}
+										checked={authenticationMethods.includes(option.value)}
+										onchange={() => toggleAuthenticationMethod(option.value)}
 									/>
 									<span>{option.label}</span>
 								</label>

--- a/packages/ar-vc/src/index.ts
+++ b/packages/ar-vc/src/index.ts
@@ -8,7 +8,7 @@
  * - DID Resolver: Resolve did:web and did:key identifiers
  *
  * Design Principles:
- * - VCs are attribute proofs, NOT login methods
+ * - VCs are attribute proofs, NOT authentication methods
  * - Raw VCs are NOT stored (data minimization)
  * - Disclosed claims are normalized to user attributes
  * - HAIP compliance for high assurance use cases


### PR DESCRIPTION
## Summary
- Replace remaining login methods wording in documentation and comments with authentication methods.
- Keep existing compatibility identifiers unchanged while cleaning tracked backup and generated comments.

## Validation
- pnpm format:check
- pnpm --filter @authrim/ar-vc typecheck
- pnpm --filter @authrim/ar-admin-ui typecheck