### PR TITLE
Fix dangling D1 foreign keys after table rebuilds

### DIFF
--- a/migrations/018_repair_device_code_client_foreign_key.sql
+++ b/migrations/018_repair_device_code_client_foreign_key.sql
@@ -1,0 +1,74 @@
+-- =============================================================================
+-- Authrim Core Migration 018: Repair Device Code Client Foreign Key
+-- =============================================================================
+-- device_codes was created with a reference to the removed legacy clients
+-- table. Runtime clients are tenant-scoped rows in oauth_clients, so rebuild
+-- the table with the matching composite foreign key. Device codes without a
+-- current client cannot be redeemed and are intentionally not carried over.
+
+CREATE TABLE device_codes_repaired (
+  device_code TEXT PRIMARY KEY,
+  user_code TEXT UNIQUE NOT NULL,
+  client_id TEXT NOT NULL,
+  scope TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('pending', 'approved', 'denied', 'expired')),
+  user_id TEXT,
+  sub TEXT,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  last_poll_at INTEGER,
+  token_issued INTEGER DEFAULT 0,
+  token_issued_at INTEGER,
+  poll_count INTEGER DEFAULT 0,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  FOREIGN KEY (tenant_id, client_id)
+    REFERENCES oauth_clients(tenant_id, client_id)
+    ON DELETE CASCADE
+);
+
+INSERT INTO device_codes_repaired (
+  device_code,
+  user_code,
+  client_id,
+  scope,
+  status,
+  user_id,
+  sub,
+  created_at,
+  expires_at,
+  last_poll_at,
+  token_issued,
+  token_issued_at,
+  poll_count,
+  tenant_id
+)
+SELECT
+  dc.device_code,
+  dc.user_code,
+  dc.client_id,
+  dc.scope,
+  dc.status,
+  dc.user_id,
+  dc.sub,
+  dc.created_at,
+  dc.expires_at,
+  dc.last_poll_at,
+  dc.token_issued,
+  dc.token_issued_at,
+  dc.poll_count,
+  dc.tenant_id
+FROM device_codes AS dc
+WHERE EXISTS (
+  SELECT 1
+  FROM oauth_clients AS client
+  WHERE client.tenant_id = dc.tenant_id
+    AND client.client_id = dc.client_id
+);
+
+DROP TABLE device_codes;
+ALTER TABLE device_codes_repaired RENAME TO device_codes;
+
+CREATE INDEX idx_device_codes_client_id ON device_codes(tenant_id, client_id);
+CREATE INDEX idx_device_codes_expires_at ON device_codes(expires_at);
+CREATE INDEX idx_device_codes_status ON device_codes(tenant_id, status);
+CREATE INDEX idx_device_codes_user_code ON device_codes(user_code);

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,7 +1,7 @@
 ---
 project: Authrim
 lang: en
-date: 2026-07-06
+date: 2026-07-11
 description: "Database migration layout for Authrim D1 and external PostgreSQL schemas."
 type: reference
 tags:
@@ -54,6 +54,7 @@ Top-level core migrations intentionally exclude the `admin`, `archive`,
 | `015_core_consent_screens_scopes.sql` | Consent policy, consent records, screen profiles, OIDC scopes, and consent canonical user IDs. |
 | `016_core_directory_auth.sql` | Directory identity links, connector fleet, directory-auth migration/compliance tables, release channels, and object catalog classes. |
 | `017_core_flow_runtime.sql` | Flow runtime contract, interaction context, templates, and unique assignments. |
+| `018_repair_device_code_client_foreign_key.sql` | Repairs tenant-scoped device-code client foreign keys. |
 
 ## Current Admin Files
 
@@ -68,6 +69,7 @@ Top-level core migrations intentionally exclude the `admin`, `archive`,
 | `007_identity_mapping_control_plane.sql` | Identity mapping, source profiles, destination profiles, and field catalog metadata. |
 | `008_persistent_identifier_profiles.sql` | Persistent identifier profiles and values. |
 | `009_directory_auth_object_catalog_classes.sql` | Directory-auth object catalog classes. |
+| `010_repair_approval_object_catalog_foreign_key.sql` | Repairs approval foreign keys after the object catalog rebuild. |
 
 ## Current PII Files
 

--- a/migrations/admin/010_repair_approval_object_catalog_foreign_key.sql
+++ b/migrations/admin/010_repair_approval_object_catalog_foreign_key.sql
@@ -1,0 +1,332 @@
+-- =============================================================================
+-- Authrim Admin Migration 010: Repair Approval Object Catalog Foreign Key
+-- =============================================================================
+-- Migration 009 rebuilt object_catalog by renaming the original table. SQLite
+-- propagated that rename into approval_requests, leaving its foreign key aimed
+-- at object_catalog_old after the temporary table was dropped.
+--
+-- D1 always enforces foreign keys, so rebuild the approval parent and both of
+-- its dependent tables together. The replacement child tables reference the
+-- replacement parent throughout the copy and are renamed only after the old
+-- dependency tree has been removed.
+
+CREATE TABLE approval_requests_repaired (
+  id TEXT PRIMARY KEY,
+  public_request_id TEXT NOT NULL UNIQUE,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  investigation_id TEXT NOT NULL,
+  requester_subject_type TEXT NOT NULL CHECK (
+    requester_subject_type IN ('admin_user', 'end_user', 'customer_delegate', 'service_principal')
+  ),
+  requester_subject_id TEXT NOT NULL,
+  target_subject_type TEXT NOT NULL CHECK (
+    target_subject_type IN ('user', 'artifact', 'service_resource', 'tenant_resource')
+  ),
+  target_subject_id TEXT NOT NULL,
+  request_surface TEXT NOT NULL,
+  requested_action TEXT NOT NULL,
+  redaction_level TEXT NOT NULL CHECK (redaction_level IN ('summary_only', 'masked', 'raw')),
+  status TEXT NOT NULL CHECK (
+    status IN ('pending', 'partially_approved', 'approved', 'denied', 'expired', 'cancelled')
+  ),
+  scope_canonical TEXT NOT NULL,
+  scope_json TEXT NOT NULL,
+  reason_code TEXT NOT NULL,
+  reason_note TEXT,
+  reference_system TEXT,
+  reference_value TEXT,
+  reference_url TEXT,
+  ticket_reference_system TEXT,
+  ticket_reference_value TEXT,
+  ticket_reference_url TEXT,
+  reuse_scope TEXT NOT NULL DEFAULT 'request' CHECK (reuse_scope IN ('request', 'case')),
+  policy_preset TEXT NOT NULL,
+  partial_access_allowed INTEGER NOT NULL DEFAULT 0,
+  requested_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  decided_at INTEGER,
+  detail_object_catalog_id TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (detail_object_catalog_id) REFERENCES object_catalog(id) ON DELETE SET NULL
+);
+
+CREATE TABLE approval_request_approvals_repaired (
+  id TEXT PRIMARY KEY,
+  approval_request_id TEXT NOT NULL,
+  step_key TEXT NOT NULL,
+  side TEXT NOT NULL CHECK (
+    side IN ('admin_operator', 'customer_data_owner', 'guardian_delegate')
+  ),
+  subject_type TEXT NOT NULL CHECK (
+    subject_type IN ('admin_user', 'end_user', 'customer_delegate', 'service_principal')
+  ),
+  subject_id TEXT,
+  relation_type TEXT,
+  relation_source TEXT,
+  status TEXT NOT NULL CHECK (
+    status IN ('pending', 'approved', 'denied', 'expired', 'cancelled')
+  ),
+  method TEXT CHECK (
+    method IN ('ciba', 'passkey', 'portal_confirm', 'email_otp', 'sms_otp', 'reauth')
+  ),
+  transport_channel TEXT,
+  reason_code TEXT,
+  reason_note TEXT,
+  requested_at INTEGER NOT NULL,
+  decided_at INTEGER,
+  expires_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  last_notification_action TEXT CHECK (
+    last_notification_action IN ('initial', 'resend', 'remind')
+  ),
+  last_notified_at INTEGER,
+  notification_count INTEGER NOT NULL DEFAULT 1,
+  FOREIGN KEY (approval_request_id) REFERENCES approval_requests_repaired(id) ON DELETE CASCADE
+);
+
+CREATE TABLE elevation_grants_repaired (
+  id TEXT PRIMARY KEY,
+  public_grant_id TEXT NOT NULL UNIQUE,
+  approval_request_id TEXT NOT NULL,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  status TEXT NOT NULL CHECK (status IN ('active', 'expired', 'revoked')),
+  target_audience TEXT NOT NULL,
+  resource_class TEXT NOT NULL,
+  redaction_level TEXT NOT NULL CHECK (redaction_level IN ('summary_only', 'masked', 'raw')),
+  scope_canonical TEXT NOT NULL,
+  scope_json TEXT NOT NULL,
+  authorization_details_json TEXT,
+  requester_subject_type TEXT NOT NULL CHECK (
+    requester_subject_type IN ('admin_user', 'end_user', 'customer_delegate', 'service_principal')
+  ),
+  requester_subject_id TEXT NOT NULL,
+  actor_subject_type TEXT NOT NULL CHECK (
+    actor_subject_type IN ('admin_user', 'end_user', 'customer_delegate', 'service_principal')
+  ),
+  actor_subject_id TEXT NOT NULL,
+  issued_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  revoked_at INTEGER,
+  revoke_reason TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (approval_request_id) REFERENCES approval_requests_repaired(id) ON DELETE CASCADE
+);
+
+INSERT INTO approval_requests_repaired (
+  id,
+  public_request_id,
+  tenant_id,
+  investigation_id,
+  requester_subject_type,
+  requester_subject_id,
+  target_subject_type,
+  target_subject_id,
+  request_surface,
+  requested_action,
+  redaction_level,
+  status,
+  scope_canonical,
+  scope_json,
+  reason_code,
+  reason_note,
+  reference_system,
+  reference_value,
+  reference_url,
+  ticket_reference_system,
+  ticket_reference_value,
+  ticket_reference_url,
+  reuse_scope,
+  policy_preset,
+  partial_access_allowed,
+  requested_at,
+  expires_at,
+  decided_at,
+  detail_object_catalog_id,
+  created_at,
+  updated_at
+)
+SELECT
+  id,
+  public_request_id,
+  tenant_id,
+  investigation_id,
+  requester_subject_type,
+  requester_subject_id,
+  target_subject_type,
+  target_subject_id,
+  request_surface,
+  requested_action,
+  redaction_level,
+  status,
+  scope_canonical,
+  scope_json,
+  reason_code,
+  reason_note,
+  reference_system,
+  reference_value,
+  reference_url,
+  ticket_reference_system,
+  ticket_reference_value,
+  ticket_reference_url,
+  reuse_scope,
+  policy_preset,
+  partial_access_allowed,
+  requested_at,
+  expires_at,
+  decided_at,
+  detail_object_catalog_id,
+  created_at,
+  updated_at
+FROM approval_requests;
+
+INSERT INTO approval_request_approvals_repaired (
+  id,
+  approval_request_id,
+  step_key,
+  side,
+  subject_type,
+  subject_id,
+  relation_type,
+  relation_source,
+  status,
+  method,
+  transport_channel,
+  reason_code,
+  reason_note,
+  requested_at,
+  decided_at,
+  expires_at,
+  created_at,
+  updated_at,
+  last_notification_action,
+  last_notified_at,
+  notification_count
+)
+SELECT
+  id,
+  approval_request_id,
+  step_key,
+  side,
+  subject_type,
+  subject_id,
+  relation_type,
+  relation_source,
+  status,
+  method,
+  transport_channel,
+  reason_code,
+  reason_note,
+  requested_at,
+  decided_at,
+  expires_at,
+  created_at,
+  updated_at,
+  last_notification_action,
+  last_notified_at,
+  notification_count
+FROM approval_request_approvals;
+
+INSERT INTO elevation_grants_repaired (
+  id,
+  public_grant_id,
+  approval_request_id,
+  tenant_id,
+  status,
+  target_audience,
+  resource_class,
+  redaction_level,
+  scope_canonical,
+  scope_json,
+  authorization_details_json,
+  requester_subject_type,
+  requester_subject_id,
+  actor_subject_type,
+  actor_subject_id,
+  issued_at,
+  expires_at,
+  revoked_at,
+  revoke_reason,
+  created_at,
+  updated_at
+)
+SELECT
+  id,
+  public_grant_id,
+  approval_request_id,
+  tenant_id,
+  status,
+  target_audience,
+  resource_class,
+  redaction_level,
+  scope_canonical,
+  scope_json,
+  authorization_details_json,
+  requester_subject_type,
+  requester_subject_id,
+  actor_subject_type,
+  actor_subject_id,
+  issued_at,
+  expires_at,
+  revoked_at,
+  revoke_reason,
+  created_at,
+  updated_at
+FROM elevation_grants;
+
+DROP TABLE approval_request_approvals;
+DROP TABLE elevation_grants;
+DROP TABLE approval_requests;
+
+ALTER TABLE approval_requests_repaired RENAME TO approval_requests;
+ALTER TABLE approval_request_approvals_repaired RENAME TO approval_request_approvals;
+ALTER TABLE elevation_grants_repaired RENAME TO elevation_grants;
+
+CREATE INDEX idx_approval_requests_tenant_status_requested
+  ON approval_requests(tenant_id, status, requested_at DESC);
+
+CREATE INDEX idx_approval_requests_investigation
+  ON approval_requests(investigation_id, created_at DESC);
+
+CREATE INDEX idx_approval_requests_requester
+  ON approval_requests(requester_subject_type, requester_subject_id, created_at DESC);
+
+CREATE INDEX idx_approval_requests_target
+  ON approval_requests(target_subject_type, target_subject_id, created_at DESC);
+
+CREATE INDEX idx_approval_requests_expires
+  ON approval_requests(expires_at);
+
+CREATE INDEX idx_approval_requests_detail_object_catalog
+  ON approval_requests(detail_object_catalog_id);
+
+CREATE UNIQUE INDEX idx_approval_request_approvals_unique_subject
+  ON approval_request_approvals(
+    approval_request_id,
+    step_key,
+    subject_type,
+    COALESCE(subject_id, '')
+  );
+
+CREATE INDEX idx_approval_request_approvals_request_status
+  ON approval_request_approvals(approval_request_id, status, created_at ASC);
+
+CREATE INDEX idx_approval_request_approvals_subject
+  ON approval_request_approvals(subject_type, subject_id, created_at DESC);
+
+CREATE INDEX idx_approval_request_approvals_expires
+  ON approval_request_approvals(expires_at);
+
+CREATE INDEX idx_elevation_grants_tenant_status_issued
+  ON elevation_grants(tenant_id, status, issued_at DESC);
+
+CREATE INDEX idx_elevation_grants_request
+  ON elevation_grants(approval_request_id, issued_at DESC);
+
+CREATE INDEX idx_elevation_grants_actor
+  ON elevation_grants(actor_subject_type, actor_subject_id, issued_at DESC);
+
+CREATE INDEX idx_elevation_grants_expires
+  ON elevation_grants(expires_at);

--- a/packages/setup/src/__tests__/cloudflare-migrations.test.ts
+++ b/packages/setup/src/__tests__/cloudflare-migrations.test.ts
@@ -81,9 +81,59 @@ function runMigrationFiles(sqlite3Path: string, dbPath: string, relativePaths: s
     runSqlite(
       sqlite3Path,
       dbPath,
-      renderPortableMigrationSql(readMigration(relativePath), 'sqlite')
+      `PRAGMA foreign_keys = ON;\n${renderPortableMigrationSql(
+        readMigration(relativePath),
+        'sqlite'
+      )}`
     );
   }
+}
+
+type ForeignKeyReference = {
+  sourceTable: string;
+  targetTable: string;
+};
+
+function readSqliteLines(sqlite3Path: string, dbPath: string, sql: string): string[] {
+  const output = readSqlite(sqlite3Path, dbPath, sql);
+  return output ? output.split(/\r?\n/u) : [];
+}
+
+function listForeignKeyReferences(sqlite3Path: string, dbPath: string): ForeignKeyReference[] {
+  const tableNames = readSqliteLines(
+    sqlite3Path,
+    dbPath,
+    "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name;"
+  );
+
+  return tableNames.flatMap((sourceTable) => {
+    const escapedTable = sourceTable.replaceAll("'", "''");
+    return readSqliteLines(
+      sqlite3Path,
+      dbPath,
+      `SELECT DISTINCT "table" FROM pragma_foreign_key_list('${escapedTable}') ORDER BY "table";`
+    ).map((targetTable) => ({ sourceTable, targetTable }));
+  });
+}
+
+function findInvalidForeignKeyReferences(
+  sqlite3Path: string,
+  dbPath: string
+): ForeignKeyReference[] {
+  const existingTables = new Set(
+    readSqliteLines(
+      sqlite3Path,
+      dbPath,
+      "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name;"
+    )
+  );
+
+  return listForeignKeyReferences(sqlite3Path, dbPath).filter(
+    ({ targetTable }) =>
+      !existingTables.has(targetTable) ||
+      targetTable.endsWith('_old') ||
+      targetTable.endsWith('_repaired')
+  );
 }
 
 function insertOAuthClientSql(tenantId: string, clientId: string, clientName: string): string {
@@ -106,6 +156,65 @@ INSERT INTO oauth_clients (
   '[]',
   1,
   1
+);
+`;
+}
+
+function insertApprovalRequestSql(id: string, detailObjectCatalogId: string | null = null): string {
+  const escapedId = id.replaceAll("'", "''");
+  const detailObjectCatalogSql = detailObjectCatalogId
+    ? `'${detailObjectCatalogId.replaceAll("'", "''")}'`
+    : 'NULL';
+
+  return `
+INSERT INTO approval_requests (
+  id,
+  public_request_id,
+  tenant_id,
+  investigation_id,
+  requester_subject_type,
+  requester_subject_id,
+  target_subject_type,
+  target_subject_id,
+  request_surface,
+  requested_action,
+  redaction_level,
+  status,
+  scope_canonical,
+  scope_json,
+  reason_code,
+  reuse_scope,
+  policy_preset,
+  partial_access_allowed,
+  requested_at,
+  expires_at,
+  detail_object_catalog_id,
+  created_at,
+  updated_at
+) VALUES (
+  '${escapedId}',
+  'apr-${escapedId}',
+  'default',
+  'inv-${escapedId}',
+  'service_principal',
+  'approval-smoke',
+  'user',
+  'user-${escapedId}',
+  'service_data',
+  'detail_read',
+  'masked',
+  'pending',
+  'surface=service_data&action=detail_read',
+  '{}',
+  'technical_support',
+  'request',
+  'technical_debug_default',
+  0,
+  100,
+  200,
+  ${detailObjectCatalogSql},
+  100,
+  100
 );
 `;
 }
@@ -744,6 +853,162 @@ INSERT INTO oauth_clients (
     sqliteMigrationApplyTimeoutMs
   );
 
+  for (const [databaseRole, migrationFiles] of [
+    ['core', activeCoreMigrationFiles()],
+    ['admin', activeAdminMigrationFiles()],
+    ['pii', activePiiMigrationFiles()],
+  ] as const) {
+    it(
+      `keeps every ${databaseRole} foreign-key target valid after all migrations`,
+      () => {
+        const sqlite3Path = findSqlite3();
+        if (!sqlite3Path) {
+          return;
+        }
+
+        const tempDir = mkdtempSync(join(tmpdir(), `authrim-${databaseRole}-foreign-keys-`));
+        const dbPath = join(tempDir, 'test.db');
+
+        try {
+          runMigrationFiles(sqlite3Path, dbPath, migrationFiles);
+
+          expect(findInvalidForeignKeyReferences(sqlite3Path, dbPath)).toEqual([]);
+          expect(readSqlite(sqlite3Path, dbPath, 'PRAGMA foreign_key_check;')).toBe('');
+        } finally {
+          rmSync(tempDir, { recursive: true, force: true });
+        }
+      },
+      sqliteMigrationApplyTimeoutMs
+    );
+  }
+
+  it(
+    'repairs device-code client foreign keys while retaining only redeemable codes',
+    () => {
+      const sqlite3Path = findSqlite3();
+      if (!sqlite3Path) {
+        return;
+      }
+
+      const tempDir = mkdtempSync(join(tmpdir(), 'authrim-device-code-fk-repair-'));
+      const dbPath = join(tempDir, 'test.db');
+      const repairMigration = '018_repair_device_code_client_foreign_key.sql';
+      const migrationsBeforeRepair = activeCoreMigrationFiles().filter(
+        (migrationFile) => migrationFile !== repairMigration
+      );
+
+      try {
+        runMigrationFiles(sqlite3Path, dbPath, migrationsBeforeRepair);
+        runSqlite(
+          sqlite3Path,
+          dbPath,
+          `
+PRAGMA foreign_keys = OFF;
+${insertOAuthClientSql('default', 'device-client', 'Device Client')}
+INSERT INTO device_codes (
+  device_code,
+  user_code,
+  client_id,
+  scope,
+  status,
+  created_at,
+  expires_at,
+  tenant_id
+) VALUES (
+  'device-valid',
+  'USER-VALID',
+  'device-client',
+  'openid',
+  'pending',
+  100,
+  200,
+  'default'
+);
+INSERT INTO device_codes (
+  device_code,
+  user_code,
+  client_id,
+  scope,
+  status,
+  created_at,
+  expires_at,
+  tenant_id
+) VALUES (
+  'device-orphan',
+  'USER-ORPHAN',
+  'missing-client',
+  'openid',
+  'pending',
+  100,
+  200,
+  'default'
+);
+`
+        );
+
+        runMigrationFiles(sqlite3Path, dbPath, [repairMigration]);
+
+        expect(readSqlite(sqlite3Path, dbPath, 'SELECT device_code FROM device_codes;')).toBe(
+          'device-valid'
+        );
+        expect(
+          readSqlite(
+            sqlite3Path,
+            dbPath,
+            `SELECT group_concat("from" || ':' || "to", ',')
+               FROM (
+                 SELECT "from", "to"
+                   FROM pragma_foreign_key_list('device_codes')
+                  WHERE "table" = 'oauth_clients'
+                  ORDER BY id, seq
+               );`
+          )
+        ).toBe('tenant_id:tenant_id,client_id:client_id');
+        expect(findInvalidForeignKeyReferences(sqlite3Path, dbPath)).toEqual([]);
+        expect(() =>
+          runSqlite(
+            sqlite3Path,
+            dbPath,
+            `PRAGMA foreign_keys = ON;
+INSERT INTO device_codes (
+  device_code,
+  user_code,
+  client_id,
+  scope,
+  status,
+  created_at,
+  expires_at,
+  tenant_id
+) VALUES (
+  'device-cross-tenant',
+  'USER-CROSS-TENANT',
+  'device-client',
+  'openid',
+  'pending',
+  100,
+  200,
+  'another-tenant'
+);`
+          )
+        ).toThrow();
+
+        runSqlite(
+          sqlite3Path,
+          dbPath,
+          `PRAGMA foreign_keys = ON;
+DELETE FROM oauth_clients
+ WHERE tenant_id = 'default'
+   AND client_id = 'device-client';`
+        );
+        expect(readSqlite(sqlite3Path, dbPath, 'SELECT COUNT(*) FROM device_codes;')).toBe('0');
+        expect(readSqlite(sqlite3Path, dbPath, 'PRAGMA foreign_key_check;')).toBe('');
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    },
+    sqliteMigrationApplyTimeoutMs
+  );
+
   it('backfills tenant lifecycle state from is_active and drops the legacy column', () => {
     const sqlite3Path = findSqlite3();
     if (!sqlite3Path) {
@@ -802,6 +1067,278 @@ INSERT INTO tenants (
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it(
+    'repairs approval object-catalog foreign keys without losing approval data',
+    () => {
+      const sqlite3Path = findSqlite3();
+      if (!sqlite3Path) {
+        return;
+      }
+
+      const tempDir = mkdtempSync(join(tmpdir(), 'authrim-admin-approval-fk-repair-'));
+      const dbPath = join(tempDir, 'test.db');
+      const directoryCatalogMigration = 'admin/009_directory_auth_object_catalog_classes.sql';
+      const repairMigration = 'admin/010_repair_approval_object_catalog_foreign_key.sql';
+      const migrationsBeforeCatalogRebuild = activeAdminMigrationFiles().filter(
+        (migrationFile) =>
+          migrationFile !== directoryCatalogMigration && migrationFile !== repairMigration
+      );
+
+      try {
+        runMigrationFiles(sqlite3Path, dbPath, migrationsBeforeCatalogRebuild);
+        runSqlite(
+          sqlite3Path,
+          dbPath,
+          `
+PRAGMA foreign_keys = ON;
+INSERT INTO object_catalog (
+  id,
+  public_artifact_id,
+  tenant_id,
+  object_class,
+  created_at,
+  updated_at
+) VALUES (
+  'catalog-existing',
+  'artifact-existing',
+  'default',
+  'approval_transport_detail',
+  100,
+  100
+);
+${insertApprovalRequestSql('request-existing')}
+INSERT INTO approval_request_approvals (
+  id,
+  approval_request_id,
+  step_key,
+  side,
+  subject_type,
+  subject_id,
+  status,
+  method,
+  requested_at,
+  expires_at,
+  created_at,
+  updated_at,
+  last_notification_action,
+  last_notified_at,
+  notification_count
+) VALUES (
+  'approval-existing',
+  'request-existing',
+  'customer-owner',
+  'customer_data_owner',
+  'end_user',
+  'user-existing',
+  'pending',
+  'portal_confirm',
+  100,
+  200,
+  100,
+  100,
+  'initial',
+  101,
+  3
+);
+INSERT INTO elevation_grants (
+  id,
+  public_grant_id,
+  approval_request_id,
+  tenant_id,
+  status,
+  target_audience,
+  resource_class,
+  redaction_level,
+  scope_canonical,
+  scope_json,
+  requester_subject_type,
+  requester_subject_id,
+  actor_subject_type,
+  actor_subject_id,
+  issued_at,
+  expires_at,
+  created_at,
+  updated_at
+) VALUES (
+  'grant-existing',
+  'egr-existing',
+  'request-existing',
+  'default',
+  'active',
+  'admin-api',
+  'customer_profile',
+  'masked',
+  'surface=service_data&action=detail_read',
+  '{}',
+  'service_principal',
+  'approval-smoke',
+  'service_principal',
+  'approval-smoke',
+  100,
+  200,
+  100,
+  100
+);
+`
+        );
+
+        runMigrationFiles(sqlite3Path, dbPath, [directoryCatalogMigration]);
+
+        expect(
+          readSqlite(
+            sqlite3Path,
+            dbPath,
+            `SELECT "table"
+               FROM pragma_foreign_key_list('approval_requests')
+              WHERE "from" = 'detail_object_catalog_id';`
+          )
+        ).toBe('object_catalog_old');
+        expect(() =>
+          runSqlite(
+            sqlite3Path,
+            dbPath,
+            `PRAGMA foreign_keys = ON;${insertApprovalRequestSql('request-before-repair')}`
+          )
+        ).toThrow();
+
+        runSqlite(
+          sqlite3Path,
+          dbPath,
+          `PRAGMA foreign_keys = ON;\n${renderPortableMigrationSql(
+            readMigration(repairMigration),
+            'sqlite'
+          )}`
+        );
+
+        expect(findInvalidForeignKeyReferences(sqlite3Path, dbPath)).toEqual([]);
+        expect(
+          readSqlite(
+            sqlite3Path,
+            dbPath,
+            `SELECT "table"
+               FROM pragma_foreign_key_list('approval_requests')
+              WHERE "from" = 'detail_object_catalog_id';`
+          )
+        ).toBe('object_catalog');
+        expect(
+          readSqlite(
+            sqlite3Path,
+            dbPath,
+            `SELECT "table"
+               FROM pragma_foreign_key_list('approval_request_approvals')
+              WHERE "from" = 'approval_request_id';`
+          )
+        ).toBe('approval_requests');
+        expect(
+          readSqlite(
+            sqlite3Path,
+            dbPath,
+            `SELECT "table"
+               FROM pragma_foreign_key_list('elevation_grants')
+              WHERE "from" = 'approval_request_id';`
+          )
+        ).toBe('approval_requests');
+        expect(
+          readSqlite(
+            sqlite3Path,
+            dbPath,
+            "SELECT public_request_id FROM approval_requests WHERE id = 'request-existing';"
+          )
+        ).toBe('apr-request-existing');
+        expect(
+          readSqlite(
+            sqlite3Path,
+            dbPath,
+            `SELECT last_notification_action || ':' || last_notified_at || ':' || notification_count
+               FROM approval_request_approvals
+              WHERE id = 'approval-existing';`
+          )
+        ).toBe('initial:101:3');
+        expect(
+          readSqlite(
+            sqlite3Path,
+            dbPath,
+            "SELECT public_grant_id FROM elevation_grants WHERE id = 'grant-existing';"
+          )
+        ).toBe('egr-existing');
+        expect(
+          readSqlite(
+            sqlite3Path,
+            dbPath,
+            `SELECT COUNT(*)
+               FROM sqlite_master
+              WHERE type = 'table'
+                AND (name LIKE '%_old' OR name LIKE '%_repaired');`
+          )
+        ).toBe('0');
+        expect(
+          readSqlite(
+            sqlite3Path,
+            dbPath,
+            `SELECT COUNT(*)
+               FROM sqlite_master
+              WHERE type = 'index'
+                AND name IN (
+                  'idx_approval_requests_tenant_status_requested',
+                  'idx_approval_requests_investigation',
+                  'idx_approval_requests_requester',
+                  'idx_approval_requests_target',
+                  'idx_approval_requests_expires',
+                  'idx_approval_requests_detail_object_catalog',
+                  'idx_approval_request_approvals_unique_subject',
+                  'idx_approval_request_approvals_request_status',
+                  'idx_approval_request_approvals_subject',
+                  'idx_approval_request_approvals_expires',
+                  'idx_elevation_grants_tenant_status_issued',
+                  'idx_elevation_grants_request',
+                  'idx_elevation_grants_actor',
+                  'idx_elevation_grants_expires'
+                );`
+          )
+        ).toBe('14');
+
+        expect(() =>
+          runSqlite(
+            sqlite3Path,
+            dbPath,
+            `PRAGMA foreign_keys = ON;${insertApprovalRequestSql('request-after-repair')}`
+          )
+        ).not.toThrow();
+        expect(() =>
+          runSqlite(
+            sqlite3Path,
+            dbPath,
+            `PRAGMA foreign_keys = ON;${insertApprovalRequestSql(
+              'request-invalid-catalog',
+              'catalog-missing'
+            )}`
+          )
+        ).toThrow();
+
+        runSqlite(
+          sqlite3Path,
+          dbPath,
+          `PRAGMA foreign_keys = ON;
+UPDATE approval_requests
+   SET detail_object_catalog_id = 'catalog-existing'
+ WHERE id = 'request-existing';
+DELETE FROM object_catalog WHERE id = 'catalog-existing';`
+        );
+        expect(
+          readSqlite(
+            sqlite3Path,
+            dbPath,
+            "SELECT detail_object_catalog_id IS NULL FROM approval_requests WHERE id = 'request-existing';"
+          )
+        ).toBe('1');
+        expect(readSqlite(sqlite3Path, dbPath, 'PRAGMA foreign_key_check;')).toBe('');
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    },
+    sqliteMigrationApplyTimeoutMs
+  );
 
   it(
     'applies the unified identity mapping admin control-plane baseline in SQLite',


### PR DESCRIPTION
## Summary

- add an Admin D1 migration that repairs the approval request foreign key left pointing at `object_catalog_old`
- rebuild the approval request dependency tree without disabling D1 foreign-key enforcement, preserving requests, approval steps, grants, constraints, and indexes
- add a Core D1 migration that replaces the legacy `device_codes -> clients` reference with the tenant-scoped `oauth_clients(tenant_id, client_id)` relationship
- make SQLite migration tests start with foreign keys enabled and validate every final Core, Admin, and PII foreign-key target
- add regression coverage for the failed approval insert, data preservation, cascade behavior, tenant isolation, and index restoration

## Root Cause

Admin migration 009 renamed `object_catalog` to `object_catalog_old`. SQLite propagated that rename into `approval_requests`, but the migration dropped the temporary parent without rebuilding `approval_requests`. D1 then failed every approval request insert while preparing the dangling foreign key.

The full-schema audit also found that `device_codes` still referenced the removed legacy `clients` table. The new Core migration repairs that pre-existing invalid relationship.

## Validation

- `pnpm --filter @authrim/setup lint`
- `pnpm --filter @authrim/setup typecheck`
- `pnpm --filter @authrim/setup test` (62 files, 796 tests)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm test` (40 tasks across 20 packages)
- read-only test D1 audit confirmed the two broken references and zero affected approval/device-code rows before migration
