### PR TITLE
fix: harden admin client validation and HTTPS redirects

### DIFF
--- a/packages/ar-admin-ui/src/hooks.server.ts
+++ b/packages/ar-admin-ui/src/hooks.server.ts
@@ -63,6 +63,21 @@ function isLoopbackHost(hostname: string): boolean {
 	return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
 }
 
+const httpsRedirect: Handle = async ({ event, resolve }) => {
+	if (event.url.protocol !== 'http:' || isLoopbackHost(event.url.hostname)) {
+		return resolve(event);
+	}
+
+	const redirectUrl = new URL(event.url);
+	redirectUrl.protocol = 'https:';
+	return new Response(null, {
+		status: 308,
+		headers: {
+			Location: redirectUrl.toString()
+		}
+	});
+};
+
 function isHttpsUrl(url: string): boolean {
 	try {
 		const parsed = new URL(url);
@@ -1046,4 +1061,4 @@ const csrfProtection: Handle = async ({ event, resolve }) => {
 	return resolve(event);
 };
 
-export const handle = sequence(apiProxy, securityHeaders, csrfProtection);
+export const handle = sequence(httpsRedirect, apiProxy, securityHeaders, csrfProtection);

--- a/packages/ar-auth/src/__tests__/https-redirect.test.ts
+++ b/packages/ar-auth/src/__tests__/https-redirect.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import app from '../index';
+
+describe('auth HTTPS redirect', () => {
+  it('redirects external HTTP requests to HTTPS before route handling', async () => {
+    const response = await app.request('http://first.test.authrim.com/login');
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get('Location')).toBe('https://first.test.authrim.com/login');
+  });
+});

--- a/packages/ar-auth/src/index.ts
+++ b/packages/ar-auth/src/index.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type Context, type Next } from 'hono';
 import { cors } from 'hono/cors';
 import { secureHeaders } from 'hono/secure-headers';
 import { logger } from 'hono/logger';
@@ -96,10 +96,34 @@ function escapeHtml(value: string): string {
 
 // Create Hono app with Cloudflare Workers types
 const app = new Hono<{ Bindings: Env }>();
+
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+}
+
+function requestUsesHttp(c: Context<{ Bindings: Env }>): boolean {
+  const requestUrl = new URL(c.req.url);
+  if (requestUrl.protocol === 'http:') {
+    return true;
+  }
+
+  return (c.req.header('x-forwarded-proto') ?? '').toLowerCase() === 'http';
+}
+
+async function redirectExternalHttpToHttps(c: Context<{ Bindings: Env }>, next: Next) {
+  const requestUrl = new URL(c.req.url);
+  if (!requestUsesHttp(c) || isLoopbackHost(requestUrl.hostname)) {
+    return next();
+  }
+
+  requestUrl.protocol = 'https:';
+  return c.redirect(requestUrl.toString(), 308);
+}
 const AUTH_REQUEST_BODY_MAX_BYTES = 100 * 1024;
 
 // Middleware
 app.use('*', logger());
+app.use('*', redirectExternalHttpToHttps);
 app.use('*', requestContextMiddleware());
 app.use('*', (c, next) =>
   bodyLimit({

--- a/packages/ar-lib-core/src/types/oidc.ts
+++ b/packages/ar-lib-core/src/types/oidc.ts
@@ -279,6 +279,7 @@ export interface ClientRegistrationRequest {
   // Grant types and response types
   grant_types?: string[];
   response_types?: string[];
+  require_pkce?: boolean;
   // Application type
   application_type?: 'web' | 'native';
   // Scopes
@@ -358,6 +359,7 @@ export interface ClientRegistrationResponse {
   token_endpoint_auth_method?: string;
   grant_types?: string[];
   response_types?: string[];
+  require_pkce?: boolean;
   application_type?: string;
   scope?: string;
   subject_type?: 'public' | 'pairwise';

--- a/packages/ar-login-ui/src/hooks.server.ts
+++ b/packages/ar-login-ui/src/hooks.server.ts
@@ -17,6 +17,25 @@ interface ServiceBinding {
 	fetch(request: Request): Promise<Response>;
 }
 
+function isLoopbackHost(hostname: string): boolean {
+	return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+}
+
+const httpsRedirectHandle: Handle = async ({ event, resolve }) => {
+	if (event.url.protocol !== 'http:' || isLoopbackHost(event.url.hostname)) {
+		return resolve(event);
+	}
+
+	const redirectUrl = new URL(event.url);
+	redirectUrl.protocol = 'https:';
+	return new Response(null, {
+		status: 308,
+		headers: {
+			Location: redirectUrl.toString()
+		}
+	});
+};
+
 function isValidProxyUrl(url: string): boolean {
 	try {
 		const parsed = new URL(url);
@@ -546,4 +565,10 @@ const localeHandle: Handle = async ({ event, resolve }) => {
 	return resolve(event);
 };
 
-export const handle = sequence(apiProxyHandle, csrfHandle, localeHandle, securityHeadersHandle);
+export const handle = sequence(
+	httpsRedirectHandle,
+	apiProxyHandle,
+	csrfHandle,
+	localeHandle,
+	securityHeadersHandle
+);

--- a/packages/ar-management/src/__tests__/admin.test.ts
+++ b/packages/ar-management/src/__tests__/admin.test.ts
@@ -1510,6 +1510,27 @@ describe('Admin API Handlers', () => {
       );
     });
 
+    it('should reject invalid email syntax before persistence', async () => {
+      const mockDB = createMockDB({});
+
+      const c = createMockContext({
+        method: 'POST',
+        body: { email: 'not-an-email', name: 'Invalid Email User' },
+        db: mockDB,
+      });
+
+      await adminUserCreateHandler(c);
+
+      expect(c.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: 'invalid_request',
+          error_description: 'Email must be a valid email address',
+        }),
+        400
+      );
+      expect(mockDB.prepare).not.toHaveBeenCalled();
+    });
+
     it('should reject create when required custom field is missing', async () => {
       const mockDB = createMockDB({
         runResult: { success: true },
@@ -2839,6 +2860,92 @@ describe('Admin API Handlers', () => {
       );
     });
 
+    it('should reject non-HTTPS non-loopback redirect_uris', async () => {
+      const c = createMockContext({
+        method: 'POST',
+        body: {
+          client_name: 'Insecure Redirect Client',
+          redirect_uris: ['http://example.com/callback'],
+        },
+      });
+
+      await adminClientCreateHandler(c);
+
+      expect(c.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: 'invalid_request',
+          error_description:
+            'redirect_uris must use HTTPS except for loopback development callbacks',
+        }),
+        400
+      );
+    });
+
+    it('should reject fragment redirect_uris', async () => {
+      const c = createMockContext({
+        method: 'POST',
+        body: {
+          client_name: 'Fragment Redirect Client',
+          redirect_uris: ['https://example.com/callback#token'],
+        },
+      });
+
+      await adminClientCreateHandler(c);
+
+      expect(c.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: 'invalid_request',
+          error_description: 'redirect_uris must not contain fragment identifiers',
+        }),
+        400
+      );
+    });
+
+    it('should reject unsupported grant_types during create', async () => {
+      const c = createMockContext({
+        method: 'POST',
+        body: {
+          client_name: 'Unsupported Grant Client',
+          redirect_uris: ['https://example.com/callback'],
+          grant_types: ['authorization_code', 'password'],
+        },
+      });
+
+      await adminClientCreateHandler(c);
+
+      expect(c.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: 'invalid_request',
+          error_description: 'Unsupported grant_type: password',
+        }),
+        400
+      );
+    });
+
+    it('should require PKCE for public authorization-code clients during create', async () => {
+      const c = createMockContext({
+        method: 'POST',
+        body: {
+          client_name: 'Public Code Client',
+          redirect_uris: ['https://example.com/callback'],
+          grant_types: ['authorization_code'],
+          token_endpoint_auth_method: 'none',
+          require_pkce: false,
+        },
+      });
+
+      await adminClientCreateHandler(c);
+
+      expect(c.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: 'invalid_request',
+          error_description:
+            'require_pkce must be true for public clients using the authorization_code grant',
+        }),
+        400
+      );
+    });
+
     it('should reject invalid allowed_redirect_origins', async () => {
       const c = createMockContext({
         method: 'POST',
@@ -3377,7 +3484,114 @@ describe('Admin API Handlers', () => {
       expect(c.json).toHaveBeenCalledWith(
         expect.objectContaining({
           error: 'invalid_request',
-          error_description: 'redirect_uris must contain valid URI strings',
+          error_description: 'Invalid redirect_uri: still-not-a-uri',
+        }),
+        400
+      );
+    });
+
+    it('should reject non-HTTPS non-loopback redirect_uris during update', async () => {
+      const clientId = 'client-insecure-redirect-update';
+      const mockDB = createMockDB({
+        runResult: { success: true },
+      });
+
+      (mockDB as any)._mockStatement.first.mockResolvedValue({
+        client_id: clientId,
+        client_name: 'Existing Client',
+        redirect_uris: '["https://example.com/callback"]',
+        grant_types: '["authorization_code"]',
+        response_types: '["code"]',
+      });
+
+      const c = createMockContext({
+        method: 'PUT',
+        params: { id: clientId },
+        body: {
+          redirect_uris: ['http://example.com/callback'],
+        },
+        db: mockDB,
+      });
+
+      await adminClientUpdateHandler(c);
+
+      expect(c.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: 'invalid_request',
+          error_description:
+            'redirect_uris must use HTTPS except for loopback development callbacks',
+        }),
+        400
+      );
+    });
+
+    it('should reject unsupported grant_types during update', async () => {
+      const clientId = 'client-unsupported-grant-update';
+      const mockDB = createMockDB({
+        runResult: { success: true },
+      });
+
+      (mockDB as any)._mockStatement.first.mockResolvedValue({
+        client_id: clientId,
+        client_name: 'Existing Client',
+        redirect_uris: '["https://example.com/callback"]',
+        grant_types: '["authorization_code"]',
+        response_types: '["code"]',
+      });
+
+      const c = createMockContext({
+        method: 'PUT',
+        params: { id: clientId },
+        body: {
+          grant_types: ['authorization_code', 'password'],
+        },
+        db: mockDB,
+      });
+
+      await adminClientUpdateHandler(c);
+
+      expect(c.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: 'invalid_request',
+          error_description: 'Unsupported grant_type: password',
+        }),
+        400
+      );
+    });
+
+    it('should require PKCE for public authorization-code clients during update', async () => {
+      const clientId = 'client-public-pkce-update';
+      const mockDB = createMockDB({
+        runResult: { success: true },
+      });
+
+      (mockDB as any)._mockStatement.first.mockResolvedValue({
+        client_id: clientId,
+        client_name: 'Existing Client',
+        redirect_uris: '["https://example.com/callback"]',
+        grant_types: '["authorization_code"]',
+        response_types: '["code"]',
+        token_endpoint_auth_method: 'client_secret_basic',
+        require_pkce: 1,
+      });
+
+      const c = createMockContext({
+        method: 'PUT',
+        params: { id: clientId },
+        body: {
+          token_endpoint_auth_method: 'none',
+          require_pkce: false,
+        },
+        db: mockDB,
+      });
+
+      await adminClientUpdateHandler(c);
+
+      expect(c.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: 'invalid_request',
+          error_description:
+            'require_pkce must be true for public clients using the authorization_code grant',
         }),
         400
       );

--- a/packages/ar-management/src/__tests__/client-config.test.ts
+++ b/packages/ar-management/src/__tests__/client-config.test.ts
@@ -203,6 +203,59 @@ describe('client-config update handler', () => {
     expect(body.error_description).toContain('internal addresses');
   });
 
+  it('rejects unsupported grant types before persistence', async () => {
+    mocked.getClientCached.mockResolvedValueOnce({
+      client_id: 'client-123',
+      client_name: 'Smoke Client',
+      redirect_uris: ['https://example.com/callback'],
+      grant_types: ['authorization_code'],
+      response_types: ['code'],
+      registration_access_token_hash: 'token-hash',
+    });
+
+    const c = createMockContext({
+      body: {
+        client_id: 'client-123',
+        redirect_uris: ['https://example.com/callback'],
+        grant_types: ['authorization_code', 'password'],
+      },
+    });
+
+    const res = await clientConfigUpdateHandler(c);
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe('invalid_client_metadata');
+    expect(body.error_description).toBe('Unsupported grant_type: password');
+  });
+
+  it('rejects non-HTTPS non-loopback redirect URIs before persistence', async () => {
+    mocked.getClientCached.mockResolvedValueOnce({
+      client_id: 'client-123',
+      client_name: 'Smoke Client',
+      redirect_uris: ['https://example.com/callback'],
+      grant_types: ['authorization_code'],
+      response_types: ['code'],
+      registration_access_token_hash: 'token-hash',
+    });
+
+    const c = createMockContext({
+      body: {
+        client_id: 'client-123',
+        redirect_uris: ['http://example.com/callback'],
+      },
+    });
+
+    const res = await clientConfigUpdateHandler(c);
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe('invalid_client_metadata');
+    expect(body.error_description).toBe(
+      'redirect_uri must use HTTPS except for loopback development callbacks'
+    );
+  });
+
   it('rejects jwks_uri values that target internal addresses', async () => {
     mocked.getClientCached.mockResolvedValueOnce({
       client_id: 'client-123',

--- a/packages/ar-management/src/__tests__/https-redirect.test.ts
+++ b/packages/ar-management/src/__tests__/https-redirect.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { app } from '../index';
+
+describe('management HTTPS redirect', () => {
+  it('redirects external HTTP requests to HTTPS before route handling', async () => {
+    const response = await app.request('http://admin.test.authrim.com/admin');
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get('Location')).toBe('https://admin.test.authrim.com/admin');
+  });
+});

--- a/packages/ar-management/src/__tests__/register.test.ts
+++ b/packages/ar-management/src/__tests__/register.test.ts
@@ -234,6 +234,31 @@ describe('Dynamic Client Registration Handler', () => {
       expect(json.scope).toBe('openid profile email');
     });
 
+    it('should default require_pkce to true for public authorization code clients', async () => {
+      const requestBody = {
+        redirect_uris: ['https://example.com/callback'],
+        token_endpoint_auth_method: 'none',
+        grant_types: ['authorization_code'],
+      };
+
+      const res = await app.request(
+        '/register',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(requestBody),
+        },
+        mockEnv
+      );
+
+      expect(res.status).toBe(201);
+
+      const json = (await res.json()) as RegistrationResponse;
+      expect(json.require_pkce).toBe(true);
+    });
+
     it('uses the request host for registration_client_uri in multi-tenant mode', async () => {
       const localApp = new Hono<{ Bindings: Env }>();
       localApp.use('*', async (c, next) => {
@@ -935,6 +960,60 @@ describe('Dynamic Client Registration Handler', () => {
       const json = (await res.json()) as RegistrationResponse;
       expect(json.error).toBe('invalid_client_metadata');
       expect(json.error_description).toContain('Unsupported grant_type');
+    });
+  });
+
+  describe('Validation - require_pkce', () => {
+    it('should reject non-boolean require_pkce', async () => {
+      const requestBody = {
+        redirect_uris: ['https://example.com/callback'],
+        require_pkce: 'true',
+      };
+
+      const res = await app.request(
+        '/register',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(requestBody),
+        },
+        mockEnv
+      );
+
+      expect(res.status).toBe(400);
+
+      const json = (await res.json()) as RegistrationResponse;
+      expect(json.error).toBe('invalid_client_metadata');
+      expect(json.error_description).toContain('require_pkce must be a boolean');
+    });
+
+    it('should reject require_pkce false for public authorization code clients', async () => {
+      const requestBody = {
+        redirect_uris: ['https://example.com/callback'],
+        token_endpoint_auth_method: 'none',
+        grant_types: ['authorization_code'],
+        require_pkce: false,
+      };
+
+      const res = await app.request(
+        '/register',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(requestBody),
+        },
+        mockEnv
+      );
+
+      expect(res.status).toBe(400);
+
+      const json = (await res.json()) as RegistrationResponse;
+      expect(json.error).toBe('invalid_client_metadata');
+      expect(json.error_description).toContain('require_pkce must be true');
     });
   });
 

--- a/packages/ar-management/src/admin-clients.ts
+++ b/packages/ar-management/src/admin-clients.ts
@@ -19,6 +19,7 @@ import {
   putClient,
   buildKVKey,
   getClient,
+  GRANT_TYPES,
   getWebOriginRegistry,
   replaceWebOriginRegistry,
   validateWebOriginRegistryPayload,
@@ -42,6 +43,12 @@ type AdminClientApplicationType = 'web' | 'native' | 'spa' | 'service';
 type AdminBrowserPublicClientMode = 'strict' | 'cookie_fallback';
 type AdminBrowserRefreshTokenPolicy = 'disabled' | 'dpop_bound';
 type AdminClientChannel = 'browser' | 'native' | 'server';
+type AdminTokenEndpointAuthMethod =
+  | 'none'
+  | 'client_secret_basic'
+  | 'client_secret_post'
+  | 'client_secret_jwt'
+  | 'private_key_jwt';
 
 interface AdminOIDCIdentityMappingSelector {
   policySetId?: string;
@@ -78,6 +85,21 @@ const VALID_ATTRIBUTE_RELEASE_CONSENT_MODES = new Set([
   'until_attributes_change',
 ]);
 const VALID_ASC_TRANSFORMED_CLAIMS = new Set(DEFAULT_ASC_ALLOWED_TRANSFORMED_CLAIMS);
+const VALID_GRANT_TYPES = new Set([
+  GRANT_TYPES.AUTHORIZATION_CODE,
+  GRANT_TYPES.REFRESH_TOKEN,
+  GRANT_TYPES.CLIENT_CREDENTIALS,
+  GRANT_TYPES.DEVICE_CODE,
+  GRANT_TYPES.CIBA,
+  GRANT_TYPES.TOKEN_EXCHANGE,
+]);
+const VALID_TOKEN_ENDPOINT_AUTH_METHODS = new Set<AdminTokenEndpointAuthMethod>([
+  'none',
+  'client_secret_basic',
+  'client_secret_post',
+  'client_secret_jwt',
+  'private_key_jwt',
+]);
 const UNSUPPORTED_LEGACY_CLIENT_FIELDS = new Set([
   'app_suite',
   'trust_group_id',
@@ -179,6 +201,125 @@ function validateOptionalStrictBooleanField(
     return { ok: false, error: `${field} must be a boolean` };
   }
   return { ok: true, value };
+}
+
+function isLoopbackRedirectHost(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+}
+
+function validateRedirectUriList(
+  value: unknown,
+  field: string,
+  required: boolean
+): { ok: true; value: string[] | undefined } | { ok: false; error: string } {
+  if (value === undefined && !required) {
+    return { ok: true, value: undefined };
+  }
+  if (!Array.isArray(value) || value.length === 0) {
+    return {
+      ok: false,
+      error: required
+        ? `${field} is required and must be a non-empty array`
+        : `${field} must be a non-empty array`,
+    };
+  }
+  if (value.some((uri) => typeof uri !== 'string')) {
+    return { ok: false, error: `${field} must contain valid URI strings` };
+  }
+  if (isCharArrayLike(value)) {
+    return { ok: false, error: `${field} appears malformed. Send full URI values.` };
+  }
+
+  for (const uri of value) {
+    let parsed: URL;
+    try {
+      parsed = new URL(uri);
+    } catch {
+      return { ok: false, error: `Invalid redirect_uri: ${uri}` };
+    }
+    if (parsed.hash) {
+      return { ok: false, error: `${field} must not contain fragment identifiers` };
+    }
+    if (
+      parsed.protocol !== 'https:' &&
+      !(parsed.protocol === 'http:' && isLoopbackRedirectHost(parsed.hostname))
+    ) {
+      return {
+        ok: false,
+        error: `${field} must use HTTPS except for loopback development callbacks`,
+      };
+    }
+  }
+
+  return { ok: true, value };
+}
+
+function validateGrantTypes(
+  value: unknown,
+  field: string,
+  defaultValue?: string[]
+): { ok: true; value: string[] | undefined } | { ok: false; error: string } {
+  if (value === undefined) {
+    return { ok: true, value: defaultValue };
+  }
+  if (!Array.isArray(value) || value.some((grantType) => typeof grantType !== 'string')) {
+    return { ok: false, error: `${field} must be an array of strings` };
+  }
+  if (value.length === 0) {
+    return { ok: false, error: `${field} must be a non-empty array` };
+  }
+  if (isCharArrayLike(value)) {
+    return {
+      ok: false,
+      error: `${field} appears malformed. Send grant type values like authorization_code, not character arrays.`,
+    };
+  }
+
+  for (const grantType of value) {
+    if (!VALID_GRANT_TYPES.has(grantType)) {
+      return { ok: false, error: `Unsupported grant_type: ${grantType}` };
+    }
+  }
+
+  return { ok: true, value };
+}
+
+function validateTokenEndpointAuthMethod(
+  value: unknown,
+  field: string,
+  defaultValue?: AdminTokenEndpointAuthMethod
+): { ok: true; value: AdminTokenEndpointAuthMethod | undefined } | { ok: false; error: string } {
+  if (value === undefined) {
+    return { ok: true, value: defaultValue };
+  }
+  if (
+    typeof value !== 'string' ||
+    !VALID_TOKEN_ENDPOINT_AUTH_METHODS.has(value as AdminTokenEndpointAuthMethod)
+  ) {
+    return {
+      ok: false,
+      error: `${field} must be one of ${Array.from(VALID_TOKEN_ENDPOINT_AUTH_METHODS).join(', ')}`,
+    };
+  }
+  return { ok: true, value: value as AdminTokenEndpointAuthMethod };
+}
+
+function validatePkcePolicy(
+  grantTypes: string[],
+  tokenEndpointAuthMethod: AdminTokenEndpointAuthMethod,
+  requirePkce: unknown
+): { ok: true } | { ok: false; error: string } {
+  if (
+    tokenEndpointAuthMethod === 'none' &&
+    grantTypes.includes(GRANT_TYPES.AUTHORIZATION_CODE) &&
+    requirePkce !== true
+  ) {
+    return {
+      ok: false,
+      error: 'require_pkce must be true for public clients using the authorization_code grant',
+    };
+  }
+  return { ok: true };
 }
 
 function validateOptionalChannelArrayField(
@@ -586,32 +727,81 @@ export async function adminClientCreateHandler(c: Context<{ Bindings: Env }>) {
       );
     }
 
-    if (
-      !body.redirect_uris ||
-      !Array.isArray(body.redirect_uris) ||
-      body.redirect_uris.length === 0
-    ) {
+    const redirectUrisValidation = validateRedirectUriList(
+      body.redirect_uris,
+      'redirect_uris',
+      true
+    );
+    if (!redirectUrisValidation.ok) {
       return c.json(
         {
           error: 'invalid_request',
-          error_description: 'redirect_uris is required and must be a non-empty array',
+          error_description: redirectUrisValidation.error,
         },
         400
       );
     }
 
-    for (const uri of body.redirect_uris) {
-      try {
-        new URL(uri);
-      } catch {
-        return c.json(
-          {
-            error: 'invalid_request',
-            error_description: `Invalid redirect_uri: ${uri}`,
-          },
-          400
-        );
-      }
+    const grantTypesValidation = validateGrantTypes(body.grant_types, 'grant_types', [
+      GRANT_TYPES.AUTHORIZATION_CODE,
+    ]);
+    if (!grantTypesValidation.ok) {
+      return c.json(
+        {
+          error: 'invalid_request',
+          error_description: grantTypesValidation.error,
+        },
+        400
+      );
+    }
+
+    const tokenEndpointAuthMethodValidation = validateTokenEndpointAuthMethod(
+      body.token_endpoint_auth_method,
+      'token_endpoint_auth_method',
+      'client_secret_basic'
+    );
+    if (!tokenEndpointAuthMethodValidation.ok) {
+      return c.json(
+        {
+          error: 'invalid_request',
+          error_description: tokenEndpointAuthMethodValidation.error,
+        },
+        400
+      );
+    }
+
+    const requirePkceValidation = validateOptionalStrictBooleanField(
+      body.require_pkce,
+      'require_pkce'
+    );
+    if (!requirePkceValidation.ok) {
+      return c.json(
+        {
+          error: 'invalid_request',
+          error_description: requirePkceValidation.error,
+        },
+        400
+      );
+    }
+
+    const validatedRedirectUris = redirectUrisValidation.value ?? [];
+    const validatedGrantTypes = grantTypesValidation.value ?? [GRANT_TYPES.AUTHORIZATION_CODE];
+    const validatedTokenEndpointAuthMethod =
+      tokenEndpointAuthMethodValidation.value ?? 'client_secret_basic';
+
+    const pkcePolicyValidation = validatePkcePolicy(
+      validatedGrantTypes,
+      validatedTokenEndpointAuthMethod,
+      requirePkceValidation.value ?? false
+    );
+    if (!pkcePolicyValidation.ok) {
+      return c.json(
+        {
+          error: 'invalid_request',
+          error_description: pkcePolicyValidation.error,
+        },
+        400
+      );
     }
 
     let validatedAllowedOrigins: string[] | undefined;
@@ -1007,8 +1197,8 @@ export async function adminClientCreateHandler(c: Context<{ Bindings: Env }>) {
       device_secret_introspection_enabled: deviceSecretIntrospectionEnabledValidation.value,
       device_secret_introspection_trust_groups:
         deviceSecretIntrospectionTrustGroupsValidation.value,
-      redirect_uris: body.redirect_uris,
-      grant_types: body.grant_types || ['authorization_code'],
+      redirect_uris: validatedRedirectUris,
+      grant_types: validatedGrantTypes,
       response_types: body.response_types || ['code'],
       scope: body.scope || 'openid profile email',
       logo_uri: body.logo_uri || null,
@@ -1016,13 +1206,7 @@ export async function adminClientCreateHandler(c: Context<{ Bindings: Env }>) {
       policy_uri: body.policy_uri || null,
       tos_uri: body.tos_uri || null,
       contacts: body.contacts || null,
-      token_endpoint_auth_method:
-        (body.token_endpoint_auth_method as
-          | 'none'
-          | 'client_secret_basic'
-          | 'client_secret_post'
-          | 'client_secret_jwt'
-          | 'private_key_jwt') || 'client_secret_basic',
+      token_endpoint_auth_method: validatedTokenEndpointAuthMethod,
       subject_type: (body.subject_type as 'public' | 'pairwise') || 'public',
       sector_identifier_uri: body.sector_identifier_uri || null,
       is_trusted: body.is_trusted || false,
@@ -1045,7 +1229,7 @@ export async function adminClientCreateHandler(c: Context<{ Bindings: Env }>) {
       default_audience: body.default_audience ?? null,
       default_resource: defaultResourceValidation.value,
       allowed_redirect_origins: validatedAllowedOrigins,
-      require_pkce: body.require_pkce || false,
+      require_pkce: requirePkceValidation.value ?? false,
     });
 
     let webOriginRegistry: WebOriginRegistryDocument = { origins: [] };
@@ -1565,59 +1749,75 @@ export async function adminClientUpdateHandler(c: Context<{ Bindings: Env }>) {
       }
     }
 
-    if (redirect_uris !== undefined) {
-      if (!Array.isArray(redirect_uris) || redirect_uris.length === 0) {
-        return c.json(
-          {
-            error: 'invalid_request',
-            error_description: 'redirect_uris must be a non-empty array',
-          },
-          400
-        );
-      }
-
-      const hasInvalidUri = redirect_uris.some((uri) => {
-        if (typeof uri !== 'string') return true;
-        try {
-          new URL(uri);
-          return false;
-        } catch {
-          return true;
-        }
-      });
-
-      if (hasInvalidUri) {
-        return c.json(
-          {
-            error: 'invalid_request',
-            error_description: 'redirect_uris must contain valid URI strings',
-          },
-          400
-        );
-      }
+    const redirectUrisValidation = validateRedirectUriList(redirect_uris, 'redirect_uris', false);
+    if (!redirectUrisValidation.ok) {
+      return c.json(
+        {
+          error: 'invalid_request',
+          error_description: redirectUrisValidation.error,
+        },
+        400
+      );
     }
 
-    if (grant_types !== undefined) {
-      if (!Array.isArray(grant_types) || grant_types.some((v) => typeof v !== 'string')) {
-        return c.json(
-          {
-            error: 'invalid_request',
-            error_description: 'grant_types must be an array of strings',
-          },
-          400
-        );
-      }
+    const grantTypesValidation = validateGrantTypes(grant_types, 'grant_types');
+    if (!grantTypesValidation.ok) {
+      return c.json(
+        {
+          error: 'invalid_request',
+          error_description: grantTypesValidation.error,
+        },
+        400
+      );
+    }
 
-      if (isCharArrayLike(grant_types)) {
-        return c.json(
-          {
-            error: 'invalid_request',
-            error_description:
-              'grant_types appears malformed. Send grant type values like authorization_code, not character arrays.',
-          },
-          400
-        );
-      }
+    const tokenEndpointAuthMethodValidation = validateTokenEndpointAuthMethod(
+      token_endpoint_auth_method,
+      'token_endpoint_auth_method'
+    );
+    if (!tokenEndpointAuthMethodValidation.ok) {
+      return c.json(
+        {
+          error: 'invalid_request',
+          error_description: tokenEndpointAuthMethodValidation.error,
+        },
+        400
+      );
+    }
+
+    const requirePkceValidation = validateOptionalStrictBooleanField(require_pkce, 'require_pkce');
+    if (!requirePkceValidation.ok) {
+      return c.json(
+        {
+          error: 'invalid_request',
+          error_description: requirePkceValidation.error,
+        },
+        400
+      );
+    }
+
+    const effectiveGrantTypes =
+      grantTypesValidation.value ??
+      parseClientStringArray(existingClient.grant_types, [GRANT_TYPES.AUTHORIZATION_CODE]);
+    const effectiveTokenEndpointAuthMethod =
+      tokenEndpointAuthMethodValidation.value ??
+      existingClient.token_endpoint_auth_method ??
+      'client_secret_basic';
+    const effectiveRequirePkce =
+      requirePkceValidation.value ?? Boolean(existingClient.require_pkce);
+    const pkcePolicyValidation = validatePkcePolicy(
+      effectiveGrantTypes,
+      effectiveTokenEndpointAuthMethod,
+      effectiveRequirePkce
+    );
+    if (!pkcePolicyValidation.ok) {
+      return c.json(
+        {
+          error: 'invalid_request',
+          error_description: pkcePolicyValidation.error,
+        },
+        400
+      );
     }
 
     if (response_types !== undefined) {
@@ -2034,10 +2234,10 @@ export async function adminClientUpdateHandler(c: Context<{ Bindings: Env }>) {
       ? await authCtx.repositories.client.update(clientId, {
           client_name,
           description: descriptionValidation.value,
-          redirect_uris,
-          grant_types,
+          redirect_uris: redirectUrisValidation.value,
+          grant_types: grantTypesValidation.value,
           response_types,
-          token_endpoint_auth_method,
+          token_endpoint_auth_method: tokenEndpointAuthMethodValidation.value,
           scope,
           logo_uri,
           client_uri,
@@ -2055,7 +2255,7 @@ export async function adminClientUpdateHandler(c: Context<{ Bindings: Env }>) {
           asc_transformed_claims_enabled: ascTransformedClaimsEnabledValidation.value ?? undefined,
           asc_allowed_transformed_claims: ascAllowedTransformedClaimsValidation.value,
           allowed_redirect_origins: validatedAllowedOrigins,
-          require_pkce,
+          require_pkce: requirePkceValidation.value,
           initiate_login_uri,
           login_ui_url,
           application_type: applicationTypeValidation.value,

--- a/packages/ar-management/src/admin-users.ts
+++ b/packages/ar-management/src/admin-users.ts
@@ -98,6 +98,50 @@ function userTypeFromAccountType(accountType: string): string {
   return 'end_user';
 }
 
+function normalizeAdminEmailInput(
+  email: unknown
+): { ok: true; value: string } | { ok: false; error: string } {
+  if (typeof email !== 'string') {
+    return { ok: false, error: 'Email is required' };
+  }
+
+  const normalized = email.trim();
+  if (!normalized) {
+    return { ok: false, error: 'Email is required' };
+  }
+  if (normalized.length > 254 || /[\s\x00-\x1f\x7f]/.test(normalized)) {
+    return { ok: false, error: 'Email must be a valid email address' };
+  }
+
+  const parts = normalized.split('@');
+  if (parts.length !== 2) {
+    return { ok: false, error: 'Email must be a valid email address' };
+  }
+
+  const [localPart, domain] = parts;
+  if (!localPart || localPart.length > 64 || !domain || domain.length > 253) {
+    return { ok: false, error: 'Email must be a valid email address' };
+  }
+  if (localPart.startsWith('.') || localPart.endsWith('.') || localPart.includes('..')) {
+    return { ok: false, error: 'Email must be a valid email address' };
+  }
+
+  const labels = domain.split('.');
+  const validDomain =
+    labels.length >= 2 &&
+    labels.every(
+      (label) =>
+        label.length > 0 &&
+        label.length <= 63 &&
+        /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/.test(label)
+    );
+  if (!validDomain) {
+    return { ok: false, error: 'Email must be a valid email address' };
+  }
+
+  return { ok: true, value: normalized };
+}
+
 function addressPartsFromProjection(projection: CanonicalRuntimeUserProjection): {
   formatted: string | null;
   street_address: string | null;
@@ -648,15 +692,17 @@ export async function adminUserCreateHandler(c: Context<{ Bindings: Env }>) {
     } = body;
     const customFieldInput = extractCustomClaimInput(body, ADMIN_USER_CREATE_RESERVED_FIELDS);
 
-    if (!email) {
+    const emailValidation = normalizeAdminEmailInput(email);
+    if (!emailValidation.ok) {
       return c.json(
         {
           error: 'invalid_request',
-          error_description: 'Email is required',
+          error_description: emailValidation.error,
         },
         400
       );
     }
+    const normalizedEmail = emailValidation.value;
 
     const tenantId = getTenantIdFromContext(c);
     const customClaimSources = await resolveCustomClaimRuntimeSourcesFromEnv(c.env, tenantId);
@@ -675,7 +721,7 @@ export async function adminUserCreateHandler(c: Context<{ Bindings: Env }>) {
           AND value_json = ?
           AND lifecycle_state = 'active'
         LIMIT 1`,
-      [tenantId, JSON.stringify(email)]
+      [tenantId, JSON.stringify(normalizedEmail)]
     );
 
     if (emailExists) {
@@ -726,7 +772,7 @@ export async function adminUserCreateHandler(c: Context<{ Bindings: Env }>) {
           user_type: typeof user_type === 'string' ? user_type : 'end_user',
         },
         {
-          email,
+          email: normalizedEmail,
           phone_number: phone_number ?? null,
           name: name ?? null,
           given_name: given_name ?? null,

--- a/packages/ar-management/src/client-config.ts
+++ b/packages/ar-management/src/client-config.ts
@@ -34,8 +34,22 @@ import {
   buildKVKey,
   getTenantIdFromContext,
   validateWebhookUrl,
+  GRANT_TYPES,
 } from '@authrim/ar-lib-core';
 import { getRequestAwareIssuerUrl } from './request-issuer';
+
+const VALID_GRANT_TYPES: ReadonlySet<string> = new Set([
+  GRANT_TYPES.AUTHORIZATION_CODE,
+  GRANT_TYPES.REFRESH_TOKEN,
+  GRANT_TYPES.CLIENT_CREDENTIALS,
+  GRANT_TYPES.DEVICE_CODE,
+  GRANT_TYPES.CIBA,
+  GRANT_TYPES.TOKEN_EXCHANGE,
+]);
+
+function isLoopbackRedirectHost(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+}
 
 /**
  * Validate URI for security (HTTPS required, no fragments, no dangerous schemes)
@@ -54,9 +68,9 @@ function validateSecureUri(uri: string, fieldName: string): string | null {
       return `${fieldName} must use HTTP or HTTPS scheme`;
     }
 
-    // HTTPS required (allow http://localhost for development only)
-    if (parsed.protocol !== 'https:' && parsed.hostname !== 'localhost') {
-      return `${fieldName} must use HTTPS (except localhost for development)`;
+    // HTTPS required (allow loopback HTTP for development only)
+    if (parsed.protocol !== 'https:' && !isLoopbackRedirectHost(parsed.hostname)) {
+      return `${fieldName} must use HTTPS except for loopback development callbacks`;
     }
 
     // Fragment identifiers not allowed (security: prevents token leakage via Referer)
@@ -161,6 +175,20 @@ function validateUpdateRequest(
         error_description:
           'grant_types appears malformed. Send grant type values, not character arrays.',
       };
+    }
+    if (body.grant_types.length === 0) {
+      return {
+        error: 'invalid_client_metadata',
+        error_description: 'grant_types must be a non-empty array',
+      };
+    }
+    for (const grantType of body.grant_types) {
+      if (!VALID_GRANT_TYPES.has(grantType)) {
+        return {
+          error: 'invalid_client_metadata',
+          error_description: `Unsupported grant_type: ${grantType}`,
+        };
+      }
     }
   }
 

--- a/packages/ar-management/src/index.ts
+++ b/packages/ar-management/src/index.ts
@@ -54,6 +54,29 @@ import { processScheduledAdminJobQueues } from './scheduled-admin-jobs';
 
 const VERSION_MANAGER_ERROR_BODY_MAX_BYTES = 64 * 1024;
 
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+}
+
+function requestUsesHttp(c: Context<{ Bindings: Env }>): boolean {
+  const requestUrl = new URL(c.req.url);
+  if (requestUrl.protocol === 'http:') {
+    return true;
+  }
+
+  return (c.req.header('x-forwarded-proto') ?? '').toLowerCase() === 'http';
+}
+
+async function redirectExternalHttpToHttps(c: Context<{ Bindings: Env }>, next: Next) {
+  const requestUrl = new URL(c.req.url);
+  if (!requestUsesHttp(c) || isLoopbackHost(requestUrl.hostname)) {
+    return next();
+  }
+
+  requestUrl.protocol = 'https:';
+  return c.redirect(requestUrl.toString(), 308);
+}
+
 // Import handlers
 import { registerHandler } from './register';
 import {
@@ -827,6 +850,7 @@ const loadPlugins = createPluginLoader([
 ]);
 
 // Middleware
+app.use('*', redirectExternalHttpToHttps);
 app.use('*', logger());
 app.use('*', requestContextMiddleware());
 app.use('*', pluginContextMiddleware({ loadPlugins }));

--- a/packages/ar-management/src/register.ts
+++ b/packages/ar-management/src/register.ts
@@ -45,6 +45,14 @@ import {
 } from '@authrim/ar-lib-core';
 import { getRequestAwareIssuerUrl } from './request-issuer';
 
+type ClientRegistrationRequestWithPkce = ClientRegistrationRequest & {
+  require_pkce?: boolean;
+};
+
+type ClientRegistrationResponseWithPkce = ClientRegistrationResponse & {
+  require_pkce: boolean;
+};
+
 function getContextTenantId(c: Context<{ Bindings: Env }>): string | null {
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
@@ -148,7 +156,9 @@ interface RegistrationValidationOptions {
 function validateRegistrationRequest(
   body: unknown,
   options: RegistrationValidationOptions = {}
-): { valid: true; data: ClientRegistrationRequest } | { valid: false; error: OAuthErrorResponse } {
+):
+  | { valid: true; data: ClientRegistrationRequestWithPkce }
+  | { valid: false; error: OAuthErrorResponse } {
   if (!body || typeof body !== 'object') {
     return {
       valid: false,
@@ -159,7 +169,7 @@ function validateRegistrationRequest(
     };
   }
 
-  const data = body as Partial<ClientRegistrationRequest>;
+  const data = body as Partial<ClientRegistrationRequestWithPkce>;
   const rawData = body as Record<string, unknown>;
 
   // Public runtime registration does not accept internal trust_group fields.
@@ -254,7 +264,7 @@ function validateRegistrationRequest(
   // Validate optional URI fields
   const uriFields = ['client_uri', 'logo_uri', 'tos_uri', 'policy_uri'];
   for (const field of uriFields) {
-    const value = data[field as keyof ClientRegistrationRequest];
+    const value = data[field as keyof ClientRegistrationRequestWithPkce];
     if (value !== undefined) {
       if (typeof value !== 'string') {
         return {
@@ -386,6 +396,33 @@ function validateRegistrationRequest(
         };
       }
     }
+  }
+
+  if (data.require_pkce !== undefined && typeof data.require_pkce !== 'boolean') {
+    return {
+      valid: false,
+      error: {
+        error: 'invalid_client_metadata',
+        error_description: 'require_pkce must be a boolean',
+      },
+    };
+  }
+
+  const effectiveTokenEndpointAuthMethod = data.token_endpoint_auth_method || 'client_secret_basic';
+  const effectiveGrantTypes = data.grant_types || ['authorization_code'];
+  if (
+    effectiveTokenEndpointAuthMethod === 'none' &&
+    effectiveGrantTypes.includes('authorization_code') &&
+    data.require_pkce === false
+  ) {
+    return {
+      valid: false,
+      error: {
+        error: 'invalid_client_metadata',
+        error_description:
+          'require_pkce must be true for public clients using the authorization_code grant',
+      },
+    };
   }
 
   // Validate response_types
@@ -796,7 +833,7 @@ function validateRegistrationRequest(
 
   return {
     valid: true,
-    data: data as ClientRegistrationRequest,
+    data: data as ClientRegistrationRequestWithPkce,
   };
 }
 
@@ -863,8 +900,9 @@ async function storeClient(
       logout_webhook_uri, logout_webhook_secret_encrypted,
       initiate_login_uri, registration_access_token_hash,
       software_id, software_version, requestable_scopes,
+      require_pkce,
       tenant_id, created_at, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `,
     [
       clientId,
@@ -929,6 +967,7 @@ async function storeClient(
       metadata.software_id || null,
       metadata.software_version || null,
       metadata.requestable_scopes ? JSON.stringify(metadata.requestable_scopes) : null,
+      metadata.require_pkce ? 1 : 0,
       // Tenant ID
       metadataTenantId,
       metadata.created_at || now,
@@ -1074,6 +1113,9 @@ export async function registerHandler(c: Context<{ Bindings: Env }>): Promise<Re
     const grantTypes = request.grant_types || ['authorization_code'];
     const responseTypes = request.response_types || ['code'];
     const applicationType = request.application_type || 'web';
+    const requirePkce =
+      request.require_pkce ??
+      (tokenEndpointAuthMethod === 'none' && grantTypes.includes('authorization_code'));
 
     // Determine if client is trusted based on redirect_uri domain
     // Trusted clients can skip consent screens (First-Party clients)
@@ -1091,7 +1133,7 @@ export async function registerHandler(c: Context<{ Bindings: Env }>): Promise<Re
     });
 
     // Build response
-    const response: ClientRegistrationResponse = {
+    const response: ClientRegistrationResponseWithPkce = {
       client_id: clientId,
       client_secret: clientSecret,
       client_id_issued_at: issuedAt,
@@ -1100,6 +1142,7 @@ export async function registerHandler(c: Context<{ Bindings: Env }>): Promise<Re
       token_endpoint_auth_method: tokenEndpointAuthMethod,
       grant_types: grantTypes,
       response_types: responseTypes,
+      require_pkce: requirePkce,
       application_type: applicationType,
     };
 

--- a/packages/ar-router/src/__tests__/router.test.ts
+++ b/packages/ar-router/src/__tests__/router.test.ts
@@ -60,6 +60,24 @@ describe('Router Worker', () => {
     });
   });
 
+  describe('HTTPS Redirect', () => {
+    it('redirects external HTTP requests before routing to service bindings', async () => {
+      const req = new Request('http://first.example.com/login');
+      const res = await app.fetch(req, mockEnv);
+
+      expect(res.status).toBe(308);
+      expect(res.headers.get('Location')).toBe('https://first.example.com/login');
+      expect(mockEnv.OP_AUTH.fetch).not.toHaveBeenCalled();
+    });
+
+    it('allows loopback HTTP requests for local development', async () => {
+      const req = new Request('http://localhost/api/health');
+      const res = await app.fetch(req, mockEnv);
+
+      expect(res.status).toBe(200);
+    });
+  });
+
   describe('Path Routing', () => {
     describe('OP_DISCOVERY routes', () => {
       it('should route /.well-known/openid-configuration to OP_DISCOVERY', async () => {

--- a/packages/ar-router/src/index.ts
+++ b/packages/ar-router/src/index.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type Context, type Next } from 'hono';
 import { cors } from 'hono/cors';
 import { secureHeaders } from 'hono/secure-headers';
 import { logger } from 'hono/logger';
@@ -235,6 +235,29 @@ async function proxyToUiWorker(
 // Create Hono app with Cloudflare Workers types
 const app = new Hono<{ Bindings: Env }>();
 
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+}
+
+function requestUsesHttp(c: Context<{ Bindings: Env }>): boolean {
+  const requestUrl = new URL(c.req.url);
+  if (requestUrl.protocol === 'http:') {
+    return true;
+  }
+
+  return (c.req.header('x-forwarded-proto') ?? '').toLowerCase() === 'http';
+}
+
+async function redirectExternalHttpToHttps(c: Context<{ Bindings: Env }>, next: Next) {
+  const requestUrl = new URL(c.req.url);
+  if (!requestUsesHttp(c) || isLoopbackHost(requestUrl.hostname)) {
+    return next();
+  }
+
+  requestUrl.protocol = 'https:';
+  return c.redirect(requestUrl.toString(), 308);
+}
+
 function notFoundResponse(): Response {
   return Response.json(
     {
@@ -246,6 +269,7 @@ function notFoundResponse(): Response {
 }
 
 // Middleware
+app.use('*', redirectExternalHttpToHttps);
 app.use('*', logger());
 
 // Enhanced security headers

--- a/scripts/backfill-openapi-route-stubs.mjs
+++ b/scripts/backfill-openapi-route-stubs.mjs
@@ -147,6 +147,33 @@ function parameterName(segment) {
   return segment.slice(1, -1);
 }
 
+function decodePointerPart(part) {
+  return part.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+function resolvePointer(document, pointer) {
+  return pointer
+    .split('/')
+    .slice(1)
+    .map(decodePointerPart)
+    .reduce((value, key) => (value == null ? undefined : value[key]), document);
+}
+
+function resolveParameter(doc, parameter) {
+  if (parameter?.$ref?.startsWith('#/')) {
+    return resolvePointer(doc, parameter.$ref.slice(1));
+  }
+  return parameter;
+}
+
+function parameterKey(doc, parameter) {
+  const resolved = resolveParameter(doc, parameter);
+  if (!resolved?.name || !resolved?.in) {
+    return null;
+  }
+  return `${resolved.in}:${resolved.name}`;
+}
+
 function pathParameters(routePath) {
   return routePath
     .split('/')
@@ -159,12 +186,48 @@ function pathParameters(routePath) {
     }));
 }
 
-function declaredPathParameterNames(pathItem, operation) {
+function declaredPathParameterNames(doc, pathItem, operation) {
   return new Set(
     [...(pathItem.parameters ?? []), ...(operation.parameters ?? [])]
+      .map((parameter) => resolveParameter(doc, parameter))
       .filter((parameter) => parameter?.in === 'path')
       .map((parameter) => parameter.name)
   );
+}
+
+function dedupeOperationParameters(doc, pathItem, operation) {
+  if (!operation.parameters) {
+    return 0;
+  }
+
+  const pathItemKeys = new Set(
+    (pathItem.parameters ?? []).map((parameter) => parameterKey(doc, parameter)).filter(Boolean)
+  );
+  const operationKeys = new Set();
+  const nextParameters = [];
+  let removed = 0;
+
+  for (const parameter of operation.parameters) {
+    const key = parameterKey(doc, parameter);
+    if (key && (pathItemKeys.has(key) || operationKeys.has(key))) {
+      removed += 1;
+      continue;
+    }
+    if (key) {
+      operationKeys.add(key);
+    }
+    nextParameters.push(parameter);
+  }
+
+  if (removed > 0) {
+    if (nextParameters.length > 0) {
+      operation.parameters = nextParameters;
+    } else {
+      delete operation.parameters;
+    }
+  }
+
+  return removed;
 }
 
 function ensurePathParameters(doc) {
@@ -181,8 +244,12 @@ function ensurePathParameters(doc) {
         continue;
       }
 
-      const declaredNames = declaredPathParameterNames(pathItem, operation);
-      const missingParameters = expectedParameters.filter((parameter) => !declaredNames.has(parameter.name));
+      changed += dedupeOperationParameters(doc, pathItem, operation);
+
+      const declaredNames = declaredPathParameterNames(doc, pathItem, operation);
+      const missingParameters = expectedParameters.filter(
+        (parameter) => !declaredNames.has(parameter.name)
+      );
       if (missingParameters.length === 0) {
         continue;
       }
@@ -221,7 +288,7 @@ function ensureOperation(doc, packageName, route) {
       'Route coverage stub generated from the Worker route table. Replace this with a detailed request and response contract when changing this API.',
     'x-authrim-route-coverage': 'inferred-from-source',
     responses: {
-      '200': {
+      200: {
         $ref: responseRef(doc),
       },
     },
@@ -297,5 +364,5 @@ for (const [target, doc] of docs) {
 }
 
 process.stdout.write(
-  `Added ${added} OpenAPI route coverage operations and ${fixedPathParameters} path parameters.\n`
+  `Added ${added} OpenAPI route coverage operations and fixed ${fixedPathParameters} path parameter declarations.\n`
 );

--- a/scripts/validate-openapi.mjs
+++ b/scripts/validate-openapi.mjs
@@ -59,10 +59,41 @@ function collectPathParameterNames(route) {
   return [...route.matchAll(/\{([^}]+)\}/g)].map((match) => match[1]);
 }
 
-function collectDeclaredPathParameters(pathItem, operation) {
+function resolveParameter(document, parameter) {
+  if (parameter?.$ref?.startsWith('#/')) {
+    return resolvePointer(document, parameter.$ref.slice(1));
+  }
+  return parameter;
+}
+
+function parameterKey(document, parameter) {
+  const resolved = resolveParameter(document, parameter);
+  if (!resolved?.name || !resolved?.in) {
+    return null;
+  }
+  return `${resolved.in}:${resolved.name}`;
+}
+
+function collectDeclaredPathParameters(document, pathItem, operation) {
   return [...(pathItem.parameters ?? []), ...(operation.parameters ?? [])]
+    .map((parameter) => resolveParameter(document, parameter))
     .filter((parameter) => parameter?.in === 'path')
     .map((parameter) => parameter.name);
+}
+
+function assertNoDuplicateParameters(file, document, route, method, pathItem, operation) {
+  const seen = new Map();
+  for (const parameter of [...(pathItem.parameters ?? []), ...(operation.parameters ?? [])]) {
+    const key = parameterKey(document, parameter);
+    if (!key) {
+      continue;
+    }
+    assert(
+      !seen.has(key),
+      `${file}: ${method.toUpperCase()} ${route} duplicate parameter ${key}; already declared at ${seen.get(key)}`
+    );
+    seen.set(key, parameter.$ref ?? `${parameter.in}:${parameter.name}`);
+  }
 }
 
 function assert(condition, message) {
@@ -82,7 +113,10 @@ function validateDocument(file, document) {
   const operationIds = new Map();
   for (const [route, pathItem] of Object.entries(document.paths)) {
     assert(route.startsWith('/'), `${file}: path must start with /: ${route}`);
-    assert(pathItem && typeof pathItem === 'object', `${file}: path item must be an object: ${route}`);
+    assert(
+      pathItem && typeof pathItem === 'object',
+      `${file}: path item must be an object: ${route}`
+    );
 
     for (const method of ['get', 'post', 'put', 'patch', 'delete']) {
       const operation = pathItem[method];
@@ -103,7 +137,11 @@ function validateDocument(file, document) {
         operationIds.set(operation.operationId, `${method.toUpperCase()} ${route}`);
       }
 
-      const declaredPathParameters = new Set(collectDeclaredPathParameters(pathItem, operation));
+      assertNoDuplicateParameters(file, document, route, method, pathItem, operation);
+
+      const declaredPathParameters = new Set(
+        collectDeclaredPathParameters(document, pathItem, operation)
+      );
       for (const parameterName of collectPathParameterNames(route)) {
         assert(
           declaredPathParameters.has(parameterName),


### PR DESCRIPTION
## Summary

- Harden admin client redirect URI, grant type, token endpoint auth method, and PKCE validation.
- Add stricter admin user email validation before persistence.
- Redirect external HTTP requests to HTTPS across auth, management, router, admin UI, and login UI entry points while preserving loopback HTTP for local development.
- Improve OpenAPI route stub and validation scripts so duplicated or referenced parameters are handled correctly.
- Add regression tests for the validation and HTTPS redirect behavior.

## Why

ZAP and follow-up manual checks identified weak metadata validation around redirect URIs, grant types, PKCE policy, invalid admin emails, and HTTP access. These changes close those gaps and add tests that should fail if the behavior regresses.

## Validation

- pnpm exec vitest run packages/ar-management/src/__tests__/admin.test.ts packages/ar-management/src/__tests__/client-config.test.ts packages/ar-management/src/__tests__/register.test.ts packages/ar-auth/src/__tests__/https-redirect.test.ts packages/ar-management/src/__tests__/https-redirect.test.ts packages/ar-router/src/__tests__/router.test.ts