### PR TITLE
Repair stale D1 lock handling during deployment

### DIFF
--- a/packages/setup/src/__tests__/deploy.test.ts
+++ b/packages/setup/src/__tests__/deploy.test.ts
@@ -10,6 +10,7 @@ import {
   deployUiWorkerComponent,
   deployUiWorkerBindingTargets,
   deployWorker,
+  hasBlockingDeploymentFailures,
 } from '../core/deploy.js';
 
 vi.mock('execa', () => ({
@@ -98,6 +99,51 @@ describe('buildUiWorkerBuildEnv', () => {
 
     expect(result.PUBLIC_API_BASE_URL).toBeUndefined();
     expect(result.PUBLIC_LOGIN_UI_CLIENT_ID).toBeUndefined();
+  });
+});
+
+describe('hasBlockingDeploymentFailures', () => {
+  const successfulState = {
+    workerFailedCount: 0,
+    migrationsSuccess: true,
+    initialTenantSuccess: true,
+    initialAdminRolesSuccess: true,
+    setupMachineAccessSuccess: true,
+    adminUiBffMachineAccessSuccess: true,
+    defaultCanonicalCatalogSeedSuccess: true,
+    runtimeProfileSeedSuccess: true,
+    uiWorkersSuccess: true,
+  };
+
+  it('accepts a fully successful deployment', () => {
+    expect(hasBlockingDeploymentFailures(successfulState)).toBe(false);
+  });
+
+  it('rejects a deployment with any Worker failure', () => {
+    expect(
+      hasBlockingDeploymentFailures({
+        ...successfulState,
+        workerFailedCount: 1,
+      })
+    ).toBe(true);
+  });
+
+  it.each([
+    'migrationsSuccess',
+    'initialTenantSuccess',
+    'initialAdminRolesSuccess',
+    'setupMachineAccessSuccess',
+    'adminUiBffMachineAccessSuccess',
+    'defaultCanonicalCatalogSeedSuccess',
+    'runtimeProfileSeedSuccess',
+    'uiWorkersSuccess',
+  ] as const)('rejects a deployment when %s is false', (key) => {
+    expect(
+      hasBlockingDeploymentFailures({
+        ...successfulState,
+        [key]: false,
+      })
+    ).toBe(true);
   });
 });
 
@@ -323,5 +369,26 @@ describe('deployAll', () => {
     expect(summary.successCount).toBe(2);
     expect(vi.mocked(execa)).toHaveBeenCalledTimes(2);
     expect(progressMessages).toContain('  ⏳ Waiting 0.1s before deploying the next worker...');
+  });
+
+  it('stops all later deployment levels after a critical Worker fails', async () => {
+    const rootDir = createTempRoot();
+    createWorkerPackage(rootDir, 'ar-lib-core', '1.0.0');
+    createWorkerPackage(rootDir, 'ar-auth', '1.0.0');
+    vi.mocked(execa).mockRejectedValue(new Error('invalid D1 binding'));
+
+    const result = await deployAll(
+      {
+        env: 'test',
+        rootDir,
+        maxRetries: 1,
+        retryDelayMs: 1,
+      },
+      ['ar-lib-core', 'ar-auth']
+    );
+
+    expect(result.failedCount).toBe(1);
+    expect(result.results.map((item) => item.component)).toEqual(['ar-lib-core']);
+    expect(vi.mocked(execa)).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/setup/src/__tests__/lock.test.ts
+++ b/packages/setup/src/__tests__/lock.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createLockFile,
+  reconcileSharedD1ResourcesInLock,
+  type AuthrimLock,
+} from '../core/lock.js';
+
+function createTestLock(): AuthrimLock {
+  const lock = createLockFile('test', {
+    d1: [
+      { binding: 'DB', name: 'test-authrim-core-db', id: 'stale-core-id' },
+      { binding: 'DB_PII', name: 'test-authrim-pii-db', id: 'stale-pii-id' },
+      { binding: 'DB_ADMIN', name: 'test-authrim-admin-db', id: 'stale-admin-id' },
+    ],
+    kv: [],
+    queues: [],
+    r2: [],
+  });
+  lock.d1.TDB_CORE_0001 = {
+    name: 'test-authrim-tenant-first-core-g1',
+    id: 'tenant-core-id',
+  };
+  return lock;
+}
+
+describe('reconcileSharedD1ResourcesInLock', () => {
+  it('refreshes stale and missing shared bindings while preserving tenant D1 entries', () => {
+    const lock = createTestLock();
+    lock.d1.DB.id = 'live-core-id';
+    delete lock.d1.DB_ADMIN;
+
+    const result = reconcileSharedD1ResourcesInLock(lock, 'test', [
+      { name: 'test-authrim-core-db', uuid: 'live-core-id' },
+      { name: 'test-authrim-pii-db', uuid: 'live-pii-id' },
+      { name: 'test-authrim-admin-db', uuid: 'live-admin-id' },
+    ]);
+
+    expect(result.updatedBindings).toEqual(['DB_PII', 'DB_ADMIN']);
+    expect(result.missingBindings).toEqual([]);
+    expect(result.lock.d1.DB).toEqual({ name: 'test-authrim-core-db', id: 'live-core-id' });
+    expect(result.lock.d1.DB_PII).toEqual({ name: 'test-authrim-pii-db', id: 'live-pii-id' });
+    expect(result.lock.d1.DB_ADMIN).toEqual({
+      name: 'test-authrim-admin-db',
+      id: 'live-admin-id',
+    });
+    expect(result.lock.d1.TDB_CORE_0001).toEqual(lock.d1.TDB_CORE_0001);
+  });
+
+  it('reports a required shared database that does not exist by canonical name', () => {
+    const lock = createTestLock();
+
+    const result = reconcileSharedD1ResourcesInLock(lock, 'test', [
+      { name: 'test-authrim-core-db', uuid: 'live-core-id' },
+      { name: 'test-authrim-pii-db', uuid: 'live-pii-id' },
+    ]);
+
+    expect(result.missingBindings).toEqual([
+      { binding: 'DB_ADMIN', name: 'test-authrim-admin-db' },
+    ]);
+    expect(result.lock.d1.DB_ADMIN).toEqual(lock.d1.DB_ADMIN);
+  });
+
+  it('returns the original lock when all shared IDs are current', () => {
+    const lock = createTestLock();
+    const databases = [
+      { name: 'test-authrim-core-db', uuid: 'stale-core-id' },
+      { name: 'test-authrim-pii-db', uuid: 'stale-pii-id' },
+      { name: 'test-authrim-admin-db', uuid: 'stale-admin-id' },
+    ];
+
+    const result = reconcileSharedD1ResourcesInLock(lock, 'test', databases);
+
+    expect(result.updatedBindings).toEqual([]);
+    expect(result.missingBindings).toEqual([]);
+    expect(result.lock).toBe(lock);
+  });
+});

--- a/packages/setup/src/cli/commands/deploy.ts
+++ b/packages/setup/src/cli/commands/deploy.ts
@@ -12,7 +12,11 @@ import { existsSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { readFile, writeFile } from 'node:fs/promises';
 import { AuthrimConfigSchema, type AuthrimConfig } from '../../core/config.js';
-import { saveLockFile, loadLockFileAuto } from '../../core/lock.js';
+import {
+  saveLockFile,
+  loadLockFileAuto,
+  reconcileSharedD1ResourcesInLock,
+} from '../../core/lock.js';
 import {
   getEnvironmentPaths,
   findLegacyConfigPath,
@@ -33,6 +37,7 @@ import {
   buildApiPackages,
   DEFAULT_INTER_DEPLOY_DELAY_MS,
   UI_WORKER_COMPONENTS,
+  hasBlockingDeploymentFailures,
   type DeployOptions,
   type UiWorkerComponent,
 } from '../../core/deploy.js';
@@ -49,14 +54,10 @@ import {
   seedRuntimeProfiles,
   getWorkersSubdomain,
   ensureWildcardDnsForMultiTenant,
+  listD1Databases,
 } from '../../core/cloudflare.js';
 import { type WorkerComponent, CORE_WORKER_COMPONENTS } from '../../core/naming.js';
-import {
-  generateWranglerConfig,
-  toToml,
-  buildResourceIdsFromLock,
-  type ResourceIds,
-} from '../../core/wrangler.js';
+import { generateWranglerConfig, toToml, buildResourceIdsFromLock } from '../../core/wrangler.js';
 import { completeInitialSetup, displaySetupInstructions } from '../../core/admin.js';
 import { ensureLoginUiClient } from '../../core/login-ui-client.js';
 import { loadAdminUiBffWorkerSecrets } from '../../core/admin-machine-access.js';
@@ -683,6 +684,39 @@ export async function deployCommand(options: DeployCommandOptions): Promise<void
     });
   }
 
+  if (!options.dryRun) {
+    const d1ReconciliationSpinner = ora('Refreshing shared D1 resource IDs...').start();
+    try {
+      const reconciliation = reconcileSharedD1ResourcesInLock(
+        currentLock,
+        env,
+        await listD1Databases()
+      );
+
+      if (reconciliation.missingBindings.length > 0) {
+        d1ReconciliationSpinner.fail('Required shared D1 databases are missing');
+        for (const missing of reconciliation.missingBindings) {
+          console.log(chalk.red(`  • ${missing.binding}: ${missing.name}`));
+        }
+        process.exit(1);
+      }
+
+      currentLock = reconciliation.lock;
+      if (reconciliation.updatedBindings.length > 0) {
+        await saveLockFile(currentLock, lockPath);
+        d1ReconciliationSpinner.succeed(
+          `Refreshed shared D1 bindings: ${reconciliation.updatedBindings.join(', ')}`
+        );
+      } else {
+        d1ReconciliationSpinner.succeed('Shared D1 resource IDs are current');
+      }
+    } catch (error) {
+      d1ReconciliationSpinner.fail('Failed to refresh shared D1 resource IDs');
+      console.log(chalk.red(`  ${error instanceof Error ? error.message : String(error)}`));
+      process.exit(1);
+    }
+  }
+
   // Refresh generated wrangler configs from the current config/lock before deployment.
   // This prevents stale bindings such as send_email from surviving across setup upgrades.
   if (structureType === 'new' && lock) {
@@ -826,18 +860,7 @@ export async function deployCommand(options: DeployCommandOptions): Promise<void
     const genSpinner = ora('Generating wrangler configs from lock file...').start();
 
     try {
-      // Build resource IDs from lock file
-      const resourceIds: ResourceIds = {
-        d1: {},
-        kv: {},
-      };
-
-      for (const [key, value] of Object.entries(lock.d1)) {
-        resourceIds.d1[key] = { id: value.id, name: value.name };
-      }
-      for (const [key, value] of Object.entries(lock.kv)) {
-        resourceIds.kv[key] = { id: value.id, name: value.name };
-      }
+      const resourceIds = buildResourceIdsFromLock(currentLock);
 
       // Get workers subdomain
       const workersSubdomain = await getWorkersSubdomain();
@@ -1565,15 +1588,7 @@ export async function deployCommand(options: DeployCommandOptions): Promise<void
   // Final summary
   console.log(chalk.bold('\n━━━ Deployment Complete ━━━\n'));
 
-  if (
-    summary.failedCount === 0 &&
-    migrationsSuccess &&
-    initialTenantSuccess &&
-    initialAdminRolesSuccess &&
-    defaultCanonicalCatalogSeedSuccess &&
-    runtimeProfileSeedSuccess &&
-    uiWorkersSuccess
-  ) {
+  if (summary.failedCount === 0 && bootstrapSuccess && uiWorkersSuccess) {
     console.log(chalk.green('✅ All components deployed and migrations applied!\n'));
   } else if (summary.failedCount === 0 && !migrationsSuccess) {
     console.log(chalk.yellow('⚠️  All components deployed, but some migrations failed.\n'));
@@ -1680,7 +1695,19 @@ export async function deployCommand(options: DeployCommandOptions): Promise<void
 
   await cleanupEphemeralSetupMachineAccess();
 
-  if (!migrationsSuccess) {
+  if (
+    hasBlockingDeploymentFailures({
+      workerFailedCount: summary.failedCount,
+      migrationsSuccess,
+      initialTenantSuccess,
+      initialAdminRolesSuccess,
+      setupMachineAccessSuccess,
+      adminUiBffMachineAccessSuccess,
+      defaultCanonicalCatalogSeedSuccess,
+      runtimeProfileSeedSuccess,
+      uiWorkersSuccess,
+    })
+  ) {
     // Let CI fail at the deploy step while still giving cleanup a chance to run.
     process.exitCode = 1;
   }

--- a/packages/setup/src/core/deploy.ts
+++ b/packages/setup/src/core/deploy.ts
@@ -97,6 +97,18 @@ export interface DeploymentSummary {
   duration: number;
 }
 
+export interface DeploymentCompletionState {
+  workerFailedCount: number;
+  migrationsSuccess: boolean;
+  initialTenantSuccess: boolean;
+  initialAdminRolesSuccess: boolean;
+  setupMachineAccessSuccess: boolean;
+  adminUiBffMachineAccessSuccess: boolean;
+  defaultCanonicalCatalogSeedSuccess: boolean;
+  runtimeProfileSeedSuccess: boolean;
+  uiWorkersSuccess: boolean;
+}
+
 export interface BuildOptions {
   rootDir: string;
   components?: WorkerComponent[];
@@ -109,6 +121,20 @@ export interface BuildResult {
 }
 
 export const DEFAULT_INTER_DEPLOY_DELAY_MS = 10_000;
+
+export function hasBlockingDeploymentFailures(state: DeploymentCompletionState): boolean {
+  return (
+    state.workerFailedCount > 0 ||
+    !state.migrationsSuccess ||
+    !state.initialTenantSuccess ||
+    !state.initialAdminRolesSuccess ||
+    !state.setupMachineAccessSuccess ||
+    !state.adminUiBffMachineAccessSuccess ||
+    !state.defaultCanonicalCatalogSeedSuccess ||
+    !state.runtimeProfileSeedSuccess ||
+    !state.uiWorkersSuccess
+  );
+}
 
 const UI_BUILD_ENV_KEYS = [
   'PUBLIC_API_BASE_URL',
@@ -385,6 +411,7 @@ export async function deployAll(
   const allResults: DeployResult[] = [];
   const totalPlannedComponents = levels.reduce((count, level) => count + level.length, 0);
   let processedComponents = 0;
+  let shouldStopDeployment = false;
 
   onProgress?.('Starting Authrim deployment...\n');
   onProgress?.(`Environment: ${options.env}`);
@@ -392,6 +419,10 @@ export async function deployAll(
   onProgress?.(`Deployment levels: ${levels.length}\n`);
 
   for (let levelIndex = 0; levelIndex < levels.length; levelIndex++) {
+    if (shouldStopDeployment) {
+      break;
+    }
+
     const level = levels[levelIndex];
     onProgress?.(`\n━━━ Level ${levelIndex} ━━━`);
 
@@ -407,6 +438,7 @@ export async function deployAll(
         // Stop deployment if critical component fails
         if (['ar-lib-core', 'ar-discovery'].includes(component)) {
           onProgress?.(`\n⚠️  Critical component ${component} failed. Stopping deployment.`);
+          shouldStopDeployment = true;
           break;
         }
       }

--- a/packages/setup/src/core/lock.ts
+++ b/packages/setup/src/core/lock.ts
@@ -19,6 +19,7 @@ import {
   type EnvironmentPaths,
   type LegacyPaths,
 } from './paths.js';
+import { D1_DATABASES, getD1DatabaseName } from './naming.js';
 
 // =============================================================================
 // Schema
@@ -56,6 +57,12 @@ export type AuthrimLock = z.infer<typeof AuthrimLockSchema>;
 export type ResourceEntry = z.infer<typeof ResourceEntrySchema>;
 export type KVResourceEntry = z.infer<typeof KVResourceEntrySchema>;
 export type WorkerEntry = z.infer<typeof WorkerEntrySchema>;
+
+export interface SharedD1LockReconciliationResult {
+  lock: AuthrimLock;
+  updatedBindings: string[];
+  missingBindings: Array<{ binding: string; name: string }>;
+}
 
 // =============================================================================
 // Lock File Operations
@@ -302,6 +309,51 @@ export async function loadLockFileAuto(
   const legacyPath = getLegacyPaths(baseDir, env).lock;
   const lock = await loadLockFile({ path: legacyPath });
   return { lock, path: legacyPath, type: 'legacy' };
+}
+
+/**
+ * Refresh shared D1 lock entries from Cloudflare's current database list.
+ *
+ * Restored or copied lock files can retain UUIDs for databases that were
+ * recreated under the same canonical name. Wrangler requires the live UUID,
+ * so deployment reconciles these three shared bindings before generating its
+ * worker configurations.
+ */
+export function reconcileSharedD1ResourcesInLock(
+  lock: AuthrimLock,
+  env: string,
+  databases: Array<{ name: string; uuid: string }>
+): SharedD1LockReconciliationResult {
+  const databasesByName = new Map(databases.map((database) => [database.name, database]));
+  const nextD1 = { ...lock.d1 };
+  const updatedBindings: string[] = [];
+  const missingBindings: Array<{ binding: string; name: string }> = [];
+
+  for (const database of D1_DATABASES) {
+    const expectedName = getD1DatabaseName(env, database.dbType);
+    const liveDatabase = databasesByName.get(expectedName);
+    if (!liveDatabase) {
+      missingBindings.push({ binding: database.binding, name: expectedName });
+      continue;
+    }
+
+    const lockedDatabase = nextD1[database.binding];
+    if (lockedDatabase?.name === liveDatabase.name && lockedDatabase.id === liveDatabase.uuid) {
+      continue;
+    }
+
+    nextD1[database.binding] = {
+      name: liveDatabase.name,
+      id: liveDatabase.uuid,
+    };
+    updatedBindings.push(database.binding);
+  }
+
+  return {
+    lock: updatedBindings.length > 0 ? { ...lock, d1: nextD1 } : lock,
+    updatedBindings,
+    missingBindings,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- reconcile the three shared D1 lock entries against Cloudflare's live database list before generating any Worker configuration
- refresh both missing lock bindings and stale UUIDs by canonical environment database name while preserving tenant D1 entries
- regenerate every Wrangler fallback path from the reconciled lock
- stop subsequent deployment levels after a critical Worker failure
- return a non-zero deploy result for Worker, migration, bootstrap, machine-access, seed, or UI deployment failures
- add regression tests for stale/missing D1 resources, critical fail-fast behavior, and every blocking completion state

## Root Cause

The test workflow restored an older generated lock from GitHub Actions secrets. Its `DB_ADMIN` entry pointed to a deleted D1 UUID even though a replacement database existed under the canonical `test-authrim-admin-db` name.

The deploy command generated all Worker bindings from that stale UUID. All 12 Worker deployments failed, but the CLI continued, skipped pending migrations because the Worker summary contained failures, and still exited with status 0. The workflow therefore ran smoke tests against the old deployment and reported the same approval failure after the schema repair had merged.

## Impact

Deployments now self-heal stale shared D1 UUIDs when the canonical databases still exist. Missing databases fail before configuration generation, and any blocking deployment failure is visible to CI instead of allowing later smoke tests against stale Workers.

## Validation

- `pnpm --filter @authrim/setup test` (63 files, 810 tests)
- `pnpm typecheck` (27 tasks)
- `pnpm lint` (20 tasks)
- `pnpm format:check`
- `pnpm test` (40 tasks across 20 packages)
