### PR TITLE
Make initial tenant screen bootstrap idempotent

### DIFF
--- a/packages/setup/src/__tests__/cloudflare-migrations.test.ts
+++ b/packages/setup/src/__tests__/cloudflare-migrations.test.ts
@@ -824,6 +824,111 @@ INSERT INTO oauth_clients (
   );
 
   it(
+    'reconciles stale default screens without overwriting initial-tenant customizations',
+    () => {
+      const sqlite3Path = findSqlite3();
+      if (!sqlite3Path) {
+        return;
+      }
+
+      const tempDir = mkdtempSync(join(tmpdir(), 'authrim-screen-bootstrap-rerun-'));
+      const dbPath = join(tempDir, 'test.db');
+      const config = createDefaultConfig('mt');
+      config.tenant.name = 'first';
+      config.tenant.displayName = 'First Tenant';
+
+      try {
+        runMigrationFiles(sqlite3Path, dbPath, activeCoreMigrationFiles());
+        runSqlite(sqlite3Path, dbPath, buildInitialTenantBootstrapSql(config));
+        runSqlite(
+          sqlite3Path,
+          dbPath,
+          `
+UPDATE screens
+SET display_name = 'Customized Login',
+    fields_json = '[{"field":"custom"}]',
+    updated_at = 123
+WHERE tenant_id = 'first' AND screen_key = 'login';
+
+INSERT INTO screens (
+  id, tenant_id, screen_key, display_name, description, screen_kind, fields_json,
+  localizations_json, settings_json, is_active, is_system, created_at, updated_at
+)
+SELECT
+  'stale-default-' || screen_key,
+  'default',
+  screen_key,
+  'Stale default ' || screen_key,
+  description,
+  screen_kind,
+  '[]',
+  NULL,
+  settings_json,
+  is_active,
+  is_system,
+  0,
+  0
+FROM screens
+WHERE tenant_id = 'first'
+  AND screen_key IN ('login', 'registration', 'profile_completion', 'code_input');
+
+INSERT INTO screens (
+  id, tenant_id, screen_key, display_name, description, screen_kind, fields_json,
+  localizations_json, settings_json, is_active, is_system, created_at, updated_at
+) VALUES (
+  'stale-default-legacy-custom',
+  'default',
+  'legacy_custom',
+  'Legacy custom',
+  NULL,
+  'custom',
+  '[]',
+  NULL,
+  '{"canvas_layout":"narrow"}',
+  1,
+  0,
+  0,
+  0
+);
+`
+        );
+
+        runSqlite(sqlite3Path, dbPath, buildInitialTenantBootstrapSql(config));
+        runSqlite(sqlite3Path, dbPath, buildInitialTenantBootstrapSql(config));
+
+        expect(
+          readSqlite(
+            sqlite3Path,
+            dbPath,
+            `SELECT display_name || ':' || fields_json || ':' || updated_at
+             FROM screens
+             WHERE tenant_id = 'first' AND screen_key = 'login';`
+          )
+        ).toBe('Customized Login:[{"field":"custom"}]:123');
+        expect(
+          readSqlite(
+            sqlite3Path,
+            dbPath,
+            `SELECT display_name
+             FROM screens
+             WHERE tenant_id = 'first' AND screen_key = 'legacy_custom';`
+          )
+        ).toBe('Legacy custom');
+        expect(
+          readSqlite(
+            sqlite3Path,
+            dbPath,
+            "SELECT COUNT(*) FROM screens WHERE tenant_id = 'default';"
+          )
+        ).toBe('0');
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    },
+    sqliteMigrationApplyTimeoutMs
+  );
+
+  it(
     'applies the consolidated PII baseline in SQLite',
     () => {
       const sqlite3Path = findSqlite3();

--- a/packages/setup/src/core/cloudflare.ts
+++ b/packages/setup/src/core/cloudflare.ts
@@ -2820,6 +2820,18 @@ WHERE tenant_id = 'default'
   AND EXISTS (SELECT 1 FROM tenants WHERE id = ${tenantIdSql})
   AND NOT EXISTS (SELECT 1 FROM tenants WHERE id = 'default');
 
+DELETE FROM screens
+WHERE tenant_id = 'default'
+  AND ${tenantIdSql} <> 'default'
+  AND EXISTS (SELECT 1 FROM tenants WHERE id = ${tenantIdSql})
+  AND NOT EXISTS (SELECT 1 FROM tenants WHERE id = 'default')
+  AND EXISTS (
+    SELECT 1
+    FROM screens target
+    WHERE target.tenant_id = ${tenantIdSql}
+      AND target.screen_key = screens.screen_key
+  );
+
 UPDATE screens
 SET tenant_id = ${tenantIdSql},
     updated_at = ${sqlExpr.nowEpochSeconds}


### PR DESCRIPTION
## Summary
- remove stale default-tenant screen seeds only when the configured initial tenant already owns the same screen key
- preserve customized initial-tenant screens instead of overwriting them during redeploy
- continue moving non-conflicting default screens into the configured initial tenant
- add a SQLite regression that recreates the live duplicate state and executes bootstrap repeatedly

## Verification
- `pnpm --dir packages/setup exec vitest run src/__tests__/cloudflare-migrations.test.ts src/__tests__/initial-tenant-bootstrap.test.ts` (39 tests)
- `pnpm --dir packages/setup test` (66 files, 828 tests)
- `pnpm typecheck` (27 tasks)
- `pnpm lint` (20 tasks)
- `pnpm format:check`
- `pnpm test` (40 tasks)