### PR TITLE
ci: update setup publish npm version

### DIFF
--- a/.github/workflows/publish-setup.yml
+++ b/.github/workflows/publish-setup.yml
@@ -27,8 +27,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
 
-      - name: Update npm for OIDC support
-        run: npm install -g npm@10.9.2
+      - name: Update npm for OIDC trusted publishing
+        run: npm install -g npm@11.5.1
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Update the setup package publish workflow to install npm 11.5.1 before publishing.
- Rename the step to clarify that it is for npm OIDC trusted publishing.

## Why

The `@authrim/setup` publish job reached `npm publish` but failed while using the older npm 10.9.2 CLI. Current npm trusted publishing requires npm 11.5.1 or later.

## Validation

- Ran `git diff --check -- .github/workflows/publish-setup.yml`.
- Confirmed the PR contains only `.github/workflows/publish-setup.yml`.