### PR TITLE
fix(setup): reconcile all lock-backed Cloudflare IDs

### DIFF
--- a/packages/setup/src/__tests__/cloudflare-kv-list.test.ts
+++ b/packages/setup/src/__tests__/cloudflare-kv-list.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execaMock = vi.hoisted(() => vi.fn());
+const fetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('execa', () => ({
+  execa: execaMock,
+}));
+
+import { listKVNamespaces, parseKVNamespaceListOutput } from '../core/cloudflare.js';
+
+describe('Cloudflare KV namespace listing', () => {
+  const originalAccountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const originalApiToken = process.env.CLOUDFLARE_API_TOKEN;
+
+  beforeEach(() => {
+    execaMock.mockReset();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    if (originalAccountId === undefined) {
+      delete process.env.CLOUDFLARE_ACCOUNT_ID;
+    } else {
+      process.env.CLOUDFLARE_ACCOUNT_ID = originalAccountId;
+    }
+    if (originalApiToken === undefined) {
+      delete process.env.CLOUDFLARE_API_TOKEN;
+    } else {
+      process.env.CLOUDFLARE_API_TOKEN = originalApiToken;
+    }
+    vi.unstubAllGlobals();
+  });
+
+  it('extracts a validated KV list from noisy Wrangler output', () => {
+    const escape = String.fromCharCode(27);
+    const output = [
+      `${escape}[33m[wrangler:notice] A newer version is available${escape}[0m`,
+      JSON.stringify([
+        { title: 'TEST-AUTHRIM_CONFIG', id: 'config-id' },
+        { title: 'TEST-SETTINGS', id: 'settings-id' },
+      ]),
+      'Wrangler command completed',
+    ].join('\n');
+
+    expect(parseKVNamespaceListOutput(output)).toEqual([
+      { title: 'TEST-AUTHRIM_CONFIG', id: 'config-id' },
+      { title: 'TEST-SETTINGS', id: 'settings-id' },
+    ]);
+  });
+
+  it('rejects JSON arrays that do not have the KV namespace shape', () => {
+    expect(() => parseKVNamespaceListOutput('["notice"]\n[{"title":"missing-id"}]')).toThrow(
+      'valid KV namespace list'
+    );
+  });
+
+  it('prefers the Cloudflare API when CI credentials are available', async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = '0123456789abcdef0123456789abcdef';
+    process.env.CLOUDFLARE_API_TOKEN = 'test-token';
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        result: [{ title: 'TEST-AUTHRIM_CONFIG', id: 'current-config-id' }],
+        result_info: { total_count: 1 },
+      }),
+    });
+
+    await expect(listKVNamespaces()).resolves.toEqual([
+      { title: 'TEST-AUTHRIM_CONFIG', id: 'current-config-id' },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL(
+        'https://api.cloudflare.com/client/v4/accounts/0123456789abcdef0123456789abcdef/storage/kv/namespaces?page=1&per_page=1000'
+      ),
+      { headers: { Authorization: 'Bearer test-token' } }
+    );
+    expect(execaMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to noisy Wrangler JSON when the Cloudflare API is unavailable', async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = '0123456789abcdef0123456789abcdef';
+    process.env.CLOUDFLARE_API_TOKEN = 'test-token';
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 503 });
+    execaMock.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout:
+        '[wrangler:notice] retrying with the CLI\n' +
+        JSON.stringify([{ title: 'TEST-SETTINGS', id: 'current-settings-id' }]),
+      stderr: '',
+    });
+
+    await expect(listKVNamespaces()).resolves.toEqual([
+      { title: 'TEST-SETTINGS', id: 'current-settings-id' },
+    ]);
+    expect(execaMock).toHaveBeenCalledWith(
+      'npx',
+      ['wrangler', 'kv', 'namespace', 'list'],
+      expect.objectContaining({ reject: false, timeout: 30000 })
+    );
+  });
+});

--- a/packages/setup/src/__tests__/generated-env-validator.test.ts
+++ b/packages/setup/src/__tests__/generated-env-validator.test.ts
@@ -5,11 +5,12 @@ import { createDefaultConfig } from '../core/config.js';
 import { saveKeysToDirectory, type GeneratedSecrets, type KeyPair } from '../core/keys.js';
 import { createLockFile } from '../core/lock.js';
 import { getEnvironmentPaths } from '../core/paths.js';
-import { WORKER_COMPONENTS } from '../core/naming.js';
+import { KV_NAMESPACES, WORKER_COMPONENTS, getKVNamespaceName } from '../core/naming.js';
 import { buildResourceIdsFromLock, generateWranglerConfig, toToml } from '../core/wrangler.js';
 import { validateGeneratedEnvironment } from '../core/generated-env-validator.js';
 
 const listD1DatabasesMock = vi.hoisted(() => vi.fn());
+const listKVNamespacesMock = vi.hoisted(() => vi.fn());
 const listR2BucketsMock = vi.hoisted(() => vi.fn());
 const queryD1RowsMock = vi.hoisted(() => vi.fn());
 
@@ -18,12 +19,24 @@ vi.mock('../core/cloudflare.js', async (importOriginal) => {
   return {
     ...actual,
     listD1Databases: listD1DatabasesMock,
+    listKVNamespaces: listKVNamespacesMock,
     listR2Buckets: listR2BucketsMock,
     queryD1Rows: queryD1RowsMock,
   };
 });
 
 const tempDirs: string[] = [];
+const PORTABLE_KV_IDS: Record<(typeof KV_NAMESPACES)[number], string> = {
+  CLIENTS_CACHE: 'kv-clients',
+  INITIAL_ACCESS_TOKENS: 'kv-iat',
+  SETTINGS: 'kv-settings',
+  REBAC_CACHE: 'kv-rebac',
+  USER_CACHE: 'kv-user',
+  AUTHRIM_CONFIG: 'kv-config',
+  TENANT_RUNTIME_REGISTRY: 'kv-tenant-runtime-registry',
+  STATE_STORE: 'kv-state',
+  CONSENT_CACHE: 'kv-consent',
+};
 
 async function createFixtureRoot() {
   const root = await mkdtemp(join(process.cwd(), '.test-generated-env-'));
@@ -286,6 +299,13 @@ function mockLiveRuntimeSchema(
 describe('validateGeneratedEnvironment', () => {
   beforeEach(() => {
     listD1DatabasesMock.mockReset();
+    listKVNamespacesMock.mockReset();
+    listKVNamespacesMock.mockResolvedValue(
+      KV_NAMESPACES.map((binding) => ({
+        title: getKVNamespaceName('portable', binding),
+        id: PORTABLE_KV_IDS[binding],
+      }))
+    );
     listR2BucketsMock.mockReset();
     queryD1RowsMock.mockReset();
   });
@@ -464,6 +484,7 @@ describe('validateGeneratedEnvironment', () => {
 
     expect(result.ok).toBe(true);
     expect(result.checks.find((check) => check.id === 'live-cloudflare-d1')?.status).toBe('pass');
+    expect(result.checks.find((check) => check.id === 'live-cloudflare-kv')?.status).toBe('pass');
     expect(result.checks.find((check) => check.id === 'live-cloudflare-r2')?.status).toBe('pass');
     expect(result.checks.find((check) => check.id === 'live-runtime-d1-schema')?.status).toBe(
       'pass'
@@ -487,6 +508,43 @@ describe('validateGeneratedEnvironment', () => {
     expect(r2Check?.status).toBe('fail');
     expect(r2Check?.details).toEqual(
       expect.arrayContaining([expect.stringContaining(`${env}-export-artifacts is missing`)])
+    );
+  });
+
+  it('fails live Cloudflare validation when a recorded KV namespace ID is stale', async () => {
+    const { root, env } = await writeGeneratedEnvironment(await createFixtureRoot());
+    mockLiveRuntimeSchema(env);
+    listD1DatabasesMock.mockResolvedValueOnce([
+      { name: `${env}-authrim-core-db`, uuid: 'db-core-id' },
+      { name: `${env}-authrim-pii-db`, uuid: 'db-pii-id' },
+      { name: `${env}-authrim-admin-db`, uuid: 'db-admin-id' },
+    ]);
+    listKVNamespacesMock.mockResolvedValueOnce(
+      KV_NAMESPACES.map((binding) => ({
+        title: getKVNamespaceName(env, binding),
+        id: binding === 'AUTHRIM_CONFIG' ? 'replacement-config-id' : PORTABLE_KV_IDS[binding],
+      }))
+    );
+    listR2BucketsMock.mockResolvedValueOnce([
+      { name: `${env}-public-assets` },
+      { name: `${env}-authrim-avatars` },
+      { name: `${env}-diagnostic-logs` },
+      { name: `${env}-audit-archive` },
+      { name: `${env}-import-artifacts` },
+      { name: `${env}-export-artifacts` },
+      { name: `${env}-sensitive-details` },
+    ]);
+
+    const result = await validateGeneratedEnvironment({ baseDir: root, env, liveCloudflare: true });
+    const kvCheck = result.checks.find((check) => check.id === 'live-cloudflare-kv');
+
+    expect(result.ok).toBe(false);
+    expect(kvCheck?.status).toBe('fail');
+    expect(kvCheck?.details).toEqual(
+      expect.arrayContaining([expect.stringContaining('AUTHRIM_CONFIG')])
+    );
+    expect(kvCheck?.details).toEqual(
+      expect.arrayContaining([expect.stringContaining('id mismatch')])
     );
   });
 

--- a/packages/setup/src/__tests__/lock.test.ts
+++ b/packages/setup/src/__tests__/lock.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
   createLockFile,
   reconcileSharedD1ResourcesInLock,
+  reconcileSharedKVResourcesInLock,
   type AuthrimLock,
 } from '../core/lock.js';
+import { KV_NAMESPACES, getKVNamespaceName } from '../core/naming.js';
 
 function createTestLock(): AuthrimLock {
   const lock = createLockFile('test', {
@@ -12,19 +14,23 @@ function createTestLock(): AuthrimLock {
       { binding: 'DB_PII', name: 'test-authrim-pii-db', id: 'stale-pii-id' },
       { binding: 'DB_ADMIN', name: 'test-authrim-admin-db', id: 'stale-admin-id' },
     ],
-    kv: [],
+    kv: KV_NAMESPACES.map((binding) => ({
+      binding,
+      name: getKVNamespaceName('test', binding),
+      id: `live-${binding.toLowerCase()}`,
+    })),
     queues: [],
     r2: [],
   });
-  lock.d1.TDB_CORE_0001 = {
-    name: 'test-authrim-tenant-first-core-g1',
-    id: 'tenant-core-id',
+  lock.d1.TDB_SLOT_0001_CORE = {
+    name: 'authrim-test-tdb-slot-0001-core',
+    id: 'stale-tenant-core-id',
   };
   return lock;
 }
 
 describe('reconcileSharedD1ResourcesInLock', () => {
-  it('refreshes stale and missing shared bindings while preserving tenant D1 entries', () => {
+  it('refreshes stale and missing shared bindings and stale tenant D1 entries', () => {
     const lock = createTestLock();
     lock.d1.DB.id = 'live-core-id';
     delete lock.d1.DB_ADMIN;
@@ -33,9 +39,10 @@ describe('reconcileSharedD1ResourcesInLock', () => {
       { name: 'test-authrim-core-db', uuid: 'live-core-id' },
       { name: 'test-authrim-pii-db', uuid: 'live-pii-id' },
       { name: 'test-authrim-admin-db', uuid: 'live-admin-id' },
+      { name: 'authrim-test-tdb-slot-0001-core', uuid: 'live-tenant-core-id' },
     ]);
 
-    expect(result.updatedBindings).toEqual(['DB_PII', 'DB_ADMIN']);
+    expect(result.updatedBindings).toEqual(['DB_PII', 'DB_ADMIN', 'TDB_SLOT_0001_CORE']);
     expect(result.missingBindings).toEqual([]);
     expect(result.lock.d1.DB).toEqual({ name: 'test-authrim-core-db', id: 'live-core-id' });
     expect(result.lock.d1.DB_PII).toEqual({ name: 'test-authrim-pii-db', id: 'live-pii-id' });
@@ -43,7 +50,10 @@ describe('reconcileSharedD1ResourcesInLock', () => {
       name: 'test-authrim-admin-db',
       id: 'live-admin-id',
     });
-    expect(result.lock.d1.TDB_CORE_0001).toEqual(lock.d1.TDB_CORE_0001);
+    expect(result.lock.d1.TDB_SLOT_0001_CORE).toEqual({
+      name: 'authrim-test-tdb-slot-0001-core',
+      id: 'live-tenant-core-id',
+    });
   });
 
   it('reports a required shared database that does not exist by canonical name', () => {
@@ -52,6 +62,7 @@ describe('reconcileSharedD1ResourcesInLock', () => {
     const result = reconcileSharedD1ResourcesInLock(lock, 'test', [
       { name: 'test-authrim-core-db', uuid: 'live-core-id' },
       { name: 'test-authrim-pii-db', uuid: 'live-pii-id' },
+      { name: 'authrim-test-tdb-slot-0001-core', uuid: 'stale-tenant-core-id' },
     ]);
 
     expect(result.missingBindings).toEqual([
@@ -66,9 +77,76 @@ describe('reconcileSharedD1ResourcesInLock', () => {
       { name: 'test-authrim-core-db', uuid: 'stale-core-id' },
       { name: 'test-authrim-pii-db', uuid: 'stale-pii-id' },
       { name: 'test-authrim-admin-db', uuid: 'stale-admin-id' },
+      { name: 'authrim-test-tdb-slot-0001-core', uuid: 'stale-tenant-core-id' },
     ];
 
     const result = reconcileSharedD1ResourcesInLock(lock, 'test', databases);
+
+    expect(result.updatedBindings).toEqual([]);
+    expect(result.missingBindings).toEqual([]);
+    expect(result.lock).toBe(lock);
+  });
+
+  it('reports a generated tenant database that no longer exists', () => {
+    const lock = createTestLock();
+
+    const result = reconcileSharedD1ResourcesInLock(lock, 'test', [
+      { name: 'test-authrim-core-db', uuid: 'stale-core-id' },
+      { name: 'test-authrim-pii-db', uuid: 'stale-pii-id' },
+      { name: 'test-authrim-admin-db', uuid: 'stale-admin-id' },
+    ]);
+
+    expect(result.missingBindings).toEqual([
+      { binding: 'TDB_SLOT_0001_CORE', name: 'authrim-test-tdb-slot-0001-core' },
+    ]);
+  });
+});
+
+function createLiveKVNamespaces() {
+  return KV_NAMESPACES.map((binding) => ({
+    title: getKVNamespaceName('test', binding),
+    id: `live-${binding.toLowerCase()}`,
+  }));
+}
+
+describe('reconcileSharedKVResourcesInLock', () => {
+  it('refreshes stale and missing canonical KV bindings', () => {
+    const lock = createTestLock();
+    lock.kv.AUTHRIM_CONFIG.id = 'stale-config-id';
+    delete lock.kv.SETTINGS;
+
+    const result = reconcileSharedKVResourcesInLock(lock, 'test', createLiveKVNamespaces());
+
+    expect(result.updatedBindings).toEqual(['SETTINGS', 'AUTHRIM_CONFIG']);
+    expect(result.missingBindings).toEqual([]);
+    expect(result.lock.kv.SETTINGS).toEqual({
+      name: 'TEST-SETTINGS',
+      id: 'live-settings',
+    });
+    expect(result.lock.kv.AUTHRIM_CONFIG).toEqual({
+      name: 'TEST-AUTHRIM_CONFIG',
+      id: 'live-authrim_config',
+    });
+  });
+
+  it('reports a required canonical KV namespace that is missing', () => {
+    const lock = createTestLock();
+    const namespaces = createLiveKVNamespaces().filter(
+      (namespace) => namespace.title !== 'TEST-AUTHRIM_CONFIG'
+    );
+
+    const result = reconcileSharedKVResourcesInLock(lock, 'test', namespaces);
+
+    expect(result.missingBindings).toEqual([
+      { binding: 'AUTHRIM_CONFIG', name: 'TEST-AUTHRIM_CONFIG' },
+    ]);
+    expect(result.lock.kv.AUTHRIM_CONFIG).toEqual(lock.kv.AUTHRIM_CONFIG);
+  });
+
+  it('returns the original lock when all canonical KV IDs are current', () => {
+    const lock = createTestLock();
+
+    const result = reconcileSharedKVResourcesInLock(lock, 'test', createLiveKVNamespaces());
 
     expect(result.updatedBindings).toEqual([]);
     expect(result.missingBindings).toEqual([]);

--- a/packages/setup/src/cli/commands/deploy.ts
+++ b/packages/setup/src/cli/commands/deploy.ts
@@ -16,6 +16,7 @@ import {
   saveLockFile,
   loadLockFileAuto,
   reconcileSharedD1ResourcesInLock,
+  reconcileSharedKVResourcesInLock,
 } from '../../core/lock.js';
 import {
   getEnvironmentPaths,
@@ -55,6 +56,7 @@ import {
   getWorkersSubdomain,
   ensureWildcardDnsForMultiTenant,
   listD1Databases,
+  listKVNamespaces,
 } from '../../core/cloudflare.js';
 import { type WorkerComponent, CORE_WORKER_COMPONENTS } from '../../core/naming.js';
 import { generateWranglerConfig, toToml, buildResourceIdsFromLock } from '../../core/wrangler.js';
@@ -685,33 +687,43 @@ export async function deployCommand(options: DeployCommandOptions): Promise<void
   }
 
   if (!options.dryRun) {
-    const d1ReconciliationSpinner = ora('Refreshing shared D1 resource IDs...').start();
+    const resourceReconciliationSpinner = ora('Refreshing Cloudflare resource IDs...').start();
     try {
-      const reconciliation = reconcileSharedD1ResourcesInLock(
-        currentLock,
+      const [databases, namespaces] = await Promise.all([listD1Databases(), listKVNamespaces()]);
+      const d1Reconciliation = reconcileSharedD1ResourcesInLock(currentLock, env, databases);
+      const kvReconciliation = reconcileSharedKVResourcesInLock(
+        d1Reconciliation.lock,
         env,
-        await listD1Databases()
+        namespaces
       );
+      const missingResources = [
+        ...d1Reconciliation.missingBindings.map((missing) => ({ type: 'D1', ...missing })),
+        ...kvReconciliation.missingBindings.map((missing) => ({ type: 'KV', ...missing })),
+      ];
 
-      if (reconciliation.missingBindings.length > 0) {
-        d1ReconciliationSpinner.fail('Required shared D1 databases are missing');
-        for (const missing of reconciliation.missingBindings) {
-          console.log(chalk.red(`  • ${missing.binding}: ${missing.name}`));
+      if (missingResources.length > 0) {
+        resourceReconciliationSpinner.fail('Required Cloudflare resources are missing');
+        for (const missing of missingResources) {
+          console.log(chalk.red(`  • ${missing.type} ${missing.binding}: ${missing.name}`));
         }
         process.exit(1);
       }
 
-      currentLock = reconciliation.lock;
-      if (reconciliation.updatedBindings.length > 0) {
+      currentLock = kvReconciliation.lock;
+      const updatedResources = [
+        ...d1Reconciliation.updatedBindings.map((binding) => `D1 ${binding}`),
+        ...kvReconciliation.updatedBindings.map((binding) => `KV ${binding}`),
+      ];
+      if (updatedResources.length > 0) {
         await saveLockFile(currentLock, lockPath);
-        d1ReconciliationSpinner.succeed(
-          `Refreshed shared D1 bindings: ${reconciliation.updatedBindings.join(', ')}`
+        resourceReconciliationSpinner.succeed(
+          `Refreshed Cloudflare bindings: ${updatedResources.join(', ')}`
         );
       } else {
-        d1ReconciliationSpinner.succeed('Shared D1 resource IDs are current');
+        resourceReconciliationSpinner.succeed('D1 and KV resource IDs are current');
       }
     } catch (error) {
-      d1ReconciliationSpinner.fail('Failed to refresh shared D1 resource IDs');
+      resourceReconciliationSpinner.fail('Failed to refresh Cloudflare resource IDs');
       console.log(chalk.red(`  ${error instanceof Error ? error.message : String(error)}`));
       process.exit(1);
     }

--- a/packages/setup/src/core/cloudflare.ts
+++ b/packages/setup/src/core/cloudflare.ts
@@ -1746,6 +1746,103 @@ function findJsonArrayCandidates(value: string): string[] {
   return candidates;
 }
 
+function parseValidatedJsonArrayOutput<T>(
+  stdout: string,
+  normalizeRows: (rows: unknown) => T[],
+  invalidOutputMessage: string
+): T[] {
+  const candidates = findJsonArrayCandidates(stdout);
+  for (let index = candidates.length - 1; index >= 0; index--) {
+    try {
+      return normalizeRows(JSON.parse(candidates[index]));
+    } catch {
+      // Wrangler can print notices containing brackets before the JSON payload.
+    }
+  }
+
+  throw new SyntaxError(invalidOutputMessage);
+}
+
+function describeInventoryError(error: unknown, fallback: string): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return fallback;
+}
+
+async function resolveCloudflareInventoryCredentials(): Promise<{
+  accountId: string;
+  token: string;
+} | null> {
+  if (
+    process.env.NODE_ENV === 'test' &&
+    (!process.env.CLOUDFLARE_ACCOUNT_ID?.trim() || !process.env.CLOUDFLARE_API_TOKEN?.trim())
+  ) {
+    return null;
+  }
+
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim() || (await getAccountId());
+  const envToken = process.env.CLOUDFLARE_API_TOKEN?.trim();
+  const tokenInfo = envToken
+    ? ({ token: envToken, source: 'env' } satisfies CloudflareApiToken)
+    : await getCloudflareApiToken();
+  if (!accountId || !tokenInfo?.token) {
+    return null;
+  }
+
+  return { accountId, token: tokenInfo.token };
+}
+
+async function listCloudflarePaginatedResourcesViaApi<T>(input: {
+  path: string;
+  label: string;
+  normalizeRows: (rows: unknown) => T[];
+}): Promise<T[] | null> {
+  const credentials = await resolveCloudflareInventoryCredentials();
+  if (!credentials) return null;
+
+  const resources: T[] = [];
+  const perPage = 1000;
+  let page = 1;
+
+  while (true) {
+    const url = new URL(
+      `https://api.cloudflare.com/client/v4/accounts/${credentials.accountId}/${input.path}`
+    );
+    url.searchParams.set('page', String(page));
+    url.searchParams.set('per_page', String(perPage));
+
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${credentials.token}`,
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Cloudflare ${input.label} failed (${response.status})`);
+    }
+
+    const payload = (await response.json()) as {
+      success?: boolean;
+      result?: unknown;
+      result_info?: { total_count?: unknown };
+    };
+    if (payload.success === false) {
+      throw new Error(`Cloudflare ${input.label} returned an unsuccessful response`);
+    }
+
+    const rows = input.normalizeRows(payload.result);
+    resources.push(...rows);
+
+    const totalCount = payload.result_info?.total_count;
+    if (
+      rows.length < perPage ||
+      (typeof totalCount === 'number' && resources.length >= totalCount)
+    ) {
+      return resources;
+    }
+    page++;
+  }
+}
+
 function normalizeD1DatabaseRows(rows: unknown): D1DatabaseListRow[] {
   if (!Array.isArray(rows)) {
     throw new TypeError('D1 database list was not an array');
@@ -1771,74 +1868,19 @@ function normalizeD1DatabaseRows(rows: unknown): D1DatabaseListRow[] {
 }
 
 export function parseD1DatabaseListOutput(stdout: string): D1DatabaseListRow[] {
-  const candidates = findJsonArrayCandidates(stdout);
-  for (let index = candidates.length - 1; index >= 0; index--) {
-    try {
-      return normalizeD1DatabaseRows(JSON.parse(candidates[index]));
-    } catch {
-      // Wrangler can print notices containing brackets before the JSON payload.
-    }
-  }
-
-  throw new SyntaxError('Wrangler output did not contain a valid D1 database list');
+  return parseValidatedJsonArrayOutput(
+    stdout,
+    normalizeD1DatabaseRows,
+    'Wrangler output did not contain a valid D1 database list'
+  );
 }
 
 async function listD1DatabasesViaApi(): Promise<D1DatabaseListRow[] | null> {
-  if (
-    process.env.NODE_ENV === 'test' &&
-    (!process.env.CLOUDFLARE_ACCOUNT_ID?.trim() || !process.env.CLOUDFLARE_API_TOKEN?.trim())
-  ) {
-    return null;
-  }
-
-  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim() || (await getAccountId());
-  const envToken = process.env.CLOUDFLARE_API_TOKEN?.trim();
-  const tokenInfo = envToken
-    ? ({ token: envToken, source: 'env' } satisfies CloudflareApiToken)
-    : await getCloudflareApiToken();
-  if (!accountId || !tokenInfo?.token) {
-    return null;
-  }
-
-  const databases: D1DatabaseListRow[] = [];
-  const perPage = 1000;
-  let page = 1;
-
-  while (true) {
-    const url = new URL(`https://api.cloudflare.com/client/v4/accounts/${accountId}/d1/database`);
-    url.searchParams.set('page', String(page));
-    url.searchParams.set('per_page', String(perPage));
-
-    const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${tokenInfo.token}`,
-      },
-    });
-    if (!response.ok) {
-      throw new Error(`Cloudflare D1 database list failed (${response.status})`);
-    }
-
-    const payload = (await response.json()) as {
-      success?: boolean;
-      result?: unknown;
-      result_info?: { total_count?: unknown };
-    };
-    if (payload.success === false) {
-      throw new Error('Cloudflare D1 database list returned an unsuccessful response');
-    }
-
-    const rows = normalizeD1DatabaseRows(payload.result);
-    databases.push(...rows);
-
-    const totalCount = payload.result_info?.total_count;
-    if (
-      rows.length < perPage ||
-      (typeof totalCount === 'number' && databases.length >= totalCount)
-    ) {
-      return databases;
-    }
-    page++;
-  }
+  return listCloudflarePaginatedResourcesViaApi({
+    path: 'd1/database',
+    label: 'D1 database list',
+    normalizeRows: normalizeD1DatabaseRows,
+  });
 }
 
 /**
@@ -1867,18 +1909,8 @@ export async function listD1Databases(): Promise<Array<{ name: string; uuid: str
     return parseD1DatabaseListOutput(stdout);
   } catch (error) {
     if (apiError) {
-      const apiMessage =
-        apiError instanceof Error
-          ? apiError.message
-          : typeof apiError === 'string'
-            ? apiError
-            : 'unknown API error';
-      const wranglerMessage =
-        error instanceof Error
-          ? error.message
-          : typeof error === 'string'
-            ? error
-            : 'unknown Wrangler error';
+      const apiMessage = describeInventoryError(apiError, 'unknown API error');
+      const wranglerMessage = describeInventoryError(error, 'unknown Wrangler error');
       throw new Error(
         `Failed to list D1 databases via the Cloudflare API (${apiMessage}) and Wrangler (${wranglerMessage})`
       );
@@ -3897,11 +3929,63 @@ export async function runD1MigrationsForEnvironmentSelection(input: {
 // KV Namespace Operations
 // =============================================================================
 
+type KVNamespaceListRow = { title: string; id: string };
+
+function normalizeKVNamespaceRows(rows: unknown): KVNamespaceListRow[] {
+  if (!Array.isArray(rows)) {
+    throw new TypeError('KV namespace list was not an array');
+  }
+
+  return rows.map((row, index) => {
+    if (!row || typeof row !== 'object') {
+      throw new TypeError(`KV namespace list row ${index} was not an object`);
+    }
+
+    const { title, id } = row as { title?: unknown; id?: unknown };
+    if (
+      typeof title !== 'string' ||
+      title.trim().length === 0 ||
+      typeof id !== 'string' ||
+      id.trim().length === 0
+    ) {
+      throw new TypeError(`KV namespace list row ${index} did not contain a title and ID`);
+    }
+
+    return { title: title.trim(), id: id.trim() };
+  });
+}
+
+export function parseKVNamespaceListOutput(stdout: string): KVNamespaceListRow[] {
+  return parseValidatedJsonArrayOutput(
+    stdout,
+    normalizeKVNamespaceRows,
+    'Wrangler output did not contain a valid KV namespace list'
+  );
+}
+
+async function listKVNamespacesViaApi(): Promise<KVNamespaceListRow[] | null> {
+  return listCloudflarePaginatedResourcesViaApi({
+    path: 'storage/kv/namespaces',
+    label: 'KV namespace list',
+    normalizeRows: normalizeKVNamespaceRows,
+  });
+}
+
 /**
  * List all KV namespaces
  * @throws Error if wrangler command fails (caller should handle)
  */
 export async function listKVNamespaces(): Promise<Array<{ title: string; id: string }>> {
+  let apiError: unknown;
+  try {
+    const apiNamespaces = await listKVNamespacesViaApi();
+    if (apiNamespaces) {
+      return apiNamespaces;
+    }
+  } catch (error) {
+    apiError = error;
+  }
+
   try {
     const { stdout, stderr } = await wrangler(['kv', 'namespace', 'list']);
 
@@ -3910,14 +3994,15 @@ export async function listKVNamespaces(): Promise<Array<{ title: string; id: str
       throw new Error('Not logged in to Cloudflare. Run: wrangler login');
     }
 
-    // wrangler kv namespace list outputs JSON
-    const namespaces = JSON.parse(stdout);
-    return namespaces.map((ns: { title: string; id: string }) => ({
-      title: ns.title,
-      id: ns.id,
-    }));
+    return parseKVNamespaceListOutput(stdout);
   } catch (error) {
-    // Re-throw with context
+    if (apiError) {
+      const apiMessage = describeInventoryError(apiError, 'unknown API error');
+      const wranglerMessage = describeInventoryError(error, 'unknown Wrangler error');
+      throw new Error(
+        `Failed to list KV namespaces via the Cloudflare API (${apiMessage}) and Wrangler (${wranglerMessage})`
+      );
+    }
     if (error instanceof SyntaxError) {
       throw new Error('Failed to parse KV namespace list - wrangler output was not valid JSON');
     }

--- a/packages/setup/src/core/generated-env-validator.ts
+++ b/packages/setup/src/core/generated-env-validator.ts
@@ -18,7 +18,7 @@ import {
 } from './wrangler.js';
 import { checkWranglerStatus } from './wrangler-sync.js';
 import { D1_DATABASES, getEnabledComponents, type WorkerComponent } from './naming.js';
-import { listD1Databases, listR2Buckets, queryD1Rows } from './cloudflare.js';
+import { listD1Databases, listKVNamespaces, listR2Buckets, queryD1Rows } from './cloudflare.js';
 
 type ValidationStatus = 'pass' | 'warn' | 'fail';
 
@@ -1063,6 +1063,42 @@ async function validateLiveCloudflareD1(lock: AuthrimLock): Promise<ValidationCh
   return finishCheck(check, 'All lock.json D1 databases exist in Cloudflare');
 }
 
+async function validateLiveCloudflareKV(lock: AuthrimLock): Promise<ValidationCheck> {
+  const check = makeCheck('live-cloudflare-kv', 'Cloudflare KV namespaces in lock.json exist');
+
+  try {
+    const cloudflareNamespaces = await listKVNamespaces();
+    const byTitle = new Map(
+      cloudflareNamespaces.map((namespace) => [namespace.title, namespace.id])
+    );
+
+    for (const [binding, namespace] of Object.entries(lock.kv)) {
+      const cloudflareId = byTitle.get(namespace.name);
+      if (!cloudflareId) {
+        pushDetail(check, 'fail', `${binding}: ${namespace.name} is missing in Cloudflare KV`);
+        continue;
+      }
+      if (cloudflareId !== namespace.id) {
+        pushDetail(
+          check,
+          'fail',
+          `${binding}: ${namespace.name} id mismatch lock=${namespace.id} cloudflare=${cloudflareId}`
+        );
+        continue;
+      }
+      pushDetail(check, 'pass', `${binding}: ${namespace.name} (${namespace.id})`);
+    }
+  } catch (error) {
+    pushDetail(
+      check,
+      'fail',
+      `Cloudflare KV list failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  return finishCheck(check, 'All lock.json KV namespaces exist in Cloudflare');
+}
+
 async function validateLiveCloudflareR2(lock: AuthrimLock): Promise<ValidationCheck> {
   const check = makeCheck('live-cloudflare-r2', 'Cloudflare R2 buckets in lock.json exist');
   const recordedBuckets = Object.entries(lock.r2 ?? {});
@@ -1321,6 +1357,7 @@ export async function validateGeneratedEnvironment(
   if (options.liveCloudflare) {
     checks.push(
       await validateLiveCloudflareD1(lock),
+      await validateLiveCloudflareKV(lock),
       await validateLiveCloudflareR2(lock),
       await validateLiveRuntimeD1Schema(lock),
       await validateLiveTenantD1Slots(config, lock)

--- a/packages/setup/src/core/lock.ts
+++ b/packages/setup/src/core/lock.ts
@@ -19,7 +19,8 @@ import {
   type EnvironmentPaths,
   type LegacyPaths,
 } from './paths.js';
-import { D1_DATABASES, getD1DatabaseName } from './naming.js';
+import { D1_DATABASES, KV_NAMESPACES, getD1DatabaseName, getKVNamespaceName } from './naming.js';
+import { isTenantDatabaseBinding } from './tenant-database.js';
 
 // =============================================================================
 // Schema
@@ -59,6 +60,12 @@ export type KVResourceEntry = z.infer<typeof KVResourceEntrySchema>;
 export type WorkerEntry = z.infer<typeof WorkerEntrySchema>;
 
 export interface SharedD1LockReconciliationResult {
+  lock: AuthrimLock;
+  updatedBindings: string[];
+  missingBindings: Array<{ binding: string; name: string }>;
+}
+
+export interface SharedKVLockReconciliationResult {
   lock: AuthrimLock;
   updatedBindings: string[];
   missingBindings: Array<{ binding: string; name: string }>;
@@ -312,12 +319,14 @@ export async function loadLockFileAuto(
 }
 
 /**
- * Refresh shared D1 lock entries from Cloudflare's current database list.
+ * Refresh shared and generated tenant D1 lock entries from Cloudflare's current database list.
  *
  * Restored or copied lock files can retain UUIDs for databases that were
  * recreated under the same canonical name. Wrangler requires the live UUID,
  * so deployment reconciles these three shared bindings before generating its
- * worker configurations.
+ * worker configurations. Generated tenant bindings are reconciled by their
+ * recorded canonical database name because they are also emitted into Worker
+ * configuration by ID.
  */
 export function reconcileSharedD1ResourcesInLock(
   lock: AuthrimLock,
@@ -328,6 +337,7 @@ export function reconcileSharedD1ResourcesInLock(
   const nextD1 = { ...lock.d1 };
   const updatedBindings: string[] = [];
   const missingBindings: Array<{ binding: string; name: string }> = [];
+  const sharedBindings = new Set<string>(D1_DATABASES.map((database) => database.binding));
 
   for (const database of D1_DATABASES) {
     const expectedName = getD1DatabaseName(env, database.dbType);
@@ -349,8 +359,64 @@ export function reconcileSharedD1ResourcesInLock(
     updatedBindings.push(database.binding);
   }
 
+  for (const [binding, lockedDatabase] of Object.entries(nextD1)) {
+    if (sharedBindings.has(binding)) continue;
+    if (!isTenantDatabaseBinding(binding)) continue;
+
+    const liveDatabase = databasesByName.get(lockedDatabase.name);
+    if (!liveDatabase) {
+      missingBindings.push({ binding, name: lockedDatabase.name });
+      continue;
+    }
+    if (lockedDatabase.id === liveDatabase.uuid) continue;
+
+    nextD1[binding] = {
+      name: liveDatabase.name,
+      id: liveDatabase.uuid,
+    };
+    updatedBindings.push(binding);
+  }
+
   return {
     lock: updatedBindings.length > 0 ? { ...lock, d1: nextD1 } : lock,
+    updatedBindings,
+    missingBindings,
+  };
+}
+
+/** Refresh every canonical KV binding from Cloudflare's current namespace list. */
+export function reconcileSharedKVResourcesInLock(
+  lock: AuthrimLock,
+  env: string,
+  namespaces: Array<{ title: string; id: string }>
+): SharedKVLockReconciliationResult {
+  const namespacesByTitle = new Map(namespaces.map((namespace) => [namespace.title, namespace]));
+  const nextKV = { ...lock.kv };
+  const updatedBindings: string[] = [];
+  const missingBindings: Array<{ binding: string; name: string }> = [];
+
+  for (const binding of KV_NAMESPACES) {
+    const expectedName = getKVNamespaceName(env, binding);
+    const liveNamespace = namespacesByTitle.get(expectedName);
+    if (!liveNamespace) {
+      missingBindings.push({ binding, name: expectedName });
+      continue;
+    }
+
+    const lockedNamespace = nextKV[binding];
+    if (lockedNamespace?.name === liveNamespace.title && lockedNamespace.id === liveNamespace.id) {
+      continue;
+    }
+
+    nextKV[binding] = {
+      name: liveNamespace.title,
+      id: liveNamespace.id,
+    };
+    updatedBindings.push(binding);
+  }
+
+  return {
+    lock: updatedBindings.length > 0 ? { ...lock, kv: nextKV } : lock,
     updatedBindings,
     missingBindings,
   };


### PR DESCRIPTION
## Summary

- reconcile every canonical KV namespace ID before generating Worker configuration
- reconcile generated tenant D1 bindings in addition to the three shared D1 bindings
- use the Cloudflare REST API for KV inventory with the same validated Wrangler fallback used for D1
- validate live KV names and IDs in generated-environment validation
- fail before deployment when any required D1 or KV resource is missing

## Root cause

After D1 lock IDs were repaired, the test deployment reached Worker publication and failed because the restored environment lock also contained deleted KV namespace IDs. `ar-lib-core` was rejected with Cloudflare error `10041` for a missing KV namespace. Lock restoration can make every ID-backed binding stale, so D1-only reconciliation was incomplete.

## Verification

- live Cloudflare inventory: 3 test D1 databases and 9 canonical test KV namespaces resolved through the built setup implementation
- `pnpm --filter @authrim/setup test` (65 files, 823 tests)
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (40 tasks)
