### PR TITLE
ci: always run setup publish workflow on main

### DIFF
--- a/.github/workflows/publish-setup.yml
+++ b/.github/workflows/publish-setup.yml
@@ -4,12 +4,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'packages/setup/**'
-      - '.github/workflows/publish-setup.yml'
 
 permissions:
-  id-token: write   # Required for OIDC trusted publishing
+  id-token: write # Required for OIDC trusted publishing
   contents: read
 
 jobs:


### PR DESCRIPTION
## Summary
- Remove the path filter from the setup npm publish workflow.
- Keep the existing package version check so main pushes only publish when @authrim/setup changes version.

## Why
Large release merges can exceed GitHub Actions path-filter diff limits, which can prevent the publish workflow from starting even when packages/setup/package.json changes. Running the workflow on every main push lets the existing version check decide whether publishing is needed.

## Validation
- pnpm exec prettier --check .github/workflows/publish-setup.yml