### PR TITLE
Fix Wrangler secret cleanup output in deployment CI

### DIFF
--- a/packages/setup/src/__tests__/deploy.test.ts
+++ b/packages/setup/src/__tests__/deploy.test.ts
@@ -411,6 +411,35 @@ describe('cleanupLegacyStaticSecrets', () => {
     expect(bulkCall?.[2]).toMatchObject({
       input: JSON.stringify({ ADMIN_API_SECRET: null, KEY_MANAGER_SECRET: null }),
     });
+
+    const listCall = vi
+      .mocked(execa)
+      .mock.calls.find(([, args]) => args.includes('secret') && args.includes('list'));
+    expect(listCall?.[1]).toEqual(expect.arrayContaining(['--format', 'json']));
+    expect(listCall?.[2]).toMatchObject({
+      env: { WRANGLER_LOG: 'log' },
+    });
+  });
+
+  it('reports a clear failure when Wrangler suppresses secret list JSON output', async () => {
+    const rootDir = createTempRoot();
+    createWorkerPackage(rootDir, 'ar-auth', '1.0.0');
+    vi.mocked(execa).mockResolvedValue({
+      ...successfulCommandResult(),
+      stdout: '',
+    } as Awaited<ReturnType<typeof execa>>);
+
+    await expect(
+      cleanupLegacyStaticSecrets({ env: 'test', rootDir }, ['ar-auth'])
+    ).resolves.toEqual({
+      failures: [
+        {
+          component: 'ar-auth',
+          error: 'Wrangler secret list returned empty JSON output',
+        },
+      ],
+      activeVersionIds: {},
+    });
   });
 
   it('defers shared KeyManager and VersionManager cleanup during a partial rollout', async () => {

--- a/packages/setup/src/core/deploy.ts
+++ b/packages/setup/src/core/deploy.ts
@@ -146,10 +146,23 @@ export interface LegacyStaticSecretCleanupResult {
 }
 
 function parseWranglerSecretNames(stdout: unknown): Set<string> {
-  const parsed = JSON.parse(String(stdout)) as Array<{ name?: unknown }>;
+  const output = String(stdout).trim();
+  if (output.length === 0) {
+    throw new Error('Wrangler secret list returned empty JSON output');
+  }
+
+  const parsed = JSON.parse(output) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error('Wrangler secret list returned a non-array JSON response');
+  }
+
   return new Set(
     parsed
-      .map((entry) => entry.name)
+      .map((entry: unknown) =>
+        typeof entry === 'object' && entry !== null && 'name' in entry
+          ? (entry as { name?: unknown }).name
+          : undefined
+      )
       .filter((name): name is string => typeof name === 'string' && name.length > 0)
   );
 }
@@ -197,8 +210,26 @@ export async function cleanupLegacyStaticSecrets(
         () =>
           execa(
             'pnpm',
-            ['exec', 'wrangler', 'secret', 'list', ...getConfigArgs(options), '--env', options.env],
-            { cwd: packageDir, reject: true, cancelSignal: options.signal }
+            [
+              'exec',
+              'wrangler',
+              'secret',
+              'list',
+              '--format',
+              'json',
+              ...getConfigArgs(options),
+              '--env',
+              options.env,
+            ],
+            {
+              cwd: packageDir,
+              reject: true,
+              cancelSignal: options.signal,
+              // Wrangler emits command results through its `log` channel. The deployment
+              // workflow uses WRANGLER_LOG=warn globally, so enable captured JSON output only
+              // for this subprocess without increasing the surrounding CI log verbosity.
+              env: { WRANGLER_LOG: 'log' },
+            }
           )
       );
       const existingNames = parseWranglerSecretNames(listed.stdout);


### PR DESCRIPTION
## Summary

- force `wrangler secret list` to emit captured JSON even when deployment CI uses `WRANGLER_LOG=warn`
- request the JSON format explicitly and validate empty or non-array responses
- add regression coverage for the scoped log-level override and suppressed output

## Root cause

The test deployment workflow globally sets `WRANGLER_LOG=warn` to avoid exposing resource identifiers. Wrangler emits `secret list` results through its `log` channel, so the cleanup subprocess returned an empty stdout value. The legacy static secret cleanup then attempted to parse that empty value as JSON and marked four otherwise successful Worker deployments as failed.

The fix overrides `WRANGLER_LOG` only for the captured `secret list` subprocess. It does not increase the surrounding workflow log verbosity.

## Validation

- `pnpm --filter @authrim/setup exec vitest run src/__tests__/deploy.test.ts`
- `pnpm --filter @authrim/setup typecheck`
- `pnpm --filter @authrim/setup lint`
- `pnpm exec prettier --check packages/setup/src/core/deploy.ts packages/setup/src/__tests__/deploy.test.ts`
