### PR TITLE
fix(setup): make D1 resource discovery deterministic

### DIFF
--- a/packages/setup/src/__tests__/cloudflare-d1-list.test.ts
+++ b/packages/setup/src/__tests__/cloudflare-d1-list.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execaMock = vi.hoisted(() => vi.fn());
+const fetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('execa', () => ({
+  execa: execaMock,
+}));
+
+import { listD1Databases, parseD1DatabaseListOutput } from '../core/cloudflare.js';
+
+describe('Cloudflare D1 database listing', () => {
+  const originalAccountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const originalApiToken = process.env.CLOUDFLARE_API_TOKEN;
+
+  beforeEach(() => {
+    execaMock.mockReset();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    if (originalAccountId === undefined) {
+      delete process.env.CLOUDFLARE_ACCOUNT_ID;
+    } else {
+      process.env.CLOUDFLARE_ACCOUNT_ID = originalAccountId;
+    }
+    if (originalApiToken === undefined) {
+      delete process.env.CLOUDFLARE_API_TOKEN;
+    } else {
+      process.env.CLOUDFLARE_API_TOKEN = originalApiToken;
+    }
+    vi.unstubAllGlobals();
+  });
+
+  it('extracts a validated D1 list from noisy Wrangler output', () => {
+    const escape = String.fromCharCode(27);
+    const output = [
+      `${escape}[33m[wrangler:notice] A newer version is available${escape}[0m`,
+      JSON.stringify([
+        { name: 'test-authrim-core-db', uuid: 'core-id' },
+        { name: 'test-authrim-admin-db', uuid: 'admin-id' },
+      ]),
+      'Wrangler command completed',
+    ].join('\n');
+
+    expect(parseD1DatabaseListOutput(output)).toEqual([
+      { name: 'test-authrim-core-db', uuid: 'core-id' },
+      { name: 'test-authrim-admin-db', uuid: 'admin-id' },
+    ]);
+  });
+
+  it('rejects JSON arrays that do not have the D1 database shape', () => {
+    expect(() => parseD1DatabaseListOutput('["notice"]\n[{"name":"missing-uuid"}]')).toThrow(
+      'valid D1 database list'
+    );
+  });
+
+  it('prefers the Cloudflare API when CI credentials are available', async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = '0123456789abcdef0123456789abcdef';
+    process.env.CLOUDFLARE_API_TOKEN = 'test-token';
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        result: [{ name: 'test-authrim-core-db', uuid: 'current-core-id' }],
+        result_info: { total_count: 1 },
+      }),
+    });
+
+    await expect(listD1Databases()).resolves.toEqual([
+      { name: 'test-authrim-core-db', uuid: 'current-core-id' },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL(
+        'https://api.cloudflare.com/client/v4/accounts/0123456789abcdef0123456789abcdef/d1/database?page=1&per_page=1000'
+      ),
+      { headers: { Authorization: 'Bearer test-token' } }
+    );
+    expect(execaMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to noisy Wrangler JSON when the Cloudflare API is unavailable', async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = '0123456789abcdef0123456789abcdef';
+    process.env.CLOUDFLARE_API_TOKEN = 'test-token';
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 503 });
+    execaMock.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout:
+        '[wrangler:notice] retrying with the CLI\n' +
+        JSON.stringify([{ name: 'test-authrim-admin-db', uuid: 'current-admin-id' }]),
+      stderr: '',
+    });
+
+    await expect(listD1Databases()).resolves.toEqual([
+      { name: 'test-authrim-admin-db', uuid: 'current-admin-id' },
+    ]);
+    expect(execaMock).toHaveBeenCalledWith(
+      'npx',
+      ['wrangler', 'd1', 'list', '--json'],
+      expect.objectContaining({ reject: false, timeout: 30000 })
+    );
+  });
+});

--- a/packages/setup/src/core/cloudflare.ts
+++ b/packages/setup/src/core/cloudflare.ts
@@ -1698,11 +1698,164 @@ export async function verifyWildcardDnsPublicResolution(baseDomain: string): Pro
 // D1 Database Operations
 // =============================================================================
 
+type D1DatabaseListRow = { name: string; uuid: string };
+
+function stripAnsiSequences(value: string): string {
+  const escape = String.fromCharCode(27);
+  return value.replace(new RegExp(`${escape}\\[[0-?]*[ -/]*[@-~]`, 'g'), '');
+}
+
+function findJsonArrayCandidates(value: string): string[] {
+  const candidates: string[] = [];
+  const normalized = stripAnsiSequences(value);
+
+  for (let start = 0; start < normalized.length; start++) {
+    if (normalized[start] !== '[') continue;
+
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+
+    for (let index = start; index < normalized.length; index++) {
+      const character = normalized[index];
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (character === '\\') {
+          escaped = true;
+        } else if (character === '"') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (character === '"') {
+        inString = true;
+      } else if (character === '[') {
+        depth++;
+      } else if (character === ']') {
+        depth--;
+        if (depth === 0) {
+          candidates.push(normalized.slice(start, index + 1));
+          break;
+        }
+      }
+    }
+  }
+
+  return candidates;
+}
+
+function normalizeD1DatabaseRows(rows: unknown): D1DatabaseListRow[] {
+  if (!Array.isArray(rows)) {
+    throw new TypeError('D1 database list was not an array');
+  }
+
+  return rows.map((row, index) => {
+    if (!row || typeof row !== 'object') {
+      throw new TypeError(`D1 database list row ${index} was not an object`);
+    }
+
+    const { name, uuid } = row as { name?: unknown; uuid?: unknown };
+    if (
+      typeof name !== 'string' ||
+      name.trim().length === 0 ||
+      typeof uuid !== 'string' ||
+      uuid.trim().length === 0
+    ) {
+      throw new TypeError(`D1 database list row ${index} did not contain a name and UUID`);
+    }
+
+    return { name: name.trim(), uuid: uuid.trim() };
+  });
+}
+
+export function parseD1DatabaseListOutput(stdout: string): D1DatabaseListRow[] {
+  const candidates = findJsonArrayCandidates(stdout);
+  for (let index = candidates.length - 1; index >= 0; index--) {
+    try {
+      return normalizeD1DatabaseRows(JSON.parse(candidates[index]));
+    } catch {
+      // Wrangler can print notices containing brackets before the JSON payload.
+    }
+  }
+
+  throw new SyntaxError('Wrangler output did not contain a valid D1 database list');
+}
+
+async function listD1DatabasesViaApi(): Promise<D1DatabaseListRow[] | null> {
+  if (
+    process.env.NODE_ENV === 'test' &&
+    (!process.env.CLOUDFLARE_ACCOUNT_ID?.trim() || !process.env.CLOUDFLARE_API_TOKEN?.trim())
+  ) {
+    return null;
+  }
+
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim() || (await getAccountId());
+  const envToken = process.env.CLOUDFLARE_API_TOKEN?.trim();
+  const tokenInfo = envToken
+    ? ({ token: envToken, source: 'env' } satisfies CloudflareApiToken)
+    : await getCloudflareApiToken();
+  if (!accountId || !tokenInfo?.token) {
+    return null;
+  }
+
+  const databases: D1DatabaseListRow[] = [];
+  const perPage = 1000;
+  let page = 1;
+
+  while (true) {
+    const url = new URL(`https://api.cloudflare.com/client/v4/accounts/${accountId}/d1/database`);
+    url.searchParams.set('page', String(page));
+    url.searchParams.set('per_page', String(perPage));
+
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${tokenInfo.token}`,
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Cloudflare D1 database list failed (${response.status})`);
+    }
+
+    const payload = (await response.json()) as {
+      success?: boolean;
+      result?: unknown;
+      result_info?: { total_count?: unknown };
+    };
+    if (payload.success === false) {
+      throw new Error('Cloudflare D1 database list returned an unsuccessful response');
+    }
+
+    const rows = normalizeD1DatabaseRows(payload.result);
+    databases.push(...rows);
+
+    const totalCount = payload.result_info?.total_count;
+    if (
+      rows.length < perPage ||
+      (typeof totalCount === 'number' && databases.length >= totalCount)
+    ) {
+      return databases;
+    }
+    page++;
+  }
+}
+
 /**
  * List all D1 databases
  * @throws Error if wrangler command fails (caller should handle)
  */
 export async function listD1Databases(): Promise<Array<{ name: string; uuid: string }>> {
+  let apiError: unknown;
+  try {
+    const apiDatabases = await listD1DatabasesViaApi();
+    if (apiDatabases) {
+      return apiDatabases;
+    }
+  } catch (error) {
+    apiError = error;
+  }
+
   try {
     const { stdout, stderr } = await wrangler(['d1', 'list', '--json']);
 
@@ -1711,13 +1864,25 @@ export async function listD1Databases(): Promise<Array<{ name: string; uuid: str
       throw new Error('Not logged in to Cloudflare. Run: wrangler login');
     }
 
-    const databases = JSON.parse(stdout);
-    return databases.map((db: { name: string; uuid: string }) => ({
-      name: db.name,
-      uuid: db.uuid,
-    }));
+    return parseD1DatabaseListOutput(stdout);
   } catch (error) {
-    // Re-throw with context
+    if (apiError) {
+      const apiMessage =
+        apiError instanceof Error
+          ? apiError.message
+          : typeof apiError === 'string'
+            ? apiError
+            : 'unknown API error';
+      const wranglerMessage =
+        error instanceof Error
+          ? error.message
+          : typeof error === 'string'
+            ? error
+            : 'unknown Wrangler error';
+      throw new Error(
+        `Failed to list D1 databases via the Cloudflare API (${apiMessage}) and Wrangler (${wranglerMessage})`
+      );
+    }
     if (error instanceof SyntaxError) {
       throw new Error('Failed to parse D1 database list - wrangler output was not valid JSON');
     }


### PR DESCRIPTION
## Summary

- prefer the Cloudflare D1 REST API when account credentials are explicitly available
- preserve Wrangler as a fallback while extracting and validating the D1 JSON payload from noisy or ANSI-decorated output
- ensure `CLOUDFLARE_API_TOKEN` takes precedence over cached OAuth credentials for the selected CI account
- add regression coverage for API discovery, noisy Wrangler output, malformed payloads, and API-to-Wrangler fallback

## Root cause

The post-merge test deployment failed before Worker deployment because `wrangler d1 list --json` produced output that was not a standalone JSON document in GitHub Actions. The deploy command parsed stdout with a direct `JSON.parse`, so shared D1 lock reconciliation stopped immediately.

## Verification

- `pnpm --filter @authrim/setup test` (64 files, 814 tests)
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (40 tasks)
