### PR TITLE
Clean authentication methods terminology

### DIFF
--- a/packages/ar-admin-ui/src/i18n/i18n-types.ts
+++ b/packages/ar-admin-ui/src/i18n/i18n-types.ts
@@ -51120,11 +51120,11 @@ Remove this role from {email}?
 	 */
 	admin_authentication_methods_error_load: () => LocalizedString;
 	/**
-	 * Failed to save login method settings
+	 * Failed to save authentication method settings
 	 */
 	admin_authentication_methods_error_save: () => LocalizedString;
 	/**
-	 * Login method settings saved.
+	 * Authentication method settings saved.
 	 */
 	admin_authentication_methods_saved: () => LocalizedString;
 	/**

--- a/packages/ar-admin-ui/src/i18n/ja/admin-tenant-discovery.ts
+++ b/packages/ar-admin-ui/src/i18n/ja/admin-tenant-discovery.ts
@@ -30,7 +30,7 @@ const adminTenantDiscovery = {
 	admin_tenant_discovery_entry_mode_discovery_optional_sample:
 		'Multi-tenant rolloutを段階的に進める場合の無難なdefaultです。',
 	admin_tenant_discovery_entry_mode_discovery_required_description:
-		'Login methodを表示する前に、ユーザーはtenantを解決する必要があります。',
+		'認証方法を表示する前に、ユーザーはtenantを解決する必要があります。',
 	admin_tenant_discovery_entry_mode_discovery_required_sample:
 		'Shared login entryで常に先にtenantを選ばせたい場合に使います。',
 	admin_tenant_discovery_example: '例: {sample}',

--- a/packages/ar-admin-ui/src/lib/api/admin-flows.ts
+++ b/packages/ar-admin-ui/src/lib/api/admin-flows.ts
@@ -42,7 +42,7 @@ export type GraphNodeType =
 
 	// === 3. Selection/UI Nodes ===
 	| 'auth_method_select' // Auth method selection (email or social)
-	| 'login_method_select' // Login method selection (passkey or OTP)
+	| 'login_method_select' // Authentication method selection (passkey or OTP)
 	| 'identifier' // Identifier input (email/phone/username)
 	| 'profile_input' // Profile input (name/birthdate etc)
 	| 'custom_form' // Admin-defined form

--- a/packages/ar-admin-ui/src/lib/components/flow-designer/NodePalette.svelte
+++ b/packages/ar-admin-ui/src/lib/components/flow-designer/NodePalette.svelte
@@ -119,7 +119,7 @@
 			label: 'Login Select',
 			icon: '🚪',
 			color: '#0ea5e9',
-			description: 'User selects login method',
+			description: 'User selects authentication method',
 			category: 'selection',
 			options: ['Email + Password', 'Social Login', 'Passkey', 'Enterprise SSO']
 		},

--- a/packages/ar-auth/src/flow-engine/types.ts
+++ b/packages/ar-auth/src/flow-engine/types.ts
@@ -113,7 +113,7 @@ export type GraphNodeType =
 
   // === 3. Selection/UI Nodes (selection/input nodes)===
   | 'auth_method_select' // authentication method selection (email, social, etc.)
-  | 'login_method_select' // login method selection (passkey, OTP, etc.)
+  | 'login_method_select' // authentication method selection (passkey, OTP, etc.)
   | 'identifier' // identifier input (email/phone/username)
   | 'profile_input' // profile input (name/birthdate, etc.)
   | 'custom_form' // administrator-defined form

--- a/packages/ar-lib-core/src/types/settings/authentication-methods.ts
+++ b/packages/ar-lib-core/src/types/settings/authentication-methods.ts
@@ -79,7 +79,7 @@ export const AUTHENTICATION_METHODS_SETTINGS_META: Record<
 export const AUTHENTICATION_METHODS_CATEGORY_META: CategoryMeta = {
   category: 'authentication-methods',
   label: 'Authentication Methods',
-  description: 'Login method discovery and custom external provider settings',
+  description: 'Authentication method discovery and custom external provider settings',
   settings: AUTHENTICATION_METHODS_SETTINGS_META,
 };
 

--- a/packages/ar-login-ui/src/routes/login/+page.svelte
+++ b/packages/ar-login-ui/src/routes/login/+page.svelte
@@ -44,7 +44,7 @@
 		passkeyLoading || emailCodeLoading || directoryPasswordLoading || externalIdpLoading !== null
 	);
 
-	// Login methods (from API)
+	// Authentication methods (from API)
 	let methodsLoading = $state(true);
 	let methodsError = $state('');
 	let passkeyEnabled = $state(false);

--- a/packages/ar-login-ui/src/routes/signup/+page.svelte
+++ b/packages/ar-login-ui/src/routes/signup/+page.svelte
@@ -40,7 +40,7 @@
 	let nameError = $state('');
 	let externalIdpLoading = $state<string | null>(null);
 
-	// Login methods (from API)
+	// Authentication methods (from API)
 	let methodsLoading = $state(true);
 	let passkeyEnabled = $state(false);
 	let emailCodeEnabled = $state(false);

--- a/packages/ar-management/src/__tests__/authentication-methods.test.ts
+++ b/packages/ar-management/src/__tests__/authentication-methods.test.ts
@@ -454,7 +454,7 @@ describe('Authentication Methods API', () => {
       expect(res.status).toBe(503);
       const body = (await res.json()) as any;
 
-      expect(body.error.code).toBe('NO_LOGIN_METHOD_AVAILABLE');
+      expect(body.error.code).toBe('NO_AUTHENTICATION_METHOD_AVAILABLE');
       expect(body.error.message).toBeDefined();
     });
 
@@ -468,7 +468,7 @@ describe('Authentication Methods API', () => {
 
       await app.request('/api/auth/authentication-methods', { method: 'GET' }, mockEnv);
 
-      expect(mockLogger.warn).toHaveBeenCalledWith('No login method available', {});
+      expect(mockLogger.warn).toHaveBeenCalledWith('No authentication method available', {});
     });
   });
 

--- a/packages/ar-management/src/authentication-methods.ts
+++ b/packages/ar-management/src/authentication-methods.ts
@@ -792,13 +792,13 @@ export async function getAuthenticationMethodsHandler(c: Context<{ Bindings: Env
     const directoryPasswordEnabled = directoryPassword.enabled;
     const externalEnabled = externalProviders.length > 0;
 
-    // Check if at least one method is available
+    // Check if at least one authentication method is available
     if (!passkeyEnabled && !emailCodeEnabled && !directoryPasswordEnabled && !externalEnabled) {
-      log.warn('No login method available', {});
+      log.warn('No authentication method available', {});
       const errorResponse: AuthenticationMethodsErrorResponse = {
         error: {
-          code: 'NO_LOGIN_METHOD_AVAILABLE',
-          message: 'No login method is enabled for this tenant',
+          code: 'NO_AUTHENTICATION_METHOD_AVAILABLE',
+          message: 'No authentication method is enabled for this tenant',
         },
       };
       c.header('Cache-Control', 'no-store');

--- a/packages/ar-vc/src/verifier/services/attribute-mapper.ts
+++ b/packages/ar-vc/src/verifier/services/attribute-mapper.ts
@@ -5,7 +5,7 @@
  * Implements data minimization by storing only normalized boolean/enum values.
  *
  * Design Philosophy:
- * - VC = Attribute Proof (NOT login method)
+ * - VC = Attribute Proof (NOT authentication method)
  * - Raw VC claims are discarded after verification
  * - Only normalized, policy-ready attributes are stored
  */


### PR DESCRIPTION
## Summary
- Replace remaining old login method wording in comments, descriptions, and UI copy
- Rename the no-methods API error code/message to authentication method terminology
- Keep compatibility identifiers such as login_method_select unchanged

## Validation
- pnpm --filter @authrim/ar-management test -- authentication-methods
- pnpm --filter @authrim/ar-admin-ui typecheck
- pnpm --filter @authrim/ar-login-ui typecheck
- pnpm --filter @authrim/ar-vc typecheck
- pnpm --filter @authrim/ar-auth typecheck
- pnpm --filter @authrim/ar-lib-core typecheck
- pnpm format:check
- pnpm typecheck