### PR TITLE
Harden security-sensitive flows and branch coverage

### DIFF
--- a/packages/ar-lib-core/src/errors/__tests__/middleware.test.ts
+++ b/packages/ar-lib-core/src/errors/__tests__/middleware.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { AR_ERROR_CODES } from '../codes';
+import {
+  AuthrimError,
+  RFCError,
+  createErrorFactoryFromContext,
+  createErrorResponse,
+  createRFCErrorResponse,
+  errorHandler,
+  errorMiddleware,
+} from '../middleware';
+
+type TestEnv = { AUTHRIM_CONFIG?: { get: (key: string) => Promise<string | null> } };
+
+function appWithError(
+  error: unknown,
+  env: TestEnv = {},
+  options: Parameters<typeof errorMiddleware>[0] = {}
+) {
+  const app = new Hono<{ Bindings: TestEnv }>();
+  app.onError(errorHandler(options));
+  app.get('/test', () => {
+    throw error;
+  });
+  app.get('/authorize', () => {
+    throw error;
+  });
+  return { app, env };
+}
+
+describe('error middleware', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('serializes an Authrim error without leaking implementation details', async () => {
+    const { app, env } = appWithError(
+      new AuthrimError(AR_ERROR_CODES.AUTH_SESSION_EXPIRED, {
+        state: 'state-1',
+        extensions: { safe_hint: 'sign_in_again' },
+      })
+    );
+
+    const response = await app.request('/authorize', {}, env);
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(body.state).toBe('state-1');
+    expect(JSON.stringify(body)).not.toContain('AuthrimError:');
+  });
+
+  it('serializes an RFC error in OAuth format', async () => {
+    const { app, env } = appWithError(new RFCError('invalid_request', 400, 'Bad request'));
+
+    const response = await app.request('/authorize', {}, env);
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('invalid_request');
+  });
+
+  it('uses problem details when requested by Accept header', async () => {
+    const { app, env } = appWithError(new RFCError('invalid_request', 422, 'Invalid input'));
+
+    const response = await app.request(
+      '/test',
+      { headers: { Accept: 'application/problem+json' } },
+      env
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(response.status).toBe(422);
+    expect(response.headers.get('content-type')).toContain('application/problem+json');
+    expect(body).toMatchObject({ status: 422 });
+  });
+
+  it('calls the supplied unhandled-error hook and returns a masked internal error', async () => {
+    const onError = vi.fn();
+    const rawError = new Error('database password must never leak');
+    const { app, env } = appWithError(rawError, {}, { onError });
+
+    const response = await app.request('/test', {}, env);
+    const text = await response.text();
+
+    expect(response.status).toBe(500);
+    expect(onError).toHaveBeenCalledWith(rawError, expect.anything());
+    expect(text).not.toContain('database password');
+  });
+
+  it('uses valid KV locale, format, and error-id settings', async () => {
+    const values: Record<string, string> = {
+      error_locale: 'ja',
+      error_response_format: 'problem_details',
+      error_id_mode: 'all',
+    };
+    const kv = { get: vi.fn(async (key: string) => values[key] ?? null) };
+    const { app, env } = appWithError(new RFCError('invalid_request', 400), {
+      AUTHRIM_CONFIG: kv,
+    });
+
+    const response = await app.request('/test', {}, env);
+
+    expect(response.headers.get('content-type')).toContain('application/problem+json');
+    expect(kv.get).toHaveBeenCalledTimes(3);
+  });
+
+  it.each([
+    ['invalid KV values', vi.fn(async () => 'invalid')],
+    ['KV read failure', vi.fn(async () => Promise.reject(new Error('KV unavailable')))],
+  ])('falls back safely after %s', async (_label, get) => {
+    const { app, env } = appWithError(new RFCError('invalid_request', 400), {
+      AUTHRIM_CONFIG: { get },
+    });
+
+    const response = await app.request('/authorize', {}, env);
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get('content-type')).toContain('application/json');
+  });
+
+  it('honors explicit middleware defaults when KV has no overrides', async () => {
+    const kv = { get: vi.fn(async () => null) };
+    const { app, env } = appWithError(
+      new RFCError('invalid_request', 400),
+      {
+        AUTHRIM_CONFIG: kv,
+      },
+      {
+        locale: 'ja',
+        format: 'problem_details',
+        errorIdMode: 'none',
+        baseUrl: 'https://errors.example.com',
+      }
+    );
+
+    const response = await app.request('/test', {}, env);
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(response.headers.get('content-type')).toContain('application/problem+json');
+    expect(String(body.type)).toContain('errors.example.com');
+  });
+
+  it('handles runtimes that propagate downstream errors through next()', async () => {
+    const middleware = errorMiddleware();
+    const context = {
+      env: {},
+      req: { path: '/authorize', header: () => undefined },
+    } as never;
+
+    const response = (await middleware(context, async () => {
+      throw new RFCError('invalid_request', 400, 'Invalid');
+    })) as Response;
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: 'invalid_request' });
+  });
+
+  it('does not replace a successful downstream response', async () => {
+    const middleware = errorMiddleware();
+    const next = vi.fn().mockResolvedValue(undefined);
+
+    const result = await middleware(
+      { env: {}, req: { path: '/test', header: () => undefined } } as never,
+      next
+    );
+
+    expect(result).toBeUndefined();
+    expect(next).toHaveBeenCalledOnce();
+  });
+});
+
+describe('error response helpers', () => {
+  it('creates a configured factory from a Hono context', async () => {
+    const app = new Hono<{ Bindings: TestEnv }>();
+    app.get('/factory', async (c) => {
+      const factory = await createErrorFactoryFromContext(c);
+      const descriptor = factory.create(AR_ERROR_CODES.AUTH_SESSION_EXPIRED);
+      return c.json({ code: descriptor.code });
+    });
+
+    const response = await app.request('/factory');
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      code: AR_ERROR_CODES.AUTH_SESSION_EXPIRED,
+    });
+  });
+
+  it('creates an Authrim error response directly', async () => {
+    const app = new Hono();
+    app.get('/error', (c) =>
+      createErrorResponse(c, AR_ERROR_CODES.AUTH_SESSION_EXPIRED, { state: 'state-2' })
+    );
+
+    const response = await app.request('/error');
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(body.state).toBe('state-2');
+  });
+
+  it('creates a legacy RFC response without throwing', async () => {
+    const app = new Hono();
+    app.get('/error', (c) => createRFCErrorResponse(c, 'invalid_request', 400, 'Invalid'));
+
+    const response = await app.request('/error');
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: 'invalid_request' });
+  });
+});

--- a/packages/ar-lib-core/src/errors/index.ts
+++ b/packages/ar-lib-core/src/errors/index.ts
@@ -168,6 +168,7 @@ export {
 export {
   AuthrimError,
   RFCError,
+  errorHandler,
   errorMiddleware,
   createErrorFactoryFromContext,
   createErrorResponse,

--- a/packages/ar-lib-core/src/errors/middleware.ts
+++ b/packages/ar-lib-core/src/errors/middleware.ts
@@ -5,10 +5,10 @@
  *
  * Usage:
  * ```ts
- * import { errorMiddleware } from '@authrim/ar-lib-core';
+ * import { errorHandler } from '@authrim/ar-lib-core';
  *
  * const app = new Hono();
- * app.use('*', errorMiddleware());
+ * app.onError(errorHandler());
  *
  * // Errors thrown with AR codes will be automatically serialized
  * app.get('/api/resource', (c) => {
@@ -138,7 +138,7 @@ async function getErrorConfig(
   format: ErrorResponseFormat;
   errorIdMode: ErrorIdMode;
 }> {
-  const env = c.env as {
+  const env = (c.env ?? {}) as {
     AUTHRIM_CONFIG?: { get: (key: string) => Promise<string | null> };
   };
 
@@ -185,56 +185,60 @@ async function getErrorConfig(
  */
 export function errorMiddleware(options: ErrorMiddlewareOptions = {}): MiddlewareHandler {
   return async (c, next) => {
+    let caughtError: unknown;
     try {
       await next();
     } catch (error) {
-      // Get configuration
-      const config = await getErrorConfig(c, options);
+      caughtError = error;
+    }
 
-      // Create factory with configuration
-      const factory = new ErrorFactory({
-        locale: config.locale,
-        errorIdMode: config.errorIdMode,
-      });
-
-      let descriptor: ErrorDescriptor;
-
-      if (error instanceof AuthrimError) {
-        // Handle AuthrimError
-        descriptor = factory.create(error.code, {
-          variables: error.options.variables,
-          state: error.options.state,
-          extensions: error.options.extensions,
-        });
-      } else if (error instanceof RFCError) {
-        // Handle RFCError
-        descriptor = factory.createFromRFC(error.rfcError, error.status, error.detail);
-      } else {
-        // Handle unexpected errors
-        descriptor = factory.createInternalError();
-
-        // Call custom error handler if provided
-        if (options.onError) {
-          options.onError(error, c);
-        } else {
-          // Default error logging
-          log.error('Unhandled error', {}, error as Error);
-        }
-      }
-
-      // Determine response format
-      // Safe access to c.req.header - may not be a function in some test mocks
-      const acceptHeader =
-        typeof c.req?.header === 'function' ? c.req.header('accept') || null : null;
-      const responseFormat = determineFormat(c.req?.path, acceptHeader, config.format);
-
-      // Serialize and return response
-      return serializeError(descriptor, {
-        format: responseFormat,
-        baseUrl: options.baseUrl,
-      });
+    // Hono normally captures downstream exceptions in c.error instead of
+    // rethrowing them through middleware. Handle both forms so the configured
+    // Authrim response is not replaced by Hono's plain-text 500 response.
+    const error = caughtError ?? c.error;
+    if (error) {
+      return handleError(error, c, options);
     }
   };
+}
+
+async function handleError(
+  error: unknown,
+  c: Context,
+  options: ErrorMiddlewareOptions
+): Promise<Response> {
+  const config = await getErrorConfig(c, options);
+  const factory = new ErrorFactory({ locale: config.locale, errorIdMode: config.errorIdMode });
+  let descriptor: ErrorDescriptor;
+
+  if (error instanceof AuthrimError) {
+    descriptor = factory.create(error.code, {
+      variables: error.options.variables,
+      state: error.options.state,
+      extensions: error.options.extensions,
+    });
+  } else if (error instanceof RFCError) {
+    descriptor = factory.createFromRFC(error.rfcError, error.status, error.detail);
+  } else {
+    descriptor = factory.createInternalError();
+    if (options.onError) {
+      options.onError(error, c);
+    } else {
+      log.error('Unhandled error', {}, error as Error);
+    }
+  }
+
+  const acceptHeader = typeof c.req?.header === 'function' ? c.req.header('accept') || null : null;
+  const responseFormat = determineFormat(c.req?.path, acceptHeader, config.format);
+  return serializeError(descriptor, { format: responseFormat, baseUrl: options.baseUrl });
+}
+
+/**
+ * Create a Hono onError handler. Hono catches route exceptions at the app
+ * boundary, so applications should register this with `app.onError(...)`.
+ */
+export function errorHandler(options: ErrorMiddlewareOptions = {}) {
+  return (error: Error, c: Context): Promise<Response> => handleError(error, c, options);
 }
 
 /**

--- a/packages/ar-lib-core/src/index.ts
+++ b/packages/ar-lib-core/src/index.ts
@@ -307,6 +307,7 @@ export { errorResponse, redirectErrorResponse, determineFormat, createSerializer
 export {
   AuthrimError,
   RFCError,
+  errorHandler,
   errorMiddleware,
   createErrorFactoryFromContext,
   createErrorResponse,

--- a/packages/ar-lib-core/src/middleware/__tests__/admin-auth.test.ts
+++ b/packages/ar-lib-core/src/middleware/__tests__/admin-auth.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 import { SignJWT, exportJWK, generateKeyPair } from 'jose';
-import { adminAuthMiddleware } from '../admin-auth';
+import { adminAuthMiddleware, requireAdminPermissions, requireMfa } from '../admin-auth';
 import type { Env } from '../../types/env';
 
 /**
@@ -206,6 +206,7 @@ async function createMachineAccessFixture(
     credentialId?: string;
     scope?: string;
     displayName?: string;
+    payloadOverrides?: Record<string, unknown>;
   } = {}
 ) {
   const principalType = options.principalType ?? 'setup_tool';
@@ -234,6 +235,7 @@ async function createMachineAccessFixture(
     sender_constrained: false,
     scope,
     tenant_scope: tenantScope,
+    ...options.payloadOverrides,
   })
     .setProtectedHeader({ alg: 'RS256', typ: 'JWT', kid: 'admin-token-key' })
     .setIssuer('https://test.example.com')
@@ -652,6 +654,36 @@ describe('adminAuthMiddleware', () => {
       expect(data.error).toBe('invalid_token');
     });
 
+    it('should require both the BFF transport credential and an admin session', async () => {
+      const fixture = await createMachineAccessFixture(['default'], {
+        principalType: 'admin_ui_bff',
+        principalId: 'amp_admin_ui_bff',
+        clientId: 'admin-ui-bff',
+        credentialId: 'amk_admin_ui_bff',
+      });
+      const db = createMockDB({
+        machinePrincipal: fixture.machinePrincipal,
+        machineCredential: fixture.machineCredential,
+      });
+      const app = createTestApp(
+        createMockEnv({ DB: db, PUBLIC_JWK_JSON: JSON.stringify(fixture.publicJwk) })
+      );
+
+      const response = await app.fetch(
+        new Request('http://localhost/api/admin/test', {
+          headers: {
+            Authorization: `Bearer ${fixture.token}`,
+            'X-Authrim-Admin-UI-Api-Mode': 'cross-site-proxy-bff',
+          },
+        })
+      );
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toMatchObject({
+        error_description: 'Admin UI BFF requests require a valid admin session.',
+      });
+    });
+
     it('should reject Admin machine tokens outside their tenant scope', async () => {
       const fixture = await createMachineAccessFixture(['other']);
       const db = createMockDB({
@@ -756,6 +788,243 @@ describe('adminAuthMiddleware', () => {
       expect(response.status).toBe(403);
       expect(data.error).toBe('insufficient_permissions');
     });
+
+    it.each([
+      ['non-machine actor', { actor_type: 'admin' }],
+      ['missing actor id', { actor_id: '' }],
+      ['missing credential id', { credential_id: '' }],
+      ['non-string scope', { scope: ['admin:tenants.read'] }],
+    ])('should reject a signed machine token with %s claims', async (_label, payloadOverrides) => {
+      const fixture = await createMachineAccessFixture(['default'], { payloadOverrides });
+      const db = createMockDB({
+        machinePrincipal: fixture.machinePrincipal,
+        machineCredential: fixture.machineCredential,
+      });
+      const app = createTestApp(
+        createMockEnv({ DB: db, PUBLIC_JWK_JSON: JSON.stringify(fixture.publicJwk) })
+      );
+
+      const response = await app.fetch(
+        new Request('http://localhost/api/admin/test', {
+          headers: { Authorization: `Bearer ${fixture.token}` },
+        })
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    it.each([
+      ['unknown principal', false, true],
+      ['unknown credential', true, false],
+    ])('should reject a token for an %s', async (_label, includePrincipal, includeCredential) => {
+      const fixture = await createMachineAccessFixture(['default']);
+      const db = createMockDB({
+        machinePrincipal: includePrincipal ? fixture.machinePrincipal : null,
+        machineCredential: includeCredential ? fixture.machineCredential : null,
+      });
+      const app = createTestApp(
+        createMockEnv({ DB: db, PUBLIC_JWK_JSON: JSON.stringify(fixture.publicJwk) })
+      );
+
+      const response = await app.fetch(
+        new Request('http://localhost/api/admin/test', {
+          headers: { Authorization: `Bearer ${fixture.token}` },
+        })
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    it('should reject a credential bound to a different machine principal', async () => {
+      const fixture = await createMachineAccessFixture(['default']);
+      const db = createMockDB({
+        machinePrincipal: fixture.machinePrincipal,
+        machineCredential: { ...fixture.machineCredential, principal_id: 'amp_other' },
+      });
+      const app = createTestApp(
+        createMockEnv({ DB: db, PUBLIC_JWK_JSON: JSON.stringify(fixture.publicJwk) })
+      );
+
+      const response = await app.fetch(
+        new Request('http://localhost/api/admin/test', {
+          headers: { Authorization: `Bearer ${fixture.token}` },
+        })
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    it('should accept a currently rotating credential with unchanged grants', async () => {
+      const fixture = await createMachineAccessFixture(['default'], {
+        scope: 'admin:clients.create',
+      });
+      const db = createMockDB({
+        machinePrincipal: fixture.machinePrincipal,
+        machineCredential: { ...fixture.machineCredential, status: 'rotating' },
+      });
+      const app = createTestApp(
+        createMockEnv({ DB: db, PUBLIC_JWK_JSON: JSON.stringify(fixture.publicJwk) })
+      );
+
+      const response = await app.fetch(
+        new Request('http://localhost/api/admin/test', {
+          headers: { Authorization: `Bearer ${fixture.token}` },
+        })
+      );
+
+      expect(response.status).toBe(200);
+    });
+
+    it.each([
+      [
+        'all principal and credential scopes',
+        [{ scope_mode: 'all', tenant_id: null }],
+        [{ scope_mode: 'all', tenant_id: null }],
+        ['*'],
+      ],
+      [
+        'all principal scope narrowed by credential',
+        [{ scope_mode: 'all', tenant_id: null }],
+        [{ scope_mode: 'allow', tenant_id: 'default' }],
+        ['default'],
+      ],
+      [
+        'tenant principal scope with all credential scope',
+        [{ scope_mode: 'allow', tenant_id: 'default' }],
+        [{ scope_mode: 'all', tenant_id: null }],
+        ['default'],
+      ],
+    ])('should enforce %s', async (_label, principalScopes, credentialScopes, claimScope) => {
+      const fixture = await createMachineAccessFixture(claimScope);
+      const db = createMockDB({
+        machinePrincipal: fixture.machinePrincipal,
+        machineCredential: fixture.machineCredential,
+        machinePrincipalTenantScopes: principalScopes,
+        machineCredentialTenantScopes: credentialScopes,
+      });
+      const app = createTestApp(
+        createMockEnv({ DB: db, PUBLIC_JWK_JSON: JSON.stringify(fixture.publicJwk) })
+      );
+
+      const response = await app.fetch(
+        new Request('http://localhost/api/admin/test', {
+          headers: { Authorization: `Bearer ${fixture.token}` },
+        })
+      );
+
+      expect(response.status).toBe(200);
+    });
+
+    it('should verify a machine token with the tenant key manager when no static JWK matches', async () => {
+      const fixture = await createMachineAccessFixture(['default']);
+      const getAllPublicKeysRpc = vi.fn().mockResolvedValue([fixture.publicJwk]);
+      const keyManager = {
+        idFromName: vi.fn().mockReturnValue('tenant-key-manager-id'),
+        get: vi.fn().mockReturnValue({ getAllPublicKeysRpc }),
+      };
+      const db = createMockDB({
+        machinePrincipal: fixture.machinePrincipal,
+        machineCredential: fixture.machineCredential,
+      });
+      const app = createTestApp(
+        createMockEnv({ DB: db, KEY_MANAGER: keyManager as unknown as Env['KEY_MANAGER'] })
+      );
+
+      const response = await app.fetch(
+        new Request('http://localhost/api/admin/test', {
+          headers: { Authorization: `Bearer ${fixture.token}` },
+        })
+      );
+
+      expect(response.status).toBe(200);
+      expect(keyManager.idFromName).toHaveBeenCalledWith('default-v3');
+      expect(getAllPublicKeysRpc).toHaveBeenCalledOnce();
+    });
+
+    it('should reject a token when the key manager has no key matching its kid', async () => {
+      const fixture = await createMachineAccessFixture(['default']);
+      const keyManager = {
+        idFromName: vi.fn().mockReturnValue('tenant-key-manager-id'),
+        get: vi.fn().mockReturnValue({ getAllPublicKeysRpc: vi.fn().mockResolvedValue([]) }),
+      };
+      const app = createTestApp(
+        createMockEnv({ KEY_MANAGER: keyManager as unknown as Env['KEY_MANAGER'] })
+      );
+
+      const response = await app.fetch(
+        new Request('http://localhost/api/admin/test', {
+          headers: { Authorization: `Bearer ${fixture.token}` },
+        })
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    it('should reject wildcard tenant claims unless the current grants are also global', async () => {
+      const fixture = await createMachineAccessFixture(['*']);
+      const db = createMockDB({
+        machinePrincipal: fixture.machinePrincipal,
+        machineCredential: fixture.machineCredential,
+        machinePrincipalTenantScopes: [{ scope_mode: 'allow', tenant_id: 'default' }],
+      });
+      const app = createTestApp(
+        createMockEnv({ DB: db, PUBLIC_JWK_JSON: JSON.stringify(fixture.publicJwk) })
+      );
+
+      const response = await app.fetch(
+        new Request('http://localhost/api/admin/test', {
+          headers: { Authorization: `Bearer ${fixture.token}` },
+        })
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    it('should reject credential permissions that do not intersect principal grants', async () => {
+      const fixture = await createMachineAccessFixture(['default'], {
+        scope: 'admin:clients.create',
+      });
+      const db = createMockDB({
+        machinePrincipal: fixture.machinePrincipal,
+        machineCredential: fixture.machineCredential,
+        machinePrincipalPermissions: [{ permission: 'admin:tenants.read' }],
+        machineCredentialPermissions: [{ permission: 'admin:clients:*' }],
+      });
+      const app = createTestApp(
+        createMockEnv({ DB: db, PUBLIC_JWK_JSON: JSON.stringify(fixture.publicJwk) })
+      );
+
+      const response = await app.fetch(
+        new Request('http://localhost/api/admin/test', {
+          headers: { Authorization: `Bearer ${fixture.token}` },
+        })
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    it('should ignore a malformed non-array tenant_scope claim without expanding access', async () => {
+      const fixture = await createMachineAccessFixture(['default'], {
+        payloadOverrides: { tenant_scope: 'default' },
+      });
+      const db = createMockDB({
+        machinePrincipal: fixture.machinePrincipal,
+        machineCredential: fixture.machineCredential,
+      });
+      const app = createTestApp(
+        createMockEnv({ DB: db, PUBLIC_JWK_JSON: JSON.stringify(fixture.publicJwk) })
+      );
+
+      const response = await app.fetch(
+        new Request('http://localhost/api/admin/test', {
+          headers: { Authorization: `Bearer ${fixture.token}` },
+        })
+      );
+      const data = (await response.json()) as Record<string, any>;
+
+      expect(response.status).toBe(403);
+      expect(data.error).toBe('access_denied');
+    });
   });
 
   describe('Session Authentication', () => {
@@ -783,6 +1052,118 @@ describe('adminAuthMiddleware', () => {
       expect(data.adminAuth.userId).toBe(userId);
       expect(data.adminAuth.authMethod).toBe('session');
       expect(data.adminAuth.roles).toContain('admin');
+    });
+
+    it('should enforce middleware MFA and permission requirements on a session', async () => {
+      const userId = 'admin-user-sensitive-operation';
+      const session = { ...createValidSession(userId), mfa_verified: 1 };
+      const roles = [
+        {
+          id: 'role_admin',
+          name: 'admin',
+          permissions_json: JSON.stringify(['admin:users:*']),
+          hierarchy_level: 80,
+          inherits_from: null,
+        },
+      ];
+      const db = createMockDB({
+        session,
+        adminUser: createValidAdminUser(userId),
+        roles,
+      });
+      const app = createTestApp(createMockEnv({ DB: db }), {
+        requireMfa: true,
+        requirePermissions: ['admin:users:write'],
+      });
+
+      const response = await app.fetch(
+        new Request('http://localhost/api/admin/test', {
+          headers: { Cookie: `authrim_admin_session=${VALID_SESSION_ID}` },
+        })
+      );
+
+      expect(response.status).toBe(200);
+    });
+
+    it('should deny a session that has not satisfied a middleware MFA requirement', async () => {
+      const userId = 'admin-user-without-mfa';
+      const db = createMockDB({
+        session: createValidSession(userId),
+        adminUser: createValidAdminUser(userId),
+        roles: createAdminRoles(['admin']),
+      });
+      const app = createTestApp(createMockEnv({ DB: db }), { requireMfa: true });
+
+      const response = await app.fetch(
+        new Request('http://localhost/api/admin/test', {
+          headers: { Cookie: `authrim_admin_session=${VALID_SESSION_ID}` },
+        })
+      );
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toMatchObject({ error: 'mfa_required' });
+    });
+
+    it('should ignore malformed, non-array, and cyclic inherited role permissions safely', async () => {
+      const userId = 'admin-user-malformed-role';
+      const roles = [
+        {
+          id: 'role_admin',
+          name: 'admin',
+          permissions_json: JSON.stringify(['admin:users:read', 42]),
+          hierarchy_level: 80,
+          inherits_from: 'role_malformed',
+        },
+        {
+          id: 'role_malformed',
+          name: 'malformed',
+          permissions_json: '{bad json',
+          hierarchy_level: 70,
+          inherits_from: 'role_non_array',
+        },
+        {
+          id: 'role_non_array',
+          name: 'non_array',
+          permissions_json: JSON.stringify({ permission: 'admin:users:write' }),
+          hierarchy_level: 60,
+          inherits_from: 'role_admin',
+        },
+      ];
+      const db = createMockDB({
+        session: createValidSession(userId),
+        adminUser: createValidAdminUser(userId),
+        roles,
+      });
+      const app = createTestApp(createMockEnv({ DB: db }));
+
+      const response = await app.fetch(
+        new Request('http://localhost/api/admin/test', {
+          headers: { Cookie: `authrim_admin_session=${VALID_SESSION_ID}` },
+        })
+      );
+      const data = (await response.json()) as Record<string, any>;
+
+      expect(response.status).toBe(200);
+      expect(data.adminAuth.permissions).toEqual(['admin:users:read']);
+    });
+
+    it('should honor an explicit IP-check exemption for bootstrap routes', async () => {
+      const userId = 'admin-user-bootstrap';
+      const db = createMockDB({
+        session: createValidSession(userId),
+        adminUser: createValidAdminUser(userId),
+        roles: createAdminRoles(['admin']),
+        ipAllowlistEntries: [{ ip_range: '203.0.113.9', ip_version: 4 }],
+      });
+      const app = createTestApp(createMockEnv({ DB: db }), { skipIpCheck: true });
+
+      const response = await app.fetch(
+        new Request('http://localhost/api/admin/test', {
+          headers: { Cookie: `authrim_admin_session=${VALID_SESSION_ID}` },
+        })
+      );
+
+      expect(response.status).toBe(200);
     });
 
     it('should allow sessions without a client IP when no IP allowlist entries exist', async () => {
@@ -858,6 +1239,70 @@ describe('adminAuthMiddleware', () => {
       expect(response.status).toBe(403);
       expect(data.error).toBe('access_denied');
     });
+
+    it.each([
+      ['exact IPv4', '203.0.113.9', '203.0.113.9', 'CF-Connecting-IP'],
+      ['IPv4 CIDR', '203.0.113.0/24', '203.0.113.42', 'CF-Connecting-IP'],
+      ['compressed IPv6 CIDR', '2001:db8::/64', '2001:db8::42', 'CF-Connecting-IP'],
+      ['first forwarded address', '198.51.100.0/24', '198.51.100.20, 10.0.0.1', 'X-Forwarded-For'],
+    ])(
+      'should allow a session when the client matches the %s allowlist entry',
+      async (_label, ipRange, clientIp, headerName) => {
+        const userId = 'admin-user-ip-allowed';
+        const db = createMockDB({
+          session: createValidSession(userId),
+          adminUser: createValidAdminUser(userId),
+          roles: createAdminRoles(['admin']),
+          ipAllowlistEntries: [{ ip_range: ipRange, ip_version: ipRange.includes(':') ? 6 : 4 }],
+        });
+        const app = createTestApp(createMockEnv({ DB: db }));
+
+        const response = await app.fetch(
+          new Request('http://localhost/api/admin/test', {
+            headers: {
+              Cookie: `authrim_admin_session=${VALID_SESSION_ID}`,
+              [headerName]: clientIp,
+            },
+          })
+        );
+
+        expect(response.status).toBe(200);
+      }
+    );
+
+    it.each([
+      ['outside IPv4 CIDR', '203.0.113.0/24', '203.0.114.1'],
+      ['IPv4 CIDR prefix above 32', '0.0.0.0/33', '203.0.113.9'],
+      ['non-numeric IPv4 suffix', '203.0.113.0/24', '203.0.113.9junk'],
+      ['malformed IPv6', '2001:db8::/32', '2001:db8::not-hex'],
+      ['IPv6 CIDR prefix above 128', '2001:db8::/129', '2001:db8::1'],
+      ['mixed IP versions', '2001:db8::/32', '203.0.113.9'],
+    ])(
+      'should deny a session for %s instead of weakening the allowlist',
+      async (_label, ipRange, clientIp) => {
+        const userId = 'admin-user-ip-denied';
+        const db = createMockDB({
+          session: createValidSession(userId),
+          adminUser: createValidAdminUser(userId),
+          roles: createAdminRoles(['admin']),
+          ipAllowlistEntries: [{ ip_range: ipRange, ip_version: ipRange.includes(':') ? 6 : 4 }],
+        });
+        const app = createTestApp(createMockEnv({ DB: db }));
+
+        const response = await app.fetch(
+          new Request('http://localhost/api/admin/test', {
+            headers: {
+              Cookie: `authrim_admin_session=${VALID_SESSION_ID}`,
+              'CF-Connecting-IP': clientIp,
+            },
+          })
+        );
+        const data = (await response.json()) as Record<string, unknown>;
+
+        expect(response.status).toBe(403);
+        expect(data.error).toBe('access_denied');
+      }
+    );
 
     it('should reject X-Session-Id without the HttpOnly admin session cookie', async () => {
       const db = createMockDB({
@@ -1409,5 +1854,78 @@ describe('adminAuthMiddleware', () => {
       const response = await app.fetch(request);
       expect(response.status).toBe(401);
     });
+  });
+});
+
+describe('admin authorization guards', () => {
+  function createGuardApp(
+    guard: ReturnType<typeof requireAdminPermissions> | ReturnType<typeof requireMfa>,
+    adminAuth?: Record<string, unknown>
+  ) {
+    const app = new Hono<{ Bindings: Env }>();
+    app.use('/guard', async (c, next) => {
+      if (adminAuth) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (c as any).set('adminAuth', adminAuth);
+      }
+      await next();
+    });
+    app.use('/guard', guard);
+    app.get('/guard', (c) => c.json({ success: true }));
+    return app;
+  }
+
+  it('requires an authenticated context before checking permissions', async () => {
+    const response = await createGuardApp(requireAdminPermissions(['admin:users:read'])).request(
+      '/guard'
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ error: 'invalid_token' });
+  });
+
+  it('denies an authenticated admin missing a required permission', async () => {
+    const response = await createGuardApp(requireAdminPermissions(['admin:users:write']), {
+      userId: 'admin-1',
+      permissions: ['admin:users:read'],
+    }).request('/guard');
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: 'insufficient_permissions' });
+  });
+
+  it('accepts wildcard permissions only when they cover every required permission', async () => {
+    const response = await createGuardApp(
+      requireAdminPermissions(['admin:users:read', 'admin:users:write']),
+      { userId: 'admin-1', permissions: ['admin:users:*'] }
+    ).request('/guard');
+
+    expect(response.status).toBe(200);
+  });
+
+  it('requires authentication before evaluating MFA state', async () => {
+    const response = await createGuardApp(requireMfa()).request('/guard');
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ error: 'invalid_token' });
+  });
+
+  it('denies a valid session that has not completed MFA', async () => {
+    const response = await createGuardApp(requireMfa(), {
+      userId: 'admin-1',
+      mfaVerified: false,
+    }).request('/guard');
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: 'mfa_required' });
+  });
+
+  it('continues only after MFA has been verified', async () => {
+    const response = await createGuardApp(requireMfa(), {
+      userId: 'admin-1',
+      mfaVerified: true,
+    }).request('/guard');
+
+    expect(response.status).toBe(200);
   });
 });

--- a/packages/ar-lib-core/src/middleware/__tests__/csrf-security.test.ts
+++ b/packages/ar-lib-core/src/middleware/__tests__/csrf-security.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import type { Env } from '../../types/env';
+
+const mocks = vi.hoisted(() => ({
+  tenantSettings: null as Record<string, unknown> | null,
+  getTenantSettings: vi.fn(),
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+}));
+
+vi.mock('../../utils/tenant-settings', () => ({
+  getTenantSettings: mocks.getTenantSettings,
+}));
+
+vi.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    module: () => ({ info: mocks.logInfo, warn: mocks.logWarn }),
+  }),
+}));
+
+import { csrfProtectionMiddleware } from '../csrf';
+
+function app(options: Parameters<typeof csrfProtectionMiddleware>[0] = {}, path = '/resource') {
+  const instance = new Hono<{ Bindings: Env }>();
+  const reached = vi.fn();
+  instance.use('*', csrfProtectionMiddleware(options));
+  instance.all(path, (c) => {
+    reached();
+    return c.json({ ok: true });
+  });
+  return { instance, reached };
+}
+
+async function request(
+  instance: Hono<{ Bindings: Env }>,
+  method: string,
+  headers: Record<string, string> = {},
+  env: Partial<Env> = {},
+  path = '/resource'
+) {
+  return instance.request(path, { method, headers }, env as Env);
+}
+
+describe('CSRF middleware security decision table', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.tenantSettings = null;
+    mocks.getTenantSettings.mockImplementation(async () => mocks.tenantSettings);
+  });
+
+  it.each(['GET', 'HEAD', 'OPTIONS'])(
+    'allows safe method %s without resolving origins',
+    async (method) => {
+      const resolver = vi.fn(() => ['https://app.example.test']);
+      const { instance, reached } = app({ resolveAllowedOrigins: resolver });
+      const response = await request(instance, method);
+      expect(response.status).toBe(200);
+      expect(reached).toHaveBeenCalledOnce();
+      expect(resolver).not.toHaveBeenCalled();
+    }
+  );
+
+  it('excludes only exact paths and their descendants, not lookalike prefixes', async () => {
+    const resolver = vi.fn(() => ['https://app.example.test']);
+    const exact = app({ excludePaths: ['/token'], resolveAllowedOrigins: resolver }, '/token');
+    expect((await request(exact.instance, 'POST', {}, {}, '/token')).status).toBe(200);
+    expect(exact.reached).toHaveBeenCalledOnce();
+
+    const child = app(
+      { excludePaths: ['/token'], resolveAllowedOrigins: resolver },
+      '/token/rotate'
+    );
+    expect((await request(child.instance, 'POST', {}, {}, '/token/rotate')).status).toBe(200);
+
+    const lookalike = app(
+      { excludePaths: ['/token'], resolveAllowedOrigins: resolver },
+      '/tokenize'
+    );
+    expect((await request(lookalike.instance, 'POST', {}, {}, '/tokenize')).status).toBe(403);
+    expect(lookalike.reached).not.toHaveBeenCalled();
+  });
+
+  it('skips browser-origin checks only for a proper Bearer authorization scheme', async () => {
+    const resolver = vi.fn(() => ['https://app.example.test']);
+    const allowed = app({ resolveAllowedOrigins: resolver });
+    expect(
+      (
+        await request(allowed.instance, 'POST', {
+          Authorization: 'Bearer server-token',
+        })
+      ).status
+    ).toBe(200);
+    expect(resolver).not.toHaveBeenCalled();
+
+    const malformed = app({ resolveAllowedOrigins: resolver });
+    expect(
+      (
+        await request(malformed.instance, 'POST', {
+          Authorization: 'bearer server-token',
+        })
+      ).status
+    ).toBe(403);
+
+    const disabled = app({ skipForBearerToken: false, resolveAllowedOrigins: resolver });
+    expect(
+      (
+        await request(disabled.instance, 'POST', {
+          Authorization: 'Bearer server-token',
+        })
+      ).status
+    ).toBe(403);
+  });
+
+  it.each(['POST', 'PUT', 'PATCH', 'DELETE'])(
+    'allows %s only from an exact configured Origin',
+    async (method) => {
+      const { instance, reached } = app({
+        resolveAllowedOrigins: async () => ['https://app.example.test'],
+      });
+      const response = await request(instance, method, { Origin: 'https://app.example.test' });
+      expect(response.status).toBe(200);
+      expect(reached).toHaveBeenCalledOnce();
+    }
+  );
+
+  it.each([
+    'https://evil.example.test',
+    'https://app.example.test.evil.test',
+    'http://app.example.test',
+    'null',
+  ])('rejects untrusted Origin %s without invoking the protected handler', async (origin) => {
+    const { instance, reached } = app({
+      resolveAllowedOrigins: () => ['https://app.example.test'],
+    });
+    const response = await request(instance, 'POST', { Origin: origin });
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: 'csrf_validation_failed',
+      error_description: 'Origin not allowed',
+    });
+    expect(reached).not.toHaveBeenCalled();
+    expect(mocks.logWarn).toHaveBeenCalled();
+  });
+
+  it('uses Referer origin only when Origin is absent', async () => {
+    const { instance, reached } = app({
+      resolveAllowedOrigins: () => ['https://app.example.test'],
+    });
+    expect(
+      (
+        await request(instance, 'POST', {
+          Referer: 'https://app.example.test/settings?tab=security',
+        })
+      ).status
+    ).toBe(200);
+    expect(reached).toHaveBeenCalledOnce();
+
+    const precedence = app({ resolveAllowedOrigins: () => ['https://app.example.test'] });
+    expect(
+      (
+        await request(precedence.instance, 'POST', {
+          Origin: 'https://evil.example.test',
+          Referer: 'https://app.example.test/settings',
+        })
+      ).status
+    ).toBe(403);
+    expect(precedence.reached).not.toHaveBeenCalled();
+  });
+
+  it.each(['not a URL', 'https://evil.example.test/page'])(
+    'rejects invalid Referer %s',
+    async (referer) => {
+      const { instance, reached } = app({
+        resolveAllowedOrigins: () => ['https://app.example.test'],
+      });
+      const response = await request(instance, 'POST', { Referer: referer });
+      expect(response.status).toBe(403);
+      expect(await response.json()).toMatchObject({
+        error_description: 'Referer origin not allowed',
+      });
+      expect(reached).not.toHaveBeenCalled();
+    }
+  );
+
+  it('fails closed when neither Origin nor Referer is present', async () => {
+    const { instance, reached } = app({
+      resolveAllowedOrigins: () => ['https://app.example.test'],
+    });
+    const response = await request(instance, 'POST');
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error_description: 'Origin or Referer header is required for state-changing requests',
+    });
+    expect(reached).not.toHaveBeenCalled();
+  });
+
+  it('combines tenant settings and environment origins without weakening exact matching', async () => {
+    mocks.tenantSettings = {
+      'tenant.allowed_origins': 'https://tenant-ui.example.test, https://shared.example.test',
+    };
+    const { instance } = app();
+    const env = {
+      ALLOWED_ORIGINS: 'https://admin.example.test,https://shared.example.test',
+      ISSUER_URL: 'https://issuer.example.test',
+    };
+    for (const origin of [
+      'https://tenant-ui.example.test',
+      'https://admin.example.test',
+      'https://issuer.example.test',
+    ]) {
+      expect((await request(instance, 'POST', { Origin: origin }, env)).status).toBe(200);
+    }
+    expect(
+      (await request(instance, 'POST', { Origin: 'https://shared.example.test.evil.test' }, env))
+        .status
+    ).toBe(403);
+  });
+
+  it.each([
+    ['https://authrim.example.test/resource', 'https://authrim.example.test', true],
+    ['https://tenant.authrim.example.test/resource', 'https://tenant.authrim.example.test', true],
+    [
+      'https://nested.tenant.authrim.example.test/resource',
+      'https://nested.tenant.authrim.example.test',
+      false,
+    ],
+    ['https://evil.example.test/resource', 'https://evil.example.test', false],
+  ])('derives only safe BASE_DOMAIN origin for %s', async (path, origin, allowed) => {
+    const instance = new Hono<{ Bindings: Env }>();
+    const reached = vi.fn();
+    instance.use('*', csrfProtectionMiddleware());
+    instance.post('*', (c) => {
+      reached();
+      return c.json({ ok: true });
+    });
+    const response = await instance.request(path, { method: 'POST', headers: { Origin: origin } }, {
+      BASE_DOMAIN: 'authrim.example.test',
+    } as Env);
+    expect(response.status).toBe(allowed ? 200 : 403);
+    expect(reached).toHaveBeenCalledTimes(allowed ? 1 : 0);
+  });
+
+  it('adds diagnostic Server-Timing only for the configured login path', async () => {
+    const { instance } = app(
+      { resolveAllowedOrigins: () => ['https://app.example.test'] },
+      '/api/v1/login/interactions/start'
+    );
+    const response = await request(
+      instance,
+      'POST',
+      { Origin: 'https://app.example.test' },
+      { AUTHRIM_FLOW_RUNTIME_TIMING: 'YES' },
+      '/api/v1/login/interactions/start'
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get('server-timing')).toContain('csrf_allowed_origins');
+    expect(response.headers.get('server-timing')).toContain('csrf_total');
+    expect(mocks.logInfo).toHaveBeenCalledWith(
+      'CSRF timing',
+      expect.objectContaining({ result: 'origin_allowed' })
+    );
+  });
+});

--- a/packages/ar-lib-core/src/middleware/__tests__/rbac-security.test.ts
+++ b/packages/ar-lib-core/src/middleware/__tests__/rbac-security.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import type { AdminAuthContext } from '../../types/admin';
+import {
+  requireAdmin,
+  requireAllRoles,
+  requireAnyRole,
+  requireRole,
+  requireSystemAdmin,
+} from '../rbac';
+
+function auth(overrides: Partial<AdminAuthContext> = {}): AdminAuthContext {
+  return {
+    userId: 'admin-a',
+    roles: [],
+    permissions: [],
+    hierarchyLevel: 0,
+    mfaVerified: false,
+    ...overrides,
+  };
+}
+
+function app(middleware: ReturnType<typeof requireRole>, context?: AdminAuthContext) {
+  const instance = new Hono();
+  const reached = vi.fn();
+  if (context) {
+    instance.use('*', async (c, next) => {
+      c.set('adminAuth', context);
+      await next();
+    });
+  }
+  instance.get('/protected', middleware, (c) => {
+    reached();
+    return c.json({ ok: true });
+  });
+  return { instance, reached };
+}
+
+describe('RBAC middleware security decisions', () => {
+  it.each([
+    requireRole('security_admin'),
+    requireAnyRole(['security_admin', 'auditor']),
+    requireAllRoles(['security_admin', 'auditor']),
+    requireAdmin(),
+    requireSystemAdmin(),
+  ])('rejects missing authentication before invoking the handler', async (middleware) => {
+    const { instance, reached } = app(middleware);
+    const response = await instance.request('/protected');
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: 'invalid_token',
+      error_description: 'Authentication required. Please authenticate first.',
+    });
+    expect(reached).not.toHaveBeenCalled();
+  });
+
+  it('requires an exact role match and does not accept case or substring variants', async () => {
+    for (const roles of [
+      ['security_admin_extra'],
+      ['SECURITY_ADMIN'],
+      [' security_admin '],
+      ['admin'],
+    ]) {
+      const { instance, reached } = app(requireRole('security_admin'), auth({ roles }));
+      const response = await instance.request('/protected');
+      expect(response.status).toBe(403);
+      expect(await response.json()).toMatchObject({
+        error: 'access_denied',
+        required_roles: ['security_admin'],
+      });
+      expect(reached).not.toHaveBeenCalled();
+    }
+
+    const allowed = app(requireRole('security_admin'), auth({ roles: ['security_admin'] }));
+    expect((await allowed.instance.request('/protected')).status).toBe(200);
+    expect(allowed.reached).toHaveBeenCalledOnce();
+  });
+
+  it.each(['super_admin', 'system_admin'])(
+    '%s bypasses single, any and all role gates',
+    async (role) => {
+      for (const middleware of [
+        requireRole('unrelated'),
+        requireAnyRole(['unrelated-a', 'unrelated-b']),
+        requireAllRoles(['unrelated-a', 'unrelated-b']),
+      ]) {
+        const { instance, reached } = app(middleware, auth({ roles: [role] }));
+        expect((await instance.request('/protected')).status).toBe(200);
+        expect(reached).toHaveBeenCalledOnce();
+      }
+    }
+  );
+
+  it('allows machine bypass only for an exact machine token and admin:* permission', async () => {
+    const allowed = app(
+      requireAllRoles(['security_admin', 'auditor']),
+      auth({ authMethod: 'machine_access_token', permissions: ['admin:*'] })
+    );
+    expect((await allowed.instance.request('/protected')).status).toBe(200);
+
+    for (const context of [
+      auth({ authMethod: 'machine_access_token', permissions: ['admin:clients:*'] }),
+      auth({ authMethod: 'machine_access_token', permissions: ['admin:*:read'] }),
+      auth({ authMethod: 'admin_session', permissions: ['admin:*'] }),
+      auth({ permissions: ['admin:*'] }),
+    ]) {
+      const denied = app(requireRole('security_admin'), context);
+      expect((await denied.instance.request('/protected')).status).toBe(403);
+      expect(denied.reached).not.toHaveBeenCalled();
+    }
+  });
+
+  it('allows any-role access with one exact role and reports all accepted roles on denial', async () => {
+    const allowed = app(
+      requireAnyRole(['security_admin', 'auditor']),
+      auth({ roles: ['auditor'] })
+    );
+    expect((await allowed.instance.request('/protected')).status).toBe(200);
+
+    const denied = app(requireAnyRole(['security_admin', 'auditor']), auth({ roles: ['viewer'] }));
+    const response = await denied.instance.request('/protected');
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: 'access_denied',
+      error_description: 'This action requires one of the following roles: security_admin, auditor',
+      required_roles: ['security_admin', 'auditor'],
+    });
+  });
+
+  it('requires every all-role entry and identifies only the missing roles', async () => {
+    const denied = app(
+      requireAllRoles(['security_admin', 'auditor', 'incident_responder']),
+      auth({ roles: ['security_admin', 'incident_responder'] })
+    );
+    const response = await denied.instance.request('/protected');
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: 'access_denied',
+      error_description: 'Missing required roles: auditor',
+      required_roles: ['security_admin', 'auditor', 'incident_responder'],
+      missing_roles: ['auditor'],
+    });
+
+    const allowed = app(
+      requireAllRoles(['security_admin', 'auditor']),
+      auth({ roles: ['auditor', 'security_admin', 'extra'] })
+    );
+    expect((await allowed.instance.request('/protected')).status).toBe(200);
+  });
+
+  it.each(['system_admin', 'distributor_admin', 'org_admin', 'admin'])(
+    'requireAdmin accepts the documented %s role',
+    async (role) => {
+      const protectedApp = app(requireAdmin(), auth({ roles: [role] }));
+      expect((await protectedApp.instance.request('/protected')).status).toBe(200);
+    }
+  );
+
+  it('requireAdmin rejects tenant_admin and end_user while requireSystemAdmin rejects lower admins', async () => {
+    for (const role of ['tenant_admin', 'end_user']) {
+      expect(
+        (await app(requireAdmin(), auth({ roles: [role] })).instance.request('/protected')).status
+      ).toBe(403);
+    }
+    expect(
+      (
+        await app(requireSystemAdmin(), auth({ roles: ['distributor_admin'] })).instance.request(
+          '/protected'
+        )
+      ).status
+    ).toBe(403);
+    expect(
+      (
+        await app(requireSystemAdmin(), auth({ roles: ['system_admin'] })).instance.request(
+          '/protected'
+        )
+      ).status
+    ).toBe(200);
+  });
+
+  it.each([
+    () => requireRole(''),
+    () => requireRole('   '),
+    () => requireAnyRole([]),
+    () => requireAnyRole(['valid', '']),
+    () => requireAllRoles([]),
+    () => requireAllRoles(['valid', '   ']),
+  ])('rejects empty role configuration at route construction time', (build) => {
+    expect(build).toThrow('requires at least one non-empty role');
+  });
+});

--- a/packages/ar-lib-core/src/middleware/admin-auth.ts
+++ b/packages/ar-lib-core/src/middleware/admin-auth.ts
@@ -587,42 +587,38 @@ function ipMatches(ip: string, range: string): boolean {
 }
 
 /**
- * Check if an IP matches a CIDR range (IPv4 only for now)
+ * Check if an IP matches an IPv4 or IPv6 CIDR range.
  */
 function ipMatchesCidr(ip: string, cidr: string): boolean {
-  const [rangeIp, prefixLengthStr] = cidr.split('/');
-  const prefixLength = parseInt(prefixLengthStr, 10);
-
-  if (isNaN(prefixLength)) {
+  const cidrParts = cidr.split('/');
+  if (cidrParts.length !== 2 || !/^\d+$/.test(cidrParts[1])) {
     return false;
   }
+  const [rangeIp, prefixLengthStr] = cidrParts;
+  const prefixLength = Number(prefixLengthStr);
 
   // IPv4 handling
   if (!ip.includes(':') && !rangeIp.includes(':')) {
     const ipNum = ipv4ToNumber(ip);
     const rangeNum = ipv4ToNumber(rangeIp);
 
-    if (ipNum === null || rangeNum === null) {
+    if (ipNum === null || rangeNum === null || prefixLength < 0 || prefixLength > 32) {
       return false;
     }
 
-    const mask = (-1 << (32 - prefixLength)) >>> 0;
+    const mask = prefixLength === 0 ? 0 : (-1 << (32 - prefixLength)) >>> 0;
     return (ipNum & mask) === (rangeNum & mask);
   }
 
-  // IPv6 - simplified check (full implementation in repository)
+  // IPv6 handling. Parse both compressed and full notation and compare prefix bits.
   if (ip.includes(':') && rangeIp.includes(':')) {
-    // For now, just check prefix match
-    const ipParts = ip.split(':');
-    const rangeParts = rangeIp.split(':');
-    const partsToCheck = Math.ceil(prefixLength / 16);
-
-    for (let i = 0; i < partsToCheck && i < ipParts.length && i < rangeParts.length; i++) {
-      if (ipParts[i] !== rangeParts[i]) {
-        return false;
-      }
+    const ipNum = ipv6ToBigInt(ip);
+    const rangeNum = ipv6ToBigInt(rangeIp);
+    if (ipNum === null || rangeNum === null || prefixLength < 0 || prefixLength > 128) {
+      return false;
     }
-    return true;
+    const hostBits = BigInt(128 - prefixLength);
+    return ipNum >> hostBits === rangeNum >> hostBits;
   }
 
   return false;
@@ -639,14 +635,44 @@ function ipv4ToNumber(ip: string): number | null {
 
   let result = 0;
   for (const part of parts) {
-    const num = parseInt(part, 10);
-    if (isNaN(num) || num < 0 || num > 255) {
+    if (!/^\d{1,3}$/.test(part)) {
+      return null;
+    }
+    const num = Number(part);
+    if (num > 255) {
       return null;
     }
     result = (result << 8) | num;
   }
 
   return result >>> 0;
+}
+
+function ipv6ToBigInt(ip: string): bigint | null {
+  if (ip.includes('.') || ip.includes(':::') || (ip.match(/::/g) ?? []).length > 1) {
+    return null;
+  }
+
+  const compressed = ip.includes('::');
+  const [leftText, rightText = ''] = compressed ? ip.split('::') : [ip, ''];
+  const left = leftText ? leftText.split(':') : [];
+  const right = rightText ? rightText.split(':') : [];
+  if ((!compressed && left.length !== 8) || (compressed && left.length + right.length >= 8)) {
+    return null;
+  }
+
+  const groups = compressed
+    ? [...left, ...Array(8 - left.length - right.length).fill('0'), ...right]
+    : left;
+  if (groups.length !== 8 || groups.some((group) => !/^[0-9a-fA-F]{1,4}$/.test(group))) {
+    return null;
+  }
+
+  let result = 0n;
+  for (const group of groups) {
+    result = (result << 16n) | BigInt(`0x${group}`);
+  }
+  return result;
 }
 
 function resolveAdminRequestTenantId(c: Context<{ Bindings: Env }>): string | null {

--- a/packages/ar-lib-core/src/middleware/rbac.ts
+++ b/packages/ar-lib-core/src/middleware/rbac.ts
@@ -90,6 +90,12 @@ function createAccessDeniedResponse(requiredRoles: string[]): RBACErrorResponse 
   };
 }
 
+function assertRequiredRoles(roleNames: string[]): void {
+  if (roleNames.length === 0 || roleNames.some((role) => role.trim().length === 0)) {
+    throw new Error('RBAC middleware requires at least one non-empty role');
+  }
+}
+
 /**
  * Require a single role
  *
@@ -105,6 +111,7 @@ function createAccessDeniedResponse(requiredRoles: string[]): RBACErrorResponse 
  * ```
  */
 export function requireRole(roleName: string) {
+  assertRequiredRoles([roleName]);
   return async (c: Context<{ Bindings: Env }>, next: Next) => {
     const authContext = getAdminAuth(c);
 
@@ -146,6 +153,7 @@ export function requireRole(roleName: string) {
  * ```
  */
 export function requireAnyRole(roleNames: string[]) {
+  assertRequiredRoles(roleNames);
   return async (c: Context<{ Bindings: Env }>, next: Next) => {
     const authContext = getAdminAuth(c);
 
@@ -189,6 +197,7 @@ export function requireAnyRole(roleNames: string[]) {
  * ```
  */
 export function requireAllRoles(roleNames: string[]) {
+  assertRequiredRoles(roleNames);
   return async (c: Context<{ Bindings: Env }>, next: Next) => {
     const authContext = getAdminAuth(c);
 

--- a/packages/ar-lib-core/src/utils/__tests__/tenant-context.test.ts
+++ b/packages/ar-lib-core/src/utils/__tests__/tenant-context.test.ts
@@ -1,5 +1,24 @@
-import { describe, it, expect } from 'vitest';
-import { remapShardIndex, getTenantIdFromHost, resolveTenantFromRequest } from '../tenant-context';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildAuthCodeShardInstanceName,
+  buildDOInstanceName,
+  buildDOInstanceNameForTenant,
+  buildDOKey,
+  buildKVKey,
+  buildKVKeyForTenant,
+  buildSessionShardInstanceName,
+  createShardedAuthCode,
+  fnv1a32,
+  getAuthCodeShardIndex,
+  getSessionShardCount,
+  getShardCount,
+  getTenantId,
+  getTenantIdFromHost,
+  getTenantIdOrThrow,
+  parseShardedAuthCode,
+  remapShardIndex,
+  resolveTenantFromRequest,
+} from '../tenant-context';
 import type { Env } from '../../types/env';
 
 describe('getTenantIdFromHost', () => {
@@ -276,5 +295,140 @@ describe('remapShardIndex', () => {
       // Verify the relationship: oldShard % shardCount === newShard
       expect(oldShard % shardCount).toBe(newShard);
     }
+  });
+});
+
+describe('tenant-prefixed storage keys', () => {
+  it('builds unambiguous tenant-prefixed keys for every storage topology', () => {
+    expect(getTenantId()).toBe('default');
+    expect(buildDOKey('session', 's1', ' tenant-a ')).toBe('tenant:tenant-a:session:s1');
+    expect(buildKVKey('client', 'c1', 'tenant-a')).toBe('tenant:tenant-a:client:c1');
+    expect(buildDOInstanceName('key-manager', 'tenant-a')).toBe('tenant:tenant-a:key-manager');
+    expect(buildDOInstanceNameForTenant('tenant-a', 'session')).toBe('tenant:tenant-a:session');
+    expect(buildKVKeyForTenant('tenant-a', 'state', 'x')).toBe('tenant:tenant-a:state:x');
+    expect(buildAuthCodeShardInstanceName(3, 'tenant-a')).toBe('tenant:tenant-a:auth-code:shard-3');
+    expect(buildSessionShardInstanceName(2, 'tenant-a')).toBe('tenant:tenant-a:session:shard-2');
+  });
+
+  it.each([
+    ['buildDOKey', () => buildDOKey('session', 's1', ' ')],
+    ['buildKVKey', () => buildKVKey('state', 'x', '')],
+    ['buildDOInstanceName', () => buildDOInstanceName('session', '\t')],
+    ['buildDOInstanceNameForTenant', () => buildDOInstanceNameForTenant('', 'session')],
+    ['buildKVKeyForTenant', () => buildKVKeyForTenant(' ', 'state', 'x')],
+    ['buildAuthCodeShardInstanceName', () => buildAuthCodeShardInstanceName(0, '')],
+    ['buildSessionShardInstanceName', () => buildSessionShardInstanceName(0, ' ')],
+  ])('rejects an empty tenant in %s', (_label, operation) => {
+    expect(operation).toThrow(/requires tenantId/);
+  });
+});
+
+describe('tenant resolution failures', () => {
+  const env: Partial<Env> = { BASE_DOMAIN: 'authrim.example', DEFAULT_TENANT_ID: 'fallback' };
+
+  it.each([
+    [undefined, 'Host header is required'],
+    ['unknown.example', 'Tenant not found'],
+  ])('throws a stable error for host %s', (host, message) => {
+    expect(() => getTenantIdOrThrow(host, env)).toThrow(message);
+  });
+
+  it('returns a resolved tenant without modification', () => {
+    expect(getTenantIdOrThrow('acme.authrim.example', env)).toBe('acme');
+  });
+
+  it('falls back to a valid Authrim forwarded host only when Host is missing', () => {
+    const request = new Request('https://runtime.invalid/path', {
+      headers: { 'X-Authrim-Forwarded-Host': 'acme.authrim.example' },
+    });
+    request.headers.delete('Host');
+
+    const result = resolveTenantFromRequest(request, env);
+
+    expect(result).toMatchObject({ success: true, tenantId: 'acme' });
+  });
+
+  it('ignores duplicate and empty forwarded host values', () => {
+    const request = new Request('https://runtime.invalid/path', {
+      headers: { Host: 'unknown.example', 'X-Authrim-Forwarded-Host': ' ,acme.authrim.example' },
+    });
+
+    const result = resolveTenantFromRequest(request, {
+      ...env,
+      AUTHRIM_TRUST_FORWARDED_HOST: 'true',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('authorization-code sharding', () => {
+  it('uses a deterministic unsigned FNV-1a hash and sticky shard', () => {
+    expect(fnv1a32('hello')).toBe(1335831723);
+    expect(getAuthCodeShardIndex('user-1', 'client-1', 16)).toBe(
+      getAuthCodeShardIndex('user-1', 'client-1', 16)
+    );
+    expect(getAuthCodeShardIndex('user-1', 'client-1', 16)).toBeLessThan(16);
+  });
+
+  it.each([0, -1, 1.5])('rejects invalid shard count %s', (count) => {
+    expect(() => getAuthCodeShardIndex('u', 'c', count)).toThrow('positive integer');
+  });
+
+  it('creates and strictly parses sharded authorization codes', () => {
+    expect(createShardedAuthCode(3, 'opaque_value')).toBe('3_opaque_value');
+    expect(parseShardedAuthCode('3_opaque_value')).toEqual({
+      shardIndex: 3,
+      opaqueCode: 'opaque_value',
+    });
+  });
+
+  it.each(['legacy-code', '-1_token', '1junk_token', '1_', '_token'])(
+    'rejects malformed sharded code %s',
+    (code) => expect(parseShardedAuthCode(code)).toBeNull()
+  );
+});
+
+describe('dynamic shard counts', () => {
+  it('prefers valid KV values and caches them briefly', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2030-01-01T00:00:00Z'));
+    const get = vi.fn(async (key: string) => (key === 'code_shards' ? '32' : '16'));
+    const env = { AUTHRIM_CONFIG: { get } } as unknown as Env;
+
+    expect(await getShardCount(env)).toBe(32);
+    expect(await getShardCount(env)).toBe(32);
+    expect(await getSessionShardCount(env)).toBe(16);
+    expect(await getSessionShardCount(env)).toBe(16);
+    expect(get).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it('refreshes after TTL and falls back through invalid KV to environment values', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2030-01-01T00:01:00Z'));
+    const env = {
+      AUTHRIM_CONFIG: { get: vi.fn(async () => 'invalid') },
+      AUTHRIM_CODE_SHARDS: '8',
+      AUTHRIM_SESSION_SHARDS: '12',
+    } as unknown as Env;
+
+    expect(await getShardCount(env)).toBe(8);
+    expect(await getSessionShardCount(env)).toBe(12);
+    vi.useRealTimers();
+  });
+
+  it('uses defaults when neither KV nor environment contains a positive count', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2030-01-01T00:02:00Z'));
+    const env = {
+      AUTHRIM_CONFIG: { get: vi.fn(async () => '-2') },
+      AUTHRIM_CODE_SHARDS: '0',
+      AUTHRIM_SESSION_SHARDS: 'NaN',
+    } as unknown as Env;
+
+    expect(await getShardCount(env)).toBe(4);
+    expect(await getSessionShardCount(env)).toBe(4);
+    vi.useRealTimers();
   });
 });

--- a/packages/ar-lib-core/src/utils/tenant-context.ts
+++ b/packages/ar-lib-core/src/utils/tenant-context.ts
@@ -12,7 +12,7 @@
  */
 
 import type { Env } from '../types/env';
-import { isMultiTenantEnabled, validateHostHeader, extractSubdomain } from './issuer';
+import { validateHostHeader } from './issuer';
 
 /**
  * Default tenant ID used in single-tenant mode.
@@ -307,6 +307,9 @@ export function getAuthCodeShardIndex(
   clientId: string,
   shardCount: number = DEFAULT_CODE_SHARD_COUNT
 ): number {
+  if (!Number.isInteger(shardCount) || shardCount <= 0) {
+    throw new Error('Invalid shard count: must be a positive integer');
+  }
   const key = `${userId}:${clientId}`;
   const hash = fnv1a32(key);
   return hash % shardCount;
@@ -343,10 +346,10 @@ export function parseShardedAuthCode(
   const shardPart = code.substring(0, underscorePos);
   const opaquePart = code.substring(underscorePos + 1);
 
-  const shardIndex = parseInt(shardPart, 10);
-  if (isNaN(shardIndex) || shardIndex < 0) {
+  if (!/^\d+$/.test(shardPart) || !opaquePart) {
     return null;
   }
+  const shardIndex = Number(shardPart);
 
   return {
     shardIndex,

--- a/packages/ar-management/src/__tests__/account-consents.test.ts
+++ b/packages/ar-management/src/__tests__/account-consents.test.ts
@@ -41,10 +41,13 @@ vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
 
 import { listAccountConsentsHandler } from '../account-consents';
 
-function createMockContext(cookie?: string) {
+function createMockContext(cookie?: string, acceptLanguage?: string) {
   const headers = new Headers();
   const request = new Request('https://op.example.com/api/account/consents', {
-    headers: cookie ? { Cookie: cookie } : {},
+    headers: {
+      ...(cookie ? { Cookie: cookie } : {}),
+      ...(acceptLanguage ? { 'Accept-Language': acceptLanguage } : {}),
+    },
   });
   return {
     env: {} as Env,
@@ -220,5 +223,148 @@ describe('Account Page consents API', () => {
       ],
       total: 3,
     });
+  });
+
+  it('requires an account session before reading consent history', async () => {
+    const response = await listAccountConsentsHandler(createMockContext());
+
+    expect(response.status).toBe(401);
+    expect(mockCoreAdapter.query).not.toHaveBeenCalled();
+  });
+
+  it('normalizes revoked/denied records and omits malformed optional consent data', async () => {
+    mockCoreAdapter.query.mockReset();
+    mockCoreAdapter.query
+      .mockResolvedValueOnce([
+        {
+          id: 'statement-minimal',
+          statement_id: 'statement-1',
+          version_id: 'version-1',
+          version: '1',
+          status: 'withdrawn',
+          granted_at: null,
+          withdrawn_at: null,
+          expires_at: null,
+          client_id: null,
+          receipt_id: null,
+          updated_at: 10,
+          slug: null,
+          category: null,
+          title: null,
+          description: null,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 'flow-revoked',
+          statement_id: 'statement-2',
+          version_id: 'version-2',
+          version: '2',
+          decision: 'accepted',
+          selected_value: null,
+          record_status: 'revoked',
+          granted_at: null,
+          withdrawn_at: 20,
+          expires_at: null,
+          client_id: null,
+          receipt_id: null,
+          updated_at: 20,
+          slug: null,
+          category: null,
+          title: null,
+          description: null,
+        },
+        {
+          id: 'flow-denied',
+          statement_id: 'statement-3',
+          version_id: 'version-3',
+          version: '3',
+          decision: 'rejected',
+          selected_value: 'no',
+          record_status: 'active',
+          granted_at: null,
+          withdrawn_at: null,
+          expires_at: null,
+          client_id: null,
+          receipt_id: null,
+          updated_at: 30,
+          slug: 'statement-three',
+          category: null,
+          title: null,
+          description: null,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 'oauth-minimal',
+          client_id: 'client-1',
+          scope: 'openid  email ',
+          selected_scopes: '{bad json',
+          granted_at: 40,
+          expires_at: null,
+          privacy_policy_version: null,
+          tos_version: null,
+          consent_version: null,
+          client_name: null,
+          logo_uri: null,
+        },
+      ]);
+
+    const response = await listAccountConsentsHandler(
+      createMockContext('authrim_session=g1%3Aapac%3A3%3Asession_current', 'ja-JP, en;q=0.8')
+    );
+    const body = (await response.json()) as { consents: Array<Record<string, unknown>> };
+
+    expect(response.status).toBe(200);
+    expect(mockCoreAdapter.query).toHaveBeenCalledWith(expect.any(String), [
+      'ja',
+      'default',
+      'user-001',
+    ]);
+    expect(body.consents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'flow-revoked', status: 'withdrawn' }),
+        expect.objectContaining({ id: 'flow-denied', status: 'denied', selectedValue: 'no' }),
+        expect.objectContaining({ id: 'statement-minimal', title: 'statement-1' }),
+        expect.objectContaining({ id: 'oauth-minimal', scopes: ['openid', 'email'] }),
+      ])
+    );
+    const oauth = body.consents.find((consent) => consent.id === 'oauth-minimal');
+    expect(oauth).not.toHaveProperty('selectedScopes');
+    expect(oauth).not.toHaveProperty('policyVersions');
+  });
+
+  it.each([
+    ['non-array JSON', JSON.stringify({ scope: 'openid' })],
+    ['mixed array JSON', JSON.stringify(['openid', 42])],
+    ['empty value', null],
+  ])('omits selected scopes for %s', async (_label, selectedScopes) => {
+    mockCoreAdapter.query.mockReset();
+    mockCoreAdapter.query
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: 'oauth-1',
+          client_id: 'client-1',
+          scope: 'openid',
+          selected_scopes: selectedScopes,
+          granted_at: 1,
+          expires_at: null,
+          privacy_policy_version: null,
+          tos_version: null,
+          consent_version: null,
+          client_name: null,
+          logo_uri: null,
+        },
+      ]);
+
+    const response = await listAccountConsentsHandler(
+      createMockContext('authrim_session=g1%3Aapac%3A3%3Asession_current')
+    );
+    const body = (await response.json()) as { consents: Array<Record<string, unknown>> };
+
+    expect(response.status).toBe(200);
+    expect(body.consents[0]).not.toHaveProperty('selectedScopes');
   });
 });

--- a/packages/ar-management/src/__tests__/account-operations.test.ts
+++ b/packages/ar-management/src/__tests__/account-operations.test.ts
@@ -124,4 +124,57 @@ describe('Account Page operation history API', () => {
       },
     ]);
   });
+
+  it('requires an authenticated account session before querying audit data', async () => {
+    const response = await listAccountOperationsHandler(createMockContext());
+
+    expect(response.status).toBe(401);
+    expect(mockCoreAdapter.query).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [undefined, 50],
+    ['0', 50],
+    ['not-a-number', 50],
+    ['25', 25],
+  ])('normalizes operation limit %s to %s', async (limit, expected) => {
+    mockCoreAdapter.query.mockResolvedValue([]);
+    const response = await listAccountOperationsHandler(
+      createMockContext({
+        cookie: 'authrim_session=g1%3Aapac%3A3%3Asession_current',
+        query: limit === undefined ? {} : { limit },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockCoreAdapter.query).toHaveBeenCalledWith(expect.any(String), [
+      'default',
+      'user-001',
+      expected,
+    ]);
+  });
+
+  it.each([[null], ['not-json'], ['[]'], ['null']])(
+    'omits unsafe or malformed metadata %s',
+    async (metadataJson) => {
+      mockCoreAdapter.query.mockResolvedValue([
+        {
+          id: 'audit-unsafe',
+          action: 'account.session.revoked',
+          resource_type: null,
+          resource_id: null,
+          metadata_json: metadataJson,
+          created_at: 1,
+        },
+      ]);
+
+      const response = await listAccountOperationsHandler(
+        createMockContext({ cookie: 'authrim_session=g1%3Aapac%3A3%3Asession_current' })
+      );
+      const body = (await response.json()) as { operations: Array<Record<string, unknown>> };
+
+      expect(response.status).toBe(200);
+      expect(body.operations[0]).not.toHaveProperty('metadata');
+    }
+  );
 });

--- a/packages/ar-management/src/__tests__/account-page.test.ts
+++ b/packages/ar-management/src/__tests__/account-page.test.ts
@@ -64,7 +64,7 @@ import {
   updateAccountProfileHandler,
 } from '../account-page';
 
-function createMockContext(cookie?: string, body?: unknown) {
+function createMockContext(cookie?: string, body?: unknown, bodyError?: Error) {
   const headers = new Headers();
   const request = new Request('https://op.example.com/api/account/profile', {
     headers: cookie ? { Cookie: cookie } : {},
@@ -76,7 +76,7 @@ function createMockContext(cookie?: string, body?: unknown) {
       url: request.url,
       raw: request,
       header: (name: string) => request.headers.get(name) ?? undefined,
-      json: vi.fn().mockResolvedValue(body),
+      json: bodyError ? vi.fn().mockRejectedValue(bodyError) : vi.fn().mockResolvedValue(body),
     },
     header: (name: string, value: string) => {
       headers.set(name, value);
@@ -323,5 +323,135 @@ describe('Account Page API', () => {
     expect(response.status).toBe(401);
     expect(body.error).toBe('unauthorized');
     expect(mockFindById).not.toHaveBeenCalled();
+  });
+
+  it('rejects legacy unsharded and missing-user sessions', async () => {
+    const legacy = await getAccountProfileHandler(
+      createMockContext('authrim_session=legacy-session')
+    );
+    expect(legacy.status).toBe(401);
+    expect(mockGetSessionStoreBySessionId).not.toHaveBeenCalled();
+
+    mockSessionStore.getSessionRpc.mockResolvedValueOnce({
+      id: 'g1:apac:3:session_123',
+      userId: '',
+      createdAt: 1,
+      expiresAt: Date.now() + 60_000,
+      data: {},
+    });
+    const missingUser = await getAccountProfileHandler(
+      createMockContext('authrim_session=g1%3Aapac%3A3%3Asession_123')
+    );
+    expect(missingUser.status).toBe(401);
+  });
+
+  it('returns a masked server error when session validation storage fails', async () => {
+    mockSessionStore.getSessionRpc.mockRejectedValueOnce(new Error('storage secret'));
+
+    const response = await getAccountProfileHandler(
+      createMockContext('authrim_session=g1%3Aapac%3A3%3Asession_123')
+    );
+    const text = await response.text();
+
+    expect(response.status).toBe(500);
+    expect(text).not.toContain('storage secret');
+  });
+
+  it('returns unauthorized when the session user no longer exists', async () => {
+    mockFindById.mockResolvedValueOnce(null);
+
+    const response = await getAccountProfileHandler(
+      createMockContext('authrim_session=g1%3Aapac%3A3%3Asession_123')
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns a masked server error when profile lookup fails', async () => {
+    mockFindById.mockRejectedValueOnce(new Error('PII backend failed'));
+
+    const response = await getAccountProfileHandler(
+      createMockContext('authrim_session=g1%3Aapac%3A3%3Asession_123')
+    );
+    const text = await response.text();
+
+    expect(response.status).toBe(500);
+    expect(text).not.toContain('PII backend');
+  });
+
+  it.each([
+    ['malformed JSON', undefined, new Error('bad json')],
+    ['missing name', {}, undefined],
+    ['non-string name', { name: 42 }, undefined],
+    ['empty normalized name', { name: '   ' }, undefined],
+    ['name above 100 characters', { name: 'x'.repeat(101) }, undefined],
+  ])('rejects profile updates with %s', async (_label, body, error) => {
+    const response = await updateAccountProfileHandler(
+      createMockContext('authrim_session=g1%3Aapac%3A3%3Asession_123', body, error)
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockSyncUser).not.toHaveBeenCalled();
+  });
+
+  it('does not recreate a user deleted between session validation and update', async () => {
+    mockFindById.mockResolvedValueOnce(null);
+
+    const response = await updateAccountProfileHandler(
+      createMockContext('authrim_session=g1%3Aapac%3A3%3Asession_123', { name: 'New' })
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockSyncUser).not.toHaveBeenCalled();
+  });
+
+  it('falls back to stable existing profile fields when post-update read misses', async () => {
+    mockFindById
+      .mockResolvedValueOnce({
+        id: 'user-001',
+        account_type: 'end_user',
+        active: 0,
+        email: 'person@example.test',
+        email_verified: 0,
+        name: 'Old',
+        given_name: 'Given',
+        family_name: 'Family',
+        locale: 'en',
+        picture: null,
+      })
+      .mockResolvedValueOnce(null);
+
+    const response = await updateAccountProfileHandler(
+      createMockContext('authrim_session=g1%3Aapac%3A3%3Asession_123', { name: 'New' })
+    );
+    const body = (await response.json()) as Record<string, any>;
+
+    expect(response.status).toBe(200);
+    expect(mockSyncUser).toHaveBeenCalledWith(expect.objectContaining({ active: false }));
+    expect(body.profile).toMatchObject({
+      email: 'person@example.test',
+      email_verified: false,
+      name: 'New',
+      given_name: 'Given',
+    });
+  });
+
+  it('uses session creation time and empty methods when auth metadata is absent', async () => {
+    mockSessionStore.getSessionRpc.mockResolvedValueOnce({
+      id: 'g1:apac:3:session_123',
+      userId: 'user-001',
+      createdAt: Date.now() - 60_000,
+      expiresAt: Date.now() + 60_000,
+      data: {},
+    });
+
+    const response = await getAccountReauthStatusHandler(
+      createMockContext('authrim_session=g1%3Aapac%3A3%3Asession_123')
+    );
+    const body = (await response.json()) as Record<string, any>;
+
+    expect(response.status).toBe(200);
+    expect(body.reauth.authenticated_at).toBe(Math.floor((Date.now() - 60_000) / 1000));
+    expect(body.reauth.methods).toEqual([]);
   });
 });

--- a/packages/ar-management/src/__tests__/account-return.test.ts
+++ b/packages/ar-management/src/__tests__/account-return.test.ts
@@ -38,6 +38,7 @@ function createSettingsKV(records: Record<string, unknown> = {}) {
 function createMockContext(
   options: {
     body?: unknown;
+    bodyError?: Error;
     params?: Record<string, string>;
     settings?: Record<string, unknown>;
   } = {}
@@ -48,7 +49,9 @@ function createMockContext(
     env: { SETTINGS: settings } as unknown as Env,
     req: {
       param: (name: string) => options.params?.[name] ?? '',
-      json: vi.fn().mockResolvedValue(options.body),
+      json: options.bodyError
+        ? vi.fn().mockRejectedValue(options.bodyError)
+        : vi.fn().mockResolvedValue(options.body),
     },
     header: (name: string, value: string) => {
       headers.append(name, value);
@@ -203,5 +206,55 @@ describe('Account Page return transaction API', () => {
 
     expect(response.status).toBe(404);
     expect(body.error).toBe('account_page_disabled');
+  });
+
+  it('rejects a non-JSON return request', async () => {
+    const response = await createAccountReturnHandler(
+      createMockContext({ bodyError: new Error('invalid JSON') })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockChallengeStore.storeChallengeRpc).not.toHaveBeenCalled();
+  });
+
+  it.each([[undefined], [42], ['https://evil.example/account'], ['javascript:alert(1)']])(
+    'rejects unsafe account return path %s',
+    async (path) => {
+      const response = await createAccountReturnHandler(createMockContext({ body: { path } }));
+
+      expect(response.status).toBe(400);
+      expect(mockChallengeStore.storeChallengeRpc).not.toHaveBeenCalled();
+    }
+  );
+
+  it('returns not found when the consume id is absent', async () => {
+    const response = await consumeAccountReturnHandler(createMockContext());
+
+    expect(response.status).toBe(404);
+    expect(mockChallengeStore.consumeChallengeRpc).not.toHaveBeenCalled();
+  });
+
+  it('rejects an expired or replayed return transaction', async () => {
+    mockChallengeStore.consumeChallengeRpc.mockRejectedValue(new Error('not found'));
+
+    const response = await consumeAccountReturnHandler(
+      createMockContext({ params: { id: 'expired' } })
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it.each([
+    [{ metadata: {} }],
+    [{ metadata: { path: '/admin/users' } }],
+    [{ metadata: { path: 42 } }],
+  ])('rejects stale or tampered consumed metadata %#', async (stored) => {
+    mockChallengeStore.consumeChallengeRpc.mockResolvedValue(stored);
+
+    const response = await consumeAccountReturnHandler(
+      createMockContext({ params: { id: 'ret_001' } })
+    );
+
+    expect(response.status).toBe(400);
   });
 });

--- a/packages/ar-management/src/__tests__/account-totp.test.ts
+++ b/packages/ar-management/src/__tests__/account-totp.test.ts
@@ -12,6 +12,7 @@ const {
   mockTotpRepo,
   mockRuntimeUserStore,
   mockRateLimiter,
+  mockPasskeyRepo,
 } = vi.hoisted(() => {
   const sessionStore = {
     getSessionRpc: vi.fn(),
@@ -55,6 +56,7 @@ const {
       findById: vi.fn(),
     },
     mockRateLimiter: rateLimiter,
+    mockPasskeyRepo: { findByUserId: vi.fn() },
   };
 });
 
@@ -70,6 +72,9 @@ vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
     CanonicalRuntimeUserStore: vi.fn(function CanonicalRuntimeUserStoreMock() {
       return mockRuntimeUserStore;
     }),
+    PasskeyRepository: vi.fn(function PasskeyRepositoryMock() {
+      return mockPasskeyRepo;
+    }),
   };
 });
 
@@ -84,6 +89,9 @@ import {
   completeAccountTotpReauthHandler,
   createAccountTotpOptionsHandler,
   deleteAccountTotpCredentialHandler,
+  listAccountTotpCredentialsHandler,
+  regenerateAccountTotpBackupCodesHandler,
+  updateAccountTotpCredentialHandler,
 } from '../account-totp';
 
 const encryptionKey = '00'.repeat(32);
@@ -102,15 +110,20 @@ const baseSession = {
 function createMockContext(
   options: {
     body?: unknown;
+    bodyError?: Error;
     settings?: Record<string, unknown>;
+    rawSettings?: Record<string, string>;
     env?: Partial<Env>;
+    cookie?: string | null;
   } = {}
 ) {
   const headers = new Headers();
+  const cookie =
+    options.cookie === null
+      ? undefined
+      : (options.cookie ?? 'authrim_session=g1%3Aapac%3A3%3Asession_current');
   const request = new Request('https://op.example.com/api/account/totp', {
-    headers: {
-      Cookie: 'authrim_session=g1%3Aapac%3A3%3Asession_current',
-    },
+    headers: cookie ? { Cookie: cookie } : {},
   });
   return {
     env: {
@@ -124,6 +137,9 @@ function createMockContext(
       },
       SETTINGS: {
         get: vi.fn(async (key: string) => {
+          if (options.rawSettings?.[key] !== undefined) {
+            return options.rawSettings[key];
+          }
           const value = options.settings?.[key];
           return value === undefined ? null : JSON.stringify(value);
         }),
@@ -136,7 +152,9 @@ function createMockContext(
       raw: request,
       header: (name: string) => request.headers.get(name) ?? undefined,
       param: vi.fn(),
-      json: vi.fn().mockResolvedValue(options.body),
+      json: options.bodyError
+        ? vi.fn().mockRejectedValue(options.bodyError)
+        : vi.fn().mockResolvedValue(options.body),
     },
     header: (name: string, value: string) => {
       headers.append(name, value);
@@ -175,6 +193,7 @@ describe('Account Page TOTP API', () => {
     });
     mockCoreAdapter.execute.mockResolvedValue({ rowsAffected: 1, success: true });
     mockRateLimiter.incrementRpc.mockResolvedValue({ allowed: true, retryAfter: 0 });
+    mockPasskeyRepo.findByUserId.mockResolvedValue([]);
     mockTotpRepo.create.mockImplementation(async (input) => ({
       id: 'totp-001',
       tenant_id: 'default',
@@ -587,5 +606,710 @@ describe('Account Page TOTP API', () => {
     });
     expect(mockTotpRepo.findActiveByUserId).not.toHaveBeenCalled();
     expect(mockSessionStore.updateSessionDataRpc).not.toHaveBeenCalled();
+  });
+
+  it('lists sanitized credentials and only backup-code counts', async () => {
+    mockTotpRepo.findByUserId.mockResolvedValue([
+      {
+        id: 'totp-001',
+        user_id: 'user-001',
+        secret_encrypted: 'must-not-leak',
+        label: 'Phone',
+        algorithm: 'SHA1',
+        digits: 6,
+        period: 30,
+        window: 1,
+        status: 'active',
+        created_at: 1,
+        activated_at: 2,
+        last_used_at: null,
+      },
+    ]);
+    mockTotpRepo.listBackupCodes.mockResolvedValue([
+      { id: 'b1', code_hash: 'secret', used_at: null },
+      { id: 'b2', code_hash: 'secret', used_at: 10 },
+    ]);
+
+    const response = await listAccountTotpCredentialsHandler(createMockContext());
+    const body = (await response.json()) as Record<string, any>;
+
+    expect(response.status).toBe(200);
+    expect(body.credentials[0]).not.toHaveProperty('secret_encrypted');
+    expect(body.backup_codes).toEqual({ total: 2, remaining: 1 });
+  });
+
+  it.each([
+    [{}, 400],
+    [{ label: 'x'.repeat(101) }, 400],
+  ])('rejects invalid TOTP rename payload %#', async (body, status) => {
+    const context = createMockContext({ body });
+    context.req.param = vi.fn(() => 'totp-001');
+
+    const response = await updateAccountTotpCredentialHandler(context);
+
+    expect(response.status).toBe(status);
+    expect(mockTotpRepo.rename).not.toHaveBeenCalled();
+  });
+
+  it('does not rename another user TOTP credential', async () => {
+    mockTotpRepo.findById.mockResolvedValue({ id: 'totp-001', user_id: 'other' });
+    const context = createMockContext({ body: { label: 'New' } });
+    context.req.param = vi.fn(() => 'totp-001');
+
+    const response = await updateAccountTotpCredentialHandler(context);
+
+    expect(response.status).toBe(404);
+    expect(mockTotpRepo.rename).not.toHaveBeenCalled();
+  });
+
+  it('renames an owned TOTP credential and records only changed fields', async () => {
+    const credential = {
+      id: 'totp-001',
+      user_id: 'user-001',
+      label: 'Old',
+      algorithm: 'SHA1',
+      digits: 6,
+      period: 30,
+      window: 1,
+      status: 'active',
+      created_at: 1,
+      activated_at: 2,
+      last_used_at: null,
+    };
+    mockTotpRepo.findById.mockResolvedValue(credential);
+    mockTotpRepo.rename.mockResolvedValue({ ...credential, label: 'New' });
+    const context = createMockContext({ body: { label: ' New ' } });
+    context.req.param = vi.fn(() => 'totp-001');
+
+    const response = await updateAccountTotpCredentialHandler(context);
+
+    expect(response.status).toBe(200);
+    expect(mockTotpRepo.rename).toHaveBeenCalledWith('totp-001', 'user-001', 'New');
+  });
+
+  it('deletes an owned pending credential without demanding authentication proof', async () => {
+    mockTotpRepo.findById.mockResolvedValue({
+      id: 'totp-pending',
+      user_id: 'user-001',
+      status: 'pending',
+      label: 'Pending',
+    });
+    mockTotpRepo.delete.mockResolvedValue(true);
+    const context = createMockContext();
+    context.req.param = vi.fn(() => 'totp-pending');
+
+    const response = await deleteAccountTotpCredentialHandler(context);
+
+    expect(response.status).toBe(200);
+    expect(mockTotpRepo.delete).toHaveBeenCalledWith('totp-pending', 'user-001');
+    expect(mockTotpRepo.consumeBackupCode).not.toHaveBeenCalled();
+  });
+
+  it('returns not found when deleting an unknown or cross-user credential', async () => {
+    mockTotpRepo.findById.mockResolvedValue(null);
+    const context = createMockContext();
+    context.req.param = vi.fn(() => 'missing');
+
+    const response = await deleteAccountTotpCredentialHandler(context);
+
+    expect(response.status).toBe(404);
+    expect(mockTotpRepo.delete).not.toHaveBeenCalled();
+  });
+
+  it('rejects backup-code regeneration when no active TOTP credential exists', async () => {
+    mockTotpRepo.findActiveByUserId.mockResolvedValue([]);
+
+    const response = await regenerateAccountTotpBackupCodesHandler(createMockContext());
+
+    expect(response.status).toBe(404);
+    expect(mockTotpRepo.replaceBackupCodes).not.toHaveBeenCalled();
+  });
+
+  it('regenerates one-time backup codes after recent passkey authentication', async () => {
+    mockTotpRepo.findActiveByUserId.mockResolvedValue([{ id: 'totp-001', user_id: 'user-001' }]);
+    mockTotpRepo.replaceBackupCodes.mockResolvedValue([]);
+
+    const response = await regenerateAccountTotpBackupCodesHandler(createMockContext());
+    const body = (await response.json()) as { backup_codes: string[] };
+
+    expect(response.status).toBe(200);
+    expect(body.backup_codes).toHaveLength(10);
+    expect(mockTotpRepo.replaceBackupCodes).toHaveBeenCalled();
+  });
+
+  it('uses enrollment defaults for malformed optional JSON but rejects oversized labels', async () => {
+    const malformedResponse = await createAccountTotpOptionsHandler(
+      createMockContext({
+        bodyError: new Error('bad json'),
+        settings: {
+          'settings:tenant:default:authentication-methods': {
+            'authentication-methods.totp.login_enabled': true,
+          },
+        },
+      })
+    );
+    expect(malformedResponse.status).toBe(201);
+    expect(mockTotpRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'Authenticator app' })
+    );
+
+    mockTotpRepo.create.mockClear();
+    const oversizedResponse = await createAccountTotpOptionsHandler(
+      createMockContext({
+        body: { label: 'x'.repeat(101) },
+        settings: {
+          'settings:tenant:default:authentication-methods': {
+            'authentication-methods.totp.login_enabled': true,
+          },
+        },
+      })
+    );
+    expect(oversizedResponse.status).toBe(400);
+    expect(mockTotpRepo.create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['malformed JSON', undefined, new Error('bad json'), 400],
+    ['missing fields', {}, undefined, 400],
+  ])('rejects activation with %s', async (_label, body, bodyError, status) => {
+    const response = await activateAccountTotpCredentialHandler(
+      createMockContext({ body, bodyError })
+    );
+
+    expect(response.status).toBe(status);
+    expect(mockTotpRepo.findById).not.toHaveBeenCalled();
+  });
+
+  it('does not activate an unknown, cross-user, or already-active credential', async () => {
+    for (const credential of [
+      null,
+      { id: 'totp-001', user_id: 'other', status: 'pending' },
+      { id: 'totp-001', user_id: 'user-001', status: 'active' },
+    ]) {
+      mockTotpRepo.findById.mockResolvedValueOnce(credential);
+      const response = await activateAccountTotpCredentialHandler(
+        createMockContext({
+          body: { credential_id: 'totp-001', code: '123456' },
+          settings: {
+            'settings:tenant:default:authentication-methods': {
+              'authentication-methods.totp.login_enabled': true,
+            },
+          },
+        })
+      );
+      expect(response.status).toBe(404);
+    }
+    expect(mockTotpRepo.activate).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid activation code without mutating pending state', async () => {
+    const secret = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
+    const encrypted = await encryptValue(secret, encryptionKey, 'AES-256-GCM', 1);
+    mockTotpRepo.findById.mockResolvedValue({
+      id: 'totp-001',
+      user_id: 'user-001',
+      secret_encrypted: encrypted.encrypted,
+      algorithm: 'SHA1',
+      digits: 6,
+      period: 30,
+      window: 1,
+      status: 'pending',
+    });
+
+    const response = await activateAccountTotpCredentialHandler(
+      createMockContext({
+        body: { credential_id: 'totp-001', code: '000000' },
+        settings: {
+          'settings:tenant:default:authentication-methods': {
+            'authentication-methods.totp.login_enabled': true,
+          },
+        },
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockTotpRepo.activate).not.toHaveBeenCalled();
+  });
+
+  it('reports a concurrent activation state change as conflict', async () => {
+    const secret = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
+    const encrypted = await encryptValue(secret, encryptionKey, 'AES-256-GCM', 1);
+    const profile: TotpProfile = { algorithm: 'SHA1', digits: 6, period: 30, window: 1 };
+    const code = await generateTotpCode(
+      secret,
+      profile,
+      getTotpTimeStep(Date.now(), profile.period)
+    );
+    mockTotpRepo.findById.mockResolvedValue({
+      id: 'totp-001',
+      user_id: 'user-001',
+      secret_encrypted: encrypted.encrypted,
+      ...profile,
+      status: 'pending',
+    });
+    mockTotpRepo.activate.mockResolvedValue(null);
+
+    const response = await activateAccountTotpCredentialHandler(
+      createMockContext({
+        body: { credential_id: 'totp-001', code },
+        settings: {
+          'settings:tenant:default:authentication-methods': {
+            'authentication-methods.totp.login_enabled': true,
+          },
+        },
+      })
+    );
+
+    expect(response.status).toBe(409);
+    expect(mockTotpRepo.replaceBackupCodes).not.toHaveBeenCalled();
+  });
+
+  it('reports a concurrent pending-credential deletion as not found', async () => {
+    mockTotpRepo.findById.mockResolvedValue({
+      id: 'totp-pending',
+      user_id: 'user-001',
+      status: 'pending',
+    });
+    mockTotpRepo.delete.mockResolvedValue(false);
+    const context = createMockContext();
+    context.req.param = vi.fn(() => 'totp-pending');
+
+    const response = await deleteAccountTotpCredentialHandler(context);
+
+    expect(response.status).toBe(404);
+  });
+
+  it.each([
+    ['malformed JSON', undefined, new Error('bad json'), 400],
+    ['missing code', {}, undefined, 400],
+  ])('rejects TOTP reauthentication with %s', async (_label, body, bodyError, status) => {
+    const response = await completeAccountTotpReauthHandler(createMockContext({ body, bodyError }));
+
+    expect(response.status).toBe(status);
+    expect(mockTotpRepo.findActiveByUserId).not.toHaveBeenCalled();
+  });
+
+  it('rejects TOTP reauthentication when the method is disabled', async () => {
+    const response = await completeAccountTotpReauthHandler(
+      createMockContext({
+        body: { code: '123456' },
+        settings: {
+          'settings:tenant:default:authentication-methods': {
+            'authentication-methods.totp.reauth_enabled': false,
+          },
+        },
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockTotpRepo.findActiveByUserId).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid TOTP reauthentication code', async () => {
+    mockTotpRepo.findActiveByUserId.mockResolvedValue([]);
+    const response = await completeAccountTotpReauthHandler(
+      createMockContext({
+        body: { code: '123456' },
+        settings: {
+          'settings:tenant:default:authentication-methods': {
+            'authentication-methods.totp.reauth_enabled': true,
+          },
+        },
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockSessionStore.updateSessionDataRpc).not.toHaveBeenCalled();
+  });
+
+  it('allows deleting one of multiple active TOTP credentials after recent TOTP auth', async () => {
+    mockSessionStore.getSessionRpc.mockResolvedValue({
+      ...baseSession,
+      expiresAt: Date.now() + 60_000,
+      data: { authTime: Math.floor(Date.now() / 1000) - 60, amr: ['totp'] },
+    });
+    mockTotpRepo.findById.mockResolvedValue({
+      id: 'totp-001',
+      user_id: 'user-001',
+      status: 'active',
+      label: 'Primary',
+    });
+    mockTotpRepo.findActiveByUserId.mockResolvedValue([
+      { id: 'totp-001', user_id: 'user-001' },
+      { id: 'totp-002', user_id: 'user-001' },
+    ]);
+    mockTotpRepo.delete.mockResolvedValue(true);
+    const context = createMockContext();
+    context.req.param = vi.fn(() => 'totp-001');
+
+    const response = await deleteAccountTotpCredentialHandler(context);
+
+    expect(response.status).toBe(200);
+    expect(mockRateLimiter.incrementRpc).not.toHaveBeenCalled();
+  });
+
+  it('accepts a passkey as the remaining login method after TOTP deletion', async () => {
+    mockSessionStore.getSessionRpc.mockResolvedValue({
+      ...baseSession,
+      expiresAt: Date.now() + 60_000,
+      data: { authTime: Math.floor(Date.now() / 1000) - 60, amr: ['totp'] },
+    });
+    mockTotpRepo.findById.mockResolvedValue({
+      id: 'totp-001',
+      user_id: 'user-001',
+      status: 'active',
+      label: 'Primary',
+    });
+    mockTotpRepo.findActiveByUserId.mockResolvedValue([{ id: 'totp-001', user_id: 'user-001' }]);
+    mockPasskeyRepo.findByUserId.mockResolvedValue([{ id: 'passkey-1' }]);
+    mockTotpRepo.delete.mockResolvedValue(true);
+    const context = createMockContext({ body: {} });
+    context.req.param = vi.fn(() => 'totp-001');
+
+    const response = await deleteAccountTotpCredentialHandler(context);
+
+    expect(response.status).toBe(200);
+    expect(mockPasskeyRepo.findByUserId).toHaveBeenCalledWith('user-001');
+  });
+
+  it('blocks deletion of the last active login method', async () => {
+    mockTotpRepo.findById.mockResolvedValue({
+      id: 'totp-001',
+      user_id: 'user-001',
+      status: 'active',
+      label: 'Only method',
+    });
+    mockTotpRepo.findActiveByUserId.mockResolvedValue([{ id: 'totp-001', user_id: 'user-001' }]);
+    mockPasskeyRepo.findByUserId.mockResolvedValue([]);
+    mockRuntimeUserStore.findById.mockResolvedValue({ email: null, email_verified: 0 });
+    const context = createMockContext({
+      settings: {
+        'settings:tenant:default:authentication-methods': {
+          'authentication-methods.passkey.login_enabled': false,
+          'authentication-methods.email_otp.login_enabled': false,
+        },
+      },
+    });
+    context.req.param = vi.fn(() => 'totp-001');
+
+    const response = await deleteAccountTotpCredentialHandler(context);
+
+    expect(response.status).toBe(400);
+    expect(mockTotpRepo.delete).not.toHaveBeenCalled();
+  });
+
+  it('requires a valid proof when deleting active TOTP without TOTP/passkey reauth', async () => {
+    mockSessionStore.getSessionRpc.mockResolvedValue({
+      ...baseSession,
+      expiresAt: Date.now() + 60_000,
+      data: { authTime: Math.floor(Date.now() / 1000) - 60, amr: ['email_otp'] },
+    });
+    mockTotpRepo.findById.mockResolvedValue({
+      id: 'totp-001',
+      user_id: 'user-001',
+      status: 'active',
+      label: 'Primary',
+    });
+    mockTotpRepo.findActiveByUserId.mockResolvedValue([
+      { id: 'totp-001', user_id: 'user-001' },
+      { id: 'totp-002', user_id: 'user-001' },
+    ]);
+    const context = createMockContext({ body: {} });
+    context.req.param = vi.fn(() => 'totp-001');
+
+    const response = await deleteAccountTotpCredentialHandler(context);
+
+    expect(response.status).toBe(400);
+    expect(mockTotpRepo.delete).not.toHaveBeenCalled();
+  });
+
+  it('consumes a valid backup code once as deletion proof', async () => {
+    mockSessionStore.getSessionRpc.mockResolvedValue({
+      ...baseSession,
+      expiresAt: Date.now() + 60_000,
+      data: { authTime: Math.floor(Date.now() / 1000) - 60, amr: ['email_otp'] },
+    });
+    mockTotpRepo.findById.mockResolvedValue({
+      id: 'totp-001',
+      user_id: 'user-001',
+      status: 'active',
+      label: 'Primary',
+    });
+    mockTotpRepo.findActiveByUserId.mockResolvedValue([
+      { id: 'totp-001', user_id: 'user-001' },
+      { id: 'totp-002', user_id: 'user-001' },
+    ]);
+    mockTotpRepo.consumeBackupCode.mockResolvedValue({ id: 'backup-1' });
+    mockTotpRepo.delete.mockResolvedValue(true);
+    const context = createMockContext({ body: { backup_code: 'ABCD-EFGH-IJKL' } });
+    context.req.param = vi.fn(() => 'totp-001');
+
+    const response = await deleteAccountTotpCredentialHandler(context);
+
+    expect(response.status).toBe(200);
+    expect(mockTotpRepo.consumeBackupCode).toHaveBeenCalledWith('user-001', expect.any(String));
+  });
+
+  it('rate limits backup-code regeneration before checking a TOTP code', async () => {
+    mockSessionStore.getSessionRpc.mockResolvedValue({
+      ...baseSession,
+      expiresAt: Date.now() + 60_000,
+      data: { authTime: Math.floor(Date.now() / 1000) - 60, amr: ['email_otp'] },
+    });
+    mockTotpRepo.findActiveByUserId.mockResolvedValue([{ id: 'totp-001', user_id: 'user-001' }]);
+    mockRateLimiter.incrementRpc.mockResolvedValue({ allowed: false, retryAfter: 30 });
+
+    const response = await regenerateAccountTotpBackupCodesHandler(
+      createMockContext({ body: { code: '123456' } })
+    );
+
+    expect(response.status).toBe(429);
+    expect(mockTotpRepo.replaceBackupCodes).not.toHaveBeenCalled();
+  });
+
+  it('returns server error when reauthentication cannot update the session', async () => {
+    const secret = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
+    const encrypted = await encryptValue(secret, encryptionKey, 'AES-256-GCM', 1);
+    const profile: TotpProfile = { algorithm: 'SHA1', digits: 6, period: 30, window: 1 };
+    const step = getTotpTimeStep(Date.now(), 30);
+    const code = await generateTotpCode(secret, profile, step);
+    mockTotpRepo.findActiveByUserId.mockResolvedValue([
+      {
+        id: 'totp-001',
+        user_id: 'user-001',
+        secret_encrypted: encrypted.encrypted,
+        last_used_time_step: null,
+        ...profile,
+      },
+    ]);
+    mockSessionStore.updateSessionDataRpc.mockResolvedValue(null);
+
+    const response = await completeAccountTotpReauthHandler(
+      createMockContext({
+        body: { code },
+        settings: {
+          'settings:tenant:default:authentication-methods': {
+            'authentication-methods.totp.reauth_enabled': true,
+          },
+        },
+      })
+    );
+
+    expect(response.status).toBe(500);
+  });
+
+  it('requires an account session before listing TOTP credentials', async () => {
+    const response = await listAccountTotpCredentialsHandler(createMockContext({ cookie: null }));
+
+    expect(response.status).toBe(401);
+    expect(mockTotpRepo.findByUserId).not.toHaveBeenCalled();
+  });
+
+  it('requires recent authentication before enrollment', async () => {
+    mockSessionStore.getSessionRpc.mockResolvedValue({
+      ...baseSession,
+      expiresAt: Date.now() + 60_000,
+      data: { authTime: Math.floor(Date.now() / 1000) - 301, amr: ['passkey'] },
+    });
+
+    const response = await createAccountTotpOptionsHandler(createMockContext());
+
+    expect(response.status).toBe(403);
+    expect(mockTotpRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('accepts string feature flags and falls back from malformed profile settings', async () => {
+    const key = 'settings:tenant:default:authentication-methods';
+    const response = await createAccountTotpOptionsHandler(
+      createMockContext({
+        body: {},
+        settings: {
+          [key]: {
+            'authentication-methods.totp.enabled': 'true',
+            'authentication-methods.totp.account_link_enabled': 'true',
+            'authentication-methods.totp.login_enabled': 'false',
+          },
+        },
+        env: { PII_ENCRYPTION_KEY_VERSION: 'invalid', ISSUER_URL: 'not a url' },
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockTotpRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ secret_key_version: 1, algorithm: 'SHA1' })
+    );
+  });
+
+  it('falls back safely when authentication-method settings contain malformed JSON', async () => {
+    const key = 'settings:tenant:default:authentication-methods';
+    const response = await createAccountTotpOptionsHandler(
+      createMockContext({ rawSettings: { [key]: '{bad json' } })
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockTotpRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('uses preferred username then user id when email is absent', async () => {
+    mockRuntimeUserStore.findById.mockResolvedValueOnce({ preferred_username: 'preferred-user' });
+    const first = await createAccountTotpOptionsHandler(
+      createMockContext({
+        body: {},
+        settings: {
+          'settings:tenant:default:authentication-methods': {
+            'authentication-methods.totp.login_enabled': true,
+          },
+        },
+        env: { ISSUER_URL: undefined },
+      })
+    );
+    expect(first.status).toBe(201);
+    expect(((await first.json()) as { otpauth_uri: string }).otpauth_uri).toContain(
+      'preferred-user'
+    );
+
+    mockRuntimeUserStore.findById.mockResolvedValueOnce(null);
+    const second = await createAccountTotpOptionsHandler(
+      createMockContext({
+        body: {},
+        settings: {
+          'settings:tenant:default:authentication-methods': {
+            'authentication-methods.totp.login_enabled': true,
+          },
+        },
+      })
+    );
+    expect(second.status).toBe(201);
+    expect(((await second.json()) as { otpauth_uri: string }).otpauth_uri).toContain('user-001');
+  });
+
+  it('rejects deletion proof when backup-code hashing is unavailable', async () => {
+    mockSessionStore.getSessionRpc.mockResolvedValue({
+      ...baseSession,
+      expiresAt: Date.now() + 60_000,
+      data: { authTime: Math.floor(Date.now() / 1000) - 60, amr: ['email_otp'] },
+    });
+    mockTotpRepo.findById.mockResolvedValue({
+      id: 'totp-001',
+      user_id: 'user-001',
+      status: 'active',
+    });
+    mockTotpRepo.findActiveByUserId.mockResolvedValue([
+      { id: 'totp-001', user_id: 'user-001' },
+      { id: 'totp-002', user_id: 'user-001' },
+    ]);
+    const context = createMockContext({
+      body: { backup_code: 'ABCD-EFGH-IJKL' },
+      env: { OTP_HMAC_SECRET: undefined },
+    });
+    context.req.param = vi.fn(() => 'totp-001');
+
+    const response = await deleteAccountTotpCredentialHandler(context);
+
+    expect(response.status).toBe(400);
+    expect(mockTotpRepo.consumeBackupCode).not.toHaveBeenCalled();
+  });
+
+  it('returns a configuration error when regenerating backup codes without HMAC secret', async () => {
+    mockTotpRepo.findActiveByUserId.mockResolvedValue([{ id: 'totp-001', user_id: 'user-001' }]);
+
+    const response = await regenerateAccountTotpBackupCodesHandler(
+      createMockContext({ env: { OTP_HMAC_SECRET: undefined } })
+    );
+
+    expect(response.status).toBe(500);
+    expect(mockTotpRepo.replaceBackupCodes).not.toHaveBeenCalled();
+  });
+
+  it('returns the requested label when rename succeeds but repository reread is unavailable', async () => {
+    const credential = {
+      id: 'totp-001',
+      user_id: 'user-001',
+      label: 'Old',
+      algorithm: 'SHA1',
+      digits: 6,
+      period: 30,
+      window: 1,
+      status: 'active',
+      created_at: 1,
+      activated_at: 2,
+      last_used_at: null,
+    };
+    mockTotpRepo.findById.mockResolvedValue(credential);
+    mockTotpRepo.rename.mockResolvedValue(null);
+    const context = createMockContext({ body: { label: 'New' } });
+    context.req.param = vi.fn(() => 'totp-001');
+
+    const response = await updateAccountTotpCredentialHandler(context);
+    const body = (await response.json()) as Record<string, any>;
+
+    expect(response.status).toBe(200);
+    expect(body.credential.label).toBe('New');
+  });
+
+  it('allows verified email OTP as the remaining login method', async () => {
+    mockSessionStore.getSessionRpc.mockResolvedValue({
+      ...baseSession,
+      expiresAt: Date.now() + 60_000,
+      data: { authTime: Math.floor(Date.now() / 1000) - 60, amr: ['totp'] },
+    });
+    mockTotpRepo.findById.mockResolvedValue({
+      id: 'totp-001',
+      user_id: 'user-001',
+      status: 'active',
+    });
+    mockTotpRepo.findActiveByUserId.mockResolvedValue([{ id: 'totp-001', user_id: 'user-001' }]);
+    mockRuntimeUserStore.findById.mockResolvedValue({
+      id: 'user-001',
+      email: 'person@example.com',
+      email_verified: 1,
+    });
+    mockTotpRepo.delete.mockResolvedValue(true);
+    const context = createMockContext({
+      bodyError: new Error('empty body'),
+      settings: {
+        'settings:tenant:default:authentication-methods': {
+          'authentication-methods.passkey.login_enabled': false,
+          'authentication-methods.email_otp.login_enabled': true,
+        },
+      },
+    });
+    context.req.param = vi.fn(() => 'totp-001');
+
+    const response = await deleteAccountTotpCredentialHandler(context);
+
+    expect(response.status).toBe(200);
+    expect(mockRuntimeUserStore.findById).toHaveBeenCalledWith('user-001');
+  });
+
+  it('rejects activation when account enrollment is disabled', async () => {
+    const response = await activateAccountTotpCredentialHandler(
+      createMockContext({
+        body: { credential_id: 'totp-001', code: '123456' },
+        settings: {
+          'settings:tenant:default:authentication-methods': {
+            'authentication-methods.totp.login_enabled': false,
+            'authentication-methods.totp.account_link_enabled': false,
+          },
+        },
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockTotpRepo.findById).not.toHaveBeenCalled();
+  });
+
+  it('requires proof before regenerating backup codes after email-only authentication', async () => {
+    mockSessionStore.getSessionRpc.mockResolvedValue({
+      ...baseSession,
+      expiresAt: Date.now() + 60_000,
+      data: { authTime: Math.floor(Date.now() / 1000) - 60, amr: ['email_otp'] },
+    });
+    mockTotpRepo.findActiveByUserId.mockResolvedValue([{ id: 'totp-001', user_id: 'user-001' }]);
+
+    const response = await regenerateAccountTotpBackupCodesHandler(createMockContext({ body: {} }));
+
+    expect(response.status).toBe(400);
+    expect(mockTotpRepo.replaceBackupCodes).not.toHaveBeenCalled();
   });
 });

--- a/packages/ar-management/src/__tests__/admin-abac-security.test.ts
+++ b/packages/ar-management/src/__tests__/admin-abac-security.test.ts
@@ -1,0 +1,360 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import type { Env } from '@authrim/ar-lib-core';
+
+const mocks = vi.hoisted(() => ({
+  listAttributes: vi.fn(),
+  getAttribute: vi.fn(),
+  getAttributeByName: vi.fn(),
+  createAttribute: vi.fn(),
+  updateAttribute: vi.fn(),
+  deleteAttribute: vi.fn(),
+  deleteAllByAttribute: vi.fn(),
+  getAttributesByUser: vi.fn(),
+  setAttributeValue: vi.fn(),
+  deleteAttributeValue: vi.fn(),
+  findAdmin: vi.fn(),
+  audit: vi.fn(),
+}));
+
+vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@authrim/ar-lib-core')>();
+
+  class AttributeRepository {
+    listAttributes = mocks.listAttributes;
+    getAttribute = mocks.getAttribute;
+    getAttributeByName = mocks.getAttributeByName;
+    createAttribute = mocks.createAttribute;
+    updateAttribute = mocks.updateAttribute;
+    deleteAttribute = mocks.deleteAttribute;
+  }
+
+  class AttributeValueRepository {
+    deleteAllByAttribute = mocks.deleteAllByAttribute;
+    getAttributesByUser = mocks.getAttributesByUser;
+    setAttributeValue = mocks.setAttributeValue;
+    deleteAttributeValue = mocks.deleteAttributeValue;
+  }
+
+  class UserRepository {
+    findByTenantAndId = mocks.findAdmin;
+  }
+
+  return {
+    ...actual,
+    AdminAttributeRepository: AttributeRepository,
+    AdminAttributeValueRepository: AttributeValueRepository,
+    AdminUserRepository: UserRepository,
+    requireDedicatedAdminDatabaseAdapter: vi.fn(() => ({})),
+    adminAuthMiddleware:
+      () =>
+      async (
+        c: {
+          req: { header: (name: string) => string | undefined };
+          set: (key: string, value: unknown) => void;
+        },
+        next: () => Promise<void>
+      ) => {
+        c.set('tenantId', c.req.header('x-test-tenant') ?? 'tenant-a');
+        c.set('adminAuth', {
+          userId: 'actor-a',
+          permissions: (c.req.header('x-test-permissions') ?? '').split(',').filter(Boolean),
+        });
+        await next();
+      },
+    getTenantIdFromContext: (c: { get: (key: string) => unknown }) => c.get('tenantId'),
+  };
+});
+
+vi.mock('../admin-shared', () => ({ writeAdminAuditLog: mocks.audit }));
+
+import { ADMIN_PERMISSIONS } from '@authrim/ar-lib-core';
+import { adminAbacRouter } from '../routes/admin-management/admin-abac';
+
+const readHeaders = { 'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_READ };
+const writeHeaders = {
+  'Content-Type': 'application/json',
+  'x-test-permissions': `${ADMIN_PERMISSIONS.ADMIN_ROLES_READ},${ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE}`,
+};
+
+function app() {
+  const instance = new Hono<{ Bindings: Env }>();
+  instance.route('/api/admin', adminAbacRouter);
+  return instance;
+}
+
+function attribute(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'attr-a',
+    tenant_id: 'tenant-a',
+    name: 'department',
+    is_system: false,
+    ...overrides,
+  };
+}
+
+async function jsonRequest(
+  path: string,
+  method: string,
+  body?: unknown,
+  headers: Record<string, string> = writeHeaders
+) {
+  return app().request(
+    path,
+    {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    },
+    { DB_ADMIN: {} } as never
+  );
+}
+
+describe('admin ABAC security boundaries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findAdmin.mockResolvedValue({ id: 'admin-a', tenant_id: 'tenant-a' });
+    mocks.getAttribute.mockResolvedValue(attribute());
+  });
+
+  it('lists and reads only attributes visible to the current tenant', async () => {
+    mocks.listAttributes.mockResolvedValue([attribute()]);
+    const list = await app().request(
+      '/api/admin/admin-attributes?include_system=true&limit=20&offset=2',
+      { headers: readHeaders },
+      { DB_ADMIN: {} } as never
+    );
+    expect(list.status).toBe(200);
+    expect(mocks.listAttributes).toHaveBeenCalledWith('tenant-a', {
+      includeSystem: true,
+      limit: 20,
+      offset: 2,
+    });
+
+    mocks.getAttribute.mockResolvedValue(attribute({ tenant_id: 'tenant-b' }));
+    expect(
+      (
+        await app().request('/api/admin/admin-attributes/attr-b', { headers: readHeaders }, {
+          DB_ADMIN: {},
+        } as never)
+      ).status
+    ).toBe(404);
+
+    mocks.getAttribute.mockResolvedValue(attribute({ tenant_id: 'system', is_system: true }));
+    expect(
+      (
+        await app().request('/api/admin/admin-attributes/system', { headers: readHeaders }, {
+          DB_ADMIN: {},
+        } as never)
+      ).status
+    ).toBe(200);
+  });
+
+  it.each([
+    ['POST', '/api/admin/admin-attributes', { name: 'department' }],
+    ['PATCH', '/api/admin/admin-attributes/attr-a', { display_name: 'Department' }],
+    ['DELETE', '/api/admin/admin-attributes/attr-a', undefined],
+    ['PUT', '/api/admin/admins/admin-a/attributes/attr-a', { value: 'security' }],
+    ['DELETE', '/api/admin/admins/admin-a/attributes/attr-a', undefined],
+  ])(
+    'denies %s %s without write permission and performs no mutation',
+    async (method, path, body) => {
+      const response = await jsonRequest(path, method, body, {
+        'Content-Type': 'application/json',
+        ...readHeaders,
+      });
+      expect(response.status).toBe(403);
+      expect(mocks.createAttribute).not.toHaveBeenCalled();
+      expect(mocks.updateAttribute).not.toHaveBeenCalled();
+      expect(mocks.deleteAttribute).not.toHaveBeenCalled();
+      expect(mocks.setAttributeValue).not.toHaveBeenCalled();
+      expect(mocks.deleteAttributeValue).not.toHaveBeenCalled();
+      expect(mocks.audit).not.toHaveBeenCalled();
+    }
+  );
+
+  it('validates creation, prevents duplicates and ignores mass-assignment fields', async () => {
+    expect((await jsonRequest('/api/admin/admin-attributes', 'POST', {})).status).toBe(400);
+
+    mocks.getAttributeByName.mockResolvedValue(attribute());
+    expect(
+      (await jsonRequest('/api/admin/admin-attributes', 'POST', { name: 'department' })).status
+    ).toBe(409);
+
+    mocks.getAttributeByName.mockResolvedValue(null);
+    mocks.createAttribute.mockResolvedValue(attribute());
+    const response = await jsonRequest('/api/admin/admin-attributes', 'POST', {
+      name: 'department',
+      display_name: 'Department',
+      tenant_id: 'tenant-b',
+      is_system: true,
+    });
+    expect(response.status).toBe(201);
+    expect(mocks.createAttribute).toHaveBeenCalledWith({
+      tenant_id: 'tenant-a',
+      name: 'department',
+      display_name: 'Department',
+      description: undefined,
+      attribute_type: undefined,
+      allowed_values: undefined,
+      min_value: undefined,
+      max_value: undefined,
+      regex_pattern: undefined,
+      is_required: undefined,
+      is_multi_valued: undefined,
+    });
+    expect(mocks.audit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'admin_attribute.create', resourceId: 'attr-a' })
+    );
+  });
+
+  it('does not update or delete attributes across tenant boundaries', async () => {
+    mocks.getAttribute.mockResolvedValue(attribute({ tenant_id: 'tenant-b' }));
+    expect(
+      (
+        await jsonRequest('/api/admin/admin-attributes/attr-a', 'PATCH', {
+          display_name: 'stolen',
+        })
+      ).status
+    ).toBe(404);
+    expect((await jsonRequest('/api/admin/admin-attributes/attr-a', 'DELETE')).status).toBe(404);
+    expect(mocks.updateAttribute).not.toHaveBeenCalled();
+    expect(mocks.deleteAllByAttribute).not.toHaveBeenCalled();
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+
+  it('returns not-found without auditing when an attribute disappears during mutation', async () => {
+    mocks.getAttribute.mockResolvedValueOnce(null);
+    expect(
+      (
+        await app().request('/api/admin/admin-attributes/missing', { headers: readHeaders }, {
+          DB_ADMIN: {},
+        } as never)
+      ).status
+    ).toBe(404);
+
+    mocks.getAttribute.mockResolvedValue(attribute());
+    mocks.updateAttribute.mockResolvedValue(null);
+    expect(
+      (
+        await jsonRequest('/api/admin/admin-attributes/attr-a', 'PATCH', {
+          display_name: 'Department',
+        })
+      ).status
+    ).toBe(404);
+
+    mocks.deleteAttribute.mockResolvedValue(false);
+    expect((await jsonRequest('/api/admin/admin-attributes/attr-a', 'DELETE')).status).toBe(404);
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+
+  it('updates and deletes a tenant attribute with auditable side effects', async () => {
+    mocks.updateAttribute.mockResolvedValue(attribute({ display_name: 'Department' }));
+    expect(
+      (
+        await jsonRequest('/api/admin/admin-attributes/attr-a', 'PATCH', {
+          display_name: 'Department',
+        })
+      ).status
+    ).toBe(200);
+    expect(mocks.updateAttribute).toHaveBeenCalledWith(
+      'attr-a',
+      expect.objectContaining({ display_name: 'Department' })
+    );
+
+    mocks.deleteAttribute.mockResolvedValue(true);
+    expect((await jsonRequest('/api/admin/admin-attributes/attr-a', 'DELETE')).status).toBe(200);
+    expect(mocks.deleteAllByAttribute).toHaveBeenCalledWith('attr-a');
+    expect(mocks.deleteAttribute).toHaveBeenCalledWith('attr-a');
+    expect(mocks.audit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'admin_attribute.delete' })
+    );
+  });
+
+  it.each([
+    ['GET', '/api/admin/admins/admin-b/attributes', undefined],
+    ['PUT', '/api/admin/admins/admin-b/attributes/attr-a', { value: 'security' }],
+    ['DELETE', '/api/admin/admins/admin-b/attributes/attr-a', undefined],
+  ])(
+    'hides another tenant admin for %s %s without reading or changing attributes',
+    async (method, path, body) => {
+      mocks.findAdmin.mockResolvedValue(null);
+      const response = await jsonRequest(path, method, body);
+      expect(response.status).toBe(404);
+      expect(mocks.getAttributesByUser).not.toHaveBeenCalled();
+      expect(mocks.setAttributeValue).not.toHaveBeenCalled();
+      expect(mocks.deleteAttributeValue).not.toHaveBeenCalled();
+      expect(mocks.audit).not.toHaveBeenCalled();
+    }
+  );
+
+  it('sets a value only for a current-tenant admin and attribute', async () => {
+    expect(
+      (await jsonRequest('/api/admin/admins/admin-a/attributes/attr-a', 'PUT', {})).status
+    ).toBe(400);
+
+    mocks.getAttribute.mockResolvedValue(attribute({ tenant_id: 'tenant-b' }));
+    expect(
+      (
+        await jsonRequest('/api/admin/admins/admin-a/attributes/attr-a', 'PUT', {
+          value: 'security',
+        })
+      ).status
+    ).toBe(404);
+
+    mocks.getAttribute.mockResolvedValue(attribute());
+    mocks.setAttributeValue.mockResolvedValue({ id: 'value-a', value: 'security' });
+    const response = await jsonRequest('/api/admin/admins/admin-a/attributes/attr-a', 'PUT', {
+      value: 'security',
+      value_index: 1,
+      assigned_by: 'attacker',
+    });
+    expect(response.status).toBe(200);
+    expect(mocks.setAttributeValue).toHaveBeenCalledWith({
+      tenant_id: 'tenant-a',
+      admin_user_id: 'admin-a',
+      admin_attribute_id: 'attr-a',
+      value: 'security',
+      value_index: 1,
+      expires_at: undefined,
+      assigned_by: 'actor-a',
+    });
+  });
+
+  it('lists and deletes values with tenant checks and observable results', async () => {
+    mocks.getAttributesByUser.mockResolvedValue([{ id: 'value-a' }]);
+    const list = await jsonRequest(
+      '/api/admin/admins/admin-a/attributes',
+      'GET',
+      undefined,
+      readHeaders
+    );
+    expect(list.status).toBe(200);
+    expect(await list.json()).toMatchObject({ total: 1 });
+
+    mocks.deleteAttributeValue.mockResolvedValue(false);
+    expect(
+      (await jsonRequest('/api/admin/admins/admin-a/attributes/attr-a?value_index=2', 'DELETE'))
+        .status
+    ).toBe(404);
+
+    mocks.deleteAttributeValue.mockResolvedValue(true);
+    expect(
+      (await jsonRequest('/api/admin/admins/admin-a/attributes/attr-a?value_index=2', 'DELETE'))
+        .status
+    ).toBe(200);
+    expect(mocks.deleteAttributeValue).toHaveBeenLastCalledWith('admin-a', 'attr-a', 2);
+  });
+
+  it('fails closed and emits no success audit when storage fails', async () => {
+    mocks.createAttribute.mockRejectedValue(new Error('database unavailable'));
+    mocks.getAttributeByName.mockResolvedValue(null);
+    const response = await jsonRequest('/api/admin/admin-attributes', 'POST', {
+      name: 'department',
+    });
+    expect(response.status).toBe(500);
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ar-management/src/__tests__/admin-rebac-security.test.ts
+++ b/packages/ar-management/src/__tests__/admin-rebac-security.test.ts
@@ -1,0 +1,549 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import type { Env } from '@authrim/ar-lib-core';
+
+const mocks = vi.hoisted(() => ({
+  listDefinitions: vi.fn(),
+  getDefinition: vi.fn(),
+  getDefinitionByName: vi.fn(),
+  createDefinition: vi.fn(),
+  updateDefinition: vi.fn(),
+  deleteDefinition: vi.fn(),
+  listRelationships: vi.fn(),
+  getRelationship: vi.fn(),
+  hasRelationship: vi.fn(),
+  createRelationship: vi.fn(),
+  deleteRelationship: vi.fn(),
+  getRelationshipsFrom: vi.fn(),
+  getRelationshipsTo: vi.fn(),
+  findAdmin: vi.fn(),
+  audit: vi.fn(),
+}));
+
+vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@authrim/ar-lib-core')>();
+
+  class DefinitionRepository {
+    listDefinitions = mocks.listDefinitions;
+    getDefinition = mocks.getDefinition;
+    getDefinitionByName = mocks.getDefinitionByName;
+    createDefinition = mocks.createDefinition;
+    updateDefinition = mocks.updateDefinition;
+    deleteDefinition = mocks.deleteDefinition;
+  }
+
+  class RelationshipRepository {
+    listRelationships = mocks.listRelationships;
+    getRelationship = mocks.getRelationship;
+    hasRelationship = mocks.hasRelationship;
+    createRelationship = mocks.createRelationship;
+    deleteRelationship = mocks.deleteRelationship;
+    getRelationshipsFrom = mocks.getRelationshipsFrom;
+    getRelationshipsTo = mocks.getRelationshipsTo;
+  }
+
+  class UserRepository {
+    findByTenantAndId = mocks.findAdmin;
+  }
+
+  return {
+    ...actual,
+    AdminRebacDefinitionRepository: DefinitionRepository,
+    AdminRelationshipRepository: RelationshipRepository,
+    AdminUserRepository: UserRepository,
+    requireDedicatedAdminDatabaseAdapter: vi.fn(() => ({})),
+    adminAuthMiddleware:
+      () =>
+      async (
+        c: {
+          req: { header: (name: string) => string | undefined };
+          set: (key: string, value: unknown) => void;
+        },
+        next: () => Promise<void>
+      ) => {
+        c.set('tenantId', c.req.header('x-test-tenant') ?? 'tenant-a');
+        c.set('adminAuth', {
+          userId: 'actor-a',
+          permissions: (c.req.header('x-test-permissions') ?? '').split(',').filter(Boolean),
+        });
+        await next();
+      },
+    getTenantIdFromContext: (c: { get: (key: string) => unknown }) => c.get('tenantId'),
+  };
+});
+
+vi.mock('../admin-shared', () => ({ writeAdminAuditLog: mocks.audit }));
+
+import { ADMIN_PERMISSIONS } from '@authrim/ar-lib-core';
+import { adminRebacRouter } from '../routes/admin-management/admin-rebac';
+
+const readHeaders = { 'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_READ };
+const writeHeaders = {
+  'Content-Type': 'application/json',
+  'x-test-permissions': `${ADMIN_PERMISSIONS.ADMIN_ROLES_READ},${ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE}`,
+};
+
+function app() {
+  const instance = new Hono<{ Bindings: Env }>();
+  instance.route('/api/admin', adminRebacRouter);
+  return instance;
+}
+
+function definition(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'definition-a',
+    tenant_id: 'tenant-a',
+    relation_name: 'manager',
+    is_system: false,
+    ...overrides,
+  };
+}
+
+function relationship(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'relationship-a',
+    tenant_id: 'tenant-a',
+    relationship_type: 'manager',
+    from_id: 'admin-a',
+    to_id: 'resource-a',
+    ...overrides,
+  };
+}
+
+async function request(
+  path: string,
+  method = 'GET',
+  body?: unknown,
+  headers: Record<string, string> = writeHeaders
+) {
+  return app().request(
+    path,
+    {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    },
+    { DB_ADMIN: {} } as never
+  );
+}
+
+describe('admin ReBAC security boundaries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findAdmin.mockResolvedValue({ id: 'admin-a', tenant_id: 'tenant-a' });
+    mocks.getDefinition.mockResolvedValue(definition());
+    mocks.getRelationship.mockResolvedValue(relationship());
+    mocks.getRelationshipsFrom.mockResolvedValue([]);
+    mocks.getRelationshipsTo.mockResolvedValue([]);
+  });
+
+  it('lists definitions using bounded tenant input and hides foreign definitions', async () => {
+    mocks.listDefinitions.mockResolvedValue([definition()]);
+    const list = await request(
+      '/api/admin/admin-rebac-definitions?include_system=false&limit=25&offset=5',
+      'GET',
+      undefined,
+      readHeaders
+    );
+    expect(list.status).toBe(200);
+    expect(mocks.listDefinitions).toHaveBeenCalledWith('tenant-a', {
+      includeSystem: false,
+      limit: 25,
+      offset: 5,
+    });
+
+    mocks.getDefinition.mockResolvedValue(definition({ tenant_id: 'tenant-b' }));
+    expect(
+      (
+        await request(
+          '/api/admin/admin-rebac-definitions/definition-b',
+          'GET',
+          undefined,
+          readHeaders
+        )
+      ).status
+    ).toBe(404);
+
+    mocks.getDefinition.mockResolvedValue(definition({ tenant_id: 'system', is_system: true }));
+    expect(
+      (await request('/api/admin/admin-rebac-definitions/system', 'GET', undefined, readHeaders))
+        .status
+    ).toBe(200);
+  });
+
+  it.each([
+    ['POST', '/api/admin/admin-rebac-definitions', { relation_name: 'manager' }],
+    ['PATCH', '/api/admin/admin-rebac-definitions/definition-a', { display_name: 'Manager' }],
+    ['DELETE', '/api/admin/admin-rebac-definitions/definition-a', undefined],
+    [
+      'POST',
+      '/api/admin/admin-relationships',
+      { relationship_type: 'manager', from_id: 'admin-a', to_id: 'resource-a' },
+    ],
+    ['DELETE', '/api/admin/admin-relationships/relationship-a', undefined],
+    [
+      'POST',
+      '/api/admin/admins/admin-a/relationships',
+      { relationship_type: 'manager', to_id: 'resource-a' },
+    ],
+    ['DELETE', '/api/admin/admins/admin-a/relationships/relationship-a', undefined],
+  ])(
+    'denies %s %s without write permission and has no mutation side effect',
+    async (method, path, body) => {
+      const response = await request(path, method, body, {
+        'Content-Type': 'application/json',
+        ...readHeaders,
+      });
+      expect(response.status).toBe(403);
+      expect(mocks.createDefinition).not.toHaveBeenCalled();
+      expect(mocks.updateDefinition).not.toHaveBeenCalled();
+      expect(mocks.deleteDefinition).not.toHaveBeenCalled();
+      expect(mocks.createRelationship).not.toHaveBeenCalled();
+      expect(mocks.deleteRelationship).not.toHaveBeenCalled();
+      expect(mocks.audit).not.toHaveBeenCalled();
+    }
+  );
+
+  it('validates definition creation, prevents duplicates and blocks mass assignment', async () => {
+    expect((await request('/api/admin/admin-rebac-definitions', 'POST', {})).status).toBe(400);
+    mocks.getDefinitionByName.mockResolvedValue(definition());
+    expect(
+      (
+        await request('/api/admin/admin-rebac-definitions', 'POST', {
+          relation_name: 'manager',
+        })
+      ).status
+    ).toBe(409);
+
+    mocks.getDefinitionByName.mockResolvedValue(null);
+    mocks.createDefinition.mockResolvedValue(definition());
+    const response = await request('/api/admin/admin-rebac-definitions', 'POST', {
+      relation_name: 'manager',
+      priority: 10,
+      tenant_id: 'tenant-b',
+      is_system: true,
+    });
+    expect(response.status).toBe(201);
+    expect(mocks.createDefinition).toHaveBeenCalledWith({
+      tenant_id: 'tenant-a',
+      relation_name: 'manager',
+      display_name: undefined,
+      description: undefined,
+      priority: 10,
+    });
+    expect(mocks.audit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'admin_rebac_definition.create' })
+    );
+  });
+
+  it('protects foreign and system definitions from mutation', async () => {
+    mocks.getDefinition.mockResolvedValue(definition({ tenant_id: 'tenant-b' }));
+    expect(
+      (
+        await request('/api/admin/admin-rebac-definitions/definition-a', 'PATCH', {
+          display_name: 'Hijacked',
+        })
+      ).status
+    ).toBe(404);
+
+    mocks.getDefinition.mockResolvedValue(definition({ is_system: true }));
+    expect(
+      (
+        await request('/api/admin/admin-rebac-definitions/definition-a', 'PATCH', {
+          display_name: 'Changed',
+        })
+      ).status
+    ).toBe(403);
+    expect(
+      (await request('/api/admin/admin-rebac-definitions/definition-a', 'DELETE')).status
+    ).toBe(403);
+    expect(mocks.updateDefinition).not.toHaveBeenCalled();
+    expect(mocks.deleteDefinition).not.toHaveBeenCalled();
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+
+  it('updates and deletes tenant definitions and audits only successful changes', async () => {
+    mocks.updateDefinition.mockResolvedValue(definition({ display_name: 'Manager' }));
+    expect(
+      (
+        await request('/api/admin/admin-rebac-definitions/definition-a', 'PATCH', {
+          display_name: 'Manager',
+        })
+      ).status
+    ).toBe(200);
+
+    mocks.deleteDefinition.mockResolvedValue(true);
+    expect(
+      (await request('/api/admin/admin-rebac-definitions/definition-a', 'DELETE')).status
+    ).toBe(200);
+    expect(mocks.audit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'admin_rebac_definition.delete' })
+    );
+  });
+
+  it('handles definition disappearance and repository policy failures without success audit', async () => {
+    mocks.getDefinition.mockResolvedValueOnce(null);
+    expect(
+      (await request('/api/admin/admin-rebac-definitions/missing', 'GET', undefined, readHeaders))
+        .status
+    ).toBe(404);
+
+    mocks.getDefinition.mockResolvedValueOnce(null);
+    expect(
+      (
+        await request('/api/admin/admin-rebac-definitions/missing', 'PATCH', {
+          display_name: 'Missing',
+        })
+      ).status
+    ).toBe(404);
+
+    mocks.getDefinition.mockResolvedValue(definition());
+    mocks.updateDefinition.mockResolvedValue(null);
+    expect(
+      (
+        await request('/api/admin/admin-rebac-definitions/definition-a', 'PATCH', {
+          display_name: 'Raced',
+        })
+      ).status
+    ).toBe(404);
+
+    mocks.getDefinition.mockResolvedValueOnce(null);
+    expect((await request('/api/admin/admin-rebac-definitions/missing', 'DELETE')).status).toBe(
+      404
+    );
+
+    mocks.getDefinition.mockResolvedValue(definition());
+    mocks.deleteDefinition.mockResolvedValue(false);
+    expect(
+      (await request('/api/admin/admin-rebac-definitions/definition-a', 'DELETE')).status
+    ).toBe(404);
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+
+  it('lists and retrieves only current-tenant relationships', async () => {
+    mocks.listRelationships.mockResolvedValue({ relationships: [relationship()], total: 1 });
+    const list = await request(
+      '/api/admin/admin-relationships?type=manager&limit=10&offset=2',
+      'GET',
+      undefined,
+      readHeaders
+    );
+    expect(list.status).toBe(200);
+    expect(mocks.listRelationships).toHaveBeenCalledWith('tenant-a', {
+      relationshipType: 'manager',
+      limit: 10,
+      offset: 2,
+    });
+
+    mocks.getRelationship.mockResolvedValue(relationship({ tenant_id: 'tenant-b' }));
+    expect(
+      (
+        await request(
+          '/api/admin/admin-relationships/relationship-b',
+          'GET',
+          undefined,
+          readHeaders
+        )
+      ).status
+    ).toBe(404);
+
+    mocks.getRelationship.mockResolvedValue(null);
+    expect(
+      (await request('/api/admin/admin-relationships/missing', 'GET', undefined, readHeaders))
+        .status
+    ).toBe(404);
+  });
+
+  it('validates relationship creation and uses the authenticated actor', async () => {
+    expect((await request('/api/admin/admin-relationships', 'POST', {})).status).toBe(400);
+    mocks.hasRelationship.mockResolvedValue(true);
+    expect(
+      (
+        await request('/api/admin/admin-relationships', 'POST', {
+          relationship_type: 'manager',
+          from_id: 'admin-a',
+          to_id: 'resource-a',
+        })
+      ).status
+    ).toBe(409);
+
+    mocks.hasRelationship.mockResolvedValue(false);
+    mocks.createRelationship.mockResolvedValue(relationship());
+    const response = await request('/api/admin/admin-relationships', 'POST', {
+      relationship_type: 'manager',
+      from_id: 'admin-a',
+      to_id: 'resource-a',
+      tenant_id: 'tenant-b',
+      created_by: 'attacker',
+    });
+    expect(response.status).toBe(201);
+    expect(mocks.createRelationship).toHaveBeenCalledWith(
+      expect.objectContaining({ tenant_id: 'tenant-a', created_by: 'actor-a' })
+    );
+  });
+
+  it('does not delete a relationship from another tenant', async () => {
+    mocks.getRelationship.mockResolvedValue(relationship({ tenant_id: 'tenant-b' }));
+    expect((await request('/api/admin/admin-relationships/relationship-a', 'DELETE')).status).toBe(
+      404
+    );
+    expect(mocks.deleteRelationship).not.toHaveBeenCalled();
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+
+  it('does not audit a relationship that disappeared before deletion', async () => {
+    mocks.getRelationship.mockResolvedValueOnce(null);
+    expect((await request('/api/admin/admin-relationships/missing', 'DELETE')).status).toBe(404);
+
+    mocks.getRelationship.mockResolvedValue(relationship());
+    mocks.deleteRelationship.mockResolvedValue(false);
+    expect((await request('/api/admin/admin-relationships/relationship-a', 'DELETE')).status).toBe(
+      404
+    );
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+
+  it('hides foreign admins and filters defensive cross-tenant rows in user relationship lists', async () => {
+    mocks.findAdmin.mockResolvedValueOnce(null);
+    expect(
+      (await request('/api/admin/admins/admin-b/relationships', 'GET', undefined, readHeaders))
+        .status
+    ).toBe(404);
+    expect(mocks.getRelationshipsFrom).not.toHaveBeenCalled();
+
+    mocks.getRelationshipsFrom.mockResolvedValue([
+      relationship(),
+      relationship({ id: 'foreign', tenant_id: 'tenant-b' }),
+    ]);
+    mocks.getRelationshipsTo.mockResolvedValue([relationship()]);
+    const response = await request(
+      '/api/admin/admins/admin-a/relationships?direction=both',
+      'GET',
+      undefined,
+      readHeaders
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json<{ items: Array<{ id: string }>; total: number }>();
+    expect(body).toEqual({ items: [expect.objectContaining({ id: 'relationship-a' })], total: 1 });
+
+    mocks.getRelationshipsFrom.mockResolvedValue([relationship({ id: 'from-only' })]);
+    mocks.getRelationshipsTo.mockClear();
+    expect(
+      (
+        await request(
+          '/api/admin/admins/admin-a/relationships?direction=from',
+          'GET',
+          undefined,
+          readHeaders
+        )
+      ).status
+    ).toBe(200);
+    expect(mocks.getRelationshipsTo).not.toHaveBeenCalled();
+
+    mocks.getRelationshipsFrom.mockClear();
+    mocks.getRelationshipsTo.mockResolvedValue([relationship({ id: 'to-only', to_id: 'admin-a' })]);
+    expect(
+      (
+        await request(
+          '/api/admin/admins/admin-a/relationships?direction=to',
+          'GET',
+          undefined,
+          readHeaders
+        )
+      ).status
+    ).toBe(200);
+    expect(mocks.getRelationshipsFrom).not.toHaveBeenCalled();
+  });
+
+  it('creates user relationships only for an admin in the current tenant', async () => {
+    mocks.findAdmin.mockResolvedValueOnce(null);
+    expect(
+      (
+        await request('/api/admin/admins/admin-b/relationships', 'POST', {
+          relationship_type: 'manager',
+          to_id: 'resource-a',
+        })
+      ).status
+    ).toBe(404);
+    expect(mocks.hasRelationship).not.toHaveBeenCalled();
+
+    mocks.hasRelationship.mockResolvedValue(false);
+    mocks.createRelationship.mockResolvedValue(relationship());
+    expect(
+      (
+        await request('/api/admin/admins/admin-a/relationships', 'POST', {
+          relationship_type: 'manager',
+          to_id: 'resource-a',
+        })
+      ).status
+    ).toBe(201);
+    expect(mocks.createRelationship).toHaveBeenCalledWith(
+      expect.objectContaining({ tenant_id: 'tenant-a', from_id: 'admin-a', created_by: 'actor-a' })
+    );
+  });
+
+  it('requires complete, non-duplicate user relationship input', async () => {
+    expect((await request('/api/admin/admins/admin-a/relationships', 'POST', {})).status).toBe(400);
+
+    mocks.hasRelationship.mockResolvedValue(true);
+    expect(
+      (
+        await request('/api/admin/admins/admin-a/relationships', 'POST', {
+          relationship_type: 'manager',
+          to_id: 'resource-a',
+        })
+      ).status
+    ).toBe(409);
+    expect(mocks.createRelationship).not.toHaveBeenCalled();
+  });
+
+  it('requires a user-path relationship to involve that current-tenant user', async () => {
+    mocks.getRelationship.mockResolvedValue(
+      relationship({ from_id: 'admin-other', to_id: 'resource-a' })
+    );
+    expect(
+      (await request('/api/admin/admins/admin-a/relationships/relationship-a', 'DELETE')).status
+    ).toBe(404);
+    expect(mocks.deleteRelationship).not.toHaveBeenCalled();
+
+    mocks.getRelationship.mockResolvedValue(relationship());
+    mocks.deleteRelationship.mockResolvedValue(true);
+    expect(
+      (await request('/api/admin/admins/admin-a/relationships/relationship-a', 'DELETE')).status
+    ).toBe(200);
+    expect(mocks.audit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'admin_relationship.delete' })
+    );
+  });
+
+  it('rejects missing, foreign and raced user-path relationships without mutation', async () => {
+    mocks.getRelationship.mockResolvedValueOnce(null);
+    expect(
+      (await request('/api/admin/admins/admin-a/relationships/missing', 'DELETE')).status
+    ).toBe(404);
+
+    mocks.getRelationship.mockResolvedValueOnce(
+      relationship({ tenant_id: 'tenant-b', from_id: 'admin-a' })
+    );
+    expect(
+      (await request('/api/admin/admins/admin-a/relationships/foreign', 'DELETE')).status
+    ).toBe(404);
+
+    mocks.getRelationship.mockResolvedValue(relationship());
+    mocks.deleteRelationship.mockResolvedValue(false);
+    expect(
+      (await request('/api/admin/admins/admin-a/relationships/relationship-a', 'DELETE')).status
+    ).toBe(404);
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+
+  it('fails closed without a success audit on repository failure', async () => {
+    mocks.listRelationships.mockRejectedValue(new Error('database unavailable'));
+    const response = await request('/api/admin/admin-relationships', 'GET', undefined, readHeaders);
+    expect(response.status).toBe(500);
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ar-management/src/__tests__/admin-roles-router.test.ts
+++ b/packages/ar-management/src/__tests__/admin-roles-router.test.ts
@@ -737,4 +737,535 @@ describe('adminRolesRouter', () => {
     expect(body.error_code).toBe(AR_ERROR_CODES.ADMIN_INSUFFICIENT_PERMISSIONS);
     expect(repoMocks.deleteRole).not.toHaveBeenCalled();
   });
+
+  it('should list tenant-only roles deterministically when system roles are excluded', async () => {
+    repoMocks.getRolesByTenant.mockResolvedValue([
+      { id: 'b', name: 'beta', hierarchy_level: 10 },
+      { id: 'a', name: 'alpha', hierarchy_level: 10 },
+      { id: 'top', name: 'top', hierarchy_level: 20 },
+    ]);
+    const { app, env } = createTestApp();
+
+    const response = await app.request('/api/admin/admin-roles?include_system=false', {}, env);
+    const body = (await response.json()) as RoleListResponseBody;
+
+    expect(response.status).toBe(200);
+    expect(body.items.map((role) => role.name)).toEqual(['top', 'alpha', 'beta']);
+    expect(repoMocks.getSystemRoles).not.toHaveBeenCalled();
+  });
+
+  it('should expose the permission catalog as a stable public contract', async () => {
+    const { app, env } = createTestApp();
+
+    const response = await app.request('/api/admin/admin-roles/permissions/list', {}, env);
+    const body = (await response.json()) as { items: Array<{ key: string }>; total: number };
+
+    expect(response.status).toBe(200);
+    expect(body.total).toBe(body.items.length);
+    expect(body.items.map((item) => item.key)).toEqual(
+      expect.arrayContaining(['*', ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE])
+    );
+  });
+
+  it('should return effective permissions only for a tenant-accessible role', async () => {
+    repoMocks.getRole.mockResolvedValue({
+      id: 'role_support',
+      tenant_id: 'tenant_123',
+      is_system: false,
+      name: 'support',
+      permissions: ['admin:users:read'],
+      inherits_from: 'role_viewer',
+    });
+    repoMocks.getEffectivePermissions.mockResolvedValue(['admin:users:read', 'admin:clients:read']);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admin-roles/role_support/effective-permissions',
+      {},
+      env
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(response.status).toBe(200);
+    expect(body.effective_permissions).toEqual(['admin:users:read', 'admin:clients:read']);
+  });
+
+  it.each([
+    ['missing role', null],
+    ['foreign custom role', { id: 'foreign', tenant_id: 'other', is_system: false }],
+  ])('should hide effective permissions for a %s', async (_label, role) => {
+    repoMocks.getRole.mockResolvedValue(role);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admin-roles/foreign/effective-permissions',
+      {},
+      env
+    );
+
+    expect(response.status).toBe(404);
+    expect(repoMocks.getEffectivePermissions).not.toHaveBeenCalled();
+  });
+
+  it('should create a custom role without exceeding the caller permissions', async () => {
+    repoMocks.findByName.mockResolvedValue(null);
+    repoMocks.createRole.mockResolvedValue({
+      id: 'role_auditor',
+      tenant_id: 'tenant_123',
+      name: 'auditor',
+      permissions: [ADMIN_PERMISSIONS.ADMIN_USERS_READ],
+      hierarchy_level: 5,
+    });
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admin-roles',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-test-permissions': `${ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE},${ADMIN_PERMISSIONS.ADMIN_USERS_READ}`,
+          'x-test-hierarchy-level': '10',
+        },
+        body: JSON.stringify({
+          name: 'auditor',
+          permissions: [ADMIN_PERMISSIONS.ADMIN_USERS_READ],
+          hierarchy_level: 5,
+        }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(201);
+    expect(repoMocks.createRole).toHaveBeenCalledWith(
+      expect.objectContaining({ tenant_id: 'tenant_123', role_type: 'custom' })
+    );
+    expect(repoMocks.createAuditLog).toHaveBeenCalled();
+  });
+
+  it.each([
+    ['missing name', { permissions: [] }, 400],
+    ['non-array permissions', { name: 'bad', permissions: 'admin:users:read' }, 400],
+    ['duplicate name', { name: 'duplicate', permissions: [] }, 409],
+  ])('should reject role creation with %s', async (_label, body, status) => {
+    repoMocks.findByName.mockResolvedValue({ id: 'existing' });
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admin-roles',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-test-permissions': '*',
+        },
+        body: JSON.stringify(body),
+      },
+      env
+    );
+
+    expect(response.status).toBe(status);
+    expect(repoMocks.createRole).not.toHaveBeenCalled();
+  });
+
+  it('should update a tenant custom role and audit the exact changes', async () => {
+    repoMocks.getRole.mockResolvedValue({
+      id: 'role_custom',
+      tenant_id: 'tenant_123',
+      is_system: false,
+      role_type: 'custom',
+    });
+    repoMocks.updateRole.mockResolvedValue({ id: 'role_custom', display_name: 'Updated' });
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admin-roles/role_custom',
+      {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-test-permissions': '*',
+          'x-test-hierarchy-level': '50',
+        },
+        body: JSON.stringify({ display_name: 'Updated', hierarchy_level: 10 }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(repoMocks.updateRole).toHaveBeenCalledWith(
+      'role_custom',
+      expect.objectContaining({ display_name: 'Updated', hierarchy_level: 10 })
+    );
+    expect(repoMocks.createAuditLog).toHaveBeenCalled();
+  });
+
+  it.each([
+    ['missing role', null, 404],
+    ['foreign role', { id: 'role_foreign', tenant_id: 'other', is_system: false }, 404],
+    ['system role', { id: 'role_system', tenant_id: 'tenant_123', is_system: true }, 403],
+  ])('should reject updates to a %s', async (_label, role, status) => {
+    repoMocks.getRole.mockResolvedValue(role);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admin-roles/role_target',
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', 'x-test-permissions': '*' },
+        body: JSON.stringify({ display_name: 'Updated' }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(status);
+    expect(repoMocks.updateRole).not.toHaveBeenCalled();
+  });
+
+  it('should delete only an unassigned tenant custom role and audit it', async () => {
+    repoMocks.getRole.mockResolvedValue({
+      id: 'role_custom',
+      tenant_id: 'tenant_123',
+      is_system: false,
+      role_type: 'custom',
+      name: 'custom',
+    });
+    repoMocks.getUsersByRole.mockResolvedValue([]);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admin-roles/role_custom',
+      { method: 'DELETE', headers: { 'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE } },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(repoMocks.deleteRole).toHaveBeenCalledWith('role_custom');
+    expect(repoMocks.createAuditLog).toHaveBeenCalled();
+  });
+
+  it('should reject deletion while a custom role remains assigned', async () => {
+    repoMocks.getRole.mockResolvedValue({
+      id: 'role_custom',
+      tenant_id: 'tenant_123',
+      is_system: false,
+      role_type: 'custom',
+    });
+    repoMocks.getUsersByRole.mockResolvedValue(['admin_2']);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admin-roles/role_custom',
+      { method: 'DELETE', headers: { 'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE } },
+      env
+    );
+
+    expect(response.status).toBe(409);
+    expect(repoMocks.deleteRole).not.toHaveBeenCalled();
+  });
+
+  it('should remove a non-platform assignment and leave audit evidence', async () => {
+    repoMocks.getRole.mockResolvedValue({
+      id: 'role_support',
+      tenant_id: 'tenant_123',
+      is_system: false,
+      name: 'support',
+    });
+    repoMocks.getAssignment.mockResolvedValue({
+      id: 'assignment_1',
+      admin_role_id: 'role_support',
+      admin_user_id: 'admin_2',
+      scope_type: 'tenant',
+      scope_id: 'tenant_123',
+    });
+    repoMocks.removeAssignmentById.mockResolvedValue(true);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admin-roles/role_support/assignments/assignment_1',
+      { method: 'DELETE', headers: { 'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE } },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(repoMocks.removeAssignmentById).toHaveBeenCalledWith('assignment_1');
+    expect(repoMocks.createAuditLog).toHaveBeenCalled();
+  });
+
+  it('should protect the final platform role assignment from deletion', async () => {
+    repoMocks.getRole.mockResolvedValue({
+      id: 'role_super_admin',
+      tenant_id: 'default',
+      is_system: true,
+      name: 'super_admin',
+    });
+    repoMocks.getAssignment.mockResolvedValue({
+      id: 'assignment_1',
+      admin_role_id: 'role_super_admin',
+      admin_user_id: 'admin_2',
+    });
+    repoMocks.adminAdapterQueryOne.mockResolvedValue({ count: 1 });
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admin-roles/role_super_admin/assignments/assignment_1',
+      { method: 'DELETE', headers: { 'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE } },
+      env
+    );
+
+    expect(response.status).toBe(409);
+    expect(repoMocks.removeAssignmentById).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['POST', '/api/admin/admin-roles/role_support/assignments'],
+    ['PATCH', '/api/admin/admin-roles/role_support/assignments/assignment_1'],
+    ['DELETE', '/api/admin/admin-roles/role_support/assignments/assignment_1'],
+    ['POST', '/api/admin/admin-roles'],
+    ['PATCH', '/api/admin/admin-roles/role_support'],
+    ['DELETE', '/api/admin/admin-roles/role_support'],
+  ])('should reject %s %s without role-write authority', async (method, path) => {
+    const { app, env } = createTestApp();
+    const response = await app.request(
+      path,
+      {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: method === 'POST' || method === 'PATCH' ? '{}' : undefined,
+      },
+      env
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it.each([
+    ['missing role', null, { admin_user_id: 'admin_2' }, { id: 'admin_2' }, 404],
+    [
+      'foreign role',
+      { id: 'foreign', tenant_id: 'other', is_system: false },
+      { admin_user_id: 'admin_2' },
+      { id: 'admin_2' },
+      404,
+    ],
+    [
+      'missing user id',
+      { id: 'role_support', tenant_id: 'tenant_123', hierarchy_level: 1 },
+      {},
+      null,
+      400,
+    ],
+    [
+      'foreign user',
+      { id: 'role_support', tenant_id: 'tenant_123', hierarchy_level: 1 },
+      { admin_user_id: 'admin_foreign' },
+      null,
+      404,
+    ],
+    [
+      'peer hierarchy role',
+      { id: 'role_support', tenant_id: 'tenant_123', hierarchy_level: 50 },
+      { admin_user_id: 'admin_2' },
+      { id: 'admin_2' },
+      403,
+    ],
+    [
+      'invalid expiry',
+      { id: 'role_support', tenant_id: 'tenant_123', hierarchy_level: 1 },
+      { admin_user_id: 'admin_2', expires_at: 0 },
+      { id: 'admin_2' },
+      400,
+    ],
+  ])('should reject assignment creation for %s', async (_label, role, body, user, status) => {
+    repoMocks.getRole.mockResolvedValue(role);
+    repoMocks.findAdminUserByTenantAndId.mockResolvedValue(user);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admin-roles/role_support/assignments',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE,
+          'x-test-hierarchy-level': '50',
+        },
+        body: JSON.stringify(body),
+      },
+      env
+    );
+
+    expect(response.status).toBe(status);
+    expect(repoMocks.assignRole).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['missing role', null, null, {}, 404],
+    [
+      'assignment for another role',
+      { id: 'role_support', tenant_id: 'tenant_123' },
+      { id: 'assignment_1', admin_role_id: 'other', admin_user_id: 'admin_2' },
+      {},
+      404,
+    ],
+    [
+      'foreign tenant scope',
+      { id: 'role_support', tenant_id: 'tenant_123' },
+      {
+        id: 'assignment_1',
+        admin_role_id: 'role_support',
+        admin_user_id: 'admin_2',
+        scope_type: 'tenant',
+        scope_id: 'tenant_123',
+      },
+      { scope_id: 'other' },
+      400,
+    ],
+    [
+      'global escalation',
+      { id: 'role_support', tenant_id: 'tenant_123' },
+      {
+        id: 'assignment_1',
+        admin_role_id: 'role_support',
+        admin_user_id: 'admin_2',
+        scope_type: 'tenant',
+        scope_id: 'tenant_123',
+      },
+      { scope_type: 'global' },
+      403,
+    ],
+    [
+      'invalid expiry',
+      { id: 'role_support', tenant_id: 'tenant_123' },
+      {
+        id: 'assignment_1',
+        admin_role_id: 'role_support',
+        admin_user_id: 'admin_2',
+        scope_type: 'tenant',
+        scope_id: 'tenant_123',
+      },
+      { expires_at: -1 },
+      400,
+    ],
+  ])('should reject assignment update for %s', async (_label, role, assignment, body, status) => {
+    repoMocks.getRole.mockResolvedValue(role);
+    repoMocks.getAssignment.mockResolvedValue(assignment);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admin-roles/role_support/assignments/assignment_1',
+      {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE,
+        },
+        body: JSON.stringify(body),
+      },
+      env
+    );
+
+    expect(response.status).toBe(status);
+    expect(repoMocks.updateAssignment).not.toHaveBeenCalled();
+  });
+
+  it('should reject an assignment update that duplicates another scope binding', async () => {
+    repoMocks.getRole.mockResolvedValue({ id: 'role_support', tenant_id: 'tenant_123' });
+    repoMocks.getAssignment.mockResolvedValue({
+      id: 'assignment_1',
+      admin_role_id: 'role_support',
+      admin_user_id: 'admin_2',
+      scope_type: 'tenant',
+      scope_id: 'tenant_123',
+    });
+    repoMocks.assignmentExists.mockResolvedValue(true);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admin-roles/role_support/assignments/assignment_1',
+      {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE,
+        },
+        body: JSON.stringify({ expires_at: null }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(409);
+    expect(repoMocks.updateAssignment).not.toHaveBeenCalled();
+  });
+
+  it('should pass the explicit expired-assignment flag to the tenant-scoped repository', async () => {
+    repoMocks.getRole.mockResolvedValue({
+      id: 'role_support',
+      tenant_id: 'tenant_123',
+      is_system: false,
+    });
+    repoMocks.getAssignmentsByRole.mockResolvedValue([]);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admin-roles/role_support/assignments?include_expired=true',
+      {},
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(repoMocks.getAssignmentsByRole).toHaveBeenCalledWith('role_support', true);
+  });
+
+  it('should report a concurrently removed assignment instead of claiming an update', async () => {
+    repoMocks.getRole.mockResolvedValue({ id: 'role_support', tenant_id: 'tenant_123' });
+    repoMocks.getAssignment.mockResolvedValue({
+      id: 'assignment_1',
+      admin_role_id: 'role_support',
+      admin_user_id: 'admin_2',
+      scope_type: 'tenant',
+      scope_id: 'tenant_123',
+    });
+    repoMocks.assignmentExists.mockResolvedValue(false);
+    repoMocks.updateAssignment.mockResolvedValue(null);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admin-roles/role_support/assignments/assignment_1',
+      {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE,
+        },
+        body: JSON.stringify({ expires_at: null }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(404);
+    expect(repoMocks.createAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('should map repository-protected role deletion to insufficient permissions', async () => {
+    repoMocks.getRole.mockResolvedValue({
+      id: 'role_protected',
+      tenant_id: 'tenant_123',
+      is_system: false,
+      role_type: 'custom',
+      name: 'protected',
+    });
+    repoMocks.getUsersByRole.mockResolvedValue([]);
+    repoMocks.deleteRole.mockRejectedValue(new Error('Cannot delete protected role'));
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admin-roles/role_protected',
+      { method: 'DELETE', headers: { 'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE } },
+      env
+    );
+
+    expect(response.status).toBe(403);
+    expect(repoMocks.createAuditLog).not.toHaveBeenCalled();
+  });
 });

--- a/packages/ar-management/src/__tests__/admin-tenant-invitations-security.test.ts
+++ b/packages/ar-management/src/__tests__/admin-tenant-invitations-security.test.ts
@@ -1,0 +1,373 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const mocks = vi.hoisted(() => ({
+  queryOne: vi.fn(),
+  query: vi.fn(),
+  execute: vi.fn(),
+  ensureTenant: vi.fn(),
+  requireAccess: vi.fn(),
+  audit: vi.fn(),
+  sendEmail: vi.fn(),
+  getNotifier: vi.fn(),
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+}));
+
+vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@authrim/ar-lib-core')>();
+  const statusByCode: Record<string, number> = {
+    [actual.AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND]: 404,
+    [actual.AR_ERROR_CODES.ADMIN_INSUFFICIENT_PERMISSIONS]: 403,
+    [actual.AR_ERROR_CODES.INTERNAL_ERROR]: 500,
+  };
+  return {
+    ...actual,
+    createAuthContextFromHono: () => ({
+      coreAdapter: {
+        queryOne: mocks.queryOne,
+        query: mocks.query,
+        execute: mocks.execute,
+      },
+    }),
+    createAuditLogFromContext: mocks.audit,
+    getRequiredPluginContext: () => ({ registry: { getNotifier: mocks.getNotifier } }),
+    getLogger: () => ({ module: () => ({ warn: mocks.logWarn, error: mocks.logError }) }),
+    createErrorResponse: (
+      c: { json: (body: unknown, status?: number) => Response },
+      code: string
+    ) => c.json({ error_code: code }, statusByCode[code] ?? 500),
+  };
+});
+
+vi.mock('../single-tenant-guard', () => ({ ensureSupportedTenantId: mocks.ensureTenant }));
+vi.mock('../admin-tenant-access', () => ({ requireTenantResourceAccess: mocks.requireAccess }));
+vi.mock('../request-issuer', () => ({
+  getCanonicalTenantBaseUrl: (_env: unknown, tenantId: string) =>
+    `https://${tenantId}.example.test`,
+}));
+
+import { AR_ERROR_CODES } from '@authrim/ar-lib-core';
+import {
+  cancelTenantInvitationHandler,
+  createTenantInvitationHandler,
+  listTenantInvitationsHandler,
+} from '../admin-tenant-invitations';
+
+function app() {
+  const instance = new Hono<{
+    Bindings: { EMAIL_FROM?: string };
+    Variables: { adminAuth: { adminId: string } };
+  }>();
+  instance.use('*', async (c, next) => {
+    c.set('adminAuth', { adminId: 'admin-actor' });
+    await next();
+  });
+  instance.post('/tenants/:id/invitations', createTenantInvitationHandler as never);
+  instance.get('/tenants/:id/invitations', listTenantInvitationsHandler as never);
+  instance.delete('/tenants/:id/invitations/:inv_id', cancelTenantInvitationHandler as never);
+  return instance;
+}
+
+function invitationRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'invitation-a',
+    token: 'secret-token',
+    tenant_id: 'tenant-a',
+    invited_email: 'user@example.test',
+    invited_by: 'admin-actor',
+    role_id: null,
+    org_id: null,
+    max_uses: 1,
+    use_count: 0,
+    expires_at: 2_000_000_000,
+    created_at: 1_900_000_000,
+    updated_at: 1_900_000_000,
+    ...overrides,
+  };
+}
+
+describe('tenant invitation security behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    mocks.ensureTenant.mockResolvedValue(null);
+    mocks.requireAccess.mockResolvedValue(null);
+    mocks.getNotifier.mockReturnValue({ send: mocks.sendEmail });
+    mocks.sendEmail.mockResolvedValue({ success: true });
+    mocks.execute.mockResolvedValue({ rowsAffected: 1 });
+    mocks.query.mockResolvedValue([]);
+    mocks.queryOne.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM tenants')) return { id: 'tenant-a', name: 'Tenant A' };
+      if (sql.includes('FROM roles')) return { id: 'role-a' };
+      if (sql.includes('FROM organizations')) return { id: 'org-a' };
+      if (sql.includes('COUNT(*)')) return { count: 0 };
+      if (sql.includes('FROM tenant_invitations')) return { id: 'invitation-a' };
+      return null;
+    });
+  });
+
+  it.each(['POST', 'GET', 'DELETE'])(
+    'stops before storage when tenant mode rejects %s',
+    async (method) => {
+      mocks.ensureTenant.mockResolvedValue(new Response('unsupported', { status: 404 }));
+      const path =
+        method === 'DELETE'
+          ? '/tenants/tenant-b/invitations/invitation-a'
+          : '/tenants/tenant-b/invitations';
+      const response = await app().request(path, {
+        method,
+        headers: method === 'POST' ? { 'Content-Type': 'application/json' } : undefined,
+        body: method === 'POST' ? '{}' : undefined,
+      });
+      expect(response.status).toBe(404);
+      expect(mocks.requireAccess).not.toHaveBeenCalled();
+      expect(mocks.queryOne).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['POST', 'GET', 'DELETE'])(
+    'denies cross-tenant access before storage for %s',
+    async (method) => {
+      mocks.requireAccess.mockResolvedValue(new Response('forbidden', { status: 403 }));
+      const path =
+        method === 'DELETE'
+          ? '/tenants/tenant-b/invitations/invitation-a'
+          : '/tenants/tenant-b/invitations';
+      const response = await app().request(path, {
+        method,
+        headers: method === 'POST' ? { 'Content-Type': 'application/json' } : undefined,
+        body: method === 'POST' ? '{}' : undefined,
+      });
+      expect(response.status).toBe(403);
+      expect(mocks.queryOne).not.toHaveBeenCalled();
+      expect(mocks.execute).not.toHaveBeenCalled();
+      expect(mocks.audit).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    { invited_email: 'not-email' },
+    { role_id: '' },
+    { org_id: 'x'.repeat(64) },
+    { max_uses: -2 },
+    { max_uses: 1001 },
+    { max_uses: 1.5 },
+    { expires_in_hours: 0 },
+    { expires_in_hours: 721 },
+  ])('rejects malformed invitation input %# before tenant lookup', async (body) => {
+    const response = await app().request('/tenants/tenant-a/invitations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    expect(response.status).toBe(400);
+    expect(mocks.queryOne).not.toHaveBeenCalled();
+    expect(mocks.execute).not.toHaveBeenCalled();
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+
+  it('requires an existing tenant before generating a privilege-bearing invitation', async () => {
+    mocks.queryOne.mockResolvedValue(null);
+    const response = await app().request('/tenants/tenant-a/invitations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    expect(response.status).toBe(404);
+    expect(mocks.execute).not.toHaveBeenCalled();
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [{ role_id: 'role-b' }, 'roles'],
+    [{ org_id: 'org-b' }, 'organizations'],
+  ])('rejects a foreign or inactive assignment target %#', async (body, table) => {
+    mocks.queryOne.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM tenants')) return { id: 'tenant-a', name: 'Tenant A' };
+      if (sql.includes(`FROM ${table}`)) return null;
+      return { id: 'valid' };
+    });
+    const response = await app().request('/tenants/tenant-a/invitations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    expect(response.status).toBe(400);
+    expect(mocks.execute).not.toHaveBeenCalled();
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+
+  it('stores a tenant-scoped invitation, returns its token once and audits the assignment', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-14T00:00:00.000Z'));
+    const response = await app().request(
+      '/tenants/tenant-a/invitations',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          role_id: 'role-a',
+          org_id: 'org-a',
+          max_uses: 2,
+          expires_in_hours: 24,
+        }),
+      },
+      { EMAIL_FROM: 'security@example.test' }
+    );
+    expect(response.status).toBe(201);
+    const body = await response.json<{ token: string; invite_url: string; email_sent: boolean }>();
+    expect(body.token).toMatch(/^[0-9a-f]{64}$/u);
+    expect(body.invite_url).toContain(`invite_token=${body.token}`);
+    expect(body.email_sent).toBe(false);
+    expect(mocks.execute).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO tenant_invitations'),
+      expect.arrayContaining(['tenant-a', 'admin-actor', 'role-a', 'org-a', 2])
+    );
+    expect(mocks.audit).toHaveBeenCalledWith(
+      expect.anything(),
+      'tenant_invitation.create',
+      'tenant_invitation',
+      expect.any(String),
+      expect.objectContaining({ tenant_id: 'tenant-a', role_id: 'role-a', org_id: 'org-a' })
+    );
+  });
+
+  it('escapes tenant-controlled HTML and sends an email without leaking the token to audit metadata', async () => {
+    mocks.queryOne.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM tenants')) {
+        return { id: 'tenant-a', name: '<img src=x onerror=alert(1)>\r\nBcc: attacker@test' };
+      }
+      return null;
+    });
+    const response = await app().request(
+      '/tenants/tenant-a/invitations',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ invited_email: 'user@example.test' }),
+      },
+      {}
+    );
+    expect(response.status).toBe(201);
+    const email = mocks.sendEmail.mock.calls[0]?.[0] as {
+      body: string;
+      metadata: { textBody: string };
+      subject: string;
+      to: string;
+    };
+    expect(email.to).toBe('user@example.test');
+    expect(email.body).toContain('&lt;img src=x onerror=alert(1)&gt;');
+    expect(email.body).not.toContain('<img src=x');
+    expect(email.subject).not.toMatch(/[\r\n]/u);
+    expect(email.subject).toContain('Bcc: attacker@test');
+    const responseBody = await response.json<{ token: string }>();
+    expect(JSON.stringify(mocks.audit.mock.calls)).not.toContain(responseBody.token);
+  });
+
+  it.each([
+    [null, 'not configured'],
+    [{ send: vi.fn(async () => ({ success: false, error: 'provider rejected' })) }, 'Failed'],
+    [{ send: vi.fn(async () => Promise.reject(new Error('provider unavailable'))) }, 'delivery'],
+  ])(
+    'keeps the stored invitation usable when optional email delivery is unavailable',
+    async (notifier, warning) => {
+      mocks.getNotifier.mockReturnValue(notifier);
+      const response = await app().request(
+        '/tenants/tenant-a/invitations',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ invited_email: 'user@example.test' }),
+        },
+        {}
+      );
+      expect(response.status).toBe(201);
+      expect(await response.json()).toMatchObject({ email_sent: false });
+      expect(mocks.logWarn).toHaveBeenCalledWith(
+        expect.stringContaining(warning),
+        expect.anything()
+      );
+      expect(mocks.audit).toHaveBeenCalled();
+    }
+  );
+
+  it('lists only tenant-filtered rows and never returns invitation tokens', async () => {
+    mocks.queryOne.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM tenants')) return { id: 'tenant-a' };
+      if (sql.includes('COUNT(*)')) return { count: 1 };
+      return null;
+    });
+    mocks.query.mockResolvedValue([invitationRow()]);
+    const response = await app().request(
+      '/tenants/tenant-a/invitations?limit=500&offset=3&include_expired=false'
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json<{ items: Array<Record<string, unknown>>; total: number }>();
+    expect(body.total).toBe(1);
+    expect(body.items[0]).not.toHaveProperty('token');
+    expect(mocks.query).toHaveBeenCalledWith(expect.stringContaining('tenant_id = ?'), [
+      'tenant-a',
+      100,
+      3,
+    ]);
+  });
+
+  it('can explicitly include expired invitations while retaining tenant filtering', async () => {
+    mocks.queryOne.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM tenants')) return { id: 'tenant-a' };
+      if (sql.includes('COUNT(*)')) return null;
+      return null;
+    });
+    mocks.query.mockResolvedValue([]);
+    const response = await app().request('/tenants/tenant-a/invitations?include_expired=true');
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ total: 0, limit: 50, offset: 0 });
+    expect(String(mocks.query.mock.calls[0]?.[0])).not.toContain('expires_at >');
+  });
+
+  it('cancels only an invitation belonging to the path tenant and audits after deletion', async () => {
+    mocks.queryOne.mockResolvedValueOnce(null);
+    expect(
+      (await app().request('/tenants/tenant-a/invitations/missing', { method: 'DELETE' })).status
+    ).toBe(404);
+    expect(mocks.execute).not.toHaveBeenCalled();
+
+    mocks.queryOne.mockResolvedValue({ id: 'invitation-a' });
+    const response = await app().request('/tenants/tenant-a/invitations/invitation-a', {
+      method: 'DELETE',
+    });
+    expect(response.status).toBe(200);
+    expect(mocks.queryOne).toHaveBeenCalledWith(
+      expect.stringContaining('id = ? AND tenant_id = ?'),
+      ['invitation-a', 'tenant-a']
+    );
+    expect(mocks.execute).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM tenant_invitations'),
+      ['invitation-a', 'tenant-a']
+    );
+    expect(mocks.audit).toHaveBeenCalledWith(
+      expect.anything(),
+      'tenant_invitation.cancel',
+      'tenant_invitation',
+      'invitation-a',
+      { tenant_id: 'tenant-a' }
+    );
+  });
+
+  it.each([
+    ['POST', '/tenants/tenant-a/invitations'],
+    ['GET', '/tenants/tenant-a/invitations'],
+    ['DELETE', '/tenants/tenant-a/invitations/invitation-a'],
+  ])('returns a redacted 500 for storage failures on %s', async (method, path) => {
+    mocks.queryOne.mockRejectedValue(new Error('database unavailable with secret details'));
+    const response = await app().request(path, {
+      method,
+      headers: method === 'POST' ? { 'Content-Type': 'application/json' } : undefined,
+      body: method === 'POST' ? '{}' : undefined,
+    });
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error_code: AR_ERROR_CODES.INTERNAL_ERROR });
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ar-management/src/__tests__/admin-users-router.test.ts
+++ b/packages/ar-management/src/__tests__/admin-users-router.test.ts
@@ -7,6 +7,7 @@ const { repoMocks, mockAdminAdapter } = vi.hoisted(() => ({
   repoMocks: {
     findByTenantAndId: vi.fn(),
     findByEmail: vi.fn(),
+    searchAdminUsers: vi.fn(),
     createAdminUser: vi.fn(),
     updateAdminUser: vi.fn(),
     suspendAccount: vi.fn(),
@@ -19,6 +20,7 @@ const { repoMocks, mockAdminAdapter } = vi.hoisted(() => ({
     removeAssignment: vi.fn(),
     removeAssignmentById: vi.fn(),
     countByUser: vi.fn(),
+    getPasskeysByUser: vi.fn(),
     getAssignmentsByUser: vi.fn(),
     getUsersByRole: vi.fn(),
     createAuditLog: vi.fn(),
@@ -39,7 +41,7 @@ vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
     suspendAccount = repoMocks.suspendAccount;
     activateAccount = repoMocks.activateAccount;
     unlockAccount = repoMocks.unlockAccount;
-    searchAdminUsers = vi.fn();
+    searchAdminUsers = repoMocks.searchAdminUsers;
   }
 
   class MockAdminRoleRepository {
@@ -58,6 +60,7 @@ vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
 
   class MockAdminPasskeyRepository {
     countByUser = repoMocks.countByUser;
+    getPasskeysByUser = repoMocks.getPasskeysByUser;
   }
 
   class MockAdminAuditLogRepository {
@@ -410,5 +413,728 @@ describe('adminUsersRouter', () => {
     expect(body.error).toBe('last_platform_admin');
     expect(body.error_description).toContain('At least one active platform administrator');
     expect(repoMocks.removeAssignment).not.toHaveBeenCalled();
+  });
+
+  it('lists only tenant-scoped users and strips password and TOTP secrets', async () => {
+    repoMocks.searchAdminUsers.mockResolvedValue({
+      items: [
+        {
+          id: 'admin_1',
+          tenant_id: 'tenant_123',
+          email: 'admin@example.com',
+          password_hash: 'secret-hash',
+          totp_secret_encrypted: 'secret-totp',
+        },
+      ],
+      total: 1,
+      page: 2,
+      limit: 10,
+      totalPages: 1,
+    });
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins?page=2&limit=10&status=active&email=admin%40example.com&mfa_enabled=false',
+      {},
+      env
+    );
+    const body = (await response.json()) as { items: Array<Record<string, unknown>> };
+
+    expect(response.status).toBe(200);
+    expect(repoMocks.searchAdminUsers).toHaveBeenCalledWith(
+      {
+        tenant_id: 'tenant_123',
+        status: 'active',
+        email: 'admin@example.com',
+        mfa_enabled: false,
+      },
+      { page: 2, limit: 10, sortBy: 'created_at', sortOrder: 'desc' }
+    );
+    expect(body.items[0]).not.toHaveProperty('password_hash');
+    expect(body.items[0]).not.toHaveProperty('totp_secret_encrypted');
+  });
+
+  it('caps list size and preserves an explicit MFA-enabled filter', async () => {
+    repoMocks.searchAdminUsers.mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      limit: 100,
+      totalPages: 0,
+    });
+    const { app, env } = createTestApp();
+
+    const response = await app.request('/api/admin/admins?limit=1000&mfa_enabled=true', {}, env);
+
+    expect(response.status).toBe(200);
+    expect(repoMocks.searchAdminUsers).toHaveBeenCalledWith(
+      expect.objectContaining({ mfa_enabled: true }),
+      expect.objectContaining({ limit: 100 })
+    );
+  });
+
+  it('returns user details with roles and non-secret passkey metadata', async () => {
+    repoMocks.findByTenantAndId.mockResolvedValue({
+      id: 'admin_target',
+      tenant_id: 'tenant_123',
+      email: 'target@example.com',
+      password_hash: 'secret-hash',
+      totp_secret_encrypted: 'secret-totp',
+    });
+    repoMocks.getAssignmentsByUser.mockResolvedValue([
+      {
+        id: 'assignment_1',
+        admin_role_id: 'role_1',
+        role: { name: 'auditor', display_name: 'Auditor' },
+        scope_type: 'tenant',
+        scope_id: 'tenant_123',
+        created_at: 10,
+        expires_at: null,
+        assigned_by: 'admin_1',
+      },
+    ]);
+    repoMocks.getPasskeysByUser.mockResolvedValue([
+      {
+        id: 'passkey_1',
+        device_name: 'Security key',
+        aaguid: 'unknown-aaguid',
+        public_key: 'must-not-leak',
+        created_at: 20,
+        last_used_at: null,
+      },
+    ]);
+    const { app, env } = createTestApp();
+
+    const response = await app.request('/api/admin/admins/admin_target', {}, env);
+    const body = (await response.json()) as Record<string, any>;
+
+    expect(response.status).toBe(200);
+    expect(body).not.toHaveProperty('password_hash');
+    expect(body.roles[0]).toMatchObject({ role_id: 'role_1', name: 'auditor' });
+    expect(body.passkeys[0]).not.toHaveProperty('public_key');
+    expect(body.passkey_count).toBe(1);
+  });
+
+  it.each([
+    ['POST', '/api/admin/admins', ADMIN_PERMISSIONS.ADMIN_USERS_READ],
+    ['PATCH', '/api/admin/admins/admin_target', ADMIN_PERMISSIONS.ADMIN_USERS_READ],
+    ['POST', '/api/admin/admins/admin_target/suspend', ADMIN_PERMISSIONS.ADMIN_USERS_READ],
+    ['POST', '/api/admin/admins/admin_target/activate', ADMIN_PERMISSIONS.ADMIN_USERS_READ],
+    ['POST', '/api/admin/admins/admin_target/unlock', ADMIN_PERMISSIONS.ADMIN_USERS_READ],
+    ['DELETE', '/api/admin/admins/admin_target', ADMIN_PERMISSIONS.ADMIN_USERS_WRITE],
+    ['POST', '/api/admin/admins/admin_target/roles', ADMIN_PERMISSIONS.ADMIN_USERS_WRITE],
+    [
+      'DELETE',
+      '/api/admin/admins/admin_target/role-assignments/assignment_1',
+      ADMIN_PERMISSIONS.ADMIN_USERS_WRITE,
+    ],
+  ])('rejects %s %s without its dedicated permission', async (method, path, permission) => {
+    const { app, env } = createTestApp();
+    const response = await app.request(
+      path,
+      {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          'x-test-permissions': permission,
+        },
+        body: method === 'POST' || method === 'PATCH' ? '{}' : undefined,
+      },
+      env
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it('creates a normalized tenant admin and records an audit event', async () => {
+    repoMocks.findByEmail.mockResolvedValue(null);
+    repoMocks.createAdminUser.mockImplementation(async (input) => ({
+      id: 'admin_new',
+      ...input,
+      password_hash: input.password,
+      totp_secret_encrypted: null,
+    }));
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_USERS_WRITE,
+        },
+        body: JSON.stringify({
+          email: 'NEW@EXAMPLE.COM',
+          name: 'New Admin',
+          password: 'a long test password',
+          mfa_enabled: true,
+        }),
+      },
+      env
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(response.status).toBe(201);
+    expect(repoMocks.createAdminUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenant_id: 'tenant_123',
+        email: 'new@example.com',
+        created_by: 'admin_1',
+        password: expect.stringMatching(/^[A-Za-z0-9+/=]+:[A-Za-z0-9+/=]+$/),
+      })
+    );
+    expect(body).not.toHaveProperty('password_hash');
+    expect(repoMocks.createAuditLog).toHaveBeenCalled();
+  });
+
+  it.each([
+    ['missing email', {}, 400],
+    ['duplicate email', { email: 'exists@example.com' }, 409],
+  ])('rejects admin creation with %s', async (_label, requestBody, expectedStatus) => {
+    repoMocks.findByEmail.mockResolvedValue({ id: 'existing' });
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_USERS_WRITE,
+        },
+        body: JSON.stringify(requestBody),
+      },
+      env
+    );
+
+    expect(response.status).toBe(expectedStatus);
+    expect(repoMocks.createAdminUser).not.toHaveBeenCalled();
+  });
+
+  it('updates the caller account and normalizes its email', async () => {
+    repoMocks.findByTenantAndId.mockResolvedValue({ id: 'admin_1', email: 'old@example.com' });
+    repoMocks.updateAdminUser.mockResolvedValue({
+      id: 'admin_1',
+      email: 'new@example.com',
+      password_hash: 'secret',
+    });
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins/admin_1',
+      {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_USERS_WRITE,
+        },
+        body: JSON.stringify({ email: 'NEW@EXAMPLE.COM', name: 'Updated' }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(repoMocks.updateAdminUser).toHaveBeenCalledWith(
+      'admin_1',
+      expect.objectContaining({ email: 'new@example.com', name: 'Updated' })
+    );
+    expect(repoMocks.createAuditLog).toHaveBeenCalled();
+  });
+
+  it.each([
+    ['activate', 'activateAccount', 'admin_user.activate'],
+    ['unlock', 'unlockAccount', 'admin_user.unlock'],
+  ])(
+    'performs %s only for a user in the current tenant',
+    async (action, repoMethod, auditAction) => {
+      repoMocks.findByTenantAndId.mockResolvedValue({
+        id: 'admin_target',
+        email: 'target@example.com',
+      });
+      const { app, env } = createTestApp();
+
+      const response = await app.request(
+        `/api/admin/admins/admin_target/${action}`,
+        {
+          method: 'POST',
+          headers: { 'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_USERS_WRITE },
+        },
+        env
+      );
+
+      expect(response.status).toBe(200);
+      expect(repoMocks[repoMethod as 'activateAccount']).toHaveBeenCalledWith('admin_target');
+      expect(repoMocks.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({ action: auditAction })
+      );
+    }
+  );
+
+  it('deletes a non-platform admin and leaves audit evidence', async () => {
+    repoMocks.findByTenantAndId.mockResolvedValue({
+      id: 'admin_target',
+      email: 'target@example.com',
+    });
+    mockAdminAdapter.queryOne.mockResolvedValue(null);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins/admin_target',
+      {
+        method: 'DELETE',
+        headers: {
+          'x-test-user-id': 'admin_actor',
+          'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_USERS_DELETE,
+        },
+      },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(repoMocks.updateAdminUser).toHaveBeenCalledWith('admin_target', { is_active: false });
+    expect(repoMocks.createAuditLog).toHaveBeenCalled();
+  });
+
+  it('assigns a lower tenant role once and records its normalized scope', async () => {
+    repoMocks.findByTenantAndId.mockResolvedValue({ id: 'admin_target' });
+    repoMocks.getRole.mockResolvedValue({
+      id: 'role_support',
+      tenant_id: 'tenant_123',
+      is_system: false,
+      hierarchy_level: 5,
+      name: 'support',
+    });
+    repoMocks.assignmentExists.mockResolvedValue(false);
+    repoMocks.assignRole.mockResolvedValue({ id: 'assignment_1' });
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins/admin_target/roles',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-test-user-id': 'admin_actor',
+          'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE,
+          'x-test-hierarchy-level': '10',
+        },
+        body: JSON.stringify({ role_id: 'role_support', expires_at: Date.now() + 60_000 }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(201);
+    expect(repoMocks.assignRole).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenant_id: 'tenant_123',
+        admin_user_id: 'admin_target',
+        scope_type: 'tenant',
+        scope_id: 'tenant_123',
+        assigned_by: 'admin_actor',
+      })
+    );
+  });
+
+  it.each([
+    ['reserved org scope', { role_id: 'role_support', scope_type: 'org' }, 400],
+    ['invalid expiry', { role_id: 'role_support', expires_at: 0 }, 400],
+    [
+      'global scope without platform authority',
+      { role_id: 'role_support', scope_type: 'global' },
+      403,
+    ],
+  ])('rejects role assignment with %s', async (_label, requestBody, expectedStatus) => {
+    repoMocks.findByTenantAndId.mockResolvedValue({ id: 'admin_target' });
+    repoMocks.getRole.mockResolvedValue({
+      id: 'role_support',
+      tenant_id: 'tenant_123',
+      is_system: false,
+      hierarchy_level: 5,
+      name: 'support',
+    });
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins/admin_target/roles',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE,
+          'x-test-hierarchy-level': '10',
+        },
+        body: JSON.stringify(requestBody),
+      },
+      env
+    );
+
+    expect(response.status).toBe(expectedStatus);
+    expect(repoMocks.assignRole).not.toHaveBeenCalled();
+  });
+
+  it('rejects a duplicate role assignment without writing another grant', async () => {
+    repoMocks.findByTenantAndId.mockResolvedValue({ id: 'admin_target' });
+    repoMocks.getRole.mockResolvedValue({
+      id: 'role_support',
+      tenant_id: 'tenant_123',
+      is_system: false,
+      hierarchy_level: 5,
+      name: 'support',
+    });
+    repoMocks.assignmentExists.mockResolvedValue(true);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins/admin_target/roles',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE,
+          'x-test-hierarchy-level': '10',
+        },
+        body: JSON.stringify({ role_id: 'role_support' }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(409);
+    expect(repoMocks.assignRole).not.toHaveBeenCalled();
+  });
+
+  it('prevents self-suspension even with user-write permission', async () => {
+    repoMocks.findByTenantAndId.mockResolvedValue({ id: 'admin_1' });
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins/admin_1/suspend',
+      {
+        method: 'POST',
+        headers: {
+          'x-test-user-id': 'admin_1',
+          'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_USERS_WRITE,
+        },
+      },
+      env
+    );
+
+    expect(response.status).toBe(403);
+    expect(repoMocks.suspendAccount).not.toHaveBeenCalled();
+  });
+
+  it('suspends a non-platform admin and records the state transition', async () => {
+    repoMocks.findByTenantAndId.mockResolvedValue({ id: 'admin_target' });
+    mockAdminAdapter.queryOne.mockResolvedValue(null);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins/admin_target/suspend',
+      {
+        method: 'POST',
+        headers: {
+          'x-test-user-id': 'admin_actor',
+          'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_USERS_WRITE,
+        },
+      },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(repoMocks.suspendAccount).toHaveBeenCalledWith('admin_target');
+    expect(repoMocks.createAuditLog).toHaveBeenCalled();
+  });
+
+  it.each(['activate', 'unlock'])(
+    'does not %s an admin outside the current tenant',
+    async (action) => {
+      repoMocks.findByTenantAndId.mockResolvedValue(null);
+      const { app, env } = createTestApp();
+
+      const response = await app.request(
+        `/api/admin/admins/admin_target/${action}`,
+        {
+          method: 'POST',
+          headers: { 'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_USERS_WRITE },
+        },
+        env
+      );
+
+      expect(response.status).toBe(404);
+    }
+  );
+
+  it('allows a platform-authorized caller to assign a shared system role globally', async () => {
+    repoMocks.findByTenantAndId.mockResolvedValue({ id: 'admin_target' });
+    repoMocks.getRole.mockResolvedValue({
+      id: 'role_system',
+      tenant_id: 'default',
+      is_system: true,
+      hierarchy_level: 100,
+      name: 'system-auditor',
+    });
+    repoMocks.assignmentExists.mockResolvedValue(false);
+    repoMocks.assignRole.mockResolvedValue({ id: 'assignment_global' });
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins/admin_target/roles',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-test-permissions': '*',
+        },
+        body: JSON.stringify({ role_id: 'role_system', scope_type: 'global' }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(201);
+    expect(repoMocks.assignRole).toHaveBeenCalledWith(
+      expect.objectContaining({ scope_type: 'global', scope_id: undefined })
+    );
+  });
+
+  it.each([
+    ['missing user', null, { id: 'role_support' }, { role_id: 'role_support' }, 404],
+    ['missing role id', { id: 'admin_target' }, null, {}, 400],
+    ['unknown role', { id: 'admin_target' }, null, { role_id: 'missing' }, 404],
+    [
+      'non-finite expiry',
+      { id: 'admin_target' },
+      {
+        id: 'role_support',
+        tenant_id: 'tenant_123',
+        is_system: false,
+        hierarchy_level: 1,
+      },
+      { role_id: 'role_support', expires_at: 'tomorrow' },
+      400,
+    ],
+  ])('rejects role assignment for %s', async (_label, user, role, body, expectedStatus) => {
+    repoMocks.findByTenantAndId.mockResolvedValue(user);
+    repoMocks.getRole.mockResolvedValue(role);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins/admin_target/roles',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE,
+        },
+        body: JSON.stringify(body),
+      },
+      env
+    );
+
+    expect(response.status).toBe(expectedStatus);
+    expect(repoMocks.assignRole).not.toHaveBeenCalled();
+  });
+
+  it('removes a specific non-platform role assignment only from its owning user', async () => {
+    repoMocks.findByTenantAndId.mockResolvedValue({ id: 'admin_target' });
+    repoMocks.getAssignment.mockResolvedValue({
+      id: 'assignment_1',
+      admin_user_id: 'admin_target',
+      admin_role_id: 'role_support',
+      scope_type: 'tenant',
+      scope_id: 'tenant_123',
+    });
+    repoMocks.getRole.mockResolvedValue({ id: 'role_support', name: 'support' });
+    repoMocks.removeAssignmentById.mockResolvedValue(true);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins/admin_target/role-assignments/assignment_1',
+      {
+        method: 'DELETE',
+        headers: { 'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE },
+      },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(repoMocks.removeAssignmentById).toHaveBeenCalledWith('assignment_1');
+    expect(repoMocks.createAuditLog).toHaveBeenCalled();
+  });
+
+  it.each([
+    ['unknown assignment', null],
+    [
+      'assignment owned by another admin',
+      { id: 'assignment_1', admin_user_id: 'admin_other', admin_role_id: 'role_support' },
+    ],
+  ])('does not remove an %s', async (_label, assignment) => {
+    repoMocks.findByTenantAndId.mockResolvedValue({ id: 'admin_target' });
+    repoMocks.getAssignment.mockResolvedValue(assignment);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins/admin_target/role-assignments/assignment_1',
+      {
+        method: 'DELETE',
+        headers: { 'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE },
+      },
+      env
+    );
+
+    expect(response.status).toBe(404);
+    expect(repoMocks.removeAssignmentById).not.toHaveBeenCalled();
+  });
+
+  it('prevents removing the caller platform role by assignment id even with redundancy', async () => {
+    repoMocks.findByTenantAndId.mockResolvedValue({ id: 'admin_1' });
+    repoMocks.getAssignment.mockResolvedValue({
+      id: 'assignment_1',
+      admin_user_id: 'admin_1',
+      admin_role_id: 'role_super_admin',
+    });
+    repoMocks.getRole.mockResolvedValue({ id: 'role_super_admin', name: 'super_admin' });
+    mockAdminAdapter.queryOne.mockResolvedValue({ count: 2 });
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins/admin_1/role-assignments/assignment_1',
+      {
+        method: 'DELETE',
+        headers: {
+          'x-test-user-id': 'admin_1',
+          'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE,
+        },
+      },
+      env
+    );
+
+    expect(response.status).toBe(403);
+    expect(repoMocks.removeAssignmentById).not.toHaveBeenCalled();
+  });
+
+  it('removes a normal role by role id and audits it', async () => {
+    repoMocks.findByTenantAndId.mockResolvedValue({ id: 'admin_target' });
+    repoMocks.getRole.mockResolvedValue({ id: 'role_support', name: 'support' });
+    repoMocks.removeAssignment.mockResolvedValue(true);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins/admin_target/roles/role_support',
+      {
+        method: 'DELETE',
+        headers: { 'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE },
+      },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(repoMocks.removeAssignment).toHaveBeenCalledWith('admin_target', 'role_support');
+    expect(repoMocks.createAuditLog).toHaveBeenCalled();
+  });
+
+  it('returns not found when a role removal did not delete an assignment', async () => {
+    repoMocks.findByTenantAndId.mockResolvedValue({ id: 'admin_target' });
+    repoMocks.getRole.mockResolvedValue({ id: 'role_support', name: 'support' });
+    repoMocks.removeAssignment.mockResolvedValue(false);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins/admin_target/roles/role_support',
+      {
+        method: 'DELETE',
+        headers: { 'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE },
+      },
+      env
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('returns not found without exposing another tenant user detail', async () => {
+    repoMocks.findByTenantAndId.mockResolvedValue(null);
+    const { app, env } = createTestApp();
+
+    const response = await app.request('/api/admin/admins/admin_foreign', {}, env);
+
+    expect(response.status).toBe(404);
+    expect(repoMocks.getAssignmentsByUser).not.toHaveBeenCalled();
+    expect(repoMocks.getPasskeysByUser).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['missing target', null, { id: 'unused' }],
+    ['concurrently removed target', { id: 'admin_1' }, null],
+  ])('returns not found when updating a %s', async (_label, existing, updated) => {
+    repoMocks.findByTenantAndId.mockResolvedValue(existing);
+    repoMocks.updateAdminUser.mockResolvedValue(updated);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins/admin_1',
+      {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_USERS_WRITE,
+        },
+        body: JSON.stringify({ name: 'Updated' }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('permits deleting one of multiple active platform admins', async () => {
+    repoMocks.findByTenantAndId.mockResolvedValue({
+      id: 'admin_target',
+      email: 'target@example.com',
+    });
+    mockAdminAdapter.queryOne
+      .mockResolvedValueOnce({ id: 'assignment_super_admin' })
+      .mockResolvedValueOnce({ id: 'role_super_admin' })
+      .mockResolvedValueOnce({ count: 2 });
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins/admin_target',
+      {
+        method: 'DELETE',
+        headers: {
+          'x-test-user-id': 'admin_actor',
+          'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_USERS_DELETE,
+        },
+      },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(repoMocks.updateAdminUser).toHaveBeenCalledWith('admin_target', { is_active: false });
+  });
+
+  it.each([
+    ['missing role', null, true],
+    ['already removed assignment', { id: 'role_support', name: 'support' }, false],
+  ])('returns not found for a role assignment with %s', async (_label, role, removed) => {
+    repoMocks.findByTenantAndId.mockResolvedValue({ id: 'admin_target' });
+    repoMocks.getAssignment.mockResolvedValue({
+      id: 'assignment_1',
+      admin_user_id: 'admin_target',
+      admin_role_id: 'role_support',
+    });
+    repoMocks.getRole.mockResolvedValue(role);
+    repoMocks.removeAssignmentById.mockResolvedValue(removed);
+    const { app, env } = createTestApp();
+
+    const response = await app.request(
+      '/api/admin/admins/admin_target/role-assignments/assignment_1',
+      {
+        method: 'DELETE',
+        headers: { 'x-test-permissions': ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE },
+      },
+      env
+    );
+
+    expect(response.status).toBe(404);
   });
 });

--- a/packages/ar-management/src/__tests__/device-secrets-security.test.ts
+++ b/packages/ar-management/src/__tests__/device-secrets-security.test.ts
@@ -1,0 +1,296 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const mocks = vi.hoisted(() => ({
+  findByUserId: vi.fn(),
+  findById: vi.fn(),
+  revoke: vi.fn(),
+  revokeByUserId: vi.fn(),
+  cleanupExpired: vi.fn(),
+  audit: vi.fn(),
+  logInfo: vi.fn(),
+  logError: vi.fn(),
+  repositoryTenants: [] as string[],
+}));
+
+vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@authrim/ar-lib-core')>();
+  class Repository {
+    findByUserId = mocks.findByUserId;
+    findById = mocks.findById;
+    revoke = mocks.revoke;
+    revokeByUserId = mocks.revokeByUserId;
+    cleanupExpired = mocks.cleanupExpired;
+
+    constructor(_adapter: unknown, tenantId: string) {
+      mocks.repositoryTenants.push(tenantId);
+    }
+  }
+  const statusByCode: Record<string, number> = {
+    [actual.AR_ERROR_CODES.VALIDATION_REQUIRED_FIELD]: 400,
+    [actual.AR_ERROR_CODES.VALIDATION_INVALID_VALUE]: 400,
+    [actual.AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND]: 404,
+    [actual.AR_ERROR_CODES.INTERNAL_ERROR]: 500,
+  };
+  return {
+    ...actual,
+    DeviceSecretRepository: Repository,
+    createAuthContextFromHono: () => ({ coreAdapter: {} }),
+    createAuditLogFromContext: mocks.audit,
+    getTenantIdFromContext: (c: { get: (key: string) => unknown }) => c.get('tenantId'),
+    getLogger: () => ({
+      module: () => ({ info: mocks.logInfo, error: mocks.logError }),
+    }),
+    createErrorResponse: (
+      c: { json: (body: unknown, status?: number) => Response },
+      code: string
+    ) => c.json({ error_code: code }, statusByCode[code] ?? 500),
+  };
+});
+
+import { AR_ERROR_CODES } from '@authrim/ar-lib-core';
+import {
+  cleanupExpiredDeviceSecrets,
+  getDeviceSecret,
+  listUserDeviceSecrets,
+  revokeAllUserDeviceSecrets,
+  revokeDeviceSecret,
+} from '../routes/device-secrets';
+
+function secret(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'device-a',
+    tenant_id: 'tenant-a',
+    user_id: 'user-a',
+    session_id: 'session-a',
+    device_name: 'Laptop',
+    device_platform: 'macOS',
+    secret_hash: 'must-never-leak',
+    created_at: Date.parse('2026-07-01T00:00:00.000Z'),
+    expires_at: Date.parse('2026-08-01T00:00:00.000Z'),
+    last_used_at: Date.parse('2026-07-10T00:00:00.000Z'),
+    use_count: 3,
+    is_active: 1,
+    revoked_at: undefined,
+    revoke_reason: undefined,
+    ...overrides,
+  };
+}
+
+function app() {
+  const instance = new Hono<{ Bindings: Record<string, never>; Variables: { tenantId: string } }>();
+  instance.use('*', async (c, next) => {
+    c.set('tenantId', c.req.header('x-test-tenant') ?? 'tenant-a');
+    await next();
+  });
+  instance.get('/users/:userId/device-secrets', listUserDeviceSecrets as never);
+  instance.delete('/users/:userId/device-secrets', revokeAllUserDeviceSecrets as never);
+  instance.post('/device-secrets/cleanup', cleanupExpiredDeviceSecrets as never);
+  instance.get('/device-secrets/:id', getDeviceSecret as never);
+  instance.delete('/device-secrets/:id', revokeDeviceSecret as never);
+  return instance;
+}
+
+describe('device secret admin security behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.repositoryTenants.length = 0;
+    mocks.findByUserId.mockResolvedValue([]);
+    mocks.findById.mockResolvedValue(secret());
+    mocks.revoke.mockResolvedValue(true);
+    mocks.revokeByUserId.mockResolvedValue(0);
+    mocks.cleanupExpired.mockResolvedValue(0);
+    mocks.audit.mockResolvedValue(undefined);
+  });
+
+  it('returns metadata only, filters revoked secrets and computes a meaningful summary', async () => {
+    const now = Date.now();
+    mocks.findByUserId.mockResolvedValue([
+      secret(),
+      secret({ id: 'expired', expires_at: now - 1, last_used_at: undefined }),
+      secret({
+        id: 'revoked',
+        is_active: 0,
+        revoked_at: Date.parse('2026-07-11T00:00:00.000Z'),
+        revoke_reason: 'compromised',
+      }),
+    ]);
+    const response = await app().request('/users/user-a/device-secrets?limit=1&offset=1');
+    expect(response.status).toBe(200);
+    const body = await response.json<{
+      items: Array<Record<string, unknown>>;
+      pagination: Record<string, unknown>;
+      summary: Record<string, unknown>;
+    }>();
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0]).not.toHaveProperty('secret_hash');
+    expect(JSON.stringify(body)).not.toContain('must-never-leak');
+    expect(body.pagination).toMatchObject({ total: 2, limit: 1, offset: 1, has_more: false });
+    expect(body.summary).toEqual({ total: 3, active: 2, revoked: 1, expired: 1 });
+    expect(mocks.repositoryTenants).toEqual(['tenant-a']);
+  });
+
+  it('includes revoked metadata only when explicitly requested and caps the page size', async () => {
+    mocks.findByUserId.mockResolvedValue([
+      secret(),
+      secret({ id: 'revoked', is_active: 0, revoked_at: Date.now() }),
+    ]);
+    const response = await app().request(
+      '/users/user-a/device-secrets?include_revoked=true&limit=500'
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      pagination: { total: 2, limit: 100, offset: 0 },
+    });
+  });
+
+  it.each(['?limit=0', '?limit=-1', '?limit=NaN', '?limit=1.5', '?offset=-1', '?offset=NaN'])(
+    'rejects invalid pagination %s before repository access',
+    async (query) => {
+      const response = await app().request(`/users/user-a/device-secrets${query}`);
+      expect(response.status).toBe(400);
+      expect(mocks.findByUserId).not.toHaveBeenCalled();
+    }
+  );
+
+  it('gets an existing tenant-scoped secret without exposing its hash', async () => {
+    const response = await app().request('/device-secrets/device-a');
+    expect(response.status).toBe(200);
+    const body = await response.json<Record<string, unknown>>();
+    expect(body).toMatchObject({
+      id: 'device-a',
+      user_id: 'user-a',
+      is_active: true,
+      created_at: '2026-07-01T00:00:00.000Z',
+    });
+    expect(body).not.toHaveProperty('secret_hash');
+  });
+
+  it('uses a uniform not-found response for an inaccessible secret', async () => {
+    mocks.findById.mockResolvedValue(null);
+    const response = await app().request('/device-secrets/unknown');
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error_code: AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND,
+    });
+  });
+
+  it.each([
+    ['{not-json', 'application/json'],
+    [JSON.stringify({ reason: 42 }), 'application/json'],
+    [JSON.stringify({ reason: 'x'.repeat(501) }), 'application/json'],
+  ])('rejects invalid individual revocation input before changing state', async (body, type) => {
+    const response = await app().request('/device-secrets/device-a', {
+      method: 'DELETE',
+      headers: { 'Content-Type': type },
+      body,
+    });
+    expect(response.status).toBe(400);
+    expect(mocks.findById).not.toHaveBeenCalled();
+    expect(mocks.revoke).not.toHaveBeenCalled();
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+
+  it('rejects an already-revoked secret without rewriting its reason', async () => {
+    mocks.findById.mockResolvedValue(secret({ revoked_at: Date.now(), is_active: 0 }));
+    const response = await app().request('/device-secrets/device-a', { method: 'DELETE' });
+    expect(response.status).toBe(400);
+    expect(mocks.revoke).not.toHaveBeenCalled();
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+
+  it('sanitizes the revocation reason and audits only after persistence', async () => {
+    const response = await app().request('/device-secrets/device-a', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason: '  compromised\nheader: injected\u0000  ' }),
+    });
+    expect(response.status).toBe(200);
+    expect(mocks.revoke).toHaveBeenCalledWith('device-a', 'compromisedheader: injected');
+    expect(mocks.audit).toHaveBeenCalledWith(
+      expect.anything(),
+      'device_secret.revoke',
+      'device_secret',
+      'device-a',
+      { user_id: 'user-a', reason: 'compromisedheader: injected' }
+    );
+  });
+
+  it('uses a safe default reason for an empty optional body', async () => {
+    const response = await app().request('/device-secrets/device-a', { method: 'DELETE' });
+    expect(response.status).toBe(200);
+    expect(mocks.revoke).toHaveBeenCalledWith('device-a', 'admin_revocation');
+  });
+
+  it('does not audit a revocation that failed to persist', async () => {
+    mocks.revoke.mockResolvedValue(false);
+    const response = await app().request('/device-secrets/device-a', { method: 'DELETE' });
+    expect(response.status).toBe(500);
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['{not-json'],
+    [JSON.stringify({ reason: false })],
+    [JSON.stringify({ reason: 'x'.repeat(501) })],
+  ])('rejects invalid bulk revocation input before mutation', async (body) => {
+    const response = await app().request('/users/user-a/device-secrets', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    });
+    expect(response.status).toBe(400);
+    expect(mocks.revokeByUserId).not.toHaveBeenCalled();
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+
+  it('bulk-revokes only within the request tenant and audits the count', async () => {
+    mocks.revokeByUserId.mockResolvedValue(3);
+    const response = await app().request('/users/user-a/device-secrets', {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-test-tenant': 'tenant-b',
+      },
+      body: JSON.stringify({ reason: 'account lockdown' }),
+    });
+    expect(response.status).toBe(200);
+    expect(mocks.revokeByUserId).toHaveBeenCalledWith('user-a', 'tenant-b', 'account lockdown');
+    expect(mocks.audit).toHaveBeenCalledWith(
+      expect.anything(),
+      'device_secret.revoke_all',
+      'user',
+      'user-a',
+      { revoked_count: 3, reason: 'account lockdown' }
+    );
+  });
+
+  it('audits manual cleanup with the number of deleted secrets', async () => {
+    mocks.cleanupExpired.mockResolvedValue(4);
+    const response = await app().request('/device-secrets/cleanup', { method: 'POST' });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ success: true, cleaned_count: 4 });
+    expect(mocks.audit).toHaveBeenCalledWith(
+      expect.anything(),
+      'device_secret.cleanup',
+      'device_secret',
+      'expired',
+      { cleaned_count: 4 }
+    );
+  });
+
+  it.each([
+    ['GET', '/users/user-a/device-secrets', 'findByUserId'],
+    ['GET', '/device-secrets/device-a', 'findById'],
+    ['DELETE', '/device-secrets/device-a', 'findById'],
+    ['DELETE', '/users/user-a/device-secrets', 'revokeByUserId'],
+    ['POST', '/device-secrets/cleanup', 'cleanupExpired'],
+  ] as const)('returns a redacted 500 when %s %s storage fails', async (method, path, mockName) => {
+    mocks[mockName].mockRejectedValueOnce(new Error('database unavailable with private details'));
+    const response = await app().request(path, { method });
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error_code: AR_ERROR_CODES.INTERNAL_ERROR });
+    expect(mocks.logError).toHaveBeenCalled();
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ar-management/src/__tests__/iat-tokens-security.test.ts
+++ b/packages/ar-management/src/__tests__/iat-tokens-security.test.ts
@@ -1,0 +1,295 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const mocks = vi.hoisted(() => ({
+  hash: vi.fn(async () => 'a'.repeat(64)),
+  audit: vi.fn(async () => undefined),
+  logError: vi.fn(),
+}));
+
+vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@authrim/ar-lib-core')>();
+  const statusByCode: Record<string, number> = {
+    [actual.AR_ERROR_CODES.VALIDATION_INVALID_VALUE]: 400,
+    [actual.AR_ERROR_CODES.VALIDATION_REQUIRED_FIELD]: 400,
+    [actual.AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND]: 404,
+    [actual.AR_ERROR_CODES.INTERNAL_ERROR]: 500,
+  };
+  return {
+    ...actual,
+    hashInitialAccessToken: mocks.hash,
+    createAuditLogFromContext: mocks.audit,
+    getLogger: () => ({ module: () => ({ error: mocks.logError }) }),
+    createErrorResponse: (
+      c: { json: (body: unknown, status?: number) => Response },
+      code: string
+    ) => c.json({ error_code: code }, statusByCode[code] ?? 500),
+  };
+});
+
+import { AR_ERROR_CODES } from '@authrim/ar-lib-core';
+import { adminIATCreateHandler, adminIATListHandler, adminIATRevokeHandler } from '../iat-tokens';
+
+type Kv = {
+  list: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+};
+
+function kv(): Kv {
+  return {
+    list: vi.fn(async () => ({ keys: [] })),
+    get: vi.fn(async () => null),
+    put: vi.fn(async () => undefined),
+    delete: vi.fn(async () => undefined),
+  };
+}
+
+function app() {
+  const instance = new Hono<{ Bindings: { INITIAL_ACCESS_TOKENS?: Kv } }>();
+  instance.get('/tokens', adminIATListHandler as never);
+  instance.post('/tokens', adminIATCreateHandler as never);
+  instance.delete('/tokens/:tokenHash', adminIATRevokeHandler as never);
+  return instance;
+}
+
+function metadata(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    description: 'registration token',
+    createdAt: '2026-07-14T00:00:00.000Z',
+    expiresAt: '2026-08-13T00:00:00.000Z',
+    single_use: false,
+    type: 'iat',
+    ...overrides,
+  });
+}
+
+describe('initial access token security behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ['GET', '/tokens'],
+    ['POST', '/tokens'],
+    ['DELETE', `/tokens/${'a'.repeat(64)}`],
+  ])('fails closed when token storage is unavailable for %s', async (method, path) => {
+    const response = await app().request(path, {
+      method,
+      headers: method === 'POST' ? { 'Content-Type': 'application/json' } : undefined,
+      body: method === 'POST' ? '{}' : undefined,
+    });
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({ error_code: AR_ERROR_CODES.INTERNAL_ERROR });
+  });
+
+  it('lists metadata without exposing token material and skips missing KV values', async () => {
+    const store = kv();
+    store.list.mockResolvedValue({
+      keys: [{ name: `iat:${'a'.repeat(64)}` }, { name: `iat:${'b'.repeat(64)}` }],
+    });
+    store.get.mockResolvedValueOnce(metadata()).mockResolvedValueOnce(null);
+
+    const response = await app().request('/tokens', {}, { INITIAL_ACCESS_TOKENS: store });
+    expect(response.status).toBe(200);
+    const body = await response.json<{ tokens: Array<Record<string, unknown>>; total: number }>();
+    expect(body.total).toBe(1);
+    expect(body.tokens[0]).toEqual({
+      tokenHash: 'a'.repeat(64),
+      description: 'registration token',
+      createdAt: '2026-07-14T00:00:00.000Z',
+      expiresAt: '2026-08-13T00:00:00.000Z',
+      single_use: false,
+    });
+    expect(JSON.stringify(body)).not.toContain('plaintext');
+    expect(store.get).toHaveBeenNthCalledWith(1, `iat:${'a'.repeat(64)}`);
+  });
+
+  it('returns a redacted internal error for corrupt token metadata', async () => {
+    const store = kv();
+    store.list.mockResolvedValue({ keys: [{ name: `iat:${'a'.repeat(64)}` }] });
+    store.get.mockResolvedValue('{not-json');
+    const response = await app().request('/tokens', {}, { INITIAL_ACCESS_TOKENS: store });
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error_code: AR_ERROR_CODES.INTERNAL_ERROR });
+    expect(mocks.logError).toHaveBeenCalled();
+  });
+
+  it.each([
+    ['not JSON', 'text/plain'],
+    [JSON.stringify({ expiresInDays: '30' }), 'application/json'],
+    [JSON.stringify({ expiresInDays: 1.5 }), 'application/json'],
+    [JSON.stringify({ expiresInDays: 0 }), 'application/json'],
+    [JSON.stringify({ expiresInDays: 366 }), 'application/json'],
+    ['{"expiresInDays":1e400}', 'application/json'],
+    [JSON.stringify({ description: 42 }), 'application/json'],
+    [JSON.stringify({ description: 'x'.repeat(257) }), 'application/json'],
+    [JSON.stringify({ single_use: 'true' }), 'application/json'],
+  ])(
+    'rejects invalid creation input before generating or storing a token',
+    async (body, contentType) => {
+      const store = kv();
+      const response = await app().request(
+        '/tokens',
+        { method: 'POST', headers: { 'Content-Type': contentType }, body },
+        { INITIAL_ACCESS_TOKENS: store }
+      );
+      expect(response.status).toBe(400);
+      expect(mocks.hash).not.toHaveBeenCalled();
+      expect(store.put).not.toHaveBeenCalled();
+      expect(mocks.audit).not.toHaveBeenCalled();
+    }
+  );
+
+  it('stores only a hash and returns the plaintext token exactly once', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-14T00:00:00.000Z'));
+    const store = kv();
+    const response = await app().request(
+      '/tokens',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          description: '  device registration\u0000  ',
+          expiresInDays: 7,
+          single_use: true,
+        }),
+      },
+      { INITIAL_ACCESS_TOKENS: store }
+    );
+
+    expect(response.status).toBe(201);
+    const body = await response.json<{ token: string; tokenHash: string }>();
+    expect(body.token).toMatch(/^[0-9a-f]{64}$/u);
+    expect(body.tokenHash).toBe('a'.repeat(64));
+    expect(mocks.hash).toHaveBeenCalledWith(body.token);
+    expect(store.put).toHaveBeenCalledTimes(1);
+    const [key, storedValue, options] = store.put.mock.calls[0] as [
+      string,
+      string,
+      { expirationTtl: number },
+    ];
+    expect(key).toBe(`iat:${'a'.repeat(64)}`);
+    expect(storedValue).not.toContain(body.token);
+    expect(JSON.parse(storedValue)).toEqual({
+      description: 'device registration',
+      createdAt: '2026-07-14T00:00:00.000Z',
+      expiresAt: '2026-07-21T00:00:00.000Z',
+      single_use: true,
+      type: 'iat',
+    });
+    expect(options.expirationTtl).toBe(7 * 24 * 60 * 60);
+    expect(mocks.audit).toHaveBeenCalledWith(
+      expect.anything(),
+      'iat.token.create',
+      'iat_token',
+      'aaaaaaaa',
+      expect.objectContaining({ expiresInDays: 7, single_use: true })
+    );
+  });
+
+  it('uses safe defaults for blank nullable creation fields', async () => {
+    const store = kv();
+    const response = await app().request(
+      '/tokens',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description: '   ', expiresInDays: null, single_use: null }),
+      },
+      { INITIAL_ACCESS_TOKENS: store }
+    );
+    expect(response.status).toBe(201);
+    expect(store.put).toHaveBeenCalledWith(
+      `iat:${'a'.repeat(64)}`,
+      expect.stringContaining('Initial Access Token for Dynamic Client Registration'),
+      { expirationTtl: 30 * 24 * 60 * 60 }
+    );
+  });
+
+  it.each(['short', 'g'.repeat(64), '../other-key', 'A'.repeat(64)])(
+    'rejects malformed token hash %s before KV access',
+    async (tokenHash) => {
+      const store = kv();
+      const response = await app().request(
+        `/tokens/${encodeURIComponent(tokenHash)}`,
+        { method: 'DELETE' },
+        { INITIAL_ACCESS_TOKENS: store }
+      );
+      expect(response.status).toBe(400);
+      expect(store.get).not.toHaveBeenCalled();
+      expect(store.delete).not.toHaveBeenCalled();
+      expect(mocks.audit).not.toHaveBeenCalled();
+    }
+  );
+
+  it('does not reveal whether an unknown valid hash has related metadata', async () => {
+    const store = kv();
+    const hash = 'b'.repeat(64);
+    const response = await app().request(
+      `/tokens/${hash}`,
+      { method: 'DELETE' },
+      { INITIAL_ACCESS_TOKENS: store }
+    );
+    expect(response.status).toBe(404);
+    expect(store.delete).not.toHaveBeenCalled();
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+
+  it('revokes an existing token and audits only a hash prefix', async () => {
+    const store = kv();
+    const hash = 'c'.repeat(64);
+    store.get.mockResolvedValue(metadata());
+    const response = await app().request(
+      `/tokens/${hash}`,
+      { method: 'DELETE' },
+      { INITIAL_ACCESS_TOKENS: store }
+    );
+    expect(response.status).toBe(200);
+    expect(store.delete).toHaveBeenCalledWith(`iat:${hash}`);
+    expect(mocks.audit).toHaveBeenCalledWith(
+      expect.anything(),
+      'iat.token.revoke',
+      'iat_token',
+      'cccccccc',
+      {},
+      'warning'
+    );
+  });
+
+  it('does not emit a success audit when storage creation or deletion fails', async () => {
+    const createStore = kv();
+    createStore.put.mockRejectedValue(new Error('KV unavailable'));
+    expect(
+      (
+        await app().request(
+          '/tokens',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: '{}',
+          },
+          { INITIAL_ACCESS_TOKENS: createStore }
+        )
+      ).status
+    ).toBe(500);
+    expect(mocks.audit).not.toHaveBeenCalled();
+
+    const revokeStore = kv();
+    revokeStore.get.mockResolvedValue(metadata());
+    revokeStore.delete.mockRejectedValue(new Error('KV unavailable'));
+    expect(
+      (
+        await app().request(
+          `/tokens/${'d'.repeat(64)}`,
+          { method: 'DELETE' },
+          { INITIAL_ACCESS_TOKENS: revokeStore }
+        )
+      ).status
+    ).toBe(500);
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ar-management/src/__tests__/ip-allowlist-security.test.ts
+++ b/packages/ar-management/src/__tests__/ip-allowlist-security.test.ts
@@ -1,0 +1,337 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import type { Env } from '@authrim/ar-lib-core';
+
+const mocks = vi.hoisted(() => ({
+  getAllEntries: vi.fn(),
+  getEnabledEntries: vi.fn(),
+  getEntry: vi.fn(),
+  entryExists: vi.fn(),
+  isIpAllowed: vi.fn(),
+  createEntry: vi.fn(),
+  updateEntry: vi.fn(),
+  deleteEntry: vi.fn(),
+  enableEntry: vi.fn(),
+  disableEntry: vi.fn(),
+  countEntries: vi.fn(),
+  audit: vi.fn(),
+}));
+
+vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@authrim/ar-lib-core')>();
+
+  class IpRepository {
+    getAllEntries = mocks.getAllEntries;
+    getEnabledEntries = mocks.getEnabledEntries;
+    getEntry = mocks.getEntry;
+    entryExists = mocks.entryExists;
+    isIpAllowed = mocks.isIpAllowed;
+    createEntry = mocks.createEntry;
+    updateEntry = mocks.updateEntry;
+    deleteEntry = mocks.deleteEntry;
+    enableEntry = mocks.enableEntry;
+    disableEntry = mocks.disableEntry;
+    countEntries = mocks.countEntries;
+  }
+
+  const statusByCode: Record<string, number> = {
+    [actual.AR_ERROR_CODES.ADMIN_INSUFFICIENT_PERMISSIONS]: 403,
+    [actual.AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND]: 404,
+    [actual.AR_ERROR_CODES.ADMIN_INVALID_REQUEST]: 400,
+    [actual.AR_ERROR_CODES.ADMIN_CONFLICT]: 409,
+    [actual.AR_ERROR_CODES.INTERNAL_ERROR]: 500,
+  };
+
+  return {
+    ...actual,
+    AdminIpAllowlistRepository: IpRepository,
+    requireDedicatedAdminDatabaseAdapter: vi.fn(() => ({})),
+    adminAuthMiddleware:
+      () =>
+      async (
+        c: {
+          req: { header: (name: string) => string | undefined };
+          set: (key: string, value: unknown) => void;
+        },
+        next: () => Promise<void>
+      ) => {
+        c.set('tenantId', c.req.header('x-test-tenant') ?? 'tenant-a');
+        c.set('adminAuth', {
+          userId: 'actor-a',
+          permissions: (c.req.header('x-test-permissions') ?? '').split(',').filter(Boolean),
+        });
+        await next();
+      },
+    getTenantIdFromContext: (c: { get: (key: string) => unknown }) => c.get('tenantId'),
+    createErrorResponse: (
+      c: { json: (body: unknown, status?: number) => Response },
+      code: string
+    ) => c.json({ error_code: code }, statusByCode[code] ?? 500),
+  };
+});
+
+vi.mock('../admin-shared', () => ({ writeAdminAuditLog: mocks.audit }));
+
+import { ADMIN_PERMISSIONS, AR_ERROR_CODES } from '@authrim/ar-lib-core';
+import { ipAllowlistRouter } from '../routes/admin-management/ip-allowlist';
+
+const readHeaders = { 'x-test-permissions': ADMIN_PERMISSIONS.IP_ALLOWLIST_READ };
+const writeHeaders = {
+  'Content-Type': 'application/json',
+  'x-test-permissions': `${ADMIN_PERMISSIONS.IP_ALLOWLIST_READ},${ADMIN_PERMISSIONS.IP_ALLOWLIST_WRITE}`,
+};
+
+function entry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'ip-a',
+    tenant_id: 'tenant-a',
+    ip_range: '192.0.2.1',
+    ip_version: 4,
+    enabled: true,
+    ...overrides,
+  };
+}
+
+function app() {
+  const instance = new Hono<{ Bindings: Env }>();
+  instance.route('/api/admin/ip-allowlist', ipAllowlistRouter);
+  return instance;
+}
+
+async function request(
+  path: string,
+  method = 'GET',
+  body?: unknown,
+  headers: Record<string, string> = writeHeaders
+) {
+  const suffix = path === '/' ? '' : path.startsWith('/?') ? path.slice(1) : path;
+  return app().request(
+    `/api/admin/ip-allowlist${suffix}`,
+    {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    },
+    { DB_ADMIN: {} } as never
+  );
+}
+
+describe('IP allowlist security boundaries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getEnabledEntries.mockResolvedValue([]);
+    mocks.getAllEntries.mockResolvedValue([]);
+    mocks.getEntry.mockResolvedValue(entry());
+    mocks.entryExists.mockResolvedValue(false);
+    mocks.isIpAllowed.mockResolvedValue(true);
+    mocks.countEntries.mockResolvedValue(1);
+  });
+
+  it('lists tenant entries and reports the trusted client-IP header', async () => {
+    mocks.getEnabledEntries.mockResolvedValue([entry()]);
+    const enabled = await request('/', 'GET', undefined, {
+      ...readHeaders,
+      'cf-connecting-ip': '192.0.2.20',
+    });
+    expect(enabled.status).toBe(200);
+    expect(await enabled.json()).toMatchObject({
+      total: 1,
+      current_ip: '192.0.2.20',
+      restriction_active: true,
+    });
+    expect(mocks.getEnabledEntries).toHaveBeenCalledWith('tenant-a');
+
+    mocks.getAllEntries.mockResolvedValue([entry({ enabled: false })]);
+    const all = await request('/?include_disabled=true', 'GET', undefined, readHeaders);
+    expect(all.status).toBe(200);
+    expect(mocks.getAllEntries).toHaveBeenCalledWith('tenant-a');
+  });
+
+  it('hides an ID-addressed entry from another tenant', async () => {
+    mocks.getEntry.mockResolvedValue(entry({ tenant_id: 'tenant-b' }));
+    const response = await request('/ip-b', 'GET', undefined, readHeaders);
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({
+      error_code: AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND,
+    });
+  });
+
+  it.each([
+    ['POST', '/', { ip_range: '192.0.2.1' }],
+    ['PATCH', '/ip-a', { description: 'office' }],
+    ['DELETE', '/ip-a', undefined],
+    ['POST', '/ip-a/enable', undefined],
+    ['POST', '/ip-a/disable', undefined],
+  ])(
+    'denies %s %s without write permission and performs no mutation',
+    async (method, path, body) => {
+      const response = await request(path, method, body, {
+        'Content-Type': 'application/json',
+        ...readHeaders,
+      });
+      expect(response.status).toBe(403);
+      expect(mocks.createEntry).not.toHaveBeenCalled();
+      expect(mocks.updateEntry).not.toHaveBeenCalled();
+      expect(mocks.deleteEntry).not.toHaveBeenCalled();
+      expect(mocks.enableEntry).not.toHaveBeenCalled();
+      expect(mocks.disableEntry).not.toHaveBeenCalled();
+      expect(mocks.audit).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    [undefined],
+    [''],
+    ['192.0.2'],
+    ['256.0.0.1'],
+    ['01.2.3.4'],
+    ['192.0.2.1/33'],
+    ['2001:db8::1/129'],
+    ['2001::db8::1'],
+    ['2001:db8:invalid::1'],
+    ['2001:db8:0:0:0:0:0'],
+  ])('rejects malformed IP range %s before accessing storage', async (ipRange) => {
+    const response = await request('/', 'POST', { ip_range: ipRange });
+    expect(response.status).toBe(400);
+    expect(mocks.entryExists).not.toHaveBeenCalled();
+    expect(mocks.createEntry).not.toHaveBeenCalled();
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate ranges without mutation', async () => {
+    mocks.entryExists.mockResolvedValue(true);
+    expect((await request('/', 'POST', { ip_range: ' 192.0.2.1 ' })).status).toBe(409);
+    expect(mocks.entryExists).toHaveBeenCalledWith('tenant-a', '192.0.2.1');
+    expect(mocks.createEntry).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['192.0.2.0/24', 4],
+    ['2001:db8::1', 6],
+    ['2001:db8::/64', 6],
+    ['2001:db8:0:0:0:0:0:1', 6],
+  ])(
+    'creates a normalized %s entry as IPv%s and writes a security audit',
+    async (ipRange, version) => {
+      mocks.createEntry.mockResolvedValue(entry({ ip_range: ipRange, ip_version: version }));
+      const response = await request('/', 'POST', {
+        ip_range: ` ${ipRange} `,
+        description: 'office',
+        enabled: false,
+        tenant_id: 'tenant-b',
+        created_by: 'attacker',
+      });
+      expect(response.status).toBe(201);
+      expect(mocks.createEntry).toHaveBeenCalledWith({
+        tenant_id: 'tenant-a',
+        ip_range: ipRange,
+        ip_version: version,
+        description: 'office',
+        enabled: false,
+        created_by: 'actor-a',
+      });
+      expect(mocks.audit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: 'ip_allowlist.create',
+          severity: 'warn',
+        })
+      );
+    }
+  );
+
+  it('does not update an entry from another tenant', async () => {
+    mocks.getEntry.mockResolvedValue(entry({ tenant_id: 'tenant-b' }));
+    expect((await request('/ip-b', 'PATCH', { description: 'hijacked' })).status).toBe(404);
+    expect(mocks.updateEntry).not.toHaveBeenCalled();
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+
+  it('validates an updated range and audits only a persisted update', async () => {
+    expect((await request('/ip-a', 'PATCH', { ip_range: '999.0.0.1' })).status).toBe(400);
+    expect(mocks.updateEntry).not.toHaveBeenCalled();
+
+    mocks.updateEntry.mockResolvedValue(null);
+    expect((await request('/ip-a', 'PATCH', { description: 'raced' })).status).toBe(404);
+    expect(mocks.audit).not.toHaveBeenCalled();
+
+    mocks.updateEntry.mockResolvedValue(entry({ ip_range: '2001:db8::/64', ip_version: 6 }));
+    const response = await request('/ip-a', 'PATCH', {
+      ip_range: ' 2001:db8::/64 ',
+      enabled: false,
+    });
+    expect(response.status).toBe(200);
+    expect(mocks.updateEntry).toHaveBeenCalledWith('ip-a', {
+      ip_range: '2001:db8::/64',
+      ip_version: 6,
+      description: undefined,
+      enabled: false,
+    });
+    expect(mocks.audit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'ip_allowlist.update' })
+    );
+  });
+
+  it('deletes only a current-tenant entry and audits after deletion', async () => {
+    mocks.getEntry.mockResolvedValueOnce(null);
+    expect((await request('/missing', 'DELETE')).status).toBe(404);
+
+    mocks.getEntry.mockResolvedValueOnce(entry({ tenant_id: 'tenant-b' }));
+    expect((await request('/foreign', 'DELETE')).status).toBe(404);
+    expect(mocks.deleteEntry).not.toHaveBeenCalled();
+
+    mocks.getEntry.mockResolvedValue(entry());
+    expect((await request('/ip-a', 'DELETE')).status).toBe(200);
+    expect(mocks.deleteEntry).toHaveBeenCalledWith('ip-a');
+    expect(mocks.audit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'ip_allowlist.delete' })
+    );
+  });
+
+  it.each([
+    ['enable', 'enableEntry'],
+    ['disable', 'disableEntry'],
+  ] as const)('protects tenant ownership and persistence for %s', async (action, method) => {
+    mocks.getEntry.mockResolvedValueOnce(entry({ tenant_id: 'tenant-b' }));
+    expect((await request(`/ip-b/${action}`, 'POST')).status).toBe(404);
+    expect(mocks[method]).not.toHaveBeenCalled();
+
+    mocks.getEntry.mockResolvedValue(entry());
+    mocks[method].mockResolvedValueOnce(false);
+    expect((await request(`/ip-a/${action}`, 'POST')).status).toBe(404);
+    expect(mocks.audit).not.toHaveBeenCalled();
+
+    mocks[method].mockResolvedValue(true);
+    expect((await request(`/ip-a/${action}`, 'POST')).status).toBe(200);
+    expect(mocks.audit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: `ip_allowlist.${action}` })
+    );
+  });
+
+  it('checks an IP using only the current tenant and exposes restriction state', async () => {
+    expect((await request('/check', 'POST', {})).status).toBe(400);
+
+    mocks.isIpAllowed.mockResolvedValue(false);
+    mocks.countEntries.mockResolvedValue(2);
+    const response = await request('/check', 'POST', { ip: '198.51.100.20' });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ip: '198.51.100.20',
+      allowed: false,
+      restriction_active: true,
+      entry_count: 2,
+    });
+    expect(mocks.isIpAllowed).toHaveBeenCalledWith('tenant-a', '198.51.100.20');
+    expect(mocks.countEntries).toHaveBeenCalledWith('tenant-a');
+  });
+
+  it('fails closed and does not audit when storage fails', async () => {
+    mocks.createEntry.mockRejectedValue(new Error('database unavailable'));
+    const response = await request('/', 'POST', { ip_range: '192.0.2.1' });
+    expect(response.status).toBe(500);
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ar-management/src/__tests__/my-passkeys-router.test.ts
+++ b/packages/ar-management/src/__tests__/my-passkeys-router.test.ts
@@ -1,0 +1,449 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import type { Env } from '@authrim/ar-lib-core';
+
+const mocks = vi.hoisted(() => ({
+  getPasskeysByUser: vi.fn(),
+  credentialExists: vi.fn(),
+  createPasskey: vi.fn(),
+  getPasskey: vi.fn(),
+  updateDeviceName: vi.fn(),
+  deletePasskeyIfUserHasAnother: vi.fn(),
+  generateRegistrationOptions: vi.fn(),
+  verifyRegistrationResponse: vi.fn(),
+  writeAdminAuditLog: vi.fn(),
+  generateId: vi.fn(() => 'challenge-id'),
+}));
+
+vi.mock('@simplewebauthn/server', () => ({
+  generateRegistrationOptions: mocks.generateRegistrationOptions,
+  verifyRegistrationResponse: mocks.verifyRegistrationResponse,
+}));
+
+vi.mock('../admin-shared', () => ({ writeAdminAuditLog: mocks.writeAdminAuditLog }));
+
+vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@authrim/ar-lib-core')>();
+  class MockAdminPasskeyRepository {
+    getPasskeysByUser = mocks.getPasskeysByUser;
+    credentialExists = mocks.credentialExists;
+    createPasskey = mocks.createPasskey;
+    getPasskey = mocks.getPasskey;
+    updateDeviceName = mocks.updateDeviceName;
+    deletePasskeyIfUserHasAnother = mocks.deletePasskeyIfUserHasAnother;
+  }
+  const status: Record<string, number> = {
+    [actual.AR_ERROR_CODES.ADMIN_INVALID_REQUEST]: 400,
+    [actual.AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND]: 404,
+    [actual.AR_ERROR_CODES.ADMIN_INSUFFICIENT_PERMISSIONS]: 403,
+    [actual.AR_ERROR_CODES.INTERNAL_ERROR]: 500,
+  };
+  return {
+    ...actual,
+    AdminPasskeyRepository: MockAdminPasskeyRepository,
+    requireDedicatedAdminDatabaseAdapter: vi.fn(() => ({})),
+    generateId: mocks.generateId,
+    adminAuthMiddleware:
+      () =>
+      async (
+        c: { req: { header: (name: string) => string | undefined }; set: Function },
+        next: () => Promise<void>
+      ) => {
+        c.set('adminAuth', {
+          userId: c.req.header('x-test-user-id') ?? 'admin-1',
+          email: c.req.header('x-test-email') ?? 'admin@example.com',
+        });
+        c.set('tenantId', 'tenant-1');
+        await next();
+      },
+    createErrorResponse: vi.fn((c: { json: Function }, code: string) =>
+      c.json({ error: 'error', error_code: code }, status[code] ?? 500)
+    ),
+  };
+});
+
+import { myPasskeysRouter } from '../routes/admin-management/my-passkeys';
+
+function passkey(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'passkey-1',
+    admin_user_id: 'admin-1',
+    credential_id: 'credential-1',
+    public_key: 'secret-public-key',
+    counter: 0,
+    transports: ['internal'],
+    device_name: 'MacBook',
+    aaguid: null,
+    created_at: 100,
+    last_used_at: null,
+    ...overrides,
+  };
+}
+
+function createApp(config = true) {
+  const kv = config ? { get: vi.fn(), put: vi.fn(), delete: vi.fn() } : undefined;
+  const app = new Hono<{ Bindings: Env }>();
+  app.route('/api/admin/me/passkeys', myPasskeysRouter);
+  return {
+    app,
+    kv,
+    env: {
+      AUTHRIM_CONFIG: kv,
+      ADMIN_UI_URL: 'https://admin.example.com',
+    } as unknown as Env,
+  };
+}
+
+function registrationResponse() {
+  return {
+    id: 'credential',
+    rawId: 'credential',
+    type: 'public-key',
+    clientExtensionResults: {},
+    response: {
+      clientDataJSON: 'client-data',
+      attestationObject: 'attestation',
+      transports: ['internal', 'invalid-transport'],
+    },
+  };
+}
+
+describe('myPasskeysRouter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getPasskeysByUser.mockResolvedValue([]);
+    mocks.credentialExists.mockResolvedValue(false);
+  });
+
+  it('lists only sanitized passkey metadata for the current admin', async () => {
+    mocks.getPasskeysByUser.mockResolvedValue([passkey()]);
+    const { app, env } = createApp();
+
+    const response = await app.request('/api/admin/me/passkeys', {}, env);
+    const body = (await response.json()) as { passkeys: Array<Record<string, unknown>> };
+
+    expect(response.status).toBe(200);
+    expect(mocks.getPasskeysByUser).toHaveBeenCalledWith('admin-1');
+    expect(body.passkeys[0]).not.toHaveProperty('credential_id');
+    expect(body.passkeys[0]).not.toHaveProperty('public_key');
+  });
+
+  it.each([
+    ['missing RP ID', {}, true, 400],
+    ['missing challenge store', { rp_id: 'admin.example.com' }, false, 500],
+    ['origin/RP mismatch', { rp_id: 'evil.example.com' }, true, 400],
+  ])('rejects registration options for %s', async (_label, body, config, status) => {
+    const { app, env } = createApp(config);
+    const response = await app.request(
+      '/api/admin/me/passkeys/options',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Origin: 'https://admin.example.com' },
+        body: JSON.stringify(body),
+      },
+      env
+    );
+
+    expect(response.status).toBe(status);
+    expect(mocks.generateRegistrationOptions).not.toHaveBeenCalled();
+  });
+
+  it('creates origin-bound registration options and excludes existing credentials', async () => {
+    mocks.getPasskeysByUser.mockResolvedValue([passkey()]);
+    mocks.generateRegistrationOptions.mockResolvedValue({ challenge: 'webauthn-challenge' });
+    const { app, env, kv } = createApp();
+
+    const response = await app.request(
+      '/api/admin/me/passkeys/options',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Origin: 'https://admin.example.com' },
+        body: JSON.stringify({ rp_id: 'admin.example.com', device_name: 'Security key' }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.generateRegistrationOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rpID: 'admin.example.com',
+        userName: 'admin@example.com',
+        excludeCredentials: [expect.objectContaining({ id: 'credential-1' })],
+      })
+    );
+    expect(kv?.put).toHaveBeenCalledWith(
+      'admin_passkey:challenge:challenge-id',
+      expect.stringContaining('https://admin.example.com'),
+      { expirationTtl: 300 }
+    );
+  });
+
+  it.each([
+    ['missing request fields', {}, null, 400],
+    [
+      'expired challenge',
+      {
+        challenge_id: 'missing',
+        passkey_response: registrationResponse(),
+        origin: 'https://admin.example.com',
+      },
+      null,
+      400,
+    ],
+    [
+      'challenge owned by another admin',
+      {
+        challenge_id: 'c',
+        passkey_response: registrationResponse(),
+        origin: 'https://admin.example.com',
+      },
+      {
+        challenge: 'x',
+        rpID: 'admin.example.com',
+        origin: 'https://admin.example.com',
+        userId: 'other',
+        deviceName: null,
+      },
+      401,
+    ],
+    [
+      'origin mismatch',
+      {
+        challenge_id: 'c',
+        passkey_response: registrationResponse(),
+        origin: 'https://evil.example.com',
+      },
+      {
+        challenge: 'x',
+        rpID: 'admin.example.com',
+        origin: 'https://admin.example.com',
+        userId: 'admin-1',
+        deviceName: null,
+      },
+      400,
+    ],
+  ])('rejects registration completion for %s', async (_label, body, stored, status) => {
+    const { app, env, kv } = createApp();
+    kv?.get.mockResolvedValue(stored ? JSON.stringify(stored) : null);
+
+    const response = await app.request(
+      '/api/admin/me/passkeys/complete',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+      env
+    );
+
+    expect(response.status).toBe(status);
+    expect(mocks.createPasskey).not.toHaveBeenCalled();
+  });
+
+  it('rejects failed WebAuthn verification and consumes the challenge', async () => {
+    const { app, env, kv } = createApp();
+    kv?.get.mockResolvedValue(
+      JSON.stringify({
+        challenge: 'x',
+        rpID: 'admin.example.com',
+        origin: 'https://admin.example.com',
+        userId: 'admin-1',
+        deviceName: null,
+      })
+    );
+    mocks.verifyRegistrationResponse.mockRejectedValue(new Error('bad attestation'));
+
+    const response = await app.request(
+      '/api/admin/me/passkeys/complete',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          challenge_id: 'c',
+          passkey_response: registrationResponse(),
+          origin: 'https://admin.example.com',
+        }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(400);
+    expect(kv?.delete).toHaveBeenCalledWith('admin_passkey:challenge:c');
+  });
+
+  it('registers a verified unique credential, filters transports, audits, and consumes challenge', async () => {
+    const { app, env, kv } = createApp();
+    kv?.get.mockResolvedValue(
+      JSON.stringify({
+        challenge: 'x',
+        rpID: 'admin.example.com',
+        origin: 'https://admin.example.com',
+        userId: 'admin-1',
+        deviceName: 'Stored name',
+      })
+    );
+    mocks.verifyRegistrationResponse.mockResolvedValue({
+      verified: true,
+      registrationInfo: {
+        credential: { id: 'Y3JlZGVudGlhbA', publicKey: new Uint8Array([1, 2]), counter: 3 },
+        attestationObject: new Uint8Array([3]),
+        aaguid: 'aaguid',
+      },
+    });
+    mocks.createPasskey.mockResolvedValue(passkey({ device_name: 'Request name' }));
+
+    const response = await app.request(
+      '/api/admin/me/passkeys/complete',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          challenge_id: 'c',
+          passkey_response: registrationResponse(),
+          origin: 'https://admin.example.com',
+          device_name: 'Request name',
+        }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(201);
+    expect(mocks.createPasskey).toHaveBeenCalledWith(
+      expect.objectContaining({
+        admin_user_id: 'admin-1',
+        counter: 3,
+        transports: ['internal'],
+        device_name: 'Request name',
+      })
+    );
+    expect(kv?.delete).toHaveBeenCalledWith('admin_passkey:challenge:c');
+    expect(mocks.writeAdminAuditLog).toHaveBeenCalled();
+  });
+
+  it.each([
+    ['unverified response', { verified: false, registrationInfo: null }, false, 400],
+    [
+      'missing credential material',
+      { verified: true, registrationInfo: { credential: {}, counter: 0 } },
+      false,
+      400,
+    ],
+    [
+      'already registered credential',
+      {
+        verified: true,
+        registrationInfo: {
+          credentialID: new Uint8Array([1, 2]).buffer,
+          credentialPublicKey: new Uint8Array([3, 4]),
+          counter: 0,
+        },
+      },
+      true,
+      409,
+    ],
+  ])('rejects a %s after consuming its challenge', async (_label, verification, exists, status) => {
+    const { app, env, kv } = createApp();
+    kv?.get.mockResolvedValue(
+      JSON.stringify({
+        challenge: 'x',
+        rpID: 'admin.example.com',
+        origin: 'https://admin.example.com',
+        userId: 'admin-1',
+        deviceName: null,
+      })
+    );
+    mocks.verifyRegistrationResponse.mockResolvedValue(verification);
+    mocks.credentialExists.mockResolvedValue(exists);
+
+    const response = await app.request(
+      '/api/admin/me/passkeys/complete',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          challenge_id: 'c',
+          passkey_response: registrationResponse(),
+          origin: 'https://admin.example.com',
+        }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(status);
+    expect(kv?.delete).toHaveBeenCalledWith('admin_passkey:challenge:c');
+    expect(mocks.createPasskey).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['missing name', {}, null, 400],
+    ['name over 100 characters', { device_name: 'x'.repeat(101) }, null, 400],
+    ['unknown passkey', { device_name: 'New' }, null, 404],
+    ['another admin passkey', { device_name: 'New' }, passkey({ admin_user_id: 'other' }), 403],
+  ])('rejects rename for %s', async (_label, body, stored, status) => {
+    mocks.getPasskey.mockResolvedValue(stored);
+    const { app, env } = createApp();
+    const response = await app.request(
+      '/api/admin/me/passkeys/passkey-1',
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+      env
+    );
+
+    expect(response.status).toBe(status);
+    expect(mocks.updateDeviceName).not.toHaveBeenCalled();
+  });
+
+  it('renames only the current admin passkey and audits old and new names', async () => {
+    mocks.getPasskey.mockResolvedValue(passkey());
+    const { app, env } = createApp();
+    const response = await app.request(
+      '/api/admin/me/passkeys/passkey-1',
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ device_name: 'New name' }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.updateDeviceName).toHaveBeenCalledWith('passkey-1', 'New name');
+    expect(mocks.writeAdminAuditLog).toHaveBeenCalled();
+  });
+
+  it.each([
+    ['unknown passkey', null, true, 404],
+    ['another admin passkey', passkey({ admin_user_id: 'other' }), true, 403],
+    ['last remaining passkey', passkey(), false, 400],
+  ])('rejects deletion of %s', async (_label, stored, deleted, status) => {
+    mocks.getPasskey.mockResolvedValue(stored);
+    mocks.deletePasskeyIfUserHasAnother.mockResolvedValue(deleted);
+    const { app, env } = createApp();
+    const response = await app.request(
+      '/api/admin/me/passkeys/passkey-1',
+      { method: 'DELETE' },
+      env
+    );
+
+    expect(response.status).toBe(status);
+  });
+
+  it('deletes an owned passkey only when another remains and audits the deletion', async () => {
+    mocks.getPasskey.mockResolvedValue(passkey());
+    mocks.deletePasskeyIfUserHasAnother.mockResolvedValue(true);
+    const { app, env } = createApp();
+
+    const response = await app.request(
+      '/api/admin/me/passkeys/passkey-1',
+      { method: 'DELETE' },
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.deletePasskeyIfUserHasAnother).toHaveBeenCalledWith('passkey-1', 'admin-1');
+    expect(mocks.writeAdminAuditLog).toHaveBeenCalled();
+  });
+});

--- a/packages/ar-management/src/admin-tenant-invitations.ts
+++ b/packages/ar-management/src/admin-tenant-invitations.ts
@@ -140,6 +140,26 @@ export async function createTenantInvitationHandler(c: Context<{ Bindings: Env }
       return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
     }
 
+    if (role_id) {
+      const role = await adapter.queryOne<{ id: string }>(
+        'SELECT id FROM roles WHERE id = ? AND tenant_id = ? AND is_assignable = 1',
+        [role_id, tenantId]
+      );
+      if (!role) {
+        return c.json({ error: 'invalid_request', message: 'role_id is not assignable' }, 400);
+      }
+    }
+
+    if (org_id) {
+      const organization = await adapter.queryOne<{ id: string }>(
+        'SELECT id FROM organizations WHERE id = ? AND tenant_id = ? AND is_active = 1',
+        [org_id, tenantId]
+      );
+      if (!organization) {
+        return c.json({ error: 'invalid_request', message: 'org_id is not active' }, 400);
+      }
+    }
+
     const now = Math.floor(Date.now() / 1000);
     const expiresAt = now + expires_in_hours * 3600;
     const invitationId = crypto.randomUUID();
@@ -170,39 +190,47 @@ export async function createTenantInvitationHandler(c: Context<{ Bindings: Env }
     // Conditionally send email if invited_email is specified and email plugin is available
     let emailSent = false;
     if (invited_email) {
-      const pluginCtx = getRequiredPluginContext(c, 'notification');
-      const emailNotifier = pluginCtx.registry.getNotifier('email');
+      try {
+        const pluginCtx = getRequiredPluginContext(c, 'notification');
+        const emailNotifier = pluginCtx.registry.getNotifier('email');
 
-      if (emailNotifier) {
-        const fromEmail = c.env.EMAIL_FROM || 'noreply@authrim.dev';
-        const emailResult = await emailNotifier.send({
-          channel: 'email',
-          to: invited_email,
-          from: fromEmail,
-          subject: `You've been invited to ${tenant.name}`,
-          body: getInvitationEmailHtml({
-            tenantName: tenant.name,
-            inviteUrl,
-            expiresInHours: expires_in_hours,
-          }),
-          metadata: {
-            textBody: getInvitationEmailText({
+        if (emailNotifier) {
+          const fromEmail = c.env.EMAIL_FROM || 'noreply@authrim.dev';
+          const emailResult = await emailNotifier.send({
+            channel: 'email',
+            to: invited_email,
+            from: fromEmail,
+            subject: `You've been invited to ${sanitizeEmailHeader(tenant.name)}`,
+            body: getInvitationEmailHtml({
               tenantName: tenant.name,
               inviteUrl,
               expiresInHours: expires_in_hours,
             }),
-          },
-        });
+            metadata: {
+              textBody: getInvitationEmailText({
+                tenantName: tenant.name,
+                inviteUrl,
+                expiresInHours: expires_in_hours,
+              }),
+            },
+          });
 
-        if (emailResult.success) {
-          emailSent = true;
+          if (emailResult.success) {
+            emailSent = true;
+          } else {
+            log.warn('Failed to send invitation email', { error: emailResult.error });
+          }
         } else {
-          log.warn('Failed to send invitation email', { error: emailResult.error });
+          log.warn('Email notifier not configured, invitation URL returned without sending email', {
+            tenant_id: tenantId,
+            invited_email,
+          });
         }
-      } else {
-        log.warn('Email notifier not configured, invitation URL returned without sending email', {
+      } catch (error) {
+        log.warn('Invitation email delivery failed', {
           tenant_id: tenantId,
           invited_email,
+          error: String(error),
         });
       }
     }
@@ -348,17 +376,40 @@ interface InvitationEmailParams {
 
 function getInvitationEmailHtml(params: InvitationEmailParams): string {
   const { tenantName, inviteUrl, expiresInHours } = params;
+  const safeTenantName = escapeHtml(tenantName);
+  const safeInviteUrl = escapeHtml(inviteUrl);
   return `<!DOCTYPE html>
 <html>
 <head><meta charset="utf-8"><meta name="referrer" content="no-referrer"></head>
 <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
-  <h2>You've been invited to ${tenantName}</h2>
+  <h2>You've been invited to ${safeTenantName}</h2>
   <p>Click the link below to accept your invitation and create your account:</p>
-  <p><a href="${inviteUrl}" style="display:inline-block;padding:12px 24px;background:#4f46e5;color:#fff;text-decoration:none;border-radius:6px;">Accept Invitation</a></p>
+  <p><a href="${safeInviteUrl}" style="display:inline-block;padding:12px 24px;background:#4f46e5;color:#fff;text-decoration:none;border-radius:6px;">Accept Invitation</a></p>
   <p style="color:#666;font-size:14px;">This invitation link expires in ${expiresInHours} hours.</p>
   <p style="color:#999;font-size:12px;">If you did not expect this invitation, you can safely ignore this email.</p>
 </body>
 </html>`;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/gu, (character) => {
+    switch (character) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      default:
+        return '&#39;';
+    }
+  });
+}
+
+function sanitizeEmailHeader(value: string): string {
+  return value.replace(/[\r\n\u0000-\u001f\u007f]+/gu, ' ').trim();
 }
 
 function getInvitationEmailText(params: InvitationEmailParams): string {

--- a/packages/ar-management/src/iat-tokens.ts
+++ b/packages/ar-management/src/iat-tokens.ts
@@ -252,6 +252,10 @@ export async function adminIATRevokeHandler(c: Context<{ Bindings: Env }>) {
       });
     }
 
+    if (!/^[0-9a-f]{64}$/u.test(tokenHash)) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE);
+    }
+
     // Check if token exists
     const existing = await c.env.INITIAL_ACCESS_TOKENS.get(`iat:${tokenHash}`);
     if (!existing) {

--- a/packages/ar-management/src/routes/admin-management/admin-abac.ts
+++ b/packages/ar-management/src/routes/admin-management/admin-abac.ts
@@ -11,6 +11,7 @@ import type { Env, AdminAuthContext } from '@authrim/ar-lib-core';
 import {
   AdminAttributeRepository,
   AdminAttributeValueRepository,
+  AdminUserRepository,
   createErrorResponse,
   AR_ERROR_CODES,
   getTenantIdFromContext,
@@ -51,6 +52,15 @@ function getAdminAdapter(c: AdminContext) {
 function hasWritePermission(authContext: AdminAuthContext): boolean {
   const permissions = authContext.permissions || [];
   return hasAdminPermission(permissions, ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE);
+}
+
+async function adminUserBelongsToTenant(
+  adapter: ReturnType<typeof getAdminAdapter>,
+  tenantId: string,
+  userId: string
+): Promise<boolean> {
+  const userRepo = new AdminUserRepository(adapter);
+  return (await userRepo.findByTenantAndId(tenantId, userId)) !== null;
 }
 
 /**
@@ -318,7 +328,12 @@ adminAbacRouter.get('/admins/:userId/attributes', async (c: AdminContext) => {
   try {
     const adapter = getAdminAdapter(c);
     const repo = new AdminAttributeValueRepository(adapter);
+    const tenantId = getTenantIdFromContext(c);
     const userId = c.req.param('userId')!;
+
+    if (!(await adminUserBelongsToTenant(adapter, tenantId, userId))) {
+      return c.json({ error: 'not_found', message: 'Admin user not found' }, 404);
+    }
 
     const values = await repo.getAttributesByUser(userId);
 
@@ -348,6 +363,10 @@ adminAbacRouter.put('/admins/:userId/attributes/:attributeId', async (c: AdminCo
     const tenantId = getTenantIdFromContext(c);
     const userId = c.req.param('userId')!;
     const attributeId = c.req.param('attributeId')!;
+
+    if (!(await adminUserBelongsToTenant(adapter, tenantId, userId))) {
+      return c.json({ error: 'not_found', message: 'Admin user not found' }, 404);
+    }
 
     // Verify attribute exists and belongs to this tenant
     const attribute = await attrRepo.getAttribute(attributeId);
@@ -400,9 +419,20 @@ adminAbacRouter.delete('/admins/:userId/attributes/:attributeId', async (c: Admi
   try {
     const adapter = getAdminAdapter(c);
     const repo = new AdminAttributeValueRepository(adapter);
+    const attrRepo = new AdminAttributeRepository(adapter);
+    const tenantId = getTenantIdFromContext(c);
     const userId = c.req.param('userId')!;
     const attributeId = c.req.param('attributeId')!;
     const valueIndex = parseInt(c.req.query('value_index') || '0');
+
+    if (!(await adminUserBelongsToTenant(adapter, tenantId, userId))) {
+      return c.json({ error: 'not_found', message: 'Admin user not found' }, 404);
+    }
+
+    const attribute = await attrRepo.getAttribute(attributeId);
+    if (!attribute || (attribute.tenant_id !== tenantId && !attribute.is_system)) {
+      return c.json({ error: 'not_found', message: 'Attribute not found' }, 404);
+    }
 
     const deleted = await repo.deleteAttributeValue(userId, attributeId, valueIndex);
     if (!deleted) {

--- a/packages/ar-management/src/routes/admin-management/admin-rebac.ts
+++ b/packages/ar-management/src/routes/admin-management/admin-rebac.ts
@@ -11,6 +11,7 @@ import type { Env, AdminAuthContext } from '@authrim/ar-lib-core';
 import {
   AdminRelationshipRepository,
   AdminRebacDefinitionRepository,
+  AdminUserRepository,
   createErrorResponse,
   AR_ERROR_CODES,
   getTenantIdFromContext,
@@ -51,6 +52,15 @@ function getAdminAdapter(c: AdminContext) {
 function hasWritePermission(authContext: AdminAuthContext): boolean {
   const permissions = authContext.permissions || [];
   return hasAdminPermission(permissions, ADMIN_PERMISSIONS.ADMIN_ROLES_WRITE);
+}
+
+async function adminUserBelongsToTenant(
+  adapter: ReturnType<typeof getAdminAdapter>,
+  tenantId: string,
+  userId: string
+): Promise<boolean> {
+  const userRepo = new AdminUserRepository(adapter);
+  return (await userRepo.findByTenantAndId(tenantId, userId)) !== null;
 }
 
 /**
@@ -514,6 +524,7 @@ adminRebacRouter.get('/admins/:userId/relationships', async (c: AdminContext) =>
   try {
     const adapter = getAdminAdapter(c);
     const repo = new AdminRelationshipRepository(adapter);
+    const tenantId = getTenantIdFromContext(c);
     const userId = c.req.param('userId')!;
     const relationshipType = c.req.query('type');
     const direction = c.req.query('direction') || 'both'; // from, to, both
@@ -521,6 +532,10 @@ adminRebacRouter.get('/admins/:userId/relationships', async (c: AdminContext) =>
     let from: typeof relationships = [];
     let to: typeof relationships = [];
     const relationships: Awaited<ReturnType<typeof repo.getRelationshipsFrom>> = [];
+
+    if (!(await adminUserBelongsToTenant(adapter, tenantId, userId))) {
+      return c.json({ error: 'not_found', message: 'Admin user not found' }, 404);
+    }
 
     if (direction === 'from' || direction === 'both') {
       from = await repo.getRelationshipsFrom(userId, { relationshipType });
@@ -530,7 +545,7 @@ adminRebacRouter.get('/admins/:userId/relationships', async (c: AdminContext) =>
     }
 
     // Combine and deduplicate
-    const combined = [...from, ...to];
+    const combined = [...from, ...to].filter((relationship) => relationship.tenant_id === tenantId);
     const seen = new Set<string>();
     for (const rel of combined) {
       if (!seen.has(rel.id)) {
@@ -573,6 +588,10 @@ adminRebacRouter.post('/admins/:userId/relationships', async (c: AdminContext) =
       is_bidirectional?: boolean;
       metadata?: Record<string, unknown>;
     }>();
+
+    if (!(await adminUserBelongsToTenant(adapter, tenantId, userId))) {
+      return c.json({ error: 'not_found', message: 'Admin user not found' }, 404);
+    }
 
     // Validate required fields
     if (!body.relationship_type || !body.to_id) {
@@ -634,7 +653,12 @@ adminRebacRouter.delete(
       const adapter = getAdminAdapter(c);
       const repo = new AdminRelationshipRepository(adapter);
       const tenantId = getTenantIdFromContext(c);
+      const userId = c.req.param('userId')!;
       const relationshipId = c.req.param('relationshipId')!;
+
+      if (!(await adminUserBelongsToTenant(adapter, tenantId, userId))) {
+        return c.json({ error: 'not_found', message: 'Admin user not found' }, 404);
+      }
 
       // Check if relationship exists and belongs to this tenant
       const existing = await repo.getRelationship(relationshipId);
@@ -644,6 +668,10 @@ adminRebacRouter.delete(
 
       // Tenant boundary check - prevent IDOR
       if (existing.tenant_id !== tenantId) {
+        return c.json({ error: 'not_found', message: 'Relationship not found' }, 404);
+      }
+
+      if (existing.from_id !== userId && existing.to_id !== userId) {
         return c.json({ error: 'not_found', message: 'Relationship not found' }, 404);
       }
 

--- a/packages/ar-management/src/routes/admin-management/ip-allowlist.ts
+++ b/packages/ar-management/src/routes/admin-management/ip-allowlist.ts
@@ -206,11 +206,12 @@ ipAllowlistRouter.get('/:id', async (c) => {
   try {
     const adapter = getAdminAdapter(c);
     const ipRepo = new AdminIpAllowlistRepository(adapter);
+    const tenantId = getTenantIdFromContext(c);
 
     const id = c.req.param('id')!;
     const entry = await ipRepo.getEntry(id);
 
-    if (!entry) {
+    if (!entry || entry.tenant_id !== tenantId) {
       return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
     }
 
@@ -305,12 +306,13 @@ ipAllowlistRouter.patch('/:id', async (c) => {
   try {
     const adapter = getAdminAdapter(c);
     const ipRepo = new AdminIpAllowlistRepository(adapter);
+    const tenantId = getTenantIdFromContext(c);
 
     const id = c.req.param('id')!;
 
     // Check if entry exists
     const existing = await ipRepo.getEntry(id);
-    if (!existing) {
+    if (!existing || existing.tenant_id !== tenantId) {
       return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
     }
 
@@ -366,12 +368,13 @@ ipAllowlistRouter.delete('/:id', async (c) => {
   try {
     const adapter = getAdminAdapter(c);
     const ipRepo = new AdminIpAllowlistRepository(adapter);
+    const tenantId = getTenantIdFromContext(c);
 
     const id = c.req.param('id')!;
 
     // Check if entry exists
     const existing = await ipRepo.getEntry(id);
-    if (!existing) {
+    if (!existing || existing.tenant_id !== tenantId) {
       return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
     }
 
@@ -402,8 +405,14 @@ ipAllowlistRouter.post('/:id/enable', async (c) => {
   try {
     const adapter = getAdminAdapter(c);
     const ipRepo = new AdminIpAllowlistRepository(adapter);
+    const tenantId = getTenantIdFromContext(c);
 
     const id = c.req.param('id')!;
+
+    const existing = await ipRepo.getEntry(id);
+    if (!existing || existing.tenant_id !== tenantId) {
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
+    }
 
     const success = await ipRepo.enableEntry(id);
     if (!success) {
@@ -433,8 +442,14 @@ ipAllowlistRouter.post('/:id/disable', async (c) => {
   try {
     const adapter = getAdminAdapter(c);
     const ipRepo = new AdminIpAllowlistRepository(adapter);
+    const tenantId = getTenantIdFromContext(c);
 
     const id = c.req.param('id')!;
+
+    const existing = await ipRepo.getEntry(id);
+    if (!existing || existing.tenant_id !== tenantId) {
+      return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
+    }
 
     const success = await ipRepo.disableEntry(id);
     if (!success) {

--- a/packages/ar-management/src/routes/device-secrets.ts
+++ b/packages/ar-management/src/routes/device-secrets.ts
@@ -18,6 +18,7 @@ import {
   AR_ERROR_CODES,
   getLogger,
   createAuthContextFromHono,
+  createAuditLogFromContext,
   getTenantIdFromContext,
 } from '@authrim/ar-lib-core';
 
@@ -53,6 +54,36 @@ function validateReason(
   const sanitized = reason.replace(REASON_SANITIZE_PATTERN, '').trim();
 
   return { valid: true, reason: sanitized || defaultValue };
+}
+
+async function parseOptionalReason(
+  c: Context<{ Bindings: Env }>,
+  defaultValue: string
+): Promise<{ valid: true; reason: string } | { valid: false }> {
+  const rawBody = await c.req.text();
+  if (!rawBody.trim()) {
+    return { valid: true, reason: defaultValue };
+  }
+
+  try {
+    const body = JSON.parse(rawBody) as { reason?: unknown };
+    const validation = validateReason(body?.reason, defaultValue);
+    return validation.valid ? validation : { valid: false };
+  } catch {
+    return { valid: false };
+  }
+}
+
+function parsePaginationValue(
+  value: string | undefined,
+  defaultValue: number,
+  maximum?: number
+): number | null {
+  if (value === undefined) return defaultValue;
+  if (!/^\d+$/u.test(value)) return null;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) return null;
+  return maximum === undefined ? parsed : Math.min(parsed, maximum);
 }
 
 /**
@@ -137,8 +168,11 @@ export async function listUserDeviceSecrets(c: Context<{ Bindings: Env }>): Prom
 
   try {
     const includeRevoked = c.req.query('include_revoked') === 'true';
-    const limit = Math.min(parseInt(c.req.query('limit') || '50', 10), 100);
-    const offset = parseInt(c.req.query('offset') || '0', 10);
+    const limit = parsePaginationValue(c.req.query('limit'), 50, 100);
+    const offset = parsePaginationValue(c.req.query('offset'), 0);
+    if (limit === null || limit < 1 || offset === null) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE);
+    }
 
     const repo = getDeviceSecretRepository(c);
 
@@ -231,19 +265,11 @@ export async function revokeDeviceSecret(c: Context<{ Bindings: Env }>): Promise
   }
 
   try {
-    let reason = 'admin_revocation';
-
-    // Try to get reason from body (optional)
-    try {
-      const body = await c.req.json();
-      const validation = validateReason(body?.reason, 'admin_revocation');
-      if (!validation.valid) {
-        return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE);
-      }
-      reason = validation.reason;
-    } catch {
-      // Body is optional, ignore parse errors
+    const parsedReason = await parseOptionalReason(c, 'admin_revocation');
+    if (!parsedReason.valid) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE);
     }
+    const reason = parsedReason.reason;
 
     const repo = getDeviceSecretRepository(c);
 
@@ -262,6 +288,11 @@ export async function revokeDeviceSecret(c: Context<{ Bindings: Env }>): Promise
     if (!success) {
       return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
     }
+
+    await createAuditLogFromContext(c, 'device_secret.revoke', 'device_secret', id, {
+      user_id: existing.user_id,
+      reason,
+    });
 
     log.info('Revoked device secret', { id, userId: existing.user_id, reason });
 
@@ -297,23 +328,20 @@ export async function revokeAllUserDeviceSecrets(c: Context<{ Bindings: Env }>):
   }
 
   try {
-    let reason = 'admin_bulk_revocation';
-
-    // Try to get reason from body (optional)
-    try {
-      const body = await c.req.json();
-      const validation = validateReason(body?.reason, 'admin_bulk_revocation');
-      if (!validation.valid) {
-        return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE);
-      }
-      reason = validation.reason;
-    } catch {
-      // Body is optional, ignore parse errors
+    const parsedReason = await parseOptionalReason(c, 'admin_bulk_revocation');
+    if (!parsedReason.valid) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE);
     }
+    const reason = parsedReason.reason;
 
     const repo = getDeviceSecretRepository(c);
 
     const revokedCount = await repo.revokeByUserId(userId, getTenantIdFromContext(c), reason);
+
+    await createAuditLogFromContext(c, 'device_secret.revoke_all', 'user', userId, {
+      revoked_count: revokedCount,
+      reason,
+    });
 
     log.info('Revoked user device secrets', { userId, revokedCount, reason });
 
@@ -344,6 +372,10 @@ export async function cleanupExpiredDeviceSecrets(
     const repo = getDeviceSecretRepository(c);
 
     const cleanedCount = await repo.cleanupExpired();
+
+    await createAuditLogFromContext(c, 'device_secret.cleanup', 'device_secret', 'expired', {
+      cleaned_count: cleanedCount,
+    });
 
     log.info('Cleaned up expired device secrets', { cleanedCount });
 

--- a/packages/ar-policy/src/__tests__/index-branches.test.ts
+++ b/packages/ar-policy/src/__tests__/index-branches.test.ts
@@ -1,0 +1,401 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import app from '../index';
+
+function createDb(options: { throwOnPrepare?: boolean } = {}) {
+  const run = vi.fn().mockResolvedValue({ success: true, meta: { changes: 0 } });
+  const first = vi.fn().mockResolvedValue(null);
+  const all = vi.fn().mockResolvedValue({ results: [] });
+  const prepare = vi.fn(() => {
+    if (options.throwOnPrepare) throw new Error('database unavailable');
+    return {
+      bind: vi.fn().mockReturnThis(),
+      first,
+      all,
+      run,
+    };
+  });
+  return { prepare, batch: vi.fn().mockResolvedValue([]), run, first, all };
+}
+
+function createKv(options: { throwOnWrite?: boolean } = {}) {
+  const data = new Map<string, string>();
+  return {
+    get: vi.fn(async (key: string) => data.get(key) ?? null),
+    put: vi.fn(async (key: string, value: string) => {
+      if (options.throwOnWrite) throw new Error('KV write failed');
+      data.set(key, value);
+    }),
+    delete: vi.fn(async (key: string) => {
+      if (options.throwOnWrite) throw new Error('KV delete failed');
+      data.delete(key);
+    }),
+    list: vi.fn().mockResolvedValue({ keys: [], list_complete: true }),
+    getWithMetadata: vi.fn().mockResolvedValue({ value: null, metadata: null }),
+  };
+}
+
+function createEnv(overrides: Record<string, unknown> = {}) {
+  return {
+    POLICY_API_SECRET: 'policy-secret',
+    ENABLE_POLICY_SIMULATION_API: 'true',
+    ENABLE_REBAC: 'true',
+    DB: createDb(),
+    VERSION_MANAGER: {
+      idFromName: vi.fn(() => ({ toString: () => 'version-id' })),
+      get: vi.fn(() => ({
+        fetch: vi.fn(async () => new Response(JSON.stringify({ uuid: 'version' }))),
+      })),
+    },
+    CODE_VERSION_UUID: '',
+    ...overrides,
+  };
+}
+
+function request(
+  path: string,
+  options: { method?: string; body?: unknown; rawBody?: string; auth?: string | null } = {}
+) {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (options.auth !== null) {
+    headers.Authorization = options.auth ?? 'Bearer policy-secret';
+  }
+  return new Request(`https://policy.example${path}`, {
+    method: options.method ?? 'GET',
+    headers,
+    body:
+      options.rawBody ?? (options.body === undefined ? undefined : JSON.stringify(options.body)),
+  });
+}
+
+describe('Policy service branch and failure behavior', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('internal authentication and feature flags', () => {
+    it.each([null, 'Basic policy-secret', 'Bearer wrong-secret', 'Bearer '])(
+      'rejects invalid internal authentication without leaking details',
+      async (auth) => {
+        const response = await app.fetch(request('/api/policy/flags', { auth }), createEnv());
+        expect(response.status).toBe(401);
+      }
+    );
+
+    it('returns flag sources with and without KV', async () => {
+      let response = await app.fetch(request('/api/policy/flags'), createEnv());
+      expect(response.status).toBe(200);
+      expect((await response.json()).kvEnabled).toBe(false);
+
+      response = await app.fetch(
+        request('/api/policy/flags'),
+        createEnv({ POLICY_FLAGS_KV: createKv() })
+      );
+      expect(response.status).toBe(200);
+      expect((await response.json()).kvEnabled).toBe(true);
+    });
+
+    it.each(['put', 'delete'] as const)(
+      '%s rejects unknown feature names and missing KV',
+      async (operation) => {
+        const method = operation.toUpperCase();
+        let response = await app.fetch(
+          request('/api/policy/flags/UNKNOWN', { method, body: { value: true } }),
+          createEnv()
+        );
+        expect(response.status).toBe(400);
+
+        response = await app.fetch(
+          request('/api/policy/flags/ENABLE_ABAC', { method, body: { value: true } }),
+          createEnv()
+        );
+        expect(response.status).toBe(500);
+      }
+    );
+
+    it('validates and persists boolean feature overrides', async () => {
+      const kv = createKv();
+      let response = await app.fetch(
+        request('/api/policy/flags/ENABLE_ABAC', {
+          method: 'PUT',
+          body: { value: 'true' },
+        }),
+        createEnv({ POLICY_FLAGS_KV: kv })
+      );
+      expect(response.status).toBe(400);
+
+      response = await app.fetch(
+        request('/api/policy/flags/ENABLE_ABAC', { method: 'PUT', body: { value: false } }),
+        createEnv({ POLICY_FLAGS_KV: kv })
+      );
+      expect(response.status).toBe(200);
+      expect(kv.put).toHaveBeenCalled();
+
+      response = await app.fetch(
+        request('/api/policy/flags/ENABLE_ABAC', { method: 'DELETE' }),
+        createEnv({ POLICY_FLAGS_KV: kv })
+      );
+      expect(response.status).toBe(200);
+      expect(kv.delete).toHaveBeenCalled();
+    });
+
+    it('maps unexpected flag storage failures to the global internal error handler', async () => {
+      const response = await app.fetch(
+        request('/api/policy/flags/ENABLE_ABAC', { method: 'PUT', body: { value: true } }),
+        createEnv({ POLICY_FLAGS_KV: createKv({ throwOnWrite: true }) })
+      );
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe('simulation endpoints', () => {
+    it.each(['/evaluate', '/check-role', '/check-access', '/is-admin'])(
+      'fails closed when simulation API is disabled: %s',
+      async (path) => {
+        const response = await app.fetch(
+          request(`/api/policy${path}`, { method: 'POST', body: {} }),
+          createEnv({ ENABLE_POLICY_SIMULATION_API: undefined })
+        );
+        expect(response.status).toBe(403);
+      }
+    );
+
+    it.each(['/evaluate', '/check-role', '/check-access', '/is-admin'])(
+      'handles malformed JSON without exposing an exception: %s',
+      async (path) => {
+        const response = await app.fetch(
+          request(`/api/policy${path}`, { method: 'POST', rawBody: '{' }),
+          createEnv()
+        );
+        expect(response.status).toBe(500);
+      }
+    );
+
+    it('uses the supplied timestamp and excludes expired roles from the response', async () => {
+      const evaluate = await app.fetch(
+        request('/api/policy/evaluate', {
+          method: 'POST',
+          body: {
+            subject: { id: 'user', roles: [{ name: 'system_admin', scope: 'global' }] },
+            resource: { type: 'document', id: 'doc' },
+            action: { name: 'read' },
+            timestamp: 1,
+          },
+        }),
+        createEnv()
+      );
+      expect(evaluate.status).toBe(200);
+
+      const roles = await app.fetch(
+        request('/api/policy/check-role', {
+          method: 'POST',
+          body: {
+            subject: {
+              id: 'user',
+              roles: [
+                { name: 'expired', scope: 'global', expiresAt: 1 },
+                { name: 'active', scope: 'global' },
+                { name: 'active', scope: 'global' },
+              ],
+            },
+            roles: ['active', 'missing'],
+          },
+        }),
+        createEnv()
+      );
+      expect(await roles.json()).toMatchObject({ hasRole: true, activeRoles: ['active'] });
+    });
+
+    it('allows claims subject override and empty direct subject ids without trusting caller data', async () => {
+      const claimsResponse = await app.fetch(
+        request('/api/policy/check-access', {
+          method: 'POST',
+          body: {
+            claims: { sub: 'claim-user', authrim_roles: ['end_user'] },
+            subjectId: 'explicit-user',
+            resourceType: 'document',
+            resourceId: 'doc',
+            resourceOwnerId: 'explicit-user',
+            resourceOrgId: 'org',
+            action: 'read',
+            operation: 'view',
+          },
+        }),
+        createEnv()
+      );
+      expect(claimsResponse.status).toBe(200);
+      expect((await claimsResponse.json()).allowed).toBe(true);
+
+      const rolesResponse = await app.fetch(
+        request('/api/policy/check-access', {
+          method: 'POST',
+          body: {
+            roles: [],
+            resourceType: 'document',
+            resourceId: 'doc',
+            action: 'read',
+          },
+        }),
+        createEnv()
+      );
+      expect(rolesResponse.status).toBe(200);
+      expect((await rolesResponse.json()).allowed).toBe(false);
+    });
+  });
+
+  describe('legacy ReBAC read APIs', () => {
+    it.each(['/check', '/batch-check', '/list-objects', '/list-users'])(
+      'requires internal authentication: %s',
+      async (path) => {
+        const response = await app.fetch(
+          request(`/api/rebac${path}`, { method: 'POST', body: {}, auth: null }),
+          createEnv()
+        );
+        expect(response.status).toBe(401);
+      }
+    );
+
+    it.each(['/batch-check', '/list-objects', '/list-users'])(
+      'fails closed when ReBAC is disabled: %s',
+      async (path) => {
+        const response = await app.fetch(
+          request(`/api/rebac${path}`, { method: 'POST', body: {} }),
+          createEnv({ ENABLE_REBAC: 'false' })
+        );
+        expect(response.status).toBe(403);
+      }
+    );
+
+    it.each([
+      ['/batch-check', {}],
+      ['/batch-check', { checks: [] }],
+      ['/list-objects', {}],
+      ['/list-users', {}],
+    ])('validates malformed requests: %s', async (path, body) => {
+      const response = await app.fetch(
+        request(`/api/rebac${path}`, { method: 'POST', body }),
+        createEnv()
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it('rejects oversized batches and missing tenant IDs in any batch item', async () => {
+      let response = await app.fetch(
+        request('/api/rebac/batch-check', {
+          method: 'POST',
+          body: { checks: Array.from({ length: 101 }, () => ({ tenant_id: 'tenant-a' })) },
+        }),
+        createEnv()
+      );
+      expect(response.status).toBe(400);
+
+      response = await app.fetch(
+        request('/api/rebac/batch-check', {
+          method: 'POST',
+          body: {
+            checks: [
+              {
+                tenant_id: 'tenant-a',
+                user_id: 'user:a',
+                relation: 'viewer',
+                object: 'document:a',
+              },
+              { tenant_id: '  ', user_id: 'user:b', relation: 'viewer', object: 'document:b' },
+            ],
+          },
+        }),
+        createEnv()
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it('executes tenant-scoped batch and list requests with bounded limits', async () => {
+      const env = createEnv();
+      const batch = await app.fetch(
+        request('/api/rebac/batch-check', {
+          method: 'POST',
+          body: {
+            checks: [
+              {
+                tenant_id: ' tenant-a ',
+                user_id: 'user:a',
+                relation: 'viewer',
+                object: 'document:a',
+              },
+            ],
+          },
+        }),
+        env
+      );
+      expect(batch.status).toBe(200);
+
+      for (const [path, body] of [
+        [
+          '/list-objects',
+          {
+            tenant_id: 'tenant-a',
+            user_id: 'user:a',
+            relation: 'viewer',
+            object_type: 'document',
+            limit: 5000,
+            cursor: 'next',
+          },
+        ],
+        [
+          '/list-users',
+          {
+            tenant_id: 'tenant-a',
+            object: 'document:a',
+            object_type: 'document',
+            relation: 'viewer',
+            limit: 0,
+            cursor: 'next',
+          },
+        ],
+      ] as const) {
+        const response = await app.fetch(
+          request(`/api/rebac${path}`, { method: 'POST', body }),
+          env
+        );
+        expect(response.status).toBe(200);
+      }
+    });
+
+    it.each(['/check', '/batch-check', '/list-objects', '/list-users'])(
+      'maps database failures to an internal error: %s',
+      async (path) => {
+        const bodies: Record<string, unknown> = {
+          '/check': {
+            tenant_id: 'tenant-a',
+            user_id: 'user:a',
+            relation: 'viewer',
+            object: 'document:a',
+          },
+          '/batch-check': {
+            checks: [
+              {
+                tenant_id: 'tenant-a',
+                user_id: 'user:a',
+                relation: 'viewer',
+                object: 'document:a',
+              },
+            ],
+          },
+          '/list-objects': {
+            tenant_id: 'tenant-a',
+            user_id: 'user:a',
+            relation: 'viewer',
+            object_type: 'document',
+          },
+          '/list-users': {
+            tenant_id: 'tenant-a',
+            object: 'document:a',
+            relation: 'viewer',
+          },
+        };
+        const response = await app.fetch(
+          request(`/api/rebac${path}`, { method: 'POST', body: bodies[path] }),
+          createEnv({ DB: createDb({ throwOnPrepare: true }) })
+        );
+        expect(response.status).toBe(500);
+      }
+    );
+  });
+});

--- a/packages/ar-policy/src/routes/__tests__/check-config.test.ts
+++ b/packages/ar-policy/src/routes/__tests__/check-config.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { checkRoutes, clearBatchSizeLimitCache } from '../check';
+
+function createDb() {
+  return {
+    prepare: vi.fn(() => ({
+      bind: vi.fn().mockReturnThis(),
+      all: vi.fn().mockResolvedValue({ results: [] }),
+      first: vi.fn().mockResolvedValue(null),
+      run: vi.fn().mockResolvedValue({ success: true, meta: { changes: 0 } }),
+    })),
+    batch: vi.fn().mockResolvedValue([]),
+  };
+}
+
+function createKv(values: Record<string, string | null> = {}, reject = false) {
+  return {
+    get: vi.fn(async (key: string) => {
+      if (reject) throw new Error('configuration unavailable');
+      return values[key] ?? null;
+    }),
+    put: vi.fn(),
+    delete: vi.fn(),
+    list: vi.fn(),
+    getWithMetadata: vi.fn(),
+  };
+}
+
+function env(overrides: Record<string, unknown> = {}) {
+  return {
+    POLICY_API_SECRET: 'policy-secret',
+    ENABLE_CHECK_API: 'true',
+    DB: createDb(),
+    ...overrides,
+  };
+}
+
+async function health(overrides: Record<string, unknown> = {}) {
+  return checkRoutes.request('/health', {}, env(overrides));
+}
+
+async function reachAuditConfiguration(overrides: Record<string, unknown> = {}) {
+  return checkRoutes.request(
+    '/',
+    {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer policy-secret',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ tenant_id: 'tenant-a' }),
+    },
+    env(overrides)
+  );
+}
+
+describe('Check API runtime configuration branches', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearBatchSizeLimitCache();
+  });
+
+  it.each([
+    ['1', 1],
+    ['1000', 1000],
+    ['0', 100],
+    ['1001', 100],
+    ['not-a-number', 100],
+  ])('validates environment batch limit %s', async (configured, expected) => {
+    const response = await health({ CHECK_API_BATCH_SIZE_LIMIT: configured });
+    expect(response.status).toBe(200);
+    expect((await response.json()).batch_size_limit).toBe(expected);
+  });
+
+  it.each([
+    ['25', 25],
+    ['0', 40],
+    ['1001', 40],
+    ['invalid', 40],
+  ])(
+    'gives valid KV batch limit priority and rejects invalid value %s',
+    async (value, expected) => {
+      const kv = createKv({ CHECK_API_BATCH_SIZE_LIMIT: value });
+      const response = await health({
+        POLICY_FLAGS_KV: kv,
+        CHECK_API_BATCH_SIZE_LIMIT: '40',
+      });
+      expect((await response.json()).batch_size_limit).toBe(expected);
+    }
+  );
+
+  it('falls back to the environment when batch-limit KV fails', async () => {
+    const response = await health({
+      POLICY_FLAGS_KV: createKv({}, true),
+      CHECK_API_BATCH_SIZE_LIMIT: '30',
+    });
+    expect((await response.json()).batch_size_limit).toBe(30);
+  });
+
+  it('uses AUTHRIM_CONFIG when the policy-specific KV is absent and caches the result', async () => {
+    const kv = createKv({ CHECK_API_BATCH_SIZE_LIMIT: '12' });
+    let response = await health({ AUTHRIM_CONFIG: kv });
+    expect((await response.json()).batch_size_limit).toBe(12);
+
+    kv.get.mockRejectedValue(new Error('should not be read while cached'));
+    response = await health({ AUTHRIM_CONFIG: kv });
+    expect((await response.json()).batch_size_limit).toBe(12);
+    expect(kv.get).toHaveBeenCalledTimes(3); // enable flag per request; batch limit only once
+    expect(kv.get.mock.calls.filter(([key]) => key === 'CHECK_API_BATCH_SIZE_LIMIT')).toHaveLength(
+      1
+    );
+  });
+
+  it('reports database, cache, debug, and disabled secure-default state', async () => {
+    const response = await health({
+      ENABLE_CHECK_API: undefined,
+      ENABLE_CHECK_API_DEBUG: 'true',
+      DB: undefined,
+      CHECK_CACHE_KV: createKv(),
+    });
+    expect(await response.json()).toMatchObject({
+      status: 'limited',
+      enabled: false,
+      database: false,
+      cache: true,
+      debug_mode: true,
+    });
+  });
+
+  it('accepts complete audit settings from KV while preserving request validation', async () => {
+    const response = await reachAuditConfiguration({
+      POLICY_FLAGS_KV: createKv({
+        CHECK_API_ENABLED: 'true',
+        CHECK_API_AUDIT_ENABLED: 'true',
+        CHECK_API_AUDIT_MODE: 'sync',
+        CHECK_API_AUDIT_LOG_ALLOW: 'always',
+        CHECK_API_AUDIT_SAMPLE_RATE: '0',
+        CHECK_API_AUDIT_RETENTION_DAYS: '1',
+      }),
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it('falls back from absent KV audit values to valid environment settings', async () => {
+    const response = await reachAuditConfiguration({
+      POLICY_FLAGS_KV: createKv(),
+      ENABLE_CHECK_API_AUDIT: 'true',
+      CHECK_API_AUDIT_MODE: 'queue',
+      CHECK_API_AUDIT_LOG_ALLOW: 'never',
+      CHECK_API_AUDIT_SAMPLE_RATE: '1',
+      CHECK_API_AUDIT_RETENTION_DAYS: '365',
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it('falls back from failed KV audit reads to environment settings', async () => {
+    const response = await reachAuditConfiguration({
+      POLICY_FLAGS_KV: createKv({}, true),
+      ENABLE_CHECK_API: 'true',
+      ENABLE_CHECK_API_AUDIT: 'true',
+      CHECK_API_AUDIT_MODE: 'waitUntil',
+      CHECK_API_AUDIT_LOG_ALLOW: 'sample',
+      CHECK_API_AUDIT_SAMPLE_RATE: '0.5',
+      CHECK_API_AUDIT_RETENTION_DAYS: '30',
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it('ignores invalid audit values and retains secure defaults', async () => {
+    const response = await reachAuditConfiguration({
+      CHECK_API_AUDIT_MODE: 'invalid',
+      CHECK_API_AUDIT_LOG_ALLOW: 'invalid',
+      CHECK_API_AUDIT_SAMPLE_RATE: '2',
+      CHECK_API_AUDIT_RETENTION_DAYS: '0',
+    });
+    expect(response.status).toBe(400);
+  });
+});

--- a/packages/ar-policy/src/routes/__tests__/subscribe.test.ts
+++ b/packages/ar-policy/src/routes/__tests__/subscribe.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authMock = vi.hoisted(() => ({
+  result: {
+    authenticated: true,
+    method: 'api_key' as const,
+    tenantId: 'tenant-a',
+    allowedOperations: ['subscribe'] as const,
+    rateLimitTier: 'moderate' as const,
+  },
+}));
+
+vi.mock('../../middleware/check-auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../middleware/check-auth')>();
+  return {
+    ...actual,
+    authenticateCheckApiRequest: vi.fn(async () => authMock.result),
+  };
+});
+
+vi.mock('../../rebac-storage-adapter', () => ({
+  getPolicyCoreAdapter: vi.fn(() => ({})),
+}));
+
+import { subscribeRoutes } from '../subscribe';
+
+function createHub(options: { statsOk?: boolean; throwOnFetch?: boolean } = {}) {
+  const fetch = vi.fn(async (input: string | Request) => {
+    if (options.throwOnFetch) throw new Error('hub unavailable');
+    const url = typeof input === 'string' ? input : input.url;
+    if (url.endsWith('/stats')) {
+      return new Response(JSON.stringify({ connections: 2 }), {
+        status: options.statsOk === false ? 503 : 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.endsWith('/setup')) return new Response(null, { status: 204 });
+    return new Response('upgraded', { status: 200 });
+  });
+
+  return {
+    fetch,
+    namespace: {
+      idFromName: vi.fn((name: string) => ({ name })),
+      get: vi.fn(() => ({ fetch })),
+    },
+  };
+}
+
+function env(overrides: Record<string, unknown> = {}) {
+  const hub = createHub();
+  return {
+    POLICY_API_SECRET: 'policy-secret',
+    ENABLE_CHECK_API: 'true',
+    ENABLE_CHECK_API_WEBSOCKET: 'true',
+    PERMISSION_CHANGE_HUB: hub.namespace,
+    ...overrides,
+  };
+}
+
+describe('WebSocket subscription routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMock.result = {
+      authenticated: true,
+      method: 'api_key',
+      tenantId: 'tenant-a',
+      allowedOperations: ['subscribe'],
+      rateLimitTier: 'moderate',
+    };
+  });
+
+  it.each([
+    [{ ENABLE_CHECK_API: 'false' }, 403],
+    [{ ENABLE_CHECK_API_WEBSOCKET: 'false' }, 403],
+    [{ PERMISSION_CHANGE_HUB: undefined }, 500],
+  ])(
+    'fails closed when required subscription capability is unavailable',
+    async (override, status) => {
+      const response = await subscribeRoutes.request(
+        '/subscribe?token=chk_test',
+        { headers: { Upgrade: 'websocket' } },
+        env(override)
+      );
+      expect(response.status).toBe(status);
+    }
+  );
+
+  it('requires an actual websocket upgrade and a query token', async () => {
+    const noUpgrade = await subscribeRoutes.request('/subscribe?token=chk_test', {}, env());
+    expect(noUpgrade.status).toBe(400);
+
+    const noToken = await subscribeRoutes.request(
+      '/subscribe',
+      { headers: { Upgrade: 'websocket' } },
+      env()
+    );
+    expect(noToken.status).toBe(401);
+  });
+
+  it('rejects unauthenticated, unauthorized, and cross-tenant subscriptions', async () => {
+    authMock.result = { authenticated: false } as typeof authMock.result;
+    let response = await subscribeRoutes.request(
+      '/subscribe?token=bad',
+      { headers: { Upgrade: 'websocket' } },
+      env()
+    );
+    expect(response.status).toBe(401);
+
+    authMock.result = {
+      authenticated: true,
+      method: 'api_key',
+      tenantId: 'tenant-a',
+      allowedOperations: [],
+      rateLimitTier: 'moderate',
+    };
+    response = await subscribeRoutes.request(
+      '/subscribe?token=chk_test',
+      { headers: { Upgrade: 'websocket' } },
+      env()
+    );
+    expect(response.status).toBe(403);
+
+    authMock.result.allowedOperations = ['subscribe'];
+    response = await subscribeRoutes.request(
+      '/subscribe?token=chk_test&tenant_id=tenant-b',
+      { headers: { Upgrade: 'websocket' } },
+      env()
+    );
+    expect(response.status).toBe(403);
+  });
+
+  it('sets up the tenant hub before forwarding the upgrade', async () => {
+    const hub = createHub();
+    const response = await subscribeRoutes.request(
+      '/subscribe?token=chk_test&tenant_id=tenant-a',
+      { headers: { Upgrade: 'websocket' } },
+      env({ PERMISSION_CHANGE_HUB: hub.namespace })
+    );
+
+    expect(response.status).toBe(200);
+    expect(hub.namespace.idFromName).toHaveBeenCalledWith('tenant-a');
+    expect(hub.fetch).toHaveBeenNthCalledWith(
+      1,
+      'https://internal/setup',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(hub.fetch).toHaveBeenNthCalledWith(2, expect.any(Request));
+  });
+
+  it('returns an internal error without leaking hub failures', async () => {
+    const hub = createHub({ throwOnFetch: true });
+    const response = await subscribeRoutes.request(
+      '/subscribe?token=chk_test',
+      { headers: { Upgrade: 'websocket' } },
+      env({ PERMISSION_CHANGE_HUB: hub.namespace })
+    );
+    expect(response.status).toBe(500);
+  });
+
+  it('protects stats and reports hub state', async () => {
+    authMock.result = { authenticated: false } as typeof authMock.result;
+    expect((await subscribeRoutes.request('/subscribe/stats', {}, env())).status).toBe(401);
+
+    authMock.result = {
+      authenticated: true,
+      method: 'api_key',
+      tenantId: 'tenant-a',
+      allowedOperations: ['subscribe'],
+      rateLimitTier: 'moderate',
+    };
+    expect(
+      (
+        await subscribeRoutes.request(
+          '/subscribe/stats',
+          {},
+          env({ PERMISSION_CHANGE_HUB: undefined })
+        )
+      ).status
+    ).toBe(500);
+    expect(
+      (await subscribeRoutes.request('/subscribe/stats?tenant_id=tenant-b', {}, env())).status
+    ).toBe(403);
+
+    const hub = createHub();
+    const response = await subscribeRoutes.request(
+      '/subscribe/stats',
+      {},
+      env({ PERMISSION_CHANGE_HUB: hub.namespace })
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      tenant_id: 'tenant-a',
+      websocket_enabled: true,
+      connections: 2,
+    });
+  });
+
+  it('fails closed when the stats hub returns an error or throws', async () => {
+    for (const hub of [createHub({ statsOk: false }), createHub({ throwOnFetch: true })]) {
+      const response = await subscribeRoutes.request(
+        '/subscribe/stats',
+        {},
+        env({ PERMISSION_CHANGE_HUB: hub.namespace })
+      );
+      expect(response.status).toBe(500);
+    }
+  });
+});

--- a/packages/ar-policy/vitest.config.ts
+++ b/packages/ar-policy/vitest.config.ts
@@ -7,9 +7,10 @@ export default defineConfig({
     globals: false,
     environment: 'node',
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        isolate: true,
+    coverage: {
+      exclude: ['**/__tests__/**'],
+      thresholds: {
+        branches: 70,
       },
     },
   },

--- a/packages/ar-saml/src/__tests__/saml-integration.test.ts
+++ b/packages/ar-saml/src/__tests__/saml-integration.test.ts
@@ -2379,15 +2379,18 @@ describe('SAML Integration', () => {
         put: vi.fn(),
       } as unknown as Env['STATE_STORE'];
 
-      await expect(
-        callIdPSLODirectly(
-          createMockLogoutResponse({
-            issuer: 'https://sp.example.com/saml',
-            inResponseTo: requestId,
-          }),
-          { tenantId: 'tenant-b' }
-        )
-      ).rejects.toThrow('LogoutResponse InResponseTo does not match an outbound LogoutRequest');
+      const response = await callIdPSLODirectly(
+        createMockLogoutResponse({
+          issuer: 'https://sp.example.com/saml',
+          inResponseTo: requestId,
+        }),
+        { tenantId: 'tenant-b' }
+      );
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({
+        error: 'invalid_request',
+        error_code: 'AR130003',
+      });
       expect(stateStoreGet).toHaveBeenCalledWith(tenantBKey);
       expect(stateStoreGet).not.toHaveBeenCalledWith(tenantAKey);
       expect(stateStoreDelete).not.toHaveBeenCalled();

--- a/packages/ar-saml/src/__tests__/scheduled.test.ts
+++ b/packages/ar-saml/src/__tests__/scheduled.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  observe: vi.fn(),
+  audit: vi.fn(async () => undefined),
+  debug: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@authrim/ar-lib-core')>();
+  return {
+    ...actual,
+    createAuditLog: mocks.audit,
+    createLogger: () => ({
+      module: () => ({ debug: mocks.debug, warn: mocks.warn, error: mocks.error }),
+    }),
+  };
+});
+
+vi.mock('../idp/slo-state', () => ({
+  observeExpiredSAMLIdPLogoutFanoutTransactions: mocks.observe,
+}));
+
+import { handleScheduled } from '../scheduled';
+
+describe('SAML scheduled logout observation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the scheduled timestamp and exits quietly when no transaction expired', async () => {
+    mocks.observe.mockResolvedValue({ scanned: 3, updated: 0, timedOutTransactions: [] });
+    await handleScheduled(
+      { scheduledTime: 1234, cron: '*/5 * * * *' },
+      { STATE_STORE: {} } as never,
+      {} as never
+    );
+    expect(mocks.observe).toHaveBeenCalledWith(expect.anything(), { now: 1234 });
+    expect(mocks.debug).toHaveBeenCalled();
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+
+  it('audits every timed-out fanout transaction using the current clock fallback', async () => {
+    mocks.observe.mockResolvedValue({
+      scanned: 1,
+      updated: 1,
+      timedOutTransactions: [
+        {
+          tenantId: 'tenant-a',
+          transactionId: 'transaction-a',
+          sessionIndex: undefined,
+          targets: [
+            {
+              spEntityId: 'https://sp.example.test/entity',
+              status: 'failed',
+              requestId: undefined,
+              failureReason: 'timeout',
+            },
+          ],
+        },
+      ],
+    });
+    await handleScheduled({}, { STATE_STORE: {} } as never, {} as never);
+    expect(mocks.warn).toHaveBeenCalled();
+    expect(mocks.audit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ tenantId: 'tenant-a', severity: 'warning' })
+    );
+  });
+
+  it('contains observation failures without rejecting the scheduled event', async () => {
+    mocks.observe.mockRejectedValue(new Error('state unavailable'));
+    await expect(handleScheduled({}, {} as never, {} as never)).resolves.toBeUndefined();
+    expect(mocks.error).toHaveBeenCalled();
+  });
+});

--- a/packages/ar-saml/src/admin/__tests__/metadata-interoperability.test.ts
+++ b/packages/ar-saml/src/admin/__tests__/metadata-interoperability.test.ts
@@ -465,6 +465,130 @@ describe('SAML metadata interoperability fixtures', () => {
   });
 });
 
+describe('SAML metadata parser rejection and fallback matrix', () => {
+  const md = SAML_NAMESPACES.MD;
+  const ds = SAML_NAMESPACES.DS;
+
+  it.each([
+    ['<root/>', 'missing EntityDescriptor'],
+    [`<md:EntityDescriptor xmlns:md="${md}"/>`, 'missing entityID'],
+    [
+      `<md:EntityDescriptor xmlns:md="${md}" entityID="id"><md:SPSSODescriptor/></md:EntityDescriptor>`,
+      'Service Provider',
+    ],
+    [
+      `<md:EntityDescriptor xmlns:md="${md}" entityID="id"><md:RoleDescriptor/></md:EntityDescriptor>`,
+      'missing IDPSSODescriptor',
+    ],
+    [
+      `<md:EntityDescriptor xmlns:md="${md}" entityID="id"><md:IDPSSODescriptor/></md:EntityDescriptor>`,
+      'no supported SSO',
+    ],
+  ])('rejects invalid IdP metadata: %s', (xml, message) => {
+    expect(() => parseIdPMetadata(xml)).toThrow(message);
+  });
+
+  it('parses post-only IdP metadata, optional SLO, default NameID, and deduplicated keys', () => {
+    const config = parseIdPMetadata(`
+      <md:EntityDescriptor xmlns:md="${md}" xmlns:ds="${ds}" entityID="https://idp.test/entity">
+        <md:IDPSSODescriptor>
+          <md:KeyDescriptor><ds:KeyInfo><ds:X509Data><ds:X509Certificate> CERT </ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>
+          <md:KeyDescriptor use="signing"><ds:KeyInfo><ds:X509Data><ds:X509Certificate>CERT</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>
+          <md:KeyDescriptor use="encryption"><ds:KeyInfo><ds:X509Data><ds:X509Certificate>ENC</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>
+          <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.test/post"/>
+          <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.test/logout"/>
+        </md:IDPSSODescriptor>
+      </md:EntityDescriptor>`);
+    expect(config).toMatchObject({
+      ssoUrl: 'https://idp.test/post',
+      sloUrl: 'https://idp.test/logout',
+      allowedBindings: ['post'],
+      certificates: [expect.stringContaining('CERT')],
+    });
+    expect(config.nameIdFormat).toContain('emailAddress');
+  });
+
+  it.each([
+    ['<root/>', 'missing EntityDescriptor'],
+    [`<md:EntityDescriptor xmlns:md="${md}"/>`, 'missing entityID'],
+    [
+      `<md:EntityDescriptor xmlns:md="${md}" entityID="id"><md:IDPSSODescriptor/></md:EntityDescriptor>`,
+      'Identity Provider',
+    ],
+    [
+      `<md:EntityDescriptor xmlns:md="${md}" entityID="id"><md:RoleDescriptor/></md:EntityDescriptor>`,
+      'missing SPSSODescriptor',
+    ],
+    [
+      `<md:EntityDescriptor xmlns:md="${md}" entityID="id"><md:SPSSODescriptor><md:AssertionConsumerService Binding="unsupported" Location="https://sp.test/acs"/></md:SPSSODescriptor></md:EntityDescriptor>`,
+      'no supported ACS',
+    ],
+  ])('rejects invalid SP metadata: %s', (xml, message) => {
+    expect(() => parseSPMetadata(xml)).toThrow(message);
+  });
+
+  it('normalizes redirect ACS, indexes, duplicate defaults, key usage, and empty optional fields', () => {
+    const config = parseSPMetadata(
+      `
+      <md:EntityDescriptor xmlns:md="${md}" xmlns:ds="${ds}" entityID="https://sp.test/entity">
+        <md:SPSSODescriptor>
+          <md:KeyDescriptor><ds:KeyInfo><ds:X509Data><ds:X509Certificate>BOTH</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>
+          <md:KeyDescriptor use="signing"><ds:KeyInfo/></md:KeyDescriptor>
+          <md:KeyDescriptor use="encryption"><ds:KeyInfo><ds:X509Data><ds:X509Certificate>   </ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>
+          <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://sp.test/acs/one" index="2"/>
+          <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://sp.test/acs/default" index="2" isDefault="true"/>
+          <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp.test/acs/post" index="not-a-number"/>
+          <md:NameIDFormat> </md:NameIDFormat>
+          <md:SingleLogoutService Binding="unsupported" Location="https://sp.test/slo/unsupported"/>
+          <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp.test/slo/post"/>
+        </md:SPSSODescriptor>
+      </md:EntityDescriptor>`,
+      'strict'
+    );
+    expect(config.acsUrl).toBe('https://sp.test/acs/post');
+    expect(config.acsServices).toEqual([
+      expect.objectContaining({
+        index: 2,
+        location: 'https://sp.test/acs/default',
+        isDefault: true,
+      }),
+    ]);
+    expect(config.sloBinding).toBe('post');
+    expect(config.certificates).toHaveLength(1);
+    expect(config.encryptionCertificates).toHaveLength(1);
+    expect(config.metadataNameIdFormats).toBeUndefined();
+  });
+
+  it('merges duplicate requested attributes and sanitizes unknown claim suggestions', () => {
+    const config = parseSPMetadata(`
+      <md:EntityDescriptor xmlns:md="${md}" entityID="https://sp.test/entity">
+        <md:SPSSODescriptor>
+          <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp.test/acs" index="9007199254740992"/>
+          <md:AttributeConsumingService index="invalid">
+            <md:ServiceName></md:ServiceName>
+            <md:RequestedAttribute FriendlyName="ignored"/>
+            <md:RequestedAttribute Name="urn:example:custom value" FriendlyName=" custom value "/>
+            <md:RequestedAttribute Name="urn:example:custom value" FriendlyName=" custom value " isRequired="true"/>
+            <md:RequestedAttribute Name=":::"/>
+          </md:AttributeConsumingService>
+        </md:SPSSODescriptor>
+      </md:EntityDescriptor>`);
+    expect(config.acsServices).toEqual([]);
+    expect(config.metadataRequestedAttributes).toHaveLength(3);
+    expect(config.metadataAttributeReleasePolicySuggestion?.attributes).toEqual([
+      expect.objectContaining({ claim: 'custom_value', required: true }),
+      expect.objectContaining({ claim: 'samlAttribute', required: false }),
+    ]);
+  });
+
+  it('rejects invalid and expired validUntil but accepts a future value', () => {
+    const xml = (validUntil: string) =>
+      `<md:EntityDescriptor xmlns:md="${md}" entityID="id" validUntil="${validUntil}"><md:SPSSODescriptor><md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp.test/acs"/></md:SPSSODescriptor></md:EntityDescriptor>`;
+    expect(() => parseSPMetadata(xml('not-a-date'))).toThrow('invalid validUntil');
+    expect(parseSPMetadata(xml('2999-01-01T00:00:00Z')).entityId).toBe('id');
+  });
+});
+
 function createPreviewContext(body: unknown) {
   return {
     req: {

--- a/packages/ar-saml/src/admin/__tests__/providers-crud.test.ts
+++ b/packages/ar-saml/src/admin/__tests__/providers-crud.test.ts
@@ -1,0 +1,544 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ADMIN_PERMISSIONS } from '@authrim/ar-lib-core';
+
+const mocks = vi.hoisted(() => ({
+  adapter: null as ReturnType<typeof createAdapter> | null,
+  audit: vi.fn(async () => undefined),
+  safeFetchText: vi.fn(),
+}));
+
+vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@authrim/ar-lib-core')>();
+  return {
+    ...actual,
+    createAuthContextFromHono: vi.fn(() => ({ coreAdapter: mocks.adapter })),
+    resolveAuthCorePersistenceAdapterFromEnv: vi.fn(async () => mocks.adapter),
+    createAuditLog: mocks.audit,
+    safeFetchText: mocks.safeFetchText,
+    getLogger: () => ({
+      module: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+    }),
+  };
+});
+
+import {
+  getIdPConfig,
+  getIdPConfigByEntityId,
+  getSPConfig,
+  handleCreateAttributePreset,
+  handleCreateProvider,
+  handleDeleteAttributePreset,
+  handleDeleteProvider,
+  handleGetProvider,
+  handleImportMetadata,
+  handleListAttributePresets,
+  handleListProviders,
+  handleRefreshMetadata,
+  handleUpdateProvider,
+  listIdPConfigs,
+  listSPConfigs,
+} from '../providers';
+
+function createAdapter() {
+  return {
+    query: vi.fn().mockResolvedValue([]),
+    queryOne: vi.fn().mockResolvedValue(null),
+    execute: vi.fn().mockResolvedValue({ rowsAffected: 1, insertId: undefined }),
+    transaction: vi.fn(),
+    batch: vi.fn(),
+    isHealthy: vi.fn().mockResolvedValue(true),
+    getType: vi.fn(() => 'mock'),
+    close: vi.fn(),
+  };
+}
+
+function context(
+  options: {
+    body?: unknown;
+    id?: string;
+    permissions?: string[] | null;
+    tenantId?: string;
+  } = {}
+) {
+  return {
+    env: {},
+    req: {
+      json: vi.fn(async () => options.body),
+      param: vi.fn((name: string) => (name === 'id' ? options.id : undefined)),
+      header: vi.fn(() => undefined),
+    },
+    get: vi.fn((name: string) => {
+      if (name === 'tenantId') return options.tenantId ?? 'tenant-a';
+      if (name === 'adminAuth') {
+        return options.permissions === null
+          ? undefined
+          : { permissions: options.permissions ?? Object.values(ADMIN_PERMISSIONS) };
+      }
+      return undefined;
+    }),
+    json: vi.fn(
+      (body: unknown, status: number = 200) =>
+        new Response(JSON.stringify(body), {
+          status,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    ),
+  } as never;
+}
+
+function providerRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'provider-a',
+    name: 'Provider A',
+    provider_type: 'saml_sp',
+    config_json: JSON.stringify({
+      entityId: 'https://sp.example.test',
+      acsUrl: 'https://sp.example.test/acs',
+      allowedBindings: ['post'],
+      identityMapping: { fieldMappingSetId: 'saml-sp' },
+    }),
+    enabled: 1,
+    created_at: 1_700_000_000_000,
+    updated_at: 1_700_000_001_000,
+    ...overrides,
+  };
+}
+
+async function responseBody<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
+
+describe('SAML provider CRUD boundaries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.adapter = createAdapter();
+    mocks.safeFetchText.mockReset();
+  });
+
+  it('requires authentication and the specific admin permission', async () => {
+    let response = await handleListProviders(context({ permissions: null }));
+    expect(response.status).toBe(401);
+
+    response = await handleListProviders(context({ permissions: [] }));
+    expect(response.status).toBe(403);
+  });
+
+  it('lists tenant-scoped providers and maps persisted values', async () => {
+    mocks.adapter!.query.mockResolvedValue([
+      providerRow(),
+      providerRow({ id: 'disabled', enabled: 0, name: 'Disabled' }),
+    ]);
+    const response = await handleListProviders(context());
+    expect(response.status).toBe(200);
+    const body = await responseBody<{
+      providers: Array<{ enabled: boolean; providerType: string }>;
+    }>(response);
+    expect(body.providers).toHaveLength(2);
+    expect(body.providers[0]).toMatchObject({ enabled: true, providerType: 'saml_sp' });
+    expect(body.providers[1].enabled).toBe(false);
+    expect(mocks.adapter!.query).toHaveBeenCalledWith(expect.any(String), ['tenant-a']);
+  });
+
+  it('maps malformed persisted provider state to an internal error', async () => {
+    mocks.adapter!.query.mockResolvedValue([providerRow({ config_json: '{' })]);
+    expect((await handleListProviders(context())).status).toBe(500);
+
+    mocks.adapter!.query.mockRejectedValue(new Error('database unavailable'));
+    expect((await handleListProviders(context())).status).toBe(500);
+  });
+
+  it('lists built-in and custom presets and tolerates an unavailable custom table', async () => {
+    mocks.adapter!.query.mockResolvedValue([
+      {
+        id: 'custom:a',
+        label: 'Custom',
+        description: null,
+        applies_to: 'sp_attribute_release',
+        profile: 'custom',
+        stability: 'custom',
+        application_mode: 'clone_edit',
+        attribute_release_policy_json: JSON.stringify({ attributes: [{ name: 'mail' }] }),
+        updated_at: 123,
+      },
+    ]);
+    let response = await handleListAttributePresets(context());
+    expect(response.status).toBe(200);
+    expect(
+      (await responseBody<{ presets: Array<{ id: string }> }>(response)).presets.some(
+        (preset) => preset.id === 'custom:a'
+      )
+    ).toBe(true);
+
+    mocks.adapter!.query.mockRejectedValue(new Error('table missing'));
+    response = await handleListAttributePresets(context());
+    expect(response.status).toBe(200);
+    expect((await responseBody<{ presets: unknown[] }>(response)).presets.length).toBeGreaterThan(
+      0
+    );
+  });
+
+  it('validates custom preset content before writing', async () => {
+    let response = await handleCreateAttributePreset(context({ body: {} }));
+    expect(response.status).toBe(400);
+
+    response = await handleCreateAttributePreset(
+      context({ body: { label: 'Preset', attributeReleasePolicy: { attributes: [{}] } } })
+    );
+    expect(response.status).toBe(400);
+    expect(mocks.adapter!.execute).not.toHaveBeenCalled();
+  });
+
+  it('creates and trims a valid custom preset', async () => {
+    const response = await handleCreateAttributePreset(
+      context({
+        body: {
+          label: '  Preset  ',
+          description: '  Description  ',
+          profile: '',
+          attributeReleasePolicy: {
+            attributes: [{ name: 'mail', source: 'email', required: true }],
+          },
+        },
+      })
+    );
+    expect(response.status).toBe(201);
+    expect(
+      (await responseBody<{ preset: Record<string, unknown> }>(response)).preset
+    ).toMatchObject({
+      label: 'Preset',
+      description: 'Description',
+      profile: 'custom',
+    });
+    expect(mocks.adapter!.execute).toHaveBeenCalled();
+    expect(mocks.audit).toHaveBeenCalled();
+  });
+
+  it('rejects deletion of built-ins and reports missing custom presets', async () => {
+    expect((await handleDeleteAttributePreset(context({ id: 'builtin' }))).status).toBe(400);
+    mocks.adapter!.execute.mockResolvedValue({ rowsAffected: 0, insertId: undefined });
+    expect((await handleDeleteAttributePreset(context({ id: 'custom:missing' }))).status).toBe(404);
+  });
+
+  it('deletes tenant-scoped custom presets and handles storage failure', async () => {
+    let response = await handleDeleteAttributePreset(context({ id: 'custom:a' }));
+    expect(response.status).toBe(200);
+    expect(mocks.audit).toHaveBeenCalled();
+
+    mocks.adapter!.execute.mockRejectedValue(new Error('database unavailable'));
+    response = await handleDeleteAttributePreset(context({ id: 'custom:a' }));
+    expect(response.status).toBe(500);
+  });
+
+  it.each([
+    [{}, 400],
+    [{ name: 'X', providerType: 'oidc', config: {} }, 400],
+    [{ name: 'X', providerType: 'saml_idp', config: {} }, 400],
+    [{ name: 'X', providerType: 'saml_sp', config: { entityId: 'sp' } }, 400],
+  ])('validates provider creation input', async (body, status) => {
+    const response = await handleCreateProvider(context({ body }));
+    expect(response.status).toBe(status);
+    expect(mocks.adapter!.execute).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      'saml_sp',
+      {
+        entityId: 'https://sp.example.test',
+        acsUrl: 'https://sp.example.test/acs',
+        allowedBindings: ['post'],
+        identityMapping: { fieldMappingSetId: 'saml-sp' },
+      },
+      true,
+    ],
+    [
+      'saml_idp',
+      {
+        entityId: 'https://idp.example.test',
+        ssoUrl: 'https://idp.example.test/sso',
+        certificate: 'not-a-certificate',
+        identityMapping: { fieldMappingSetId: 'saml-idp' },
+      },
+      false,
+    ],
+  ] as const)('creates normalized %s configuration', async (providerType, config, enabled) => {
+    const response = await handleCreateProvider(
+      context({ body: { name: 'Provider', providerType, config, enabled } })
+    );
+    expect(response.status).toBe(201);
+    expect((await responseBody<{ enabled: boolean }>(response)).enabled).toBe(enabled);
+    expect(mocks.adapter!.execute).toHaveBeenCalled();
+  });
+
+  it('records creation failures without exposing storage errors', async () => {
+    mocks.adapter!.execute.mockRejectedValue(new Error('database unavailable'));
+    const response = await handleCreateProvider(
+      context({
+        body: {
+          name: 'Provider',
+          providerType: 'saml_sp',
+          config: {
+            entityId: 'sp',
+            acsUrl: 'https://sp.example.test/acs',
+            identityMapping: { fieldMappingSetId: 'saml-sp' },
+          },
+        },
+      })
+    );
+    expect(response.status).toBe(500);
+  });
+
+  it('rejects missing and unknown provider IDs', async () => {
+    expect((await handleGetProvider(context())).status).toBe(404);
+    expect((await handleGetProvider(context({ id: 'missing' }))).status).toBe(404);
+  });
+
+  it('returns a provider and maps disabled state', async () => {
+    mocks.adapter!.queryOne.mockResolvedValue(providerRow({ enabled: 0 }));
+    const response = await handleGetProvider(context({ id: 'provider-a' }));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ id: 'provider-a', enabled: false });
+  });
+
+  it('fails safely when the persisted provider JSON is malformed', async () => {
+    mocks.adapter!.queryOne.mockResolvedValue(providerRow({ config_json: '{' }));
+    expect((await handleGetProvider(context({ id: 'provider-a' }))).status).toBe(500);
+  });
+
+  it('rejects update of an unknown provider', async () => {
+    expect((await handleUpdateProvider(context({ id: 'missing', body: {} }))).status).toBe(404);
+  });
+
+  it('updates an SP while retaining omitted name and enabled state', async () => {
+    mocks.adapter!.queryOne.mockResolvedValue(providerRow());
+    const response = await handleUpdateProvider(
+      context({
+        id: 'provider-a',
+        body: { config: { acsUrl: 'https://sp.example.test/new-acs' } },
+      })
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ name: 'Provider A', enabled: true });
+    expect(mocks.adapter!.execute).toHaveBeenCalled();
+  });
+
+  it('updates an IdP and honors explicit name and disabled state', async () => {
+    mocks.adapter!.queryOne.mockResolvedValue(
+      providerRow({
+        provider_type: 'saml_idp',
+        enabled: 1,
+        config_json: JSON.stringify({
+          entityId: 'idp',
+          ssoUrl: 'https://idp.example.test/sso',
+          certificate: 'not-a-certificate',
+          identityMapping: { fieldMappingSetId: 'saml-idp' },
+        }),
+      })
+    );
+    const response = await handleUpdateProvider(
+      context({ id: 'provider-a', body: { name: 'Next', enabled: false } })
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ name: 'Next', enabled: false });
+  });
+
+  it('returns internal error when update storage fails', async () => {
+    mocks.adapter!.queryOne.mockResolvedValue(providerRow());
+    mocks.adapter!.execute.mockRejectedValue(new Error('database unavailable'));
+    expect((await handleUpdateProvider(context({ id: 'provider-a', body: {} }))).status).toBe(500);
+  });
+
+  it('distinguishes a missing provider from a successful deletion', async () => {
+    mocks.adapter!.execute.mockResolvedValueOnce({ rowsAffected: 0, insertId: undefined });
+    expect((await handleDeleteProvider(context({ id: 'missing' }))).status).toBe(404);
+
+    mocks.adapter!.execute.mockResolvedValueOnce({ rowsAffected: 1, insertId: undefined });
+    expect((await handleDeleteProvider(context({ id: 'provider-a' }))).status).toBe(200);
+  });
+
+  it('does not expose provider deletion storage errors', async () => {
+    mocks.adapter!.execute.mockRejectedValue(new Error('database unavailable'));
+    expect((await handleDeleteProvider(context({ id: 'provider-a' }))).status).toBe(500);
+  });
+
+  it('loads provider configs only from tenant-scoped enabled rows', async () => {
+    mocks.adapter!.query.mockResolvedValue([
+      { config_json: JSON.stringify({ entityId: 'other' }) },
+      { config_json: JSON.stringify({ entityId: 'target', acsUrl: 'https://sp/acs' }) },
+    ]);
+    expect(await getSPConfig({} as never, 'tenant-a', 'target')).toMatchObject({
+      entityId: 'target',
+    });
+    expect(await getSPConfig({} as never, 'tenant-a', 'missing')).toBeNull();
+
+    expect(await getIdPConfigByEntityId({} as never, 'tenant-a', 'target')).toMatchObject({
+      entityId: 'target',
+    });
+    expect(await getIdPConfigByEntityId({} as never, 'tenant-a', 'missing')).toBeNull();
+  });
+
+  it('gets and lists normalized provider summaries', async () => {
+    mocks.adapter!.queryOne.mockResolvedValue({
+      config_json: JSON.stringify({ entityId: 'idp' }),
+    });
+    expect(await getIdPConfig({} as never, 'tenant-a', 'provider-a')).toEqual({ entityId: 'idp' });
+    mocks.adapter!.queryOne.mockResolvedValue(null);
+    expect(await getIdPConfig({} as never, 'tenant-a', 'missing')).toBeNull();
+
+    mocks.adapter!.query.mockResolvedValue([
+      { id: 'a', name: 'A', config_json: JSON.stringify({ entityId: 'entity-a' }) },
+    ]);
+    expect(await listSPConfigs({} as never, 'tenant-a')).toEqual([
+      { id: 'a', name: 'A', entityId: 'entity-a' },
+    ]);
+    expect(await listIdPConfigs({} as never, 'tenant-a')).toEqual([
+      { id: 'a', name: 'A', entityId: 'entity-a' },
+    ]);
+  });
+
+  it('rejects metadata import for missing providers and missing inputs', async () => {
+    expect((await handleImportMetadata(context({ id: 'missing', body: {} }))).status).toBe(404);
+
+    mocks.adapter!.queryOne.mockResolvedValue(providerRow());
+    expect((await handleImportMetadata(context({ id: 'provider-a', body: {} }))).status).toBe(400);
+  });
+
+  it.each([['http://metadata.example.test/sp.xml'], ['https://127.0.0.1/sp.xml'], ['not-a-url']])(
+    'rejects unsafe metadata URL %s',
+    async (metadataUrl) => {
+      mocks.adapter!.queryOne.mockResolvedValue(providerRow());
+      const response = await handleImportMetadata(
+        context({ id: 'provider-a', body: { metadataUrl } })
+      );
+      expect(response.status).toBe(400);
+      expect(mocks.safeFetchText).not.toHaveBeenCalled();
+    }
+  );
+
+  it('imports inline SP metadata and preserves tenant-scoped custom configuration', async () => {
+    mocks.adapter!.queryOne.mockResolvedValue(providerRow());
+    const response = await handleImportMetadata(
+      context({ id: 'provider-a', body: { metadataXml: validSpMetadata() } })
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ success: true, enabled: true });
+    expect(mocks.adapter!.execute).toHaveBeenCalled();
+    expect(mocks.audit).toHaveBeenCalled();
+  });
+
+  it('fetches HTTPS metadata with a bounded response size', async () => {
+    mocks.adapter!.queryOne.mockResolvedValue(providerRow());
+    mocks.safeFetchText.mockResolvedValue(validSpMetadata());
+    const response = await handleImportMetadata(
+      context({
+        id: 'provider-a',
+        body: { metadataUrl: 'https://metadata.example.test/sp.xml' },
+      })
+    );
+    expect(response.status).toBe(200);
+    const fetchCalls = mocks.safeFetchText.mock.calls as unknown as Array<
+      [string, { maxResponseSize?: number }]
+    >;
+    expect(fetchCalls[0]?.[0]).toBe('https://metadata.example.test/sp.xml');
+    expect(typeof fetchCalls[0]?.[1].maxResponseSize).toBe('number');
+  });
+
+  it.each([
+    ['malformed XML', '<not-metadata/>'],
+    ['aggregate XML', aggregateMetadata()],
+  ])('rejects %s during metadata import', async (_name, metadataXml) => {
+    mocks.adapter!.queryOne.mockResolvedValue(providerRow());
+    const response = await handleImportMetadata(
+      context({ id: 'provider-a', body: { metadataXml } })
+    );
+    expect(response.status).toBe(400);
+    expect(mocks.adapter!.execute).not.toHaveBeenCalled();
+  });
+
+  it('does not expose metadata import persistence failures', async () => {
+    mocks.adapter!.queryOne.mockResolvedValue(providerRow());
+    mocks.adapter!.execute.mockRejectedValue(new Error('database unavailable'));
+    const response = await handleImportMetadata(
+      context({ id: 'provider-a', body: { metadataXml: validSpMetadata() } })
+    );
+    expect(response.status).toBe(500);
+  });
+
+  it('requires an existing provider and configured URL for refresh', async () => {
+    expect((await handleRefreshMetadata(context({ body: {} }))).status).toBe(404);
+    expect((await handleRefreshMetadata(context({ id: 'missing', body: {} }))).status).toBe(404);
+
+    mocks.adapter!.queryOne.mockResolvedValue(providerRow());
+    expect((await handleRefreshMetadata(context({ id: 'provider-a', body: {} }))).status).toBe(400);
+  });
+
+  it('rejects unsafe refresh URLs and upstream fetch failures', async () => {
+    mocks.adapter!.queryOne.mockResolvedValue(providerRow());
+    let response = await handleRefreshMetadata(
+      context({ id: 'provider-a', body: { metadataUrl: 'http://metadata.example.test/sp.xml' } })
+    );
+    expect(response.status).toBe(400);
+
+    mocks.safeFetchText.mockRejectedValue(new Error('upstream unavailable'));
+    response = await handleRefreshMetadata(
+      context({
+        id: 'provider-a',
+        body: { metadataUrl: 'https://metadata.example.test/sp.xml' },
+      })
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('refreshes configured metadata and records its changed state', async () => {
+    mocks.adapter!.queryOne.mockResolvedValue(
+      providerRow({
+        config_json: JSON.stringify({
+          entityId: 'https://sp.example.test',
+          acsUrl: 'https://sp.example.test/old-acs',
+          metadataUrl: 'https://metadata.example.test/sp.xml',
+          identityMapping: { fieldMappingSetId: 'saml-sp' },
+        }),
+      })
+    );
+    mocks.safeFetchText.mockResolvedValue(validSpMetadata());
+    const response = await handleRefreshMetadata(context({ id: 'provider-a', body: {} }));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ success: true, enabled: true });
+    expect(mocks.adapter!.execute).toHaveBeenCalled();
+  });
+
+  it('rejects aggregate refresh without the stored aggregate entity snapshot', async () => {
+    mocks.adapter!.queryOne.mockResolvedValue(
+      providerRow({
+        config_json: JSON.stringify({
+          entityId: 'https://sp.example.test',
+          acsUrl: 'https://sp.example.test/acs',
+          metadataUrl: 'https://metadata.example.test/aggregate.xml',
+          identityMapping: { fieldMappingSetId: 'saml-sp' },
+        }),
+      })
+    );
+    mocks.safeFetchText.mockResolvedValue(aggregateMetadata());
+    const response = await handleRefreshMetadata(context({ id: 'provider-a', body: {} }));
+    expect(response.status).toBe(400);
+  });
+});
+
+function validSpMetadata() {
+  return `<?xml version="1.0"?>
+  <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+    entityID="https://sp.example.test">
+    <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+      <md:AssertionConsumerService
+        Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+        Location="https://sp.example.test/acs" index="0" isDefault="true" />
+    </md:SPSSODescriptor>
+  </md:EntityDescriptor>`;
+}
+
+function aggregateMetadata() {
+  return `<?xml version="1.0"?>
+  <md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata">
+    ${validSpMetadata().replace('<?xml version="1.0"?>', '')}
+  </md:EntitiesDescriptor>`;
+}

--- a/packages/ar-saml/src/admin/__tests__/providers-settings.test.ts
+++ b/packages/ar-saml/src/admin/__tests__/providers-settings.test.ts
@@ -1,0 +1,421 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ADMIN_PERMISSIONS } from '@authrim/ar-lib-core';
+
+const mocks = vi.hoisted(() => ({
+  settings: null as Record<string, unknown> | null,
+  settingsError: false,
+  putPublic: vi.fn(async (_env: unknown, _tenant: string, value: unknown) => value),
+  putSigning: vi.fn(async (_env: unknown, _tenant: string, value: unknown) => value),
+  rotate: vi.fn(async () => ({
+    keyRef: 'generated-key-ref',
+    kid: 'generated-kid',
+    certificate: 'generated-certificate',
+  })),
+  audit: vi.fn(async () => undefined),
+  exportDR: vi.fn(async () => ({
+    version: 1,
+    kdf: { name: 'PBKDF2', iterations: 210000 },
+    ciphertext: 'encrypted',
+  })),
+  importDR: vi.fn(async () => ({ importedKeys: 2, restoredRoles: ['idp', 'sp'] })),
+}));
+
+vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@authrim/ar-lib-core')>();
+  return {
+    ...actual,
+    createAuditLog: mocks.audit,
+    getLogger: () => ({
+      module: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+    }),
+  };
+});
+
+vi.mock('../../common/entity-id', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../common/entity-id')>();
+  return {
+    ...actual,
+    getSAMLPublicSettings: vi.fn(async () => {
+      if (mocks.settingsError) throw new Error('settings unavailable');
+      return mocks.settings;
+    }),
+    getSAMLLocalEntityIds: vi.fn(async () => ({
+      issuerUrl: 'https://tenant.example.test',
+      idpEntityId: 'https://tenant.example.test/saml/idp',
+      spEntityId: 'https://tenant.example.test/saml/sp',
+      idpMetadataUrl: 'https://tenant.example.test/saml/idp/metadata',
+      spMetadataUrl: 'https://tenant.example.test/saml/sp/metadata',
+    })),
+    putSAMLPublicSettings: mocks.putPublic,
+    putSAMLLocalSigningSettings: mocks.putSigning,
+    normalizeSAMLEntityIdStyle: vi.fn((value: unknown) =>
+      value === 'issuer_path' || value === 'role_path' ? value : null
+    ),
+    normalizeSAMLInteractiveLoginUrlPolicy: vi.fn((value: unknown) =>
+      value === 'ui_base_url' || value === 'tenant_host' ? value : null
+    ),
+    normalizeCertificateSubjectAlternativeNames: vi.fn((value: unknown) =>
+      Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+    ),
+    buildSAMLSigningCertificateSubjectAlternativeNames: vi.fn(
+      (_ids: unknown, role: string, configured: string[]) => [`${role}.example.test`, ...configured]
+    ),
+  };
+});
+
+vi.mock('../../common/key-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../common/key-utils')>();
+  return { ...actual, rotateSigningKeyWithCertificate: mocks.rotate };
+});
+
+vi.mock('../signing-rollover', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../signing-rollover')>();
+  return {
+    ...actual,
+    getSAMLNextSigningCertificates: vi.fn((policy: { next?: unknown }) =>
+      policy.next ? [policy.next] : []
+    ),
+    publishSAMLNextSigningCertificate: vi.fn((policy: object, next: object) => ({
+      ...policy,
+      next: { ...next, slot: 'next', state: 'published' },
+    })),
+    promoteSAMLNextSigningCertificate: vi.fn((policy: object, options: object) => ({
+      ...policy,
+      promoted: options,
+    })),
+    retireSAMLBackupSigningCertificate: vi.fn((policy: object) => ({
+      ...policy,
+      backup: undefined,
+    })),
+    deleteSAMLNextSigningCertificate: vi.fn((policy: object) => ({
+      ...policy,
+      next: undefined,
+    })),
+  };
+});
+
+vi.mock('../local-signing-dr-bundle', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../local-signing-dr-bundle')>();
+  return {
+    ...actual,
+    buildEncryptedSAMLLocalSigningSecretDRBundle: mocks.exportDR,
+    restoreEncryptedSAMLLocalSigningSecretDRBundle: mocks.importDR,
+  };
+});
+
+import {
+  handleExportSAMLLocalSigningDRBundle,
+  handleGetSAMLSettings,
+  handleImportSAMLLocalSigningDRBundle,
+  handleUpdateSAMLLocalSigning,
+  handleUpdateSAMLSettings,
+} from '../providers';
+import { SAMLDRBundleOperationError } from '../local-signing-dr-bundle';
+
+function defaultSettings() {
+  return {
+    entityIdStyle: 'issuer_path',
+    interactiveLoginUrlPolicy: 'ui_base_url',
+    certificateSubject: {
+      countryName: 'US',
+      stateOrProvinceName: '',
+      localityName: '',
+      organizationName: 'Authrim',
+      organizationalUnitName: '',
+      commonName: 'Authrim SAML Signing',
+    },
+    certificateSubjectAlternativeNames: [],
+    signingKeyPolicies: {
+      idp: {
+        active: { slot: 'active', keyRef: 'active-ref', kid: 'active-kid', state: 'active' },
+      },
+      sp: {},
+    },
+  };
+}
+
+function context(
+  body: unknown = {},
+  permissions: string[] | null = Object.values(ADMIN_PERMISSIONS)
+) {
+  return {
+    env: {},
+    req: { json: vi.fn(async () => body), header: vi.fn(() => undefined) },
+    get: vi.fn((name: string) => {
+      if (name === 'tenantId') return 'tenant-a';
+      if (name === 'adminAuth') return permissions === null ? undefined : { permissions };
+      return undefined;
+    }),
+    json: vi.fn(
+      (value: unknown, status: number = 200) =>
+        new Response(JSON.stringify(value), {
+          status,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    ),
+    header: vi.fn(),
+  } as never;
+}
+
+describe('SAML settings administration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.settings = defaultSettings();
+    mocks.settingsError = false;
+    mocks.exportDR.mockResolvedValue({
+      version: 1,
+      kdf: { name: 'PBKDF2', iterations: 210000 },
+      ciphertext: 'encrypted',
+    });
+    mocks.importDR.mockResolvedValue({ importedKeys: 2, restoredRoles: ['idp', 'sp'] });
+  });
+
+  it('requires read permission before disclosing settings', async () => {
+    expect((await handleGetSAMLSettings(context({}, null))).status).toBe(401);
+    expect((await handleGetSAMLSettings(context({}, []))).status).toBe(403);
+  });
+
+  it('returns public settings and generated local endpoints', async () => {
+    const response = await handleGetSAMLSettings(context());
+    expect(response.status).toBe(200);
+    const body = await response.json<{
+      tenantId: string;
+      generated: { idpEntityId: string };
+      localSigning: { idpSigningKeyPolicy: unknown };
+    }>();
+    expect(body).toMatchObject({
+      tenantId: 'tenant-a',
+      generated: { idpEntityId: 'https://tenant.example.test/saml/idp' },
+    });
+    expect(body.localSigning.idpSigningKeyPolicy).toBeTypeOf('object');
+  });
+
+  it('maps settings storage failures to an internal error', async () => {
+    mocks.settingsError = true;
+    expect((await handleGetSAMLSettings(context())).status).toBe(500);
+    expect((await handleUpdateSAMLSettings(context())).status).toBe(500);
+  });
+
+  it.each([
+    [{ entityIdStyle: 'invalid' }, 'entityIdStyle'],
+    [{ interactiveLoginUrlPolicy: 'invalid' }, 'interactiveLoginUrlPolicy'],
+  ])('rejects invalid public settings field %s', async (body, _field) => {
+    const response = await handleUpdateSAMLSettings(context(body));
+    expect(response.status).toBe(400);
+    expect(mocks.putPublic).not.toHaveBeenCalled();
+  });
+
+  it('retains omitted values and reports unchanged certificate data', async () => {
+    const response = await handleUpdateSAMLSettings(context({}));
+    expect(response.status).toBe(200);
+    expect(mocks.putPublic).toHaveBeenCalledWith(
+      expect.anything(),
+      'tenant-a',
+      expect.objectContaining({ entityIdStyle: 'issuer_path' })
+    );
+    expect(mocks.audit).toHaveBeenCalled();
+  });
+
+  it('normalizes certificate subject text and SANs', async () => {
+    const response = await handleUpdateSAMLSettings(
+      context({
+        entityIdStyle: 'role_path',
+        interactiveLoginUrlPolicy: 'tenant_host',
+        certificateSubject: {
+          countryName: ' jp ',
+          organizationName: '\u0000 Example Org ',
+          commonName: ' '.repeat(2),
+          localityName: 123,
+        },
+        certificateSubjectAlternativeNames: ['saml.example.test', 1],
+      })
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      entityIdStyle: 'role_path',
+      interactiveLoginUrlPolicy: 'tenant_host',
+      certificateSubject: {
+        countryName: 'JP',
+        organizationName: 'Example Org',
+        commonName: 'Authrim SAML Signing',
+        localityName: '',
+      },
+      certificateSubjectAlternativeNames: ['saml.example.test'],
+    });
+  });
+
+  it.each([
+    [{}, 'role'],
+    [{ role: 'invalid', action: 'publish_next' }, 'role'],
+    [{ role: 'idp', action: 'invalid' }, 'action'],
+    [
+      {
+        role: 'idp',
+        action: 'publish_next',
+        validFrom: '2030-01-02T00:00:00Z',
+        validTo: '2030-01-01T00:00:00Z',
+      },
+      'validTo',
+    ],
+  ])('validates local signing request field %s', async (body, _field) => {
+    const response = await handleUpdateSAMLLocalSigning(context(body));
+    expect(response.status).toBe(400);
+    expect(mocks.putSigning).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['recreate_active', 'idp'],
+    ['publish_next', 'idp'],
+    ['promote_next', 'idp'],
+    ['retire_backup', 'idp'],
+    ['delete_next', 'idp'],
+    ['recreate_active', 'sp'],
+  ] as const)('applies %s signing transition for %s', async (action, role) => {
+    const response = await handleUpdateSAMLLocalSigning(
+      context({
+        role,
+        action,
+        keepPreviousAsBackup: false,
+        targetKid: 'target-kid',
+        targetKeyRef: 'target-ref',
+        validFrom: 1_900_000_000_000,
+        validTo: '2031-01-01T00:00:00Z',
+        publicKeyAlgorithm: 'RSA',
+        publicKeySizeBits: '4096',
+        certificateSubjectAlternativeNames: ['extra.example.test'],
+      })
+    );
+    expect(response.status).toBe(200);
+    expect(mocks.putSigning).toHaveBeenCalled();
+    expect(mocks.audit).toHaveBeenCalled();
+  });
+
+  it('uses defaults for invalid optional key-generation values', async () => {
+    const response = await handleUpdateSAMLLocalSigning(
+      context({
+        role: 'sp',
+        action: 'publish_next',
+        validFrom: 'invalid',
+        validTo: {},
+        publicKeyAlgorithm: 'EC',
+        publicKeySizeBits: 1024,
+      })
+    );
+    expect(response.status).toBe(200);
+    const rotateCalls = mocks.rotate.mock.calls as unknown as Array<
+      [unknown, string, { certificateOptions: Record<string, unknown> }]
+    >;
+    expect(rotateCalls[0]?.[1]).toBe('tenant-a');
+    expect(rotateCalls[0]?.[2].certificateOptions).toMatchObject({
+      validFrom: undefined,
+      validTo: undefined,
+      publicKeyAlgorithm: undefined,
+      publicKeySizeBits: undefined,
+    });
+  });
+
+  it('fails closed when key rotation or settings persistence fails', async () => {
+    mocks.rotate.mockRejectedValueOnce(new Error('key manager unavailable'));
+    expect(
+      (await handleUpdateSAMLLocalSigning(context({ role: 'idp', action: 'recreate_active' })))
+        .status
+    ).toBe(500);
+
+    mocks.putSigning.mockRejectedValueOnce(new Error('settings unavailable'));
+    expect(
+      (await handleUpdateSAMLLocalSigning(context({ role: 'idp', action: 'retire_backup' }))).status
+    ).toBe(500);
+  });
+});
+
+describe('SAML signing disaster-recovery bundle administration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.settings = defaultSettings();
+    mocks.settingsError = false;
+    mocks.exportDR.mockResolvedValue({
+      version: 1,
+      kdf: { name: 'PBKDF2', iterations: 210000 },
+      ciphertext: 'encrypted',
+    });
+    mocks.importDR.mockResolvedValue({ importedKeys: 2, restoredRoles: ['idp', 'sp'] });
+  });
+
+  it('requires separate export and import permissions', async () => {
+    expect((await handleExportSAMLLocalSigningDRBundle(context({}, null))).status).toBe(401);
+    expect((await handleExportSAMLLocalSigningDRBundle(context({}, []))).status).toBe(403);
+    expect((await handleImportSAMLLocalSigningDRBundle(context({}, null))).status).toBe(401);
+    expect((await handleImportSAMLLocalSigningDRBundle(context({}, []))).status).toBe(403);
+  });
+
+  it('exports only an encrypted, non-cacheable bundle and audits the operation', async () => {
+    const c = context({ passphrase: 'correct horse battery staple' });
+    const response = await handleExportSAMLLocalSigningDRBundle(c);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ ciphertext: 'encrypted' });
+    expect(mocks.exportDR).toHaveBeenCalledWith(
+      expect.anything(),
+      'tenant-a',
+      'correct horse battery staple'
+    );
+    expect(mocks.audit).toHaveBeenCalled();
+  });
+
+  it('imports a bundle, reloads public settings, and reports restored roles', async () => {
+    const response = await handleImportSAMLLocalSigningDRBundle(
+      context({ bundle: { ciphertext: 'encrypted' }, passphrase: 'secret' })
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json<{
+      tenantId: string;
+      imported: { importedKeys: number; restoredRoles: string[] };
+      localSigning: { idpSigningKeyPolicy: unknown };
+    }>();
+    expect(body).toMatchObject({
+      tenantId: 'tenant-a',
+      imported: { importedKeys: 2, restoredRoles: ['idp', 'sp'] },
+    });
+    expect(body.localSigning.idpSigningKeyPolicy).toBeTypeOf('object');
+    expect(mocks.audit).toHaveBeenCalled();
+  });
+
+  it.each([
+    ['SAML DR bundle is malformed'],
+    ['encrypted SAML DR bundle payload is missing'],
+    ['cannot decrypt SAML DR bundle'],
+    ['passphrase is too short'],
+  ])('maps validation failure %s to a redacted 400 response', async (message) => {
+    mocks.exportDR.mockRejectedValueOnce(new Error(message));
+    const response = await handleExportSAMLLocalSigningDRBundle(context({ passphrase: 'secret' }));
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: 'invalid_request' });
+  });
+
+  it('reports the typed operation stage without exposing PEM or passphrase material', async () => {
+    mocks.importDR.mockRejectedValueOnce(
+      new SAMLDRBundleOperationError(
+        'decrypt_bundle',
+        'passphrase=topsecret -----BEGIN PRIVATE KEY----- secret -----END PRIVATE KEY-----'
+      )
+    );
+    const response = await handleImportSAMLLocalSigningDRBundle(
+      context({ bundle: {}, passphrase: 'topsecret' })
+    );
+    expect(response.status).toBe(400);
+    const body = JSON.stringify(await response.json());
+    expect(body).toContain('stage=decrypt bundle');
+    expect(body).not.toContain('topsecret');
+    expect(body).not.toContain('PRIVATE KEY');
+  });
+
+  it('maps unexpected export, audit, and settings-reload failures to stage-aware 500s', async () => {
+    mocks.exportDR.mockRejectedValueOnce({ reason: 'unknown' });
+    expect((await handleExportSAMLLocalSigningDRBundle(context())).status).toBe(500);
+
+    mocks.audit.mockRejectedValueOnce(new Error('audit unavailable'));
+    expect((await handleExportSAMLLocalSigningDRBundle(context())).status).toBe(500);
+
+    mocks.settingsError = true;
+    expect((await handleImportSAMLLocalSigningDRBundle(context())).status).toBe(500);
+  });
+});

--- a/packages/ar-saml/src/admin/providers.ts
+++ b/packages/ar-saml/src/admin/providers.ts
@@ -1745,7 +1745,12 @@ export async function handleImportMetadata(c: AdminSAMLContext): Promise<Respons
     const metadataUrl = resolvedMetadata.metadataUrl;
     const existingConfig = JSON.parse(existing.config_json) as SAMLIdPConfig | SAMLSPConfig;
     const previousAnalysis = buildPreviousMetadataAnalysis(existingConfig);
-    const currentAnalysis = analyzeSAMLMetadata(resolvedMetadata.metadataXml);
+    let currentAnalysis: SAMLMetadataAnalysis;
+    try {
+      currentAnalysis = analyzeSAMLMetadata(resolvedMetadata.metadataXml);
+    } catch (error) {
+      throw toSAMLMetadataValidationError(error);
+    }
     const refreshStatus = buildSAMLMetadataRefreshStatus(previousAnalysis, currentAnalysis);
     let newConfig: SAMLIdPConfig | SAMLSPConfig;
 
@@ -1923,7 +1928,12 @@ export async function handleRefreshMetadata(c: AdminSAMLContext): Promise<Respon
     }
 
     const previousAnalysis = buildPreviousMetadataAnalysis(existingConfig);
-    const currentAnalysis = analyzeSAMLMetadata(metadataXml);
+    let currentAnalysis: SAMLMetadataAnalysis;
+    try {
+      currentAnalysis = analyzeSAMLMetadata(metadataXml);
+    } catch (error) {
+      throw toSAMLMetadataValidationError(error);
+    }
     const refreshStatus = buildSAMLMetadataRefreshStatus(previousAnalysis, currentAnalysis);
     const now = Date.now();
 
@@ -3173,7 +3183,7 @@ export function parseSPMetadata(xml: string, profile?: SAMLSPProfile): SAMLSPCon
           });
         }
       }
-      if (!acsUrl || isDefault === 'true') {
+      if (!acsUrl || isDefault === 'true' || !allowedBindings.has('post')) {
         acsUrl = location || '';
       }
       allowedBindings.add('post');

--- a/packages/ar-saml/src/idp/__tests__/attribute-release-consent.test.ts
+++ b/packages/ar-saml/src/idp/__tests__/attribute-release-consent.test.ts
@@ -1,4 +1,33 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  trust: null as Record<string, unknown> | null,
+  requirements: [] as Array<{ is_required: boolean }>,
+  requirementsError: false,
+  existing: null as Record<string, unknown> | null,
+  latest: null as Record<string, unknown> | null,
+  decision: { action: 'release', reasonCodes: ['release.granted'] } as Record<string, unknown>,
+  findGranted: vi.fn(),
+  findLatest: vi.fn(),
+}));
+
+vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@authrim/ar-lib-core')>();
+  return {
+    ...actual,
+    resolveAuthCorePersistenceAdapterFromEnv: vi.fn(async () => ({})),
+    resolveClientTrustPolicy: vi.fn(async () => mocks.trust),
+    resolveConsentRequirements: vi.fn(async () => {
+      if (mocks.requirementsError) throw new Error('policy unavailable');
+      return mocks.requirements;
+    }),
+    evaluateReleaseConsentGate: vi.fn(() => mocks.decision),
+    AttributeReleaseConsentRepository: class {
+      findGrantedConsent = mocks.findGranted;
+      findLatestGrantedConsentForDestination = mocks.findLatest;
+    },
+  };
+});
 import {
   buildSAMLAttributeSetHash,
   enforceSAMLAttributeReleaseConsent,
@@ -6,6 +35,18 @@ import {
 } from '../attribute-release-consent';
 
 describe('SAML attribute release consent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.trust = null;
+    mocks.requirements = [];
+    mocks.requirementsError = false;
+    mocks.existing = null;
+    mocks.latest = null;
+    mocks.decision = { action: 'release', reasonCodes: ['release.granted'] };
+    mocks.findGranted.mockImplementation(async () => mocks.existing);
+    mocks.findLatest.mockImplementation(async () => mocks.latest);
+  });
+
   it('normalizes protocol-neutral attribute release consent policy config', () => {
     expect(
       normalizeAttributeReleaseConsentPolicy({
@@ -18,6 +59,13 @@ describe('SAML attribute release consent', () => {
     });
 
     expect(normalizeAttributeReleaseConsentPolicy({ enabled: true, mode: 'invalid' })).toBeNull();
+    expect(normalizeAttributeReleaseConsentPolicy(null)).toBeNull();
+    expect(normalizeAttributeReleaseConsentPolicy([])).toBeNull();
+    expect(normalizeAttributeReleaseConsentPolicy('once')).toBeNull();
+    expect(normalizeAttributeReleaseConsentPolicy({ enabled: false })).toEqual({
+      enabled: false,
+      mode: 'once',
+    });
   });
 
   it('builds a stable attribute set hash without storing raw values', async () => {
@@ -92,4 +140,184 @@ describe('SAML attribute release consent', () => {
       reasonCodes: ['release.attribute_consent.transaction_confirmed'],
     });
   });
+
+  it('releases empty attribute sets without persistence', async () => {
+    await expect(enforceSAMLAttributeReleaseConsent(input({ attributes: [] }))).resolves.toEqual({
+      action: 'release',
+      attributeSetHash: null,
+      reasonCodes: [],
+    });
+    expect(mocks.findLatest).not.toHaveBeenCalled();
+  });
+
+  it.each([{ trusted: true }, { skip_authorization_consent: true }])(
+    'bypasses consent for trusted SP policy %#',
+    async (trust) => {
+      mocks.trust = trust;
+      await expect(enforceSAMLAttributeReleaseConsent(input())).resolves.toMatchObject({
+        action: 'release',
+        reasonCodes: ['release.trusted_saml_sp'],
+      });
+    }
+  );
+
+  it('keeps consent disabled when no higher-level policy requires it or lookup fails', async () => {
+    await expect(
+      enforceSAMLAttributeReleaseConsent(input({ attributeReleaseConsent: undefined }))
+    ).resolves.toMatchObject({ action: 'release', attributeSetHash: null });
+    mocks.requirementsError = true;
+    await expect(
+      enforceSAMLAttributeReleaseConsent(input({ attributeReleaseConsent: undefined }))
+    ).resolves.toMatchObject({ action: 'release', attributeSetHash: null });
+  });
+
+  it('enables one-time consent when a protocol-neutral policy requires it', async () => {
+    mocks.requirements = [{ is_required: false }, { is_required: true }];
+    await enforceSAMLAttributeReleaseConsent(input({ attributeReleaseConsent: undefined }));
+    expect(mocks.findLatest).toHaveBeenCalled();
+  });
+
+  it('accepts transaction confirmation after a protocol-neutral policy enables consent', async () => {
+    const attributes = standardAttributes();
+    const attributeSetHash = await buildSAMLAttributeSetHash(attributes);
+    mocks.requirements = [{ is_required: true }];
+    await expect(
+      enforceSAMLAttributeReleaseConsent(
+        input({
+          attributeReleaseConsent: undefined,
+          attributes,
+          confirmedRelease: {
+            subjectId: 'user-1',
+            destinationType: 'saml_sp',
+            destinationId: 'https://sp.example.edu/saml',
+            attributeSetHash,
+            confirmedAt: Date.now(),
+          },
+        })
+      )
+    ).resolves.toMatchObject({
+      action: 'release',
+      reasonCodes: ['release.attribute_consent.transaction_confirmed'],
+    });
+  });
+
+  it.each([
+    { subjectId: 'other' },
+    { destinationType: 'oidc_client' },
+    { destinationId: 'other' },
+    { attributeSetHash: 'other' },
+    { confirmedAt: 0 },
+  ])('does not accept mismatched transaction confirmation %#', async (override) => {
+    const attributes = standardAttributes();
+    const hash = await buildSAMLAttributeSetHash(attributes);
+    await enforceSAMLAttributeReleaseConsent(
+      input({
+        attributes,
+        confirmedRelease: {
+          subjectId: 'user-1',
+          destinationType: 'saml_sp',
+          destinationId: 'https://sp.example.edu/saml',
+          attributeSetHash: hash,
+          confirmedAt: Date.now(),
+          ...override,
+        } as never,
+      })
+    );
+    expect(mocks.findLatest).toHaveBeenCalled();
+  });
+
+  it('checks exact and latest grants for until-attributes-change mode', async () => {
+    mocks.existing = null;
+    mocks.latest = {
+      consent_state: 'granted',
+      attribute_set_hash: 'old',
+      consent_record_id: 'record-a',
+    };
+    await enforceSAMLAttributeReleaseConsent(
+      input({ attributeReleaseConsent: { enabled: true, mode: 'until_attributes_change' } })
+    );
+    expect(mocks.findGranted).toHaveBeenCalled();
+    expect(mocks.findLatest).toHaveBeenCalled();
+
+    mocks.existing = { consent_state: 'granted' };
+    await enforceSAMLAttributeReleaseConsent(
+      input({ attributeReleaseConsent: { enabled: true, mode: 'until_attributes_change' } })
+    );
+    expect(mocks.findLatest).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['granted', 'denied', 'revoked', 'expired', 'unknown', undefined])(
+    'normalizes stored consent state %s before evaluation',
+    async (consentState) => {
+      mocks.latest = {
+        consent_state: consentState,
+        attribute_set_hash: undefined,
+        consent_record_id: undefined,
+      };
+      await expect(enforceSAMLAttributeReleaseConsent(input())).resolves.toMatchObject({
+        action: 'release',
+      });
+    }
+  );
+
+  it('throws a privacy-safe challenge with attribute summaries', async () => {
+    mocks.decision = { action: 'challenge', reasonCodes: ['release.consent_required'] };
+    await expect(enforceSAMLAttributeReleaseConsent(input())).rejects.toMatchObject({
+      name: 'SAMLAttributeReleaseConsentRequiredError',
+      consentMode: 'once',
+      reasonCodes: ['release.consent_required'],
+      attributeSummaries: [
+        {
+          name: 'mail',
+          friendlyName: 'Email',
+          nameFormat: 'uri',
+          valueCount: 2,
+        },
+      ],
+    });
+  });
+
+  it('canonically sorts duplicate names through format and friendly-name tie breakers', async () => {
+    const hash = await buildSAMLAttributeSetHash([
+      { name: 'same', nameFormat: 'b', friendlyName: 'same', values: ['1'] },
+      { name: 'same', nameFormat: 'a', friendlyName: 'same', values: ['2'] },
+      { name: 'same', nameFormat: 'a', friendlyName: 'z', values: ['3'] },
+      { name: 'same', nameFormat: 'a', friendlyName: 'a', values: ['4'] },
+      { name: 'same', nameFormat: 'a', friendlyName: 'a', values: ['5'] },
+    ]);
+    expect(hash).toMatch(/^sha256:/);
+  });
 });
+
+function standardAttributes() {
+  return [
+    {
+      name: 'mail',
+      friendlyName: 'Email',
+      nameFormat: 'uri',
+      values: ['a@example.test', 'b@example.test'],
+    },
+  ];
+}
+
+function input(overrides: Record<string, unknown> = {}) {
+  return {
+    env: {} as never,
+    tenantId: 'tenant-a',
+    subjectId: 'user-1',
+    spConfig: {
+      entityId: 'https://sp.example.edu/saml',
+      acsUrl: 'https://sp.example.edu/acs',
+      nameIdFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+      attributeMapping: {},
+      allowedBindings: ['post'],
+      signAssertions: true,
+      signResponses: true,
+      ...(Object.prototype.hasOwnProperty.call(overrides, 'attributeReleaseConsent')
+        ? { attributeReleaseConsent: overrides.attributeReleaseConsent }
+        : { attributeReleaseConsent: { enabled: true, mode: 'once' } }),
+    },
+    attributes: standardAttributes(),
+    ...overrides,
+  } as never;
+}

--- a/packages/ar-saml/src/idp/__tests__/attributes.test.ts
+++ b/packages/ar-saml/src/idp/__tests__/attributes.test.ts
@@ -664,6 +664,151 @@ describe('buildSAMLAttributesFromMapping', () => {
       },
     ]);
   });
+
+  it('reads every supported identity-mapping source namespace without crossing data stores', () => {
+    const cases = [
+      ['authrim.profile', 'email', 'profile@example.test'],
+      ['authrim.claim', 'name', 'Profile Name'],
+      ['oidc.claim', 'email', 'profile@example.test'],
+      ['authrim.claims', 'department', 'engineering'],
+      ['claims', 'department', 'engineering'],
+      ['authrim.custom_claims', 'entitlement', 'licensed'],
+      ['custom_claims', 'entitlement', 'licensed'],
+      ['authrim.custom_fields', 'employeeNumber', 42],
+      ['custom_fields', 'employeeNumber', 42],
+      ['authrim.attributes', 'groups', ['admin', 'editor']],
+      ['attributes', 'groups', ['admin', 'editor']],
+      ['authrim.system', 'uid', 'user-123'],
+      ['authrim.system', 'email', 'profile@example.test'],
+      ['vendor.extension', 'name', 'Profile Name'],
+    ] as const;
+    const entries: FieldCatalogBundle['entries'] = [];
+    const edges = cases.map(([namespace, path], index) => {
+      const sourceId = `source.${index}`;
+      const destinationId = `destination.${index}`;
+      entries.push(
+        {
+          id: sourceId,
+          namespace,
+          path,
+          valueType: 'string',
+          cardinality: 'multi',
+          classification: 'internal',
+          targetType: 'canonical',
+        },
+        {
+          id: destinationId,
+          namespace: 'saml.attribute',
+          path: `urn:test:attribute:${index}`,
+          valueType: 'string',
+          cardinality: 'multi',
+          classification: 'internal',
+          targetType: 'destination-only',
+        }
+      );
+      return identityMappingEdge(
+        sourceId,
+        namespace,
+        path,
+        destinationId,
+        `urn:test:attribute:${index}`
+      );
+    });
+    const attributes = buildSAMLAttributesForSP(
+      {
+        id: 'user-123',
+        email: 'profile@example.test',
+        name: 'Profile Name',
+        claims: { department: 'engineering' },
+        customClaims: { entitlement: 'licensed' },
+        customFields: { employeeNumber: 42 },
+        attributes: { groups: ['admin', 'editor'] },
+      },
+      {
+        attributeMapping: {},
+        identityMapping: {
+          catalog: {
+            identity: {
+              id: 'namespace-matrix',
+              version: '1',
+              contentHash: 'namespace-matrix',
+              compatibilityRange: '^0.3.0',
+            },
+            entries,
+          },
+          edges,
+        },
+      }
+    );
+    expect(attributes).toHaveLength(cases.length);
+    expect(attributes[9]?.values).toEqual(['admin', 'editor']);
+    expect(attributes[11]?.values).toEqual(['user-123']);
+  });
+
+  it.each([
+    ['saml:persistent-nameid', 'saml:persistent-nameid'],
+    [' XS:BOOLEAN ', 'xs:boolean'],
+    ['xs:integer', 'xs:integer'],
+    ['xs:datetime', 'xs:dateTime'],
+    ['xs:anyuri', 'xs:anyURI'],
+    ['xs:string', 'xs:string'],
+    ['unsupported', undefined],
+    ['', undefined],
+  ] as const)('normalizes mapped SAML value type %s', (configured, expected) => {
+    const catalog = identityMappingSamlCatalog({ mailRequired: false });
+    catalog.entries.find((entry) => entry.id === 'field.saml.mail')!.valueType =
+      configured as never;
+    const attributes = buildSAMLAttributesForSP(
+      { id: 'user-123', email: 'user@example.test' },
+      {
+        attributeMapping: {},
+        identityMapping: {
+          catalog,
+          edges: [
+            identityMappingEdge(
+              'field.profile.email',
+              'authrim.profile',
+              'email',
+              'field.saml.mail',
+              'urn:oid:0.9.2342.19200300.100.1.3'
+            ),
+          ],
+        },
+      }
+    );
+    expect(attributes[0]?.valueType).toBe(expected);
+  });
+
+  it('resolves descriptors by destination path and namespace key and deduplicates required errors', () => {
+    const catalog = identityMappingSamlCatalog();
+    expect(() =>
+      buildSAMLAttributesForSP(
+        { id: 'user-123' },
+        {
+          attributeMapping: {},
+          identityMapping: {
+            catalog,
+            edges: [
+              identityMappingEdge(
+                'field.profile.email',
+                'authrim.profile',
+                'email',
+                'field.saml.mail',
+                'urn:oid:0.9.2342.19200300.100.1.3'
+              ),
+            ],
+            attributeDescriptors: {
+              'urn:oid:0.9.2342.19200300.100.1.3': { name: 'mail', required: true },
+              'saml.attribute:urn:oid:0.9.2342.19200300.100.1.3': {
+                name: 'mail',
+                required: true,
+              },
+            },
+          },
+        }
+      )
+    ).toThrow(MissingRequiredSAMLAttributeError);
+  });
 });
 
 function identityMappingSamlCatalog(options: { mailRequired?: boolean } = {}): FieldCatalogBundle {

--- a/packages/ar-saml/src/idp/__tests__/authn-request-parsing.test.ts
+++ b/packages/ar-saml/src/idp/__tests__/authn-request-parsing.test.ts
@@ -34,19 +34,99 @@ describe('parseAuthnRequestXml', () => {
       'Invalid XML boolean value'
     );
   });
+
+  it('parses destination, ACS selection, protocol binding, qualifiers, and authn context', () => {
+    const request = parseAuthnRequestXml(`
+      <samlp:AuthnRequest xmlns:samlp="${SAML_NAMESPACES.SAML2P}" xmlns:saml="${SAML_NAMESPACES.SAML2}"
+        ID="_full" IssueInstant="2026-07-10T00:00:00Z"
+        Destination="https://idp.example.test/sso"
+        AssertionConsumerServiceURL="https://sp.example.test/acs"
+        AssertionConsumerServiceIndex="2"
+        ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST">
+        <saml:Issuer>https://sp.example.test/entity</saml:Issuer>
+        <samlp:NameIDPolicy Format="${NAMEID_FORMATS.PERSISTENT}"
+          AllowCreate="true" SPNameQualifier="https://sp.example.test/entity" />
+        <samlp:RequestedAuthnContext Comparison="minimum">
+          <saml:AuthnContextClassRef>urn:test:loa:1</saml:AuthnContextClassRef>
+          <saml:AuthnContextClassRef> urn:test:loa:2 </saml:AuthnContextClassRef>
+        </samlp:RequestedAuthnContext>
+      </samlp:AuthnRequest>`);
+
+    expect(request).toMatchObject({
+      id: '_full',
+      issuer: 'https://sp.example.test/entity',
+      destination: 'https://idp.example.test/sso',
+      assertionConsumerServiceURL: 'https://sp.example.test/acs',
+      assertionConsumerServiceIndex: 2,
+      requestedAuthnContext: {
+        comparison: 'minimum',
+        authnContextClassRef: ['urn:test:loa:1', 'urn:test:loa:2'],
+      },
+      nameIdPolicy: {
+        format: NAMEID_FORMATS.PERSISTENT,
+        allowCreate: true,
+        spNameQualifier: 'https://sp.example.test/entity',
+      },
+    });
+  });
+
+  it.each([
+    ['wrong root namespace', '<AuthnRequest ID="x" IssueInstant="now"/>', 'missing AuthnRequest'],
+    [
+      'wrong root element',
+      `<samlp:Response xmlns:samlp="${SAML_NAMESPACES.SAML2P}" ID="x" IssueInstant="now"/>`,
+      'missing AuthnRequest',
+    ],
+    [
+      'missing required attributes',
+      `<samlp:AuthnRequest xmlns:samlp="${SAML_NAMESPACES.SAML2P}"/>`,
+      'missing required attributes',
+    ],
+    [
+      'missing issuer',
+      `<samlp:AuthnRequest xmlns:samlp="${SAML_NAMESPACES.SAML2P}" ID="x" IssueInstant="now"/>`,
+      'missing Issuer',
+    ],
+  ])('rejects %s', (_name, xml, message) => {
+    expect(() => parseAuthnRequestXml(xml)).toThrow(message);
+  });
+
+  it.each(['-1', '1.5', 'abc', '9007199254740992'])('ignores invalid ACS index %s', (index) => {
+    const request = parseAuthnRequestXml(authnRequestXml({ assertionConsumerServiceIndex: index }));
+    expect(request.assertionConsumerServiceIndex).toBeUndefined();
+  });
+
+  it('omits optional policy and request values when absent', () => {
+    const request = parseAuthnRequestXml(authnRequestXml({ includeNameIdPolicy: false }));
+    expect(request).toMatchObject({ forceAuthn: false, isPassive: false });
+    expect(request.nameIdPolicy).toBeUndefined();
+    expect(request.destination).toBeUndefined();
+    expect(request.assertionConsumerServiceURL).toBeUndefined();
+    expect(request.requestedAuthnContext).toBeUndefined();
+  });
 });
 
 function authnRequestXml(options: {
   allowCreate?: string;
   forceAuthn?: string;
   isPassive?: string;
+  assertionConsumerServiceIndex?: string;
+  includeNameIdPolicy?: boolean;
 }): string {
   const allowCreate =
     options.allowCreate === undefined ? '' : ` AllowCreate="${options.allowCreate}"`;
   const forceAuthn = options.forceAuthn === undefined ? '' : ` ForceAuthn="${options.forceAuthn}"`;
   const isPassive = options.isPassive === undefined ? '' : ` IsPassive="${options.isPassive}"`;
-  return `<samlp:AuthnRequest xmlns:samlp="${SAML_NAMESPACES.SAML2P}" xmlns:saml="${SAML_NAMESPACES.SAML2}" ID="_request123" IssueInstant="2026-07-10T00:00:00Z"${forceAuthn}${isPassive}>
+  const assertionConsumerServiceIndex =
+    options.assertionConsumerServiceIndex === undefined
+      ? ''
+      : ` AssertionConsumerServiceIndex="${options.assertionConsumerServiceIndex}"`;
+  const nameIdPolicy =
+    options.includeNameIdPolicy === false
+      ? ''
+      : `<samlp:NameIDPolicy Format="${NAMEID_FORMATS.PERSISTENT}"${allowCreate}/>`;
+  return `<samlp:AuthnRequest xmlns:samlp="${SAML_NAMESPACES.SAML2P}" xmlns:saml="${SAML_NAMESPACES.SAML2}" ID="_request123" IssueInstant="2026-07-10T00:00:00Z"${forceAuthn}${isPassive}${assertionConsumerServiceIndex}>
     <saml:Issuer>https://sp.example.com/saml</saml:Issuer>
-    <samlp:NameIDPolicy Format="${NAMEID_FORMATS.PERSISTENT}"${allowCreate}/>
+    ${nameIdPolicy}
   </samlp:AuthnRequest>`;
 }

--- a/packages/ar-saml/src/idp/__tests__/idp-initiated.test.ts
+++ b/packages/ar-saml/src/idp/__tests__/idp-initiated.test.ts
@@ -1,0 +1,317 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  sp: null as Record<string, unknown> | null,
+  spList: [] as Array<{ id: string; name: string; entityId: string }>,
+  cookieSessionId: undefined as string | undefined,
+  sharded: true,
+  sessionResponse: new Response(null, { status: 404 }),
+  sessionThrows: false,
+  user: null as Record<string, unknown> | null,
+  builtin: false,
+  uiConfig: undefined as { baseUrl: string; paths?: { login?: string } } | undefined,
+  loginPolicy: 'ui_base_url' as 'ui_base_url' | 'tenant_host',
+  nakedDomain: false,
+  runtimeBinding: null as Record<string, unknown> | null,
+  buildResponse: vi.fn(() => '<saml-response/>'),
+  applySigning: vi.fn(async () => '<signed-response/>'),
+  resolveNameId: vi.fn(async () => 'name-id'),
+  buildAttributes: vi.fn(() => ({ email: ['user@example.test'] })),
+}));
+
+vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@authrim/ar-lib-core')>();
+  return {
+    ...actual,
+    getSessionStoreBySessionId: vi.fn(() => ({
+      stub: {
+        fetch: vi.fn(async () => {
+          if (mocks.sessionThrows) throw new Error('session unavailable');
+          return mocks.sessionResponse.clone();
+        }),
+      },
+    })),
+    isShardedSessionId: vi.fn(() => mocks.sharded),
+    getUIConfig: vi.fn(async () => mocks.uiConfig),
+    buildUIUrl: vi.fn(
+      (
+        config: { baseUrl: string },
+        _path: string,
+        query: Record<string, string>,
+        tenant?: string
+      ) => {
+        const url = new URL('/login', config.baseUrl);
+        Object.entries(query).forEach(([key, value]) => url.searchParams.set(key, value));
+        if (tenant) url.searchParams.set('tenant', tenant);
+        return url.toString();
+      }
+    ),
+    shouldUseBuiltinForms: vi.fn(async () => mocks.builtin),
+    usesNakedDomainIssuer: vi.fn(() => mocks.nakedDomain),
+    resolveAuthCorePersistenceAdapterFromEnv: vi.fn(async () => ({})),
+    resolveRuntimeIdentityMappingBinding: vi.fn(async () => mocks.runtimeBinding),
+    getLogger: () => ({ module: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn() }) }),
+  };
+});
+
+vi.mock('../../admin/providers', () => ({
+  getSPConfig: vi.fn(async () => mocks.sp),
+  listSPConfigs: vi.fn(async () => mocks.spList),
+}));
+
+vi.mock('../../common/session-cookie', () => ({
+  extractAuthrimSessionIdFromCookieHeader: vi.fn(() => mocks.cookieSessionId),
+}));
+
+vi.mock('../../common/user-store', () => ({
+  getSamlUserInfoById: vi.fn(async () => mocks.user),
+}));
+
+vi.mock('../../common/idp-signing', () => ({
+  getSAMLIdPSigningMaterial: vi.fn(async () => ({
+    privateKeyPem: 'private-key',
+    certificate: 'certificate',
+  })),
+}));
+
+vi.mock('../../common/entity-id', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../common/entity-id')>();
+  return {
+    ...actual,
+    getSAMLInteractiveLoginUrlPolicy: vi.fn(async () => mocks.loginPolicy),
+    getSAMLLocalEntityIds: vi.fn(async () => ({
+      issuerUrl: 'https://tenant.example.test',
+      idpEntityId: 'https://tenant.example.test/saml/idp',
+    })),
+  };
+});
+
+vi.mock('../assertion', () => ({ buildSAMLResponse: mocks.buildResponse }));
+vi.mock('../signing', () => ({ applySAMLResponseSigningPolicy: mocks.applySigning }));
+vi.mock('../attributes', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../attributes')>();
+  return { ...actual, buildSAMLAttributesForSP: mocks.buildAttributes };
+});
+vi.mock('../subject', () => ({
+  createSAMLSessionIndex: vi.fn(async () => 'session-index'),
+  resolveSAMLNameIDValue: mocks.resolveNameId,
+  resolveSAMLPairwiseSecret: vi.fn(async () => 'pairwise-secret'),
+  resolveSAMLPersistentNameIDRegistryStore: vi.fn(() => undefined),
+  resolveSAMLTransientNameIDStore: vi.fn(() => undefined),
+}));
+
+import { handleIdPInitiated } from '../idp-initiated';
+
+function baseSp(overrides: Record<string, unknown> = {}) {
+  return {
+    entityId: 'https://sp.example.test',
+    acsUrl: 'https://sp.example.test/acs',
+    enabled: true,
+    signResponses: false,
+    signAssertions: false,
+    ...overrides,
+  };
+}
+
+function context(sp?: string) {
+  return {
+    env: { STATE_STORE: {} },
+    req: {
+      query: vi.fn((name: string) => (name === 'sp' ? sp : undefined)),
+      header: vi.fn((name: string) =>
+        name.toLowerCase() === 'cookie' && mocks.cookieSessionId
+          ? 'authrim_session=test'
+          : undefined
+      ),
+    },
+    get: vi.fn((name: string) => (name === 'tenantId' ? 'tenant-a' : undefined)),
+    html: vi.fn((body: string) => new Response(body, { headers: { 'Content-Type': 'text/html' } })),
+    json: vi.fn(
+      (body: unknown, status: number = 200) =>
+        new Response(JSON.stringify(body), {
+          status,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    ),
+    redirect: vi.fn((location: string) =>
+      Response.redirect(location.startsWith('http') ? location : `https://fallback.test${location}`)
+    ),
+  } as never;
+}
+
+describe('IdP-initiated SSO', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.sp = baseSp();
+    mocks.spList = [];
+    mocks.cookieSessionId = undefined;
+    mocks.sharded = true;
+    mocks.sessionResponse = new Response(null, { status: 404 });
+    mocks.sessionThrows = false;
+    mocks.user = null;
+    mocks.builtin = false;
+    mocks.uiConfig = undefined;
+    mocks.loginPolicy = 'ui_base_url';
+    mocks.nakedDomain = false;
+    mocks.runtimeBinding = null;
+  });
+
+  it('renders an empty SP selection without reflecting unsafe markup', async () => {
+    let response = await handleIdPInitiated(context());
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('No service providers configured');
+
+    mocks.spList = [
+      {
+        id: 'sp-1',
+        name: '<script>unsafe & name</script>',
+        entityId: 'https://sp.example.test/?a=1&b=2',
+      },
+    ];
+    response = await handleIdPInitiated(context());
+    const html = await response.text();
+    expect(html).toContain('&lt;script&gt;unsafe &amp; name&lt;/script&gt;');
+    expect(html).not.toContain('<script>');
+  });
+
+  it('does not disclose an unknown SP', async () => {
+    mocks.sp = null;
+    const response = await handleIdPInitiated(context('unknown'));
+    expect(response.status).toBe(404);
+  });
+
+  it('redirects unauthenticated users to builtin login when enabled', async () => {
+    mocks.builtin = true;
+    const response = await handleIdPInitiated(context('https://sp.example.test'));
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toContain('/flow/login');
+    expect(response.headers.get('location')).toContain('return_to=');
+  });
+
+  it('fails safely when no interactive UI is configured', async () => {
+    const response = await handleIdPInitiated(context('https://sp.example.test'));
+    expect(response.status).toBe(500);
+  });
+
+  it.each([
+    ['tenant_host', false, 'https://tenant.example.test/custom-login', false],
+    ['ui_base_url', false, 'https://ui.example.test/login', true],
+    ['ui_base_url', true, 'https://ui.example.test/login', false],
+  ] as const)(
+    'builds a constrained %s login redirect',
+    async (policy, naked, expectedPrefix, expectsTenant) => {
+      mocks.uiConfig = { baseUrl: 'https://ui.example.test', paths: { login: '/custom-login' } };
+      mocks.loginPolicy = policy;
+      mocks.nakedDomain = naked;
+      const response = await handleIdPInitiated(context('https://sp.example.test'));
+      const location = response.headers.get('location') ?? '';
+      expect(location).toContain(expectedPrefix);
+      expect(location.includes('tenant=tenant-a')).toBe(expectsTenant);
+    }
+  );
+
+  it.each([
+    ['not sharded', false, false, new Response(null, { status: 200 })],
+    ['store throws', true, true, new Response(null, { status: 200 })],
+    ['store rejects', true, false, new Response(null, { status: 401 })],
+    [
+      'session has no user',
+      true,
+      false,
+      new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ],
+  ] as const)('treats %s as unauthenticated', async (_name, sharded, throws, response) => {
+    mocks.cookieSessionId = 'session-id';
+    mocks.sharded = sharded;
+    mocks.sessionThrows = throws;
+    mocks.sessionResponse = response;
+    mocks.builtin = true;
+    const result = await handleIdPInitiated(context('https://sp.example.test'));
+    expect(result.headers.get('location')).toContain('/flow/login');
+  });
+
+  it('rejects an authenticated session whose user no longer exists', async () => {
+    mocks.cookieSessionId = 'session-id';
+    mocks.sessionResponse = new Response(
+      JSON.stringify({ userId: 'deleted-user', data: { acr: 123, amr: 'pwd' } }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+    const response = await handleIdPInitiated(context('https://sp.example.test'));
+    expect(response.status).toBe(404);
+  });
+
+  it('issues an unsigned response using configured identity mapping', async () => {
+    mocks.cookieSessionId = 'session-id';
+    mocks.sessionResponse = new Response(
+      JSON.stringify({ userId: 'user-a', data: { acr: 'loa2', amr: ['pwd', 1, 'mfa'] } }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+    mocks.user = { id: 'user-a', email: 'user@example.test' };
+    mocks.sp = baseSp({
+      identityMapping: { catalog: { entries: [] } },
+      nameIdFormat: undefined,
+      assertionValiditySeconds: 0,
+    });
+
+    const response = await handleIdPInitiated(context('https://sp.example.test'));
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('SAMLResponse');
+    expect(mocks.buildResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ nameId: 'name-id' })
+    );
+    const calls = mocks.buildResponse.mock.calls as unknown as Array<[Record<string, unknown>]>;
+    expect(calls[0]?.[0]).not.toHaveProperty('inResponseTo');
+    expect(mocks.applySigning).not.toHaveBeenCalled();
+  });
+
+  it('loads runtime identity mapping and applies signing policy', async () => {
+    mocks.cookieSessionId = 'session-id';
+    mocks.sessionResponse = new Response(JSON.stringify({ userId: 'user-a' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    mocks.user = { id: 'user-a', email: 'user@example.test' };
+    mocks.runtimeBinding = {
+      id: 'binding',
+      tenantId: 'tenant-a',
+      catalog: { entries: [] },
+      edges: [],
+      transforms: [],
+      validationRules: [],
+      fieldMappingSet: {},
+      fieldMappingSetId: 'set',
+      fieldMappingVersionId: 'version',
+      destinationNamespace: 'saml',
+      sourceProfileId: 'source',
+      destinationProfileId: 'destination',
+    };
+    mocks.sp = baseSp({
+      signResponses: true,
+      assertionValiditySeconds: 120,
+      identityMapping: {
+        fieldMappingSetId: 'set',
+        destinationNamespace: 'override',
+        sourceProfileId: 'source-override',
+        destinationProfileId: 'destination-override',
+      },
+    });
+    const response = await handleIdPInitiated(context('https://sp.example.test'));
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('PHNpZ25lZC1yZXNwb25zZS8+');
+    expect(mocks.applySigning).toHaveBeenCalled();
+  });
+
+  it('fails closed when runtime identity mapping is missing', async () => {
+    mocks.cookieSessionId = 'session-id';
+    mocks.sessionResponse = new Response(JSON.stringify({ userId: 'user-a' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    mocks.user = { id: 'user-a', email: 'user@example.test' };
+    const response = await handleIdPInitiated(context('https://sp.example.test'));
+    expect(response.status).toBe(500);
+  });
+});

--- a/packages/ar-saml/src/idp/__tests__/slo-handler.test.ts
+++ b/packages/ar-saml/src/idp/__tests__/slo-handler.test.ts
@@ -1,0 +1,551 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { NAMEID_FORMATS, SAML_NAMESPACES, STATUS_CODES } from '../../common/constants';
+
+const mocks = vi.hoisted(() => ({
+  sp: null as Record<string, unknown> | null,
+  builtin: true,
+  ui: undefined as { baseUrl: string } | undefined,
+  sessionDelete: new Response(null, { status: 204 }),
+  sessionThrows: false,
+  resolvedSessionId: null as string | null,
+  activeUser: null as { id: string } | null,
+  outbound: {
+    requestId: '_outbound',
+    spEntityId: 'https://sp.example.test/entity',
+  } as Record<string, unknown> | null,
+  outboundThrows: false,
+  deleteOutbound: vi.fn(async () => undefined),
+  audit: vi.fn(),
+  userNameId: null as string | null,
+  userInfo: null as Record<string, unknown> | null,
+  signingError: false,
+  storeOutbound: vi.fn(async () => undefined),
+  markSent: vi.fn(async () => undefined),
+  markCompleted: vi.fn(async () => undefined),
+}));
+
+vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@authrim/ar-lib-core')>();
+  return {
+    ...actual,
+    getSessionStoreBySessionId: vi.fn(() => ({
+      stub: {
+        fetch: vi.fn(async () => {
+          if (mocks.sessionThrows) throw new Error('session unavailable');
+          return mocks.sessionDelete.clone();
+        }),
+      },
+    })),
+    isShardedSessionId: vi.fn((id: string) => id.startsWith('sess_')),
+    getUIConfig: vi.fn(async () => mocks.ui),
+    buildUIUrl: vi.fn((config: { baseUrl: string }) => `${config.baseUrl}/logout-complete`),
+    shouldUseBuiltinForms: vi.fn(async () => mocks.builtin),
+    usesNakedDomainIssuer: vi.fn(() => false),
+    buildIssuerUrl: vi.fn(() => 'https://tenant.example.test'),
+    createAuthContextFromHono: vi.fn(() => ({ coreAdapter: {} })),
+    recordUserSessionRevocationEpoch: vi.fn(async () => undefined),
+    createAuditLog: mocks.audit,
+    getLogger: () => ({
+      module: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+    }),
+    createLogger: () => ({ module: () => ({ error: vi.fn() }) }),
+  };
+});
+
+vi.mock('../../admin/providers', () => ({
+  getSPConfig: vi.fn(async () => mocks.sp),
+}));
+
+vi.mock('../../common/entity-id', () => ({
+  getSAMLLocalEntityIds: vi.fn(async () => ({
+    issuerUrl: 'https://tenant.example.test',
+    idpEntityId: 'https://tenant.example.test/saml/idp',
+  })),
+}));
+
+vi.mock('../../common/idp-signing', () => ({
+  getSAMLIdPSigningMaterial: vi.fn(async () => {
+    if (mocks.signingError) throw new Error('signing unavailable');
+    return { privateKeyPem: 'private-key', certificate: 'certificate' };
+  }),
+}));
+
+vi.mock('../../common/signature', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../common/signature')>();
+  return {
+    ...actual,
+    signXml: vi.fn((xml: string) => xml),
+    signRedirectBinding: vi.fn(async () => ({
+      signedUrl: 'SAMLRequest=encoded&SigAlg=rsa-sha256&Signature=signature',
+      signature: 'signature',
+      sigAlg: 'rsa-sha256',
+    })),
+  };
+});
+
+vi.mock('../../common/user-store', () => ({
+  findActiveSamlUserByEmail: vi.fn(async () => mocks.activeUser),
+  getSamlUserInfoById: vi.fn(async () => mocks.userInfo),
+  getSamlUserNameIdById: vi.fn(async () => mocks.userNameId),
+}));
+
+vi.mock('../subject', () => ({
+  resolveSAMLPersistentNameIDRegistryStore: vi.fn(() => undefined),
+  resolveSAMLNameIDValue: vi.fn(async () => 'persistent-name-id'),
+  resolveSAMLPairwiseSecret: vi.fn(async () => 'pairwise-secret'),
+  resolveSAMLSessionIndexToSessionId: vi.fn(async () => mocks.resolvedSessionId),
+}));
+
+vi.mock('../slo-state', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../slo-state')>();
+  return {
+    ...actual,
+    getSAMLOutboundLogoutRequest: vi.fn(async () => {
+      if (mocks.outboundThrows) throw new Error('state store unavailable');
+      if (!mocks.outbound) {
+        throw new actual.SAMLLogoutResponseCorrelationError('missing request', {
+          in_response_to: 'missing',
+        });
+      }
+      return mocks.outbound;
+    }),
+    deleteSAMLOutboundLogoutRequest: mocks.deleteOutbound,
+    storeSAMLOutboundLogoutRequest: mocks.storeOutbound,
+    createSAMLIdPLogoutFanoutTransaction: vi.fn(
+      async (
+        _store: unknown,
+        input: {
+          transactionId?: string;
+          userId: string;
+          sessionIndex?: string;
+          relayState?: string;
+          targets: string[];
+        }
+      ) => ({
+        transactionId: input.transactionId ?? 'transaction-id',
+        userId: input.userId,
+        sessionIndex: input.sessionIndex,
+        relayState: input.relayState,
+        targets: input.targets.map((spEntityId) => ({ spEntityId, status: 'pending' })),
+      })
+    ),
+    getSAMLIdPLogoutFanoutTransaction: vi.fn(async () => null),
+    markSAMLIdPLogoutFanoutTargetSent: mocks.markSent,
+    markSAMLIdPLogoutFanoutTargetCompleted: mocks.markCompleted,
+  };
+});
+
+import {
+  handleIdPSLO,
+  initiateIdPLogout,
+  initiateIdPLogoutBindingResponse,
+  initiateIdPMultiSPLogoutBindingResponse,
+  resolveIdPLogoutNameID,
+} from '../slo';
+
+function sp(overrides: Record<string, unknown> = {}) {
+  return {
+    entityId: 'https://sp.example.test/entity',
+    acsUrl: 'https://sp.example.test/acs',
+    sloUrl: 'https://sp.example.test/slo',
+    sloResponseUrl: 'https://sp.example.test/slo/response',
+    allowedBindings: ['post'],
+    logoutRequestSignaturePolicy: 'disabled',
+    logoutResponseSignaturePolicy: 'disabled',
+    ...overrides,
+  };
+}
+
+function app() {
+  const route = new Hono();
+  route.use('*', async (c, next) => {
+    (c.set as (key: string, value: string) => void)('tenantId', 'tenant-a');
+    await next();
+  });
+  route.all('/slo', handleIdPSLO as never);
+  return route;
+}
+
+function environment() {
+  return { STATE_STORE: {} };
+}
+
+function requestXml(
+  options: {
+    issueInstant?: string;
+    destination?: string;
+    notOnOrAfter?: string;
+    nameIdFormat?: string;
+    nameQualifier?: string;
+    spNameQualifier?: string;
+    sessionIndex?: string;
+  } = {}
+) {
+  const attrs = [
+    'ID="_logout"',
+    `IssueInstant="${options.issueInstant ?? new Date().toISOString()}"`,
+    options.destination ? `Destination="${options.destination}"` : '',
+    options.notOnOrAfter ? `NotOnOrAfter="${options.notOnOrAfter}"` : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const nameAttrs = [
+    `Format="${options.nameIdFormat ?? NAMEID_FORMATS.EMAIL}"`,
+    options.nameQualifier ? `NameQualifier="${options.nameQualifier}"` : '',
+    options.spNameQualifier ? `SPNameQualifier="${options.spNameQualifier}"` : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+  return `<samlp:LogoutRequest xmlns:samlp="${SAML_NAMESPACES.SAML2P}" xmlns:saml="${SAML_NAMESPACES.SAML2}" ${attrs}>
+    <saml:Issuer>https://sp.example.test/entity</saml:Issuer>
+    <saml:NameID ${nameAttrs}>user@example.test</saml:NameID>
+    ${options.sessionIndex ? `<samlp:SessionIndex>${options.sessionIndex}</samlp:SessionIndex>` : ''}
+  </samlp:LogoutRequest>`;
+}
+
+function responseXml(
+  options: {
+    destination?: string;
+    statusCode?: string;
+    inResponseTo?: string;
+  } = {}
+) {
+  return `<samlp:LogoutResponse xmlns:samlp="${SAML_NAMESPACES.SAML2P}" xmlns:saml="${SAML_NAMESPACES.SAML2}"
+    ID="_response" IssueInstant="${new Date().toISOString()}"
+    InResponseTo="${options.inResponseTo ?? '_outbound'}"
+    ${options.destination ? `Destination="${options.destination}"` : ''}>
+    <saml:Issuer>https://sp.example.test/entity</saml:Issuer>
+    <samlp:Status><samlp:StatusCode Value="${options.statusCode ?? STATUS_CODES.SUCCESS}"/></samlp:Status>
+  </samlp:LogoutResponse>`;
+}
+
+async function post(field?: 'SAMLRequest' | 'SAMLResponse', xml?: string, relayState?: string) {
+  const form = new FormData();
+  if (field && xml) form.set(field, btoa(xml));
+  if (relayState) form.set('RelayState', relayState);
+  return app().fetch(
+    new Request('https://tenant.example.test/slo', { method: 'POST', body: form }),
+    environment(),
+    { waitUntil: vi.fn(), passThroughOnException: vi.fn(), props: {} } as never
+  );
+}
+
+describe('IdP SLO handler policy boundaries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.sp = sp();
+    mocks.builtin = true;
+    mocks.ui = undefined;
+    mocks.sessionDelete = new Response(null, { status: 204 });
+    mocks.sessionThrows = false;
+    mocks.resolvedSessionId = null;
+    mocks.activeUser = null;
+    mocks.outbound = {
+      requestId: '_outbound',
+      spEntityId: 'https://sp.example.test/entity',
+    };
+    mocks.outboundThrows = false;
+    mocks.userNameId = null;
+    mocks.userInfo = null;
+    mocks.signingError = false;
+  });
+
+  it('requires either a SAMLRequest or SAMLResponse for both bindings', async () => {
+    expect((await post()).status).toBe(400);
+    const get = await app().fetch(new Request('https://tenant.example.test/slo'), environment(), {
+      waitUntil: vi.fn(),
+      passThroughOnException: vi.fn(),
+      props: {},
+    } as never);
+    expect(get.status).toBe(400);
+  });
+
+  it('maps malformed POST logout messages to validation errors', async () => {
+    await expectValidationError(await post('SAMLRequest', '<not-saml/>'));
+    await expectValidationError(await post('SAMLResponse', '<not-saml/>'));
+  });
+
+  it('rejects an oversized RelayState as invalid input', async () => {
+    await expectValidationError(await post('SAMLRequest', requestXml(), 'x'.repeat(81)));
+  });
+
+  it.each([
+    [new Date(Date.now() + 10 * 60_000).toISOString(), undefined, undefined],
+    [new Date(Date.now() - 30 * 60_000).toISOString(), undefined, undefined],
+    [new Date().toISOString(), new Date(Date.now() - 10 * 60_000).toISOString(), undefined],
+    [new Date().toISOString(), undefined, 'https://attacker.example/slo'],
+  ])('rejects invalid LogoutRequest timing and destination', async (issue, expiry, destination) => {
+    const response = await post(
+      'SAMLRequest',
+      requestXml({ issueInstant: issue, notOnOrAfter: expiry, destination })
+    );
+    await expectValidationError(response);
+  });
+
+  it('handles unknown SP without redirecting to an untrusted endpoint', async () => {
+    mocks.sp = null;
+    const response = await post('SAMLRequest', requestXml(), 'relay');
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toContain('/logout-complete');
+  });
+
+  it.each([
+    [{ nameQualifier: 'https://wrong.example/idp' }, 'NameQualifier'],
+    [{ spNameQualifier: 'https://wrong.example/sp' }, 'SPNameQualifier'],
+    [{ nameIdFormat: 'urn:unsupported' }, 'format'],
+    [{ nameIdFormat: NAMEID_FORMATS.PERSISTENT }, 'SessionIndex'],
+  ] as const)('returns a protocol response for invalid %s policy', async (options, _label) => {
+    const response = await post('SAMLRequest', requestXml(options), 'relay');
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('SAMLResponse');
+  });
+
+  it('accepts legacy persistent logout without SessionIndex', async () => {
+    mocks.sp = sp({ samlProfile: 'legacy' });
+    const response = await post(
+      'SAMLRequest',
+      requestXml({ nameIdFormat: NAMEID_FORMATS.PERSISTENT })
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get('set-cookie')).toContain('Max-Age=0');
+  });
+
+  it('deletes a resolved sharded session and clears the browser cookie', async () => {
+    mocks.resolvedSessionId = 'sess_123';
+    const response = await post('SAMLRequest', requestXml({ sessionIndex: 'sidx_123' }), 'relay');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('set-cookie')).toContain('Max-Age=0');
+  });
+
+  it.each([
+    ['unresolved', null, false, new Response(null, { status: 204 })],
+    ['not sharded', 'legacy-session', false, new Response(null, { status: 204 })],
+    ['already deleted', 'sess_missing', false, new Response(null, { status: 404 })],
+    ['store failure', 'sess_error', true, new Response(null, { status: 204 })],
+  ] as const)(
+    'does not fail logout when a session is %s',
+    async (_name, resolved, throws, result) => {
+      mocks.resolvedSessionId = resolved;
+      mocks.sessionThrows = throws;
+      mocks.sessionDelete = result;
+      const response = await post('SAMLRequest', requestXml({ sessionIndex: 'sidx_123' }));
+      expect(response.status).toBe(200);
+    }
+  );
+
+  it('uses revocation epoch fallback for an email NameID', async () => {
+    mocks.activeUser = { id: 'user-a' };
+    const response = await post('SAMLRequest', requestXml());
+    expect(response.status).toBe(200);
+  });
+
+  it('rejects an unsigned request when the SP requires signatures', async () => {
+    mocks.sp = sp({ logoutRequestSignaturePolicy: 'required' });
+    const response = await post('SAMLRequest', requestXml());
+    expect(response.status).toBe(200);
+  });
+
+  it('rejects a LogoutResponse from an unknown SP', async () => {
+    mocks.sp = null;
+    await expectValidationError(await post('SAMLResponse', responseXml()));
+  });
+
+  it('rejects invalid LogoutResponse destination and correlation', async () => {
+    let response = await post(
+      'SAMLResponse',
+      responseXml({ destination: 'https://attacker.example/slo' })
+    );
+    await expectValidationError(response);
+
+    mocks.outbound = null;
+    response = await post('SAMLResponse', responseXml());
+    await expectValidationError(response);
+  });
+
+  it('preserves a 500 response for unexpected state-store failures', async () => {
+    mocks.outboundThrows = true;
+    expect((await post('SAMLResponse', responseXml())).status).toBe(500);
+  });
+
+  it.each([STATUS_CODES.SUCCESS, STATUS_CODES.RESPONDER])(
+    'consumes a correlated LogoutResponse with status %s',
+    async (statusCode) => {
+      const response = await post('SAMLResponse', responseXml({ statusCode }), 'relay');
+      expect(response.status).toBe(302);
+      expect(response.headers.get('location')).toContain('/logout-complete');
+      expect(mocks.deleteOutbound).toHaveBeenCalled();
+    }
+  );
+
+  it('returns configuration error when no logout-complete UI exists', async () => {
+    mocks.builtin = false;
+    mocks.ui = undefined;
+    const response = await post('SAMLResponse', responseXml());
+    expect(response.status).toBe(500);
+  });
+
+  it('uses configured UI for the logout-complete redirect', async () => {
+    mocks.builtin = false;
+    mocks.ui = { baseUrl: 'https://ui.example.test' };
+    const response = await post('SAMLResponse', responseXml());
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('https://ui.example.test/logout-complete');
+  });
+
+  it('requires an explicit tenant for IdP-initiated logout', async () => {
+    await expect(
+      initiateIdPLogout(environment() as never, 'user-a', sp() as never)
+    ).rejects.toThrow('tenant');
+    await expect(
+      initiateIdPLogoutBindingResponse(environment() as never, 'user-a', sp() as never)
+    ).rejects.toThrow('tenant');
+  });
+
+  it('fails closed when no NameID can be resolved', async () => {
+    await expect(
+      initiateIdPLogout(
+        environment() as never,
+        'user-a',
+        sp({ nameIdFormat: NAMEID_FORMATS.EMAIL }) as never,
+        undefined,
+        'tenant-a'
+      )
+    ).rejects.toThrow('could not be processed');
+  });
+
+  it('builds, signs, and stores a core IdP-initiated LogoutRequest', async () => {
+    mocks.userNameId = 'user@example.test';
+    const result = await initiateIdPLogout(
+      environment() as never,
+      'user-a',
+      sp({ sloUrl: undefined }) as never,
+      'session-index',
+      'tenant-a'
+    );
+    expect(result.destination).toBe('https://sp.example.test/acs');
+    expect(result.logoutRequestXml).toContain('LogoutRequest');
+    expect(mocks.storeOutbound).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ tenantId: 'tenant-a' })
+    );
+  });
+
+  it('propagates signing failure without storing an outbound request', async () => {
+    mocks.userNameId = 'user@example.test';
+    mocks.signingError = true;
+    await expect(
+      initiateIdPLogout(environment() as never, 'user-a', sp() as never, undefined, 'tenant-a')
+    ).rejects.toThrow('signing unavailable');
+    expect(mocks.storeOutbound).not.toHaveBeenCalled();
+  });
+
+  it.each(['post', 'redirect'] as const)(
+    'returns a signed %s binding response and preserves RelayState',
+    async (binding) => {
+      mocks.userNameId = 'user@example.test';
+      const response = await initiateIdPLogoutBindingResponse(
+        environment() as never,
+        'user-a',
+        sp() as never,
+        {
+          tenantId: 'tenant-a',
+          binding,
+          sessionIndex: 'session-index',
+          relayState: 'relay-state',
+        }
+      );
+      expect(response.status).toBe(binding === 'redirect' ? 302 : 200);
+      if (binding === 'redirect') {
+        expect(response.headers.get('location')).toContain('SAMLRequest=');
+      } else {
+        expect(await response.text()).toContain('RelayState');
+      }
+      expect(mocks.storeOutbound).toHaveBeenCalled();
+    }
+  );
+
+  it('uses SP profile to choose the default binding', async () => {
+    mocks.userNameId = 'user@example.test';
+    const response = await initiateIdPLogoutBindingResponse(
+      environment() as never,
+      'user-a',
+      sp({ samlProfile: 'legacy', sloBinding: undefined }) as never,
+      { tenantId: 'tenant-a' }
+    );
+    expect(response.status).toBe(200);
+  });
+
+  it('deduplicates multi-SP targets and starts a fanout transaction', async () => {
+    mocks.userNameId = 'user@example.test';
+    const target = sp() as never;
+    const result = await initiateIdPMultiSPLogoutBindingResponse(
+      environment() as never,
+      'user-a',
+      [target, target],
+      {
+        tenantId: 'tenant-a',
+        transactionId: 'transaction-custom',
+        binding: 'post',
+        relayState: 'relay',
+      }
+    );
+    expect(result.transactionId).toBe('transaction-custom');
+    expect(result.response.status).toBe(200);
+    expect(mocks.markSent).toHaveBeenCalled();
+  });
+
+  it('rejects an empty multi-SP fanout and records target send failure', async () => {
+    await expect(
+      initiateIdPMultiSPLogoutBindingResponse(environment() as never, 'user-a', [], {
+        tenantId: 'tenant-a',
+      })
+    ).rejects.toThrow('at least one SP target');
+
+    mocks.userNameId = 'user@example.test';
+    mocks.signingError = true;
+    await expect(
+      initiateIdPMultiSPLogoutBindingResponse(environment() as never, 'user-a', [sp() as never], {
+        tenantId: 'tenant-a',
+      })
+    ).rejects.toThrow('signing unavailable');
+    expect(mocks.markCompleted).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ status: 'failed', failureReason: 'send_failed' })
+    );
+  });
+
+  it('resolves email and persistent NameIDs without cross-tenant fallback', async () => {
+    mocks.userNameId = 'user@example.test';
+    expect(
+      await resolveIdPLogoutNameID(environment() as never, 'tenant-a', 'user-a', {
+        entityId: 'sp',
+        nameIdFormat: NAMEID_FORMATS.EMAIL,
+      })
+    ).toBe('user@example.test');
+
+    mocks.userInfo = null;
+    expect(
+      await resolveIdPLogoutNameID(environment() as never, 'tenant-a', 'user-a', {
+        entityId: 'sp',
+        nameIdFormat: NAMEID_FORMATS.PERSISTENT,
+      })
+    ).toBeNull();
+
+    mocks.userInfo = { id: 'user-a', email: 'user@example.test' };
+    expect(
+      await resolveIdPLogoutNameID(environment() as never, 'tenant-a', 'user-a', {
+        entityId: 'sp',
+        nameIdFormat: NAMEID_FORMATS.PERSISTENT,
+      })
+    ).toBe('persistent-name-id');
+  });
+});
+
+async function expectValidationError(response: Response) {
+  expect(response.status).toBe(400);
+  expect(await response.json()).toMatchObject({
+    error: 'invalid_request',
+    error_code: 'AR130003',
+  });
+}

--- a/packages/ar-saml/src/idp/__tests__/sso-handler.test.ts
+++ b/packages/ar-saml/src/idp/__tests__/sso-handler.test.ts
@@ -1,0 +1,788 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { BINDING_URIS, SAML_NAMESPACES } from '../../common/constants';
+
+const mocks = vi.hoisted(() => ({
+  sp: null as Record<string, unknown> | null,
+  builtin: false,
+  ui: undefined as { baseUrl: string; paths?: { login?: string } } | undefined,
+  loginPolicy: 'ui_base_url' as 'ui_base_url' | 'tenant_host',
+  storeFetch: vi.fn(async (_url?: string) => new Response('{}', { status: 200 })),
+  audit: vi.fn(),
+  sessionId: undefined as string | undefined,
+  shardedSession: true,
+  sessionResponse: new Response(null, { status: 404 }),
+  sessionThrows: false,
+  user: null as Record<string, unknown> | null,
+  attributeError: null as Error | null,
+  consentError: null as Error | null,
+  authnContextError: null as Error | null,
+  nameIdError: null as Error | null,
+  consentGrant: vi.fn(async () => undefined),
+  pairwiseSecret: 'pairwise-secret' as string | undefined,
+  pairwiseSecretForRef: 'referenced-secret' as string | undefined,
+  persistentProfileRows: [] as Array<Record<string, unknown>>,
+  targetedIdOptions: null as Record<string, unknown> | null,
+  buildResponse: vi.fn(() => '<saml-success-response/>'),
+  buildErrorResponse: vi.fn(() => '<saml-error-response/>'),
+}));
+
+vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@authrim/ar-lib-core')>();
+  return {
+    ...actual,
+    getUIConfig: vi.fn(async () => mocks.ui),
+    getTenantSettings: vi.fn(async () => ({})),
+    buildIssuerUrl: vi.fn(() => 'https://tenant.example.test'),
+    buildSAMLRequestStoreInstanceName: vi.fn(
+      (tenant: string, role: string, entity: string) => `${tenant}:${role}:${entity}`
+    ),
+    shouldUseBuiltinForms: vi.fn(async () => mocks.builtin),
+    getSessionStoreBySessionId: vi.fn(() => ({
+      stub: {
+        fetch: vi.fn(async () => {
+          if (mocks.sessionThrows) throw new Error('session unavailable');
+          return mocks.sessionResponse.clone();
+        }),
+      },
+    })),
+    isShardedSessionId: vi.fn(() => mocks.shardedSession),
+    resolveAuthCorePersistenceAdapterFromEnv: vi.fn(async () => ({})),
+    requireAdminDatabaseAdapter: vi.fn(() => ({
+      query: vi.fn(async () => mocks.persistentProfileRows),
+    })),
+    resolveRuntimeIdentityMappingBinding: vi.fn(async () => ({
+      id: 'binding',
+      tenantId: 'tenant-a',
+      catalog: { entries: [] },
+      edges: [],
+      transforms: [],
+      validationRules: [],
+      fieldMappingSet: {},
+      fieldMappingSetId: 'set',
+      fieldMappingVersionId: 'version',
+      destinationNamespace: 'saml',
+    })),
+    getLocalization: vi.fn(async () => ({ locale: 'en', t: (key: string) => key })),
+    getLogger: () => ({
+      module: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+    }),
+    createAuditLog: mocks.audit,
+    AttributeReleaseConsentRepository: class {
+      grant = mocks.consentGrant;
+    },
+  };
+});
+
+vi.mock('../../admin/providers', () => ({
+  getSPConfig: vi.fn(async () => mocks.sp),
+}));
+
+vi.mock('../../common/entity-id', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../common/entity-id')>();
+  return {
+    ...actual,
+    getSAMLInteractiveLoginUrlPolicy: vi.fn(async () => mocks.loginPolicy),
+    getSAMLLocalEntityIds: vi.fn(async () => ({
+      issuerUrl: 'https://tenant.example.test',
+      idpEntityId: 'https://tenant.example.test/saml/idp',
+    })),
+  };
+});
+
+vi.mock('../../common/session-cookie', () => ({
+  extractAuthrimSessionIdFromCookieHeader: vi.fn(() => mocks.sessionId),
+}));
+
+vi.mock('../../common/user-store', () => ({
+  getSamlUserInfoById: vi.fn(async () => mocks.user),
+}));
+
+vi.mock('../../common/idp-signing', () => ({
+  getSAMLIdPSigningMaterial: vi.fn(async () => ({
+    privateKeyPem: 'private-key',
+    certificate: 'certificate',
+  })),
+}));
+
+vi.mock('../signing', () => ({
+  applySAMLResponseSigningPolicy: vi.fn(async (xml: string) => xml),
+}));
+
+vi.mock('../assertion', () => ({
+  buildSAMLResponse: mocks.buildResponse,
+}));
+
+vi.mock('../attributes', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../attributes')>();
+  return {
+    ...actual,
+    buildSAMLAttributesForSPWithDiagnostics: vi.fn(() => {
+      if (mocks.attributeError) throw mocks.attributeError;
+      return {
+        attributes: [{ name: 'mail', values: ['user@example.test'] }],
+        optionalMissingAttributes: [],
+      };
+    }),
+  };
+});
+
+vi.mock('../attribute-release-consent', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../attribute-release-consent')>();
+  return {
+    ...actual,
+    enforceSAMLAttributeReleaseConsent: vi.fn(async () => {
+      if (mocks.consentError) throw mocks.consentError;
+    }),
+  };
+});
+
+vi.mock('../authn-context', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../authn-context')>();
+  return {
+    ...actual,
+    resolveSAMLAuthnContextClassRef: vi.fn(() => {
+      if (mocks.authnContextError) throw mocks.authnContextError;
+      return 'urn:test:loa:1';
+    }),
+  };
+});
+
+vi.mock('../subject', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../subject')>();
+  return {
+    ...actual,
+    createSAMLSessionIndex: vi.fn(async () => 'session-index'),
+    resolveSAMLNameIDFormat: vi.fn(() => {
+      if (mocks.nameIdError) throw mocks.nameIdError;
+      return 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress';
+    }),
+    resolveSAMLNameIDValue: vi.fn(async () => 'user@example.test'),
+    resolveSAMLEduPersonTargetedIDOpaque: vi.fn(
+      async (_user: unknown, options: Record<string, unknown>) => {
+        mocks.targetedIdOptions = options;
+        return 'targeted-id';
+      }
+    ),
+    resolveSAMLPairwiseSecret: vi.fn(async () => mocks.pairwiseSecret),
+    resolveSAMLPairwiseSecretForRef: vi.fn(async () => mocks.pairwiseSecretForRef),
+    resolveSAMLPersistentNameIDRegistryStore: vi.fn(() => undefined),
+    resolveSAMLTransientNameIDStore: vi.fn(() => undefined),
+  };
+});
+
+vi.mock('../encryption', () => ({
+  applySAMLAssertionEncryptionPolicy: vi.fn(async (xml: string) => xml),
+}));
+
+vi.mock('../error-response', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../error-response')>();
+  return {
+    ...actual,
+    buildSAMLIdPErrorResponse: mocks.buildErrorResponse,
+    applySAMLErrorResponseOverride: vi.fn((xml: string) => xml),
+  };
+});
+
+import { handleIdPAttributeReleaseConsent, handleIdPSSO } from '../sso';
+import { MissingRequiredSAMLAttributeError, SAMLIdentityMappingRuntimeError } from '../attributes';
+import { SAMLAttributeReleaseConsentRequiredError } from '../attribute-release-consent';
+import { SAMLAuthnContextPolicyError } from '../authn-context';
+import { SAMLNameIDPolicyError } from '../subject';
+
+function sp(overrides: Record<string, unknown> = {}) {
+  return {
+    entityId: 'https://sp.example.test/entity',
+    acsUrl: 'https://sp.example.test/acs',
+    acsUrls: ['https://sp.example.test/acs'],
+    allowedBindings: ['post'],
+    authnRequestSignaturePolicy: 'optional',
+    signResponses: true,
+    signAssertions: false,
+    ...overrides,
+  };
+}
+
+function app() {
+  const route = new Hono();
+  route.use('*', async (c, next) => {
+    (c.set as (key: string, value: string) => void)('tenantId', 'tenant-a');
+    await next();
+  });
+  route.all('/sso', handleIdPSSO as never);
+  route.post('/consent', handleIdPAttributeReleaseConsent as never);
+  return route;
+}
+
+function environment() {
+  return {
+    SAML_REQUEST_STORE: {
+      idFromName: vi.fn((name: string) => ({ name })),
+      get: vi.fn(() => ({ fetch: mocks.storeFetch })),
+    },
+  };
+}
+
+function authnRequest(
+  options: {
+    issueInstant?: string;
+    destination?: string;
+    acsUrl?: string;
+    protocolBinding?: string;
+    forceAuthn?: boolean;
+    isPassive?: boolean;
+  } = {}
+) {
+  const issueInstant = options.issueInstant ?? new Date().toISOString();
+  const attrs = [
+    'ID="_request"',
+    `IssueInstant="${issueInstant}"`,
+    options.destination ? `Destination="${options.destination}"` : '',
+    options.acsUrl ? `AssertionConsumerServiceURL="${options.acsUrl}"` : '',
+    options.protocolBinding ? `ProtocolBinding="${options.protocolBinding}"` : '',
+    options.forceAuthn ? 'ForceAuthn="true"' : '',
+    options.isPassive ? 'IsPassive="true"' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+  return `<samlp:AuthnRequest xmlns:samlp="${SAML_NAMESPACES.SAML2P}" xmlns:saml="${SAML_NAMESPACES.SAML2}" ${attrs}>
+    <saml:Issuer>https://sp.example.test/entity</saml:Issuer>
+  </samlp:AuthnRequest>`;
+}
+
+async function post(xml?: string, relayState?: string) {
+  const form = new FormData();
+  if (xml !== undefined) form.set('SAMLRequest', btoa(xml));
+  if (relayState !== undefined) form.set('RelayState', relayState);
+  return app().fetch(
+    new Request('https://tenant.example.test/sso', { method: 'POST', body: form }),
+    environment(),
+    { waitUntil: vi.fn(), passThroughOnException: vi.fn(), props: {} } as never
+  );
+}
+
+describe('IdP SSO handler policy boundaries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.sp = sp();
+    mocks.builtin = false;
+    mocks.ui = undefined;
+    mocks.loginPolicy = 'ui_base_url';
+    mocks.storeFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+    mocks.sessionId = undefined;
+    mocks.shardedSession = true;
+    mocks.sessionResponse = new Response(null, { status: 404 });
+    mocks.sessionThrows = false;
+    mocks.user = null;
+    mocks.attributeError = null;
+    mocks.consentError = null;
+    mocks.authnContextError = null;
+    mocks.nameIdError = null;
+    mocks.pairwiseSecret = 'pairwise-secret';
+    mocks.pairwiseSecretForRef = 'referenced-secret';
+    mocks.persistentProfileRows = [];
+    mocks.targetedIdOptions = null;
+  });
+
+  it('rejects missing and malformed POST messages without details', async () => {
+    expect((await post()).status).toBe(400);
+    expect((await post('<not-saml/>')).status).toBe(400);
+  });
+
+  it('rejects an unknown SP before creating login state', async () => {
+    mocks.sp = null;
+    const response = await post(authnRequest());
+    expect(response.status).toBe(400);
+    expect(mocks.storeFetch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [new Date(Date.now() + 10 * 60_000).toISOString(), undefined],
+    [new Date(Date.now() - 30 * 60_000).toISOString(), undefined],
+    [new Date().toISOString(), 'https://attacker.example/sso'],
+  ])('rejects invalid request timing or Destination', async (issueInstant, destination) => {
+    const response = await post(authnRequest({ issueInstant, destination }));
+    expect(response.status).toBe(400);
+    expect(mocks.storeFetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unregistered ACS URL without redirecting to it', async () => {
+    const response = await post(authnRequest({ acsUrl: 'https://attacker.example/acs' }));
+    expect(response.status).toBe(400);
+    expect(response.headers.get('location')).toBeNull();
+  });
+
+  it('returns a signed protocol error for unsupported response binding', async () => {
+    const response = await post(
+      authnRequest({ protocolBinding: BINDING_URIS.HTTP_REDIRECT }),
+      'relay'
+    );
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain('SAMLResponse');
+    expect(html).toContain('RelayState');
+    expect(mocks.buildErrorResponse).toHaveBeenCalled();
+    expect(mocks.buildResponse).not.toHaveBeenCalled();
+  });
+
+  it('returns a protocol error when a required request signature is absent', async () => {
+    mocks.sp = sp({ authnRequestSignaturePolicy: 'required' });
+    const response = await post(authnRequest());
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('SAMLResponse');
+    expect(mocks.buildErrorResponse).toHaveBeenCalled();
+    expect(mocks.buildResponse).not.toHaveBeenCalled();
+  });
+
+  it('handles passive authentication without starting an interactive login', async () => {
+    const response = await post(authnRequest({ isPassive: true }));
+    expect(response.status).toBe(200);
+    expect(mocks.storeFetch).not.toHaveBeenCalled();
+  });
+
+  it('stores the request before builtin login and preserves force-authn intent', async () => {
+    mocks.builtin = true;
+    const response = await post(authnRequest({ forceAuthn: true }), 'relay-state');
+    expect(response.status).toBe(302);
+    const location = response.headers.get('location') ?? '';
+    expect(location).toContain('/flow/login');
+    expect(location).toContain('force_authn=true');
+    expect(mocks.storeFetch).toHaveBeenCalledWith(
+      'https://saml-request-store/store',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('fails safely after storing when interactive UI is not configured', async () => {
+    const response = await post(authnRequest());
+    expect(response.status).toBe(500);
+    expect(mocks.storeFetch).toHaveBeenCalled();
+  });
+
+  it.each([
+    ['ui_base_url', '/custom-login', 'https://ui.example.test/custom-login', true],
+    ['ui_base_url', undefined, 'https://ui.example.test/login', true],
+    ['tenant_host', '/custom-login', 'https://tenant.example.test/custom-login', false],
+  ] as const)(
+    'redirects through the constrained %s UI policy',
+    async (policy, path, expected, tenantHint) => {
+      mocks.loginPolicy = policy;
+      mocks.ui = { baseUrl: 'https://ui.example.test', paths: path ? { login: path } : undefined };
+      const response = await post(authnRequest());
+      const location = response.headers.get('location') ?? '';
+      expect(location).toContain(expected);
+      expect(location.includes('tenant_hint=tenant-a')).toBe(tenantHint);
+    }
+  );
+
+  it('fails closed if request state cannot be stored', async () => {
+    mocks.builtin = true;
+    mocks.storeFetch.mockRejectedValue(new Error('state unavailable'));
+    const response = await post(authnRequest());
+    expect(response.status).toBe(400);
+  });
+
+  it.each([
+    ['non-sharded cookie', false, false, new Response(null, { status: 200 })],
+    ['session store failure', true, true, new Response(null, { status: 200 })],
+    ['expired session', true, false, new Response(null, { status: 401 })],
+    [
+      'session without user',
+      true,
+      false,
+      new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ],
+  ] as const)('treats %s as unauthenticated', async (_name, sharded, throws, response) => {
+    mocks.sessionId = 'session-id';
+    mocks.shardedSession = sharded;
+    mocks.sessionThrows = throws;
+    mocks.sessionResponse = response;
+    mocks.builtin = true;
+    const result = await post(authnRequest());
+    expect(result.status).toBe(302);
+    expect(result.headers.get('location')).toContain('/flow/login');
+  });
+
+  it('fails authentication when the session user no longer exists', async () => {
+    authenticateSession();
+    mocks.user = null;
+    const response = await post(authnRequest());
+    expect(response.status).toBe(400);
+  });
+
+  it('forces an authenticated session through interactive reauthentication', async () => {
+    authenticateSession();
+    mocks.user = { id: 'user-a', email: 'user@example.test' };
+    mocks.builtin = true;
+    const response = await post(authnRequest({ forceAuthn: true }));
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toContain('force_authn=true');
+  });
+
+  it('issues a SAML response for an authenticated user and preserves RelayState', async () => {
+    authenticateSession({ acr: 'loa2', amr: ['pwd', 1, 'mfa'] });
+    mocks.user = { id: 'user-a', email: 'user@example.test', name: 'User A' };
+    const response = await post(authnRequest(), 'relay-state');
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain('SAMLResponse');
+    expect(html).toContain('RelayState');
+    expect(mocks.buildResponse).toHaveBeenCalled();
+    expect(mocks.buildErrorResponse).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      'missing required attribute',
+      () =>
+        (mocks.attributeError = new MissingRequiredSAMLAttributeError([
+          { name: 'mail', friendlyName: 'Email', source: 'email' } as never,
+        ])),
+    ],
+    [
+      'identity mapping failure',
+      () =>
+        (mocks.attributeError = new SAMLIdentityMappingRuntimeError([
+          { category: 'policy', code: 'policy.mapping_failed', severity: 'critical' },
+        ] as never)),
+    ],
+    [
+      'unsupported authentication context',
+      () =>
+        (mocks.authnContextError = new SAMLAuthnContextPolicyError('unsupported', {
+          comparison: 'exact',
+          authnContextClassRef: ['urn:unsupported'],
+        })),
+    ],
+    [
+      'invalid NameID policy',
+      () => (mocks.nameIdError = new SAMLNameIDPolicyError('invalid', { format: 'unsupported' })),
+    ],
+  ] as const)('returns a protocol error for %s', async (_name, configure) => {
+    authenticateSession();
+    mocks.user = { id: 'user-a', email: 'user@example.test' };
+    configure();
+    const response = await post(authnRequest());
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('SAMLResponse');
+    expect(mocks.buildErrorResponse).toHaveBeenCalled();
+    expect(mocks.buildResponse).not.toHaveBeenCalled();
+  });
+
+  it('renders an attribute consent challenge and stores its binding', async () => {
+    authenticateSession();
+    mocks.user = { id: 'user-a', email: 'user@example.test' };
+    mocks.consentError = new SAMLAttributeReleaseConsentRequiredError({
+      attributeSetHash: 'hash',
+      reasonCodes: ['consent.required'],
+      consentMode: 'once',
+      attributes: [{ name: 'mail', values: ['user@example.test'] }],
+    });
+    const response = await post(authnRequest());
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('name="challenge_id"');
+    expect(mocks.storeFetch).toHaveBeenCalledTimes(1);
+    const storeCall = mocks.storeFetch.mock.calls[0] as unknown as [string, { body?: unknown }];
+    const storedBody = storeCall[1].body;
+    expect(typeof storedBody).toBe('string');
+    if (typeof storedBody !== 'string') throw new Error('Expected serialized request state');
+    const stored = JSON.parse(storedBody) as {
+      context: { attributeReleaseConsentChallenge: Record<string, unknown> };
+    };
+    expect(stored.context.attributeReleaseConsentChallenge).toMatchObject({
+      subjectId: 'user-a',
+      destinationType: 'saml_sp',
+      destinationId: 'https://sp.example.test/entity',
+      attributeSetHash: 'hash',
+      consentMode: 'once',
+    });
+  });
+
+  it('rejects GET redirect binding without a SAMLRequest', async () => {
+    const response = await app().fetch(
+      new Request('https://tenant.example.test/sso'),
+      environment(),
+      { waitUntil: vi.fn(), passThroughOnException: vi.fn(), props: {} } as never
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('builds eduPersonTargetedID runtime context from the tenant pairwise secret', async () => {
+    authenticateSession();
+    mocks.user = { id: 'user-a', email: 'user@example.test' };
+    mocks.sp = sp({
+      identityMapping: targetedIdMapping(),
+    });
+    expect((await post(authnRequest())).status).toBe(200);
+    expect(mocks.targetedIdOptions).toMatchObject({
+      tenantId: 'tenant-a',
+      spEntityId: 'https://sp.example.test/entity',
+      pairwiseSalt: 'pairwise-secret',
+    });
+  });
+
+  it.each([
+    [[], 'policy.persistent_identifier_profile_not_found'],
+    [
+      [{ id: 'profile-a', mode: 'stored', protocol_scope: 'saml', algorithm: 'sha256' }],
+      'policy.persistent_identifier_profile_unsupported_mode',
+    ],
+    [
+      [{ id: 'profile-a', mode: 'computed', protocol_scope: 'oidc', algorithm: 'sha256' }],
+      'policy.persistent_identifier_profile_unsupported_mode',
+    ],
+  ])('fails closed for unusable persistent identifier profile %#', async (rows) => {
+    authenticateSession();
+    mocks.user = { id: 'user-a', email: 'user@example.test' };
+    mocks.sp = sp({ identityMapping: targetedIdMapping('profile-a') });
+    mocks.persistentProfileRows = rows;
+    const response = await post(authnRequest());
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('SAMLResponse');
+    expect(mocks.targetedIdOptions).toBeNull();
+    expect(mocks.buildErrorResponse).toHaveBeenCalled();
+    expect(mocks.buildResponse).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [targetedIdMapping(), undefined, [], undefined],
+    [
+      targetedIdMapping('profile-a'),
+      'pairwise-secret',
+      [
+        {
+          id: 'profile-a',
+          mode: 'computed',
+          protocol_scope: 'saml',
+          algorithm: 'sha256',
+          secret_ref: 'secret-ref',
+        },
+      ],
+      undefined,
+    ],
+  ])(
+    'fails closed when targeted identifier secret is unavailable %#',
+    async (identityMapping, baseSecret, rows, refSecret) => {
+      authenticateSession();
+      mocks.user = { id: 'user-a', email: 'user@example.test' };
+      mocks.sp = sp({ identityMapping });
+      mocks.pairwiseSecret = baseSecret;
+      mocks.pairwiseSecretForRef = refSecret;
+      mocks.persistentProfileRows = rows;
+      expect((await post(authnRequest())).status).toBe(200);
+      expect(mocks.targetedIdOptions).toBeNull();
+      expect(mocks.buildErrorResponse).toHaveBeenCalled();
+      expect(mocks.buildResponse).not.toHaveBeenCalled();
+    }
+  );
+
+  it('applies a complete computed persistent identifier profile', async () => {
+    authenticateSession();
+    mocks.user = { id: 'user-a', email: 'user@example.test' };
+    mocks.sp = sp({ identityMapping: targetedIdMapping('profile-a') });
+    mocks.persistentProfileRows = [
+      {
+        id: 'profile-a',
+        mode: 'computed',
+        protocol_scope: 'generic',
+        algorithm: 'shibboleth_sha1_base64',
+        secret_ref: 'secret-ref',
+        issuer_entity_id: 'https://persistent.example.test/idp',
+        audience_mode: 'saml_sp_entity_id',
+      },
+    ];
+    expect((await post(authnRequest())).status).toBe(200);
+    expect(mocks.targetedIdOptions).toMatchObject({
+      pairwiseSalt: 'referenced-secret',
+      pairwiseAlgorithm: 'shibboleth_sha1_base64',
+      pairwiseAudienceMode: 'saml_sp_entity_id',
+      persistentProfileId: 'profile-a',
+    });
+  });
+});
+
+function targetedIdMapping(profileId?: string) {
+  return {
+    catalog: { entries: [] },
+    edges: [],
+    transforms: [
+      {
+        operation: 'saml_edu_person_targeted_id',
+        parameters: profileId ? { persistentIdentifierProfileId: profileId } : {},
+      },
+    ],
+  };
+}
+
+function authenticateSession(data: Record<string, unknown> = {}) {
+  mocks.sessionId = 'session-id';
+  mocks.shardedSession = true;
+  mocks.sessionResponse = new Response(JSON.stringify({ userId: 'user-a', data }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function storedConsentRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'authn_request',
+    issuer: 'https://sp.example.test/entity',
+    requestId: '_request',
+    relayState: 'relay-state',
+    binding: 'post',
+    data: {
+      id: '_request',
+      issueInstant: new Date().toISOString(),
+      issuer: 'https://sp.example.test/entity',
+      assertionConsumerServiceURL: 'https://sp.example.test/acs',
+    },
+    context: {
+      attributeReleaseConsentChallenge: {
+        challengeId: 'challenge-a',
+        subjectId: 'user-a',
+        destinationType: 'saml_sp',
+        destinationId: 'https://sp.example.test/entity',
+        attributeSetHash: 'hash-a',
+        createdAt: Date.now(),
+        consentMode: 'once',
+        attributeSummaries: [{ name: 'mail', valueCount: 1 }],
+        ...overrides,
+      },
+    },
+  };
+}
+
+async function postConsent(fields: Record<string, string> = {}) {
+  const form = new FormData();
+  for (const [key, value] of Object.entries(fields)) form.set(key, value);
+  return app().fetch(
+    new Request('https://tenant.example.test/consent', { method: 'POST', body: form }),
+    environment(),
+    { waitUntil: vi.fn(), passThroughOnException: vi.fn(), props: {} } as never
+  );
+}
+
+function validConsentFields(overrides: Record<string, string> = {}) {
+  return {
+    saml_request_id: '_request',
+    saml_sp_entity_id: 'https://sp.example.test/entity',
+    challenge_id: 'challenge-a',
+    attribute_set_hash: 'hash-a',
+    decision: 'approve_once',
+    ...overrides,
+  } as Record<string, string>;
+}
+
+describe('IdP attribute-release consent callback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.sp = sp();
+    mocks.sessionId = undefined;
+    mocks.shardedSession = true;
+    mocks.sessionResponse = new Response(null, { status: 404 });
+    mocks.storeFetch.mockImplementation(async (url?: string) =>
+      url?.includes('/consume/')
+        ? new Response(JSON.stringify(storedConsentRequest()), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        : new Response('{}', { status: 200 })
+    );
+  });
+
+  it('requires an authenticated session', async () => {
+    expect((await postConsent(validConsentFields())).status).toBe(400);
+    expect(mocks.storeFetch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {},
+    { saml_request_id: '_request' },
+    { saml_request_id: '_request', saml_sp_entity_id: 'https://sp.example.test/entity' },
+    {
+      saml_request_id: '_request',
+      saml_sp_entity_id: 'https://sp.example.test/entity',
+      challenge_id: 'challenge-a',
+    },
+    {
+      saml_request_id: '_request',
+      saml_sp_entity_id: 'https://sp.example.test/entity',
+      challenge_id: 'challenge-a',
+      attribute_set_hash: 'hash-a',
+    },
+  ])('rejects incomplete consent callback fields', async (fields) => {
+    authenticateSession();
+    expect((await postConsent(fields as Record<string, string>)).status).toBe(400);
+  });
+
+  it.each(['approve-later', '', 'APPROVE'])('rejects invalid decision %s', async (decision) => {
+    authenticateSession();
+    expect((await postConsent(validConsentFields({ decision }))).status).toBe(400);
+  });
+
+  it.each([
+    ['challengeId', 'other'],
+    ['subjectId', 'user-b'],
+    ['destinationType', 'oidc_client'],
+    ['destinationId', 'https://other-sp.example/entity'],
+    ['attributeSetHash', 'other-hash'],
+    ['createdAt', 0],
+  ])('rejects mismatched or expired challenge field %s', async (key, value) => {
+    authenticateSession();
+    mocks.storeFetch.mockImplementation(async (url?: string) =>
+      url?.includes('/consume/')
+        ? new Response(JSON.stringify(storedConsentRequest({ [key]: value })), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        : new Response('{}', { status: 200 })
+    );
+    expect((await postConsent(validConsentFields())).status).toBe(400);
+  });
+
+  it('rejects a consumed request without a consent challenge or configured SP', async () => {
+    authenticateSession();
+    mocks.storeFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ...storedConsentRequest(), context: {} }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    expect((await postConsent(validConsentFields())).status).toBe(400);
+
+    mocks.sp = null;
+    expect((await postConsent(validConsentFields())).status).toBe(400);
+  });
+
+  it('returns a protocol denial response without persisting consent', async () => {
+    authenticateSession();
+    const response = await postConsent(validConsentFields({ decision: 'deny' }));
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('SAMLResponse');
+    expect(mocks.consentGrant).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['approve_once', undefined, false],
+    ['approve', 'once', false],
+    ['approve', 'remember', true],
+    ['approve_remember', undefined, true],
+  ])('handles %s with scope %s', async (decision, releaseScope, persists) => {
+    authenticateSession();
+    const fields = validConsentFields({ decision });
+    if (releaseScope) fields.release_scope = releaseScope;
+    const response = await postConsent(fields);
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toContain('saml_request_id=_request');
+    expect(mocks.consentGrant).toHaveBeenCalledTimes(persists ? 1 : 0);
+  });
+
+  it('fails closed when consumed state cannot be read', async () => {
+    authenticateSession();
+    mocks.storeFetch.mockRejectedValue(new Error('state unavailable'));
+    expect((await postConsent(validConsentFields())).status).toBe(400);
+  });
+});

--- a/packages/ar-saml/src/idp/slo.ts
+++ b/packages/ar-saml/src/idp/slo.ts
@@ -87,7 +87,7 @@ import {
   type SAMLOutboundLogoutRequestRecord,
 } from './slo-state';
 import { getSAMLLocalEntityIds } from '../common/entity-id';
-import { assertSAMLRelayStateSize } from '../common/relay-state';
+import { assertSAMLRelayStateSize, SAMLRelayStateTooLargeError } from '../common/relay-state';
 import { buildIdPSLODestinationUrls, isAllowedIdPSLODestination } from './shibboleth-compat';
 
 interface ParsedLogoutRequestInput {
@@ -104,6 +104,13 @@ interface ParsedLogoutResponseInput {
   binding: 'post' | 'redirect';
   xml: string;
   redirectSignature?: SAMLRedirectSignatureInput;
+}
+
+class SAMLLogoutMessageValidationError extends Error {
+  constructor() {
+    super('Invalid SAML logout message');
+    this.name = 'SAMLLogoutMessageValidationError';
+  }
 }
 
 export interface IdPLogoutBindingResponseOptions {
@@ -135,12 +142,15 @@ export async function handleIdPSLO(c: Context<{ Bindings: Env }>): Promise<Respo
 
   try {
     if (method === 'GET') {
-      return handleRedirectBinding(c, env, issuerUrl);
+      return await handleRedirectBinding(c, env, issuerUrl);
     } else {
-      return handlePostBinding(c, env, issuerUrl);
+      return await handlePostBinding(c, env, issuerUrl);
     }
   } catch (error) {
     log.error('IdP SLO Error', { method }, error as Error);
+    if (isSAMLLogoutValidationError(error)) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE);
+    }
     return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
   }
 }
@@ -160,17 +170,21 @@ async function handlePostBinding(
   assertSAMLRelayStateSize(relayState);
 
   if (samlRequest) {
-    const xml = decodePostBindingMessage(samlRequest, 'SAML LogoutRequest');
+    const xml = parseSAMLLogoutMessage(() =>
+      decodePostBindingMessage(samlRequest, 'SAML LogoutRequest')
+    );
     return processLogoutRequest(c, env, issuerUrl, {
-      logoutRequest: parseLogoutRequestXml(xml),
+      logoutRequest: parseSAMLLogoutMessage(() => parseLogoutRequestXml(xml)),
       relayState,
       binding: 'post',
       xml,
     });
   } else if (samlResponse) {
-    const xml = decodePostBindingMessage(samlResponse, 'SAML LogoutResponse');
+    const xml = parseSAMLLogoutMessage(() =>
+      decodePostBindingMessage(samlResponse, 'SAML LogoutResponse')
+    );
     return processLogoutResponse(c, env, issuerUrl, {
-      logoutResponse: parseLogoutResponseXml(xml),
+      logoutResponse: parseSAMLLogoutMessage(() => parseLogoutResponseXml(xml)),
       relayState,
       binding: 'post',
       xml,
@@ -197,9 +211,11 @@ async function handleRedirectBinding(
   assertSAMLRelayStateSize(relayState);
 
   if (samlRequest) {
-    const xml = inflateRedirectBindingMessage(samlRequest, 'SAML LogoutRequest');
+    const xml = parseSAMLLogoutMessage(() =>
+      inflateRedirectBindingMessage(samlRequest, 'SAML LogoutRequest')
+    );
     return processLogoutRequest(c, env, issuerUrl, {
-      logoutRequest: parseLogoutRequestXml(xml),
+      logoutRequest: parseSAMLLogoutMessage(() => parseLogoutRequestXml(xml)),
       relayState,
       binding: 'redirect',
       xml,
@@ -211,9 +227,11 @@ async function handleRedirectBinding(
       },
     });
   } else if (samlResponse) {
-    const xml = inflateRedirectBindingMessage(samlResponse, 'SAML LogoutResponse');
+    const xml = parseSAMLLogoutMessage(() =>
+      inflateRedirectBindingMessage(samlResponse, 'SAML LogoutResponse')
+    );
     return processLogoutResponse(c, env, issuerUrl, {
-      logoutResponse: parseLogoutResponseXml(xml),
+      logoutResponse: parseSAMLLogoutMessage(() => parseLogoutResponseXml(xml)),
       relayState,
       binding: 'redirect',
       xml,
@@ -410,7 +428,7 @@ async function processLogoutResponse(
 
   const spConfig = await getSPConfig(env, tenantId, logoutResponse.issuer);
   if (!spConfig) {
-    throw new Error('Unknown Service Provider in LogoutResponse');
+    throw new SAMLLogoutMessageValidationError();
   }
 
   try {
@@ -558,28 +576,45 @@ function validateLogoutRequest(logoutRequest: ParsedLogoutRequest, issuerUrl: st
   const maxAge = DEFAULTS.REQUEST_VALIDITY_SECONDS * 1000;
 
   if (issueInstant.getTime() > now.getTime() + skewMs) {
-    throw new Error('LogoutRequest IssueInstant is in the future');
+    throw new SAMLLogoutMessageValidationError();
   }
 
   if (now.getTime() - issueInstant.getTime() > maxAge + skewMs) {
-    throw new Error('LogoutRequest has expired');
+    throw new SAMLLogoutMessageValidationError();
   }
 
   // Check NotOnOrAfter if present
   if (logoutRequest.notOnOrAfter) {
     const notOnOrAfter = new Date(logoutRequest.notOnOrAfter);
     if (now.getTime() > notOnOrAfter.getTime() + skewMs) {
-      throw new Error('LogoutRequest has expired (NotOnOrAfter)');
+      throw new SAMLLogoutMessageValidationError();
     }
   }
 
   // Validate Destination if present
   if (logoutRequest.destination) {
     if (!isAllowedIdPSLODestination(logoutRequest.destination, issuerUrl)) {
-      // SECURITY: Do not expose endpoint URLs in error message
-      throw new Error('Invalid Destination in SAML LogoutRequest');
+      throw new SAMLLogoutMessageValidationError();
     }
   }
+}
+
+function parseSAMLLogoutMessage<T>(parse: () => T): T {
+  try {
+    return parse();
+  } catch {
+    throw new SAMLLogoutMessageValidationError();
+  }
+}
+
+function isSAMLLogoutValidationError(error: unknown): boolean {
+  return (
+    error instanceof SAMLLogoutMessageValidationError ||
+    error instanceof SAMLRelayStateTooLargeError ||
+    error instanceof SAMLLogoutResponseCorrelationError ||
+    error instanceof SAMLLogoutRequestSignatureValidationError ||
+    error instanceof SAMLLogoutResponseSignatureValidationError
+  );
 }
 
 function validateLogoutRequestSessionPolicy(

--- a/packages/ar-saml/src/sp/__tests__/slo-handler.test.ts
+++ b/packages/ar-saml/src/sp/__tests__/slo-handler.test.ts
@@ -1,0 +1,382 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { SAML_NAMESPACES, STATUS_CODES } from '../../common/constants';
+
+const mocks = vi.hoisted(() => ({
+  idp: null as Record<string, unknown> | null,
+  builtin: true,
+  ui: undefined as { baseUrl: string } | undefined,
+  activeUser: null as { id: string } | null,
+  userNameId: null as string | null,
+  sessionDelete: new Response(null, { status: 204 }),
+  sessionThrows: false,
+  signingError: false,
+  signaturePolicyError: null as Error | null,
+  outbound: { requestId: '_outbound', relayState: undefined } as Record<string, unknown> | null,
+  outboundThrows: false,
+  storeOutbound: vi.fn(async () => undefined),
+  consumeOutbound: vi.fn(),
+  revoke: vi.fn(async () => undefined),
+  verify: vi.fn(),
+}));
+
+vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@authrim/ar-lib-core')>();
+  return {
+    ...actual,
+    getSessionStoreBySessionId: vi.fn(() => ({
+      stub: {
+        fetch: vi.fn(async () => {
+          if (mocks.sessionThrows) throw new Error('session unavailable');
+          return mocks.sessionDelete.clone();
+        }),
+      },
+    })),
+    isShardedSessionId: vi.fn((id: string) => id.startsWith('sess_')),
+    getUIConfig: vi.fn(async () => mocks.ui),
+    buildUIUrl: vi.fn((config: { baseUrl: string }) => `${config.baseUrl}/logout-complete`),
+    shouldUseBuiltinForms: vi.fn(async () => mocks.builtin),
+    usesNakedDomainIssuer: vi.fn(() => false),
+    buildIssuerUrl: vi.fn(() => 'https://tenant.example.test'),
+    createAuthContextFromHono: vi.fn(() => ({ coreAdapter: {} })),
+    recordUserSessionRevocationEpoch: mocks.revoke,
+    getLogger: () => ({
+      module: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+    }),
+    createLogger: () => ({ module: () => ({ error: vi.fn() }) }),
+  };
+});
+
+vi.mock('../../admin/providers', () => ({
+  getIdPConfigByEntityId: vi.fn(async () => mocks.idp),
+}));
+
+vi.mock('../../common/entity-id', () => ({
+  getSAMLLocalEntityIds: vi.fn(async () => ({
+    issuerUrl: 'https://tenant.example.test',
+    spEntityId: 'https://tenant.example.test/saml/sp',
+  })),
+}));
+
+vi.mock('../../common/saml-signing-keys', () => ({
+  getSAMLSigningPolicy: vi.fn(() => 'optional'),
+  getSAMLSigningMaterial: vi.fn(async () => {
+    if (mocks.signingError) throw new Error('signing unavailable');
+    return { privateKeyPem: 'private-key', certificate: 'certificate' };
+  }),
+}));
+
+vi.mock('../../common/signature', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../common/signature')>();
+  return {
+    ...actual,
+    hasSignature: vi.fn((xml: string) => xml.includes('<Signature')),
+    verifyXmlSignature: mocks.verify,
+    signXml: vi.fn((xml: string) => xml),
+  };
+});
+
+vi.mock('../../common/user-store', () => ({
+  findActiveSamlUserByEmail: vi.fn(async () => mocks.activeUser),
+  getSamlUserNameIdById: vi.fn(async () => mocks.userNameId),
+}));
+
+vi.mock('../logout-request-signature', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../logout-request-signature')>();
+  return {
+    ...actual,
+    validateSAMLIdPLogoutRequestSignature: vi.fn(async () => {
+      if (mocks.signaturePolicyError) throw mocks.signaturePolicyError;
+    }),
+  };
+});
+
+vi.mock('../../idp/slo-state', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../idp/slo-state')>();
+  return {
+    ...actual,
+    consumeSAMLOutboundLogoutRequest: mocks.consumeOutbound.mockImplementation(async () => {
+      if (mocks.outboundThrows) throw new Error('state store unavailable');
+      if (!mocks.outbound) {
+        throw new actual.SAMLLogoutResponseCorrelationError('missing request', {});
+      }
+      return mocks.outbound;
+    }),
+    storeSAMLOutboundLogoutRequest: mocks.storeOutbound,
+  };
+});
+
+import { handleSPSLO, initiateSPLogout } from '../slo';
+import { SAMLIdPLogoutRequestSignatureValidationError } from '../logout-request-signature';
+
+function idp(overrides: Record<string, unknown> = {}) {
+  return {
+    entityId: 'https://idp.example.test/entity',
+    ssoUrl: 'https://idp.example.test/sso',
+    sloUrl: 'https://idp.example.test/slo',
+    certificate: 'certificate',
+    ...overrides,
+  };
+}
+
+function app() {
+  const route = new Hono();
+  route.use('*', async (c, next) => {
+    (c.set as (key: string, value: string) => void)('tenantId', 'tenant-a');
+    await next();
+  });
+  route.all('/slo', handleSPSLO as never);
+  return route;
+}
+
+function environment(withState = true) {
+  return withState ? { STATE_STORE: {} } : {};
+}
+
+function requestXml(
+  options: {
+    issueInstant?: string;
+    destination?: string;
+    sessionIndex?: string;
+  } = {}
+) {
+  return `<samlp:LogoutRequest xmlns:samlp="${SAML_NAMESPACES.SAML2P}" xmlns:saml="${SAML_NAMESPACES.SAML2}"
+    ID="_logout" IssueInstant="${options.issueInstant ?? new Date().toISOString()}"
+    ${options.destination ? `Destination="${options.destination}"` : ''}>
+    <saml:Issuer>https://idp.example.test/entity</saml:Issuer>
+    <saml:NameID>user@example.test</saml:NameID>
+    ${options.sessionIndex ? `<samlp:SessionIndex>${options.sessionIndex}</samlp:SessionIndex>` : ''}
+  </samlp:LogoutRequest>`;
+}
+
+function responseXml(
+  options: { statusCode?: string; inResponseTo?: string; signature?: boolean } = {}
+) {
+  return `<samlp:LogoutResponse xmlns:samlp="${SAML_NAMESPACES.SAML2P}" xmlns:saml="${SAML_NAMESPACES.SAML2}"
+    ID="_response" IssueInstant="${new Date().toISOString()}" InResponseTo="${options.inResponseTo ?? '_outbound'}">
+    <saml:Issuer>https://idp.example.test/entity</saml:Issuer>
+    ${options.signature ? '<Signature />' : ''}
+    <samlp:Status><samlp:StatusCode Value="${options.statusCode ?? STATUS_CODES.SUCCESS}"/></samlp:Status>
+  </samlp:LogoutResponse>`;
+}
+
+async function post(field?: 'SAMLRequest' | 'SAMLResponse', xml?: string, relayState?: string) {
+  const form = new FormData();
+  if (field && xml) form.set(field, btoa(xml));
+  if (relayState) form.set('RelayState', relayState);
+  return app().fetch(
+    new Request('https://tenant.example.test/slo', { method: 'POST', body: form }),
+    environment(),
+    { waitUntil: vi.fn(), passThroughOnException: vi.fn(), props: {} } as never
+  );
+}
+
+describe('SP SLO handler policy boundaries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.idp = idp();
+    mocks.builtin = true;
+    mocks.ui = undefined;
+    mocks.activeUser = null;
+    mocks.userNameId = null;
+    mocks.sessionDelete = new Response(null, { status: 204 });
+    mocks.sessionThrows = false;
+    mocks.signingError = false;
+    mocks.signaturePolicyError = null;
+    mocks.outbound = { requestId: '_outbound', relayState: undefined };
+    mocks.outboundThrows = false;
+  });
+
+  it('requires a SAML message for POST and GET bindings', async () => {
+    expect((await post()).status).toBe(400);
+    expect((await app().request('https://tenant.example.test/slo', {}, environment())).status).toBe(
+      400
+    );
+  });
+
+  it('maps malformed POST logout messages to validation errors', async () => {
+    await expectValidationError(await post('SAMLRequest', '<not-saml/>'));
+    await expectValidationError(await post('SAMLResponse', '<not-saml/>'));
+  });
+
+  it('rejects an oversized RelayState as invalid input', async () => {
+    await expectValidationError(await post('SAMLRequest', requestXml(), 'x'.repeat(81)));
+  });
+
+  it('rejects an unknown IdP and signature-policy failures', async () => {
+    mocks.idp = null;
+    expect((await post('SAMLRequest', requestXml())).status).toBe(400);
+
+    mocks.idp = idp();
+    mocks.signaturePolicyError = new SAMLIdPLogoutRequestSignatureValidationError(
+      'idp_logout_request_signature_required',
+      'signature required'
+    );
+    expect((await post('SAMLRequest', requestXml())).status).toBe(400);
+  });
+
+  it.each([
+    [new Date(Date.now() + 10 * 60_000).toISOString(), undefined],
+    [new Date(Date.now() - 30 * 60_000).toISOString(), undefined],
+    [new Date().toISOString(), 'https://attacker.example.test/slo'],
+  ])('rejects invalid request timing or destination', async (issueInstant, destination) => {
+    await expectValidationError(
+      await post('SAMLRequest', requestXml({ issueInstant, destination }))
+    );
+  });
+
+  it.each([
+    ['sess_valid', 204, false],
+    ['sess_missing', 404, false],
+    ['legacy-session', 204, false],
+    [undefined, 204, false],
+    ['sess_error', 204, true],
+  ])('handles session termination boundary %s', async (sessionIndex, status, throws) => {
+    mocks.sessionDelete = new Response(null, { status });
+    mocks.sessionThrows = throws;
+    mocks.activeUser = { id: 'user-a' };
+    const response = await post('SAMLRequest', requestXml({ sessionIndex }));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('set-cookie')).toContain('Max-Age=0');
+  });
+
+  it('continues safely when signing a LogoutResponse fails', async () => {
+    mocks.signingError = true;
+    expect((await post('SAMLRequest', requestXml())).status).toBe(200);
+  });
+
+  it('rejects unknown and uncorrelated LogoutResponses', async () => {
+    mocks.idp = null;
+    expect((await post('SAMLResponse', responseXml())).status).toBe(400);
+
+    mocks.idp = idp();
+    mocks.outbound = null;
+    expect((await post('SAMLResponse', responseXml())).status).toBe(400);
+  });
+
+  it('preserves a 500 response for unexpected state-store failures', async () => {
+    mocks.outboundThrows = true;
+    expect((await post('SAMLResponse', responseXml())).status).toBe(500);
+  });
+
+  it('requires state storage and exact RelayState correlation', async () => {
+    const form = new FormData();
+    form.set('SAMLResponse', btoa(responseXml()));
+    expect(
+      (
+        await app().fetch(
+          new Request('https://tenant.example.test/slo', { method: 'POST', body: form }),
+          environment(false)
+        )
+      ).status
+    ).toBe(400);
+
+    expect((await post('SAMLResponse', responseXml(), 'wrong')).status).toBe(400);
+  });
+
+  it.each([STATUS_CODES.SUCCESS, STATUS_CODES.RESPONDER])(
+    'redirects a correlated %s response to its preserved return URL',
+    async (statusCode) => {
+      mocks.outbound = { requestId: '_outbound', relayState: 'https://app.example.test/done' };
+      const response = await post('SAMLResponse', responseXml({ statusCode }), '_outbound');
+      expect(response.status).toBe(302);
+      expect(response.headers.get('location')).toBe('https://app.example.test/done');
+    }
+  );
+
+  it('rejects a signed POST response when IdP signature verification fails', async () => {
+    mocks.verify.mockImplementationOnce(() => {
+      throw new Error('invalid signature');
+    });
+    const response = await post('SAMLResponse', responseXml({ signature: true }));
+    await expectValidationError(response);
+    expect(mocks.verify).toHaveBeenCalled();
+    expect(mocks.consumeOutbound).not.toHaveBeenCalled();
+  });
+
+  it('uses builtin, external, and configuration-error logout completion destinations', async () => {
+    expect((await post('SAMLResponse', responseXml())).headers.get('location')).toBe(
+      'https://tenant.example.test/logout-complete'
+    );
+
+    mocks.builtin = false;
+    mocks.ui = { baseUrl: 'https://ui.example.test' };
+    expect((await post('SAMLResponse', responseXml())).headers.get('location')).toBe(
+      'https://ui.example.test/logout-complete'
+    );
+
+    mocks.ui = undefined;
+    expect((await post('SAMLResponse', responseXml())).status).toBe(500);
+  });
+});
+
+async function expectValidationError(response: Response) {
+  expect(response.status).toBe(400);
+  expect(await response.json()).toMatchObject({
+    error: 'invalid_request',
+    error_code: 'AR130003',
+  });
+}
+
+describe('SP-initiated SLO', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.userNameId = 'user@example.test';
+    mocks.signingError = false;
+  });
+
+  it('requires an explicit tenant, resolvable NameID, and state storage', async () => {
+    await expect(
+      initiateSPLogout(environment() as never, 'user-a', idp() as never)
+    ).rejects.toThrow(/tenant/i);
+    mocks.userNameId = null;
+    await expect(
+      initiateSPLogout(
+        environment() as never,
+        'user-a',
+        idp() as never,
+        undefined,
+        undefined,
+        'tenant-a'
+      )
+    ).rejects.toThrow('could not be processed');
+    mocks.userNameId = 'user@example.test';
+    await expect(
+      initiateSPLogout({} as never, 'user-a', idp() as never, undefined, undefined, 'tenant-a')
+    ).rejects.toThrow('STATE_STORE');
+  });
+
+  it.each([
+    [undefined, undefined, 'https://idp.example.test/slo'],
+    ['sess_valid', 'https://app.example.test/done', 'https://idp.example.test/sso'],
+  ])(
+    'builds and stores a request for optional session and return state',
+    async (sessionIndex, returnUrl, destination) => {
+      const config = idp(returnUrl ? { sloUrl: undefined } : {});
+      const result = await initiateSPLogout(
+        environment() as never,
+        'user-a',
+        config as never,
+        sessionIndex,
+        returnUrl,
+        'tenant-a'
+      );
+      expect(result.html).toContain(destination);
+      expect(result.html).toContain('SAMLRequest');
+      expect(mocks.storeOutbound).toHaveBeenCalled();
+    }
+  );
+
+  it('continues with an unsigned request when signing material is unavailable', async () => {
+    mocks.signingError = true;
+    const result = await initiateSPLogout(
+      environment() as never,
+      'user-a',
+      idp() as never,
+      undefined,
+      undefined,
+      'tenant-a'
+    );
+    expect(typeof result.html).toBe('string');
+  });
+});

--- a/packages/ar-saml/src/sp/slo.ts
+++ b/packages/ar-saml/src/sp/slo.ts
@@ -63,7 +63,14 @@ import {
   storeSAMLOutboundLogoutRequest,
   SAMLLogoutResponseCorrelationError,
 } from '../idp/slo-state';
-import { assertSAMLRelayStateSize } from '../common/relay-state';
+import { assertSAMLRelayStateSize, SAMLRelayStateTooLargeError } from '../common/relay-state';
+
+class SAMLLogoutMessageValidationError extends Error {
+  constructor() {
+    super('Invalid SAML logout message');
+    this.name = 'SAMLLogoutMessageValidationError';
+  }
+}
 
 /**
  * Handle SP Single Logout (both POST and GET)
@@ -76,12 +83,15 @@ export async function handleSPSLO(c: Context<{ Bindings: Env }>): Promise<Respon
 
   try {
     if (method === 'GET') {
-      return handleRedirectBinding(c, env, issuerUrl);
+      return await handleRedirectBinding(c, env, issuerUrl);
     } else {
-      return handlePostBinding(c, env, issuerUrl);
+      return await handlePostBinding(c, env, issuerUrl);
     }
   } catch (error) {
     log.error('SP SLO Error', { method }, error as Error);
+    if (isSAMLLogoutMessageValidationError(error)) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE);
+    }
     return createErrorResponse(c, AR_ERROR_CODES.INTERNAL_ERROR);
   }
 }
@@ -101,8 +111,10 @@ async function handlePostBinding(
   assertSAMLRelayStateSize(relayState);
 
   if (samlRequest) {
-    const xml = decodePostBindingMessage(samlRequest, 'SAML LogoutRequest');
-    const logoutRequest = parseLogoutRequestXml(xml);
+    const xml = parseSAMLLogoutMessage(() =>
+      decodePostBindingMessage(samlRequest, 'SAML LogoutRequest')
+    );
+    const logoutRequest = parseSAMLLogoutMessage(() => parseLogoutRequestXml(xml));
     return processLogoutRequest(c, env, issuerUrl, {
       logoutRequest,
       relayState,
@@ -110,7 +122,7 @@ async function handlePostBinding(
       xml,
     });
   } else if (samlResponse) {
-    const logoutResponse = parseLogoutResponsePost(samlResponse);
+    const logoutResponse = parseSAMLLogoutMessage(() => parseLogoutResponsePost(samlResponse));
     return processLogoutResponse(c, env, logoutResponse, relayState, samlResponse);
   } else {
     return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_REQUIRED_FIELD, {
@@ -134,8 +146,10 @@ async function handleRedirectBinding(
   assertSAMLRelayStateSize(relayState);
 
   if (samlRequest) {
-    const xml = inflateRedirectBindingMessage(samlRequest, 'SAML LogoutRequest');
-    const logoutRequest = parseLogoutRequestXml(xml);
+    const xml = parseSAMLLogoutMessage(() =>
+      inflateRedirectBindingMessage(samlRequest, 'SAML LogoutRequest')
+    );
+    const logoutRequest = parseSAMLLogoutMessage(() => parseLogoutRequestXml(xml));
     return processLogoutRequest(c, env, issuerUrl, {
       logoutRequest,
       relayState,
@@ -149,7 +163,7 @@ async function handleRedirectBinding(
       },
     });
   } else if (samlResponse) {
-    const logoutResponse = parseLogoutResponseRedirect(samlResponse);
+    const logoutResponse = parseSAMLLogoutMessage(() => parseLogoutResponseRedirect(samlResponse));
     return processLogoutResponse(c, env, logoutResponse, relayState);
   } else {
     return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_REQUIRED_FIELD, {
@@ -277,7 +291,7 @@ async function processLogoutResponse(
         });
       } catch (error) {
         log.error('LogoutResponse signature verification failed', {}, error as Error);
-        // Log but continue - some IdPs may not sign LogoutResponses
+        return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE);
       }
     }
   }
@@ -357,21 +371,35 @@ function validateLogoutRequest(logoutRequest: ParsedLogoutRequest, issuerUrl: st
   const maxAge = DEFAULTS.REQUEST_VALIDITY_SECONDS * 1000;
 
   if (issueInstant.getTime() > now.getTime() + skewMs) {
-    throw new Error('LogoutRequest IssueInstant is in the future');
+    throw new SAMLLogoutMessageValidationError();
   }
 
   if (now.getTime() - issueInstant.getTime() > maxAge + skewMs) {
-    throw new Error('LogoutRequest has expired');
+    throw new SAMLLogoutMessageValidationError();
   }
 
   // Validate Destination if present
   if (logoutRequest.destination) {
     const expectedDestination = `${issuerUrl}/saml/sp/slo`;
     if (logoutRequest.destination !== expectedDestination) {
-      // SECURITY: Do not expose endpoint URLs in error message
-      throw new Error('Invalid Destination in SAML LogoutRequest');
+      throw new SAMLLogoutMessageValidationError();
     }
   }
+}
+
+function parseSAMLLogoutMessage<T>(parse: () => T): T {
+  try {
+    return parse();
+  } catch {
+    throw new SAMLLogoutMessageValidationError();
+  }
+}
+
+function isSAMLLogoutMessageValidationError(error: unknown): boolean {
+  return (
+    error instanceof SAMLLogoutMessageValidationError ||
+    error instanceof SAMLRelayStateTooLargeError
+  );
 }
 
 /**
@@ -449,7 +477,7 @@ async function sendLogoutResponse(
   },
   cookieHeader: string
 ): Promise<Response> {
-  const { inResponseTo, statusCode, statusMessage, relayState, binding } = options;
+  const { inResponseTo, statusCode, statusMessage, relayState } = options;
 
   const destination = idpConfig.sloUrl || idpConfig.ssoUrl;
   const responseId = generateSAMLId();

--- a/packages/ar-saml/vitest.config.ts
+++ b/packages/ar-saml/vitest.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts'],
+    coverage: {
+      thresholds: {
+        branches: 75,
+      },
+    },
   },
   resolve: {
     alias: {

--- a/packages/ar-token/src/__tests__/client-auth.test.ts
+++ b/packages/ar-token/src/__tests__/client-auth.test.ts
@@ -799,6 +799,509 @@ describe('Client Authentication Tests', () => {
     });
   });
 
+  describe('CIBA grant state and client binding', () => {
+    const authReqId = 'auth-req-state-matrix';
+
+    function configureCIBARequest(
+      client: TestClientMetadata,
+      metadata: Record<string, unknown>,
+      options: { markIssuedResponse?: Response; updatePollError?: Error } = {}
+    ) {
+      const fetch = vi.fn().mockImplementation(async (request: Request) => {
+        const pathname = new URL(request.url).pathname;
+        if (pathname === '/update-poll') {
+          if (options.updatePollError) {
+            throw options.updatePollError;
+          }
+          return Response.json({ success: true });
+        }
+        if (pathname === '/get-by-auth-req-id') {
+          return Response.json(metadata);
+        }
+        if (pathname === '/mark-token-issued') {
+          return options.markIssuedResponse ?? Response.json({ success: true });
+        }
+        if (pathname === '/delete') {
+          return Response.json({ success: true });
+        }
+        return Response.json({ error: 'not_found' }, { status: 404 });
+      });
+      mockEnv.CIBA_REQUEST_STORE.get = vi.fn().mockReturnValue({ fetch });
+      mocks.mockGetClientCached.mockResolvedValue(client);
+      return fetch;
+    }
+
+    async function requestCIBAToken(client: TestClientMetadata) {
+      const ctx = createMockContext({
+        body: {
+          grant_type: 'urn:openid:params:grant-type:ciba',
+          auth_req_id: authReqId,
+          client_id: client.client_id,
+          client_secret: CIBA_CLIENT_SECRET,
+        },
+        env: mockEnv,
+      });
+      const response = await tokenHandler(ctx);
+      return {
+        response,
+        body: await parseJsonResponse<Record<string, unknown>>(response),
+      };
+    }
+
+    function baseCIBAMetadata(client: TestClientMetadata, overrides = {}) {
+      return {
+        auth_req_id: authReqId,
+        client_id: client.client_id,
+        scope: 'openid profile',
+        status: 'pending',
+        delivery_mode: 'ping',
+        interval: 5,
+        created_at: Date.now() - 1_000,
+        expires_at: Date.now() + 60_000,
+        token_issued: false,
+        ...overrides,
+      };
+    }
+
+    it('rejects clients that are not authorized for the CIBA grant before storage access', async () => {
+      const client = createCIBAClient({
+        client_secret_hash: CIBA_CLIENT_SECRET_HASH,
+        grant_types: ['authorization_code'],
+      });
+      mocks.mockGetClientCached.mockResolvedValue(client);
+
+      const { response, body } = await requestCIBAToken(client);
+
+      expect(response.status).toBe(400);
+      expect(body).toMatchObject({
+        error: 'unauthorized_client',
+        error_description: 'Client is not authorized for CIBA grant',
+      });
+      expect(mockEnv.CIBA_REQUEST_STORE.get).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when CIBA storage returns missing request metadata', async () => {
+      const client = createCIBAClient({ client_secret_hash: CIBA_CLIENT_SECRET_HASH });
+      configureCIBARequest(client, {});
+
+      const { response, body } = await requestCIBAToken(client);
+
+      expect(response.status).toBe(400);
+      expect(body).toMatchObject({
+        error: 'expired_token',
+        error_description: 'CIBA request has expired or is invalid',
+      });
+      expect(mocks.mockCreateAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('rejects cross-client auth_req_id redemption', async () => {
+      const client = createCIBAClient({ client_secret_hash: CIBA_CLIENT_SECRET_HASH });
+      configureCIBARequest(client, baseCIBAMetadata(client, { client_id: 'other-client' }));
+
+      const { response, body } = await requestCIBAToken(client);
+
+      expect(response.status).toBe(400);
+      expect(body).toMatchObject({
+        error: 'invalid_grant',
+        error_description: 'auth_req_id does not belong to this client',
+      });
+      expect(mocks.mockCreateAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('rejects replay after tokens were already issued', async () => {
+      const client = createCIBAClient({ client_secret_hash: CIBA_CLIENT_SECRET_HASH });
+      configureCIBARequest(client, baseCIBAMetadata(client, { token_issued: true }));
+
+      const { response, body } = await requestCIBAToken(client);
+
+      expect(response.status).toBe(400);
+      expect(body).toMatchObject({
+        error: 'invalid_grant',
+        error_description: 'Tokens have already been issued for this auth_req_id',
+      });
+      expect(mocks.mockCreateAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('deletes denied requests and returns access_denied', async () => {
+      const client = createCIBAClient({ client_secret_hash: CIBA_CLIENT_SECRET_HASH });
+      const fetch = configureCIBARequest(client, baseCIBAMetadata(client, { status: 'denied' }));
+
+      const { response, body } = await requestCIBAToken(client);
+
+      expect(response.status).toBe(403);
+      expect(body).toMatchObject({
+        error: 'access_denied',
+        error_description: 'User denied the authentication request',
+      });
+      expect(
+        fetch.mock.calls.some(
+          ([request]) => new URL((request as Request).url).pathname === '/delete'
+        )
+      ).toBe(true);
+    });
+
+    it('returns expired_token for an expired request without issuing tokens', async () => {
+      const client = createCIBAClient({ client_secret_hash: CIBA_CLIENT_SECRET_HASH });
+      configureCIBARequest(client, baseCIBAMetadata(client, { status: 'expired' }));
+
+      const { response, body } = await requestCIBAToken(client);
+
+      expect(response.status).toBe(400);
+      expect(body).toMatchObject({
+        error: 'expired_token',
+        error_description: 'CIBA request has expired',
+      });
+      expect(mocks.mockCreateAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('rejects an approved request without a bound subject', async () => {
+      const client = createCIBAClient({ client_secret_hash: CIBA_CLIENT_SECRET_HASH });
+      configureCIBARequest(client, baseCIBAMetadata(client, { status: 'approved' }));
+
+      const { response, body } = await requestCIBAToken(client);
+
+      expect(response.status).toBe(400);
+      expect(body).toMatchObject({
+        error: 'invalid_grant',
+        error_description: 'CIBA request is not approved',
+      });
+      expect(mocks.mockCreateAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('continues safely when updating poll metadata fails', async () => {
+      const client = createCIBAClient({ client_secret_hash: CIBA_CLIENT_SECRET_HASH });
+      configureCIBARequest(client, baseCIBAMetadata(client), {
+        updatePollError: new Error('poll metadata unavailable'),
+      });
+
+      const { response, body } = await requestCIBAToken(client);
+
+      expect(response.status).toBe(400);
+      expect(body).toMatchObject({ error: 'authorization_pending' });
+      expect(mocks.mockLoggerMethods.error).toHaveBeenCalledWith(
+        'Failed to update poll time',
+        {},
+        expect.any(Error)
+      );
+    });
+
+    it('rejects a concurrent replay reported by the atomic mark-issued operation', async () => {
+      const client = createCIBAClient({ client_secret_hash: CIBA_CLIENT_SECRET_HASH });
+      configureCIBARequest(
+        client,
+        baseCIBAMetadata(client, { status: 'approved', sub: 'user-123' }),
+        {
+          markIssuedResponse: Response.json(
+            { error_description: 'tokens already issued by another request' },
+            { status: 409 }
+          ),
+        }
+      );
+
+      const { response, body } = await requestCIBAToken(client);
+
+      expect(response.status).toBe(400);
+      expect(body).toMatchObject({
+        error: 'invalid_grant',
+        error_description: 'Tokens have already been issued for this auth_req_id',
+      });
+      expect(mocks.mockCreateAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('fails without leaking user existence when the approved subject is missing', async () => {
+      const client = createCIBAClient({ client_secret_hash: CIBA_CLIENT_SECRET_HASH });
+      configureCIBARequest(
+        client,
+        baseCIBAMetadata(client, { status: 'approved', sub: 'missing-user' })
+      );
+      mocks.mockFindCanonicalRuntimeAccount.mockResolvedValueOnce(null);
+
+      const { response, body } = await requestCIBAToken(client);
+
+      expect(response.status).toBe(500);
+      expect(body).toEqual({
+        error: 'server_error',
+        error_description: 'An unexpected error occurred',
+      });
+      expect(mocks.mockCreateAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('issues tokens once for an approved request and deletes the consumed request', async () => {
+      const client = createCIBAClient({ client_secret_hash: CIBA_CLIENT_SECRET_HASH });
+      const fetch = configureCIBARequest(
+        client,
+        baseCIBAMetadata(client, {
+          status: 'approved',
+          sub: 'user-123',
+          nonce: 'nonce-123',
+        })
+      );
+
+      const { response, body } = await requestCIBAToken(client);
+
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        access_token: 'mock-access-token',
+        id_token: 'mock-id-token',
+        refresh_token: 'mock-refresh-token',
+        token_type: 'Bearer',
+        scope: 'openid profile',
+      });
+      expect(mocks.mockCreateAccessToken).toHaveBeenCalledTimes(1);
+      expect(mocks.mockCreateIDToken).toHaveBeenCalledTimes(1);
+      expect(mocks.mockCreateRefreshToken).toHaveBeenCalledTimes(1);
+      const paths = fetch.mock.calls.map(([request]) => new URL((request as Request).url).pathname);
+      expect(paths).toContain('/mark-token-issued');
+      expect(paths).toContain('/delete');
+    });
+  });
+
+  describe('Device code grant state transitions', () => {
+    const deviceCode = 'device-code-state-matrix';
+    const clientId = 'device-client-001';
+
+    function configureDeviceCode(
+      metadata: Record<string, unknown>,
+      options: { consumeStatus?: number; updatePollError?: Error } = {}
+    ) {
+      const fetch = vi.fn().mockImplementation(async (request: Request) => {
+        const pathname = new URL(request.url).pathname;
+        if (pathname === '/update-poll') {
+          if (options.updatePollError) throw options.updatePollError;
+          return Response.json({ success: true });
+        }
+        if (pathname === '/get-by-device-code') return Response.json(metadata);
+        if (pathname === '/mark-token-issued') {
+          return Response.json(
+            { success: options.consumeStatus === undefined },
+            { status: options.consumeStatus ?? 200 }
+          );
+        }
+        if (pathname === '/delete') return Response.json({ success: true });
+        return Response.json({ error: 'not_found' }, { status: 404 });
+      });
+      mockEnv.DEVICE_CODE_STORE.get = vi.fn().mockReturnValue({ fetch });
+      return fetch;
+    }
+
+    function baseDeviceMetadata(overrides = {}) {
+      return {
+        device_code: deviceCode,
+        user_code: 'ABCD-EFGH',
+        client_id: clientId,
+        scope: 'openid profile',
+        status: 'pending',
+        created_at: Date.now() - 10_000,
+        expires_at: Date.now() + 60_000,
+        ...overrides,
+      };
+    }
+
+    async function requestDeviceToken() {
+      const response = await tokenHandler(
+        createMockContext({
+          body: {
+            grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+            device_code: deviceCode,
+            client_id: clientId,
+          },
+          env: mockEnv,
+        })
+      );
+      return {
+        response,
+        body: await parseJsonResponse<Record<string, unknown>>(response),
+      };
+    }
+
+    it('fails closed when device storage returns no metadata', async () => {
+      configureDeviceCode({});
+
+      const { response, body } = await requestDeviceToken();
+
+      expect(response.status).toBe(400);
+      expect(body).toMatchObject({
+        error: 'expired_token',
+        error_description: 'Device code has expired or is invalid',
+      });
+      expect(mocks.mockCreateAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('rejects a device code bound to another client', async () => {
+      configureDeviceCode(baseDeviceMetadata({ client_id: 'other-client' }));
+
+      const { response, body } = await requestDeviceToken();
+
+      expect(response.status).toBe(400);
+      expect(body).toMatchObject({
+        error: 'invalid_grant',
+        error_description: 'Device code does not belong to this client',
+      });
+    });
+
+    it('deletes denied device codes before returning access_denied', async () => {
+      const fetch = configureDeviceCode(baseDeviceMetadata({ status: 'denied' }));
+
+      const { response, body } = await requestDeviceToken();
+
+      expect(response.status).toBe(403);
+      expect(body).toMatchObject({ error: 'access_denied' });
+      expect(
+        fetch.mock.calls.some(
+          ([request]) => new URL((request as Request).url).pathname === '/delete'
+        )
+      ).toBe(true);
+    });
+
+    it('returns expired_token for an expired device code', async () => {
+      configureDeviceCode(baseDeviceMetadata({ status: 'expired' }));
+
+      const { response, body } = await requestDeviceToken();
+
+      expect(response.status).toBe(400);
+      expect(body).toMatchObject({ error: 'expired_token' });
+      expect(mocks.mockCreateAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('rejects approved metadata without a bound subject', async () => {
+      configureDeviceCode(baseDeviceMetadata({ status: 'approved' }));
+
+      const { response, body } = await requestDeviceToken();
+
+      expect(response.status).toBe(400);
+      expect(body).toMatchObject({
+        error: 'invalid_grant',
+        error_description: 'Device code is not approved',
+      });
+    });
+
+    it('rejects an approved device code when the client was removed', async () => {
+      configureDeviceCode(baseDeviceMetadata({ status: 'approved', sub: 'user-123' }));
+      mocks.mockGetClientCached.mockResolvedValueOnce(null);
+
+      const { response, body } = await requestDeviceToken();
+
+      expect(response.status).toBe(401);
+      expect(body).toMatchObject({ error: 'invalid_client' });
+      expect(mocks.mockCreateAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('rejects a concurrent redemption before signing any tokens', async () => {
+      const client = createPublicClient({
+        client_id: clientId,
+        default_resource: 'https://api.example.com',
+      });
+      configureDeviceCode(baseDeviceMetadata({ status: 'approved', sub: 'user-123' }), {
+        consumeStatus: 409,
+      });
+      mocks.mockGetClientCached.mockResolvedValue(client);
+
+      const { response, body } = await requestDeviceToken();
+
+      expect(response.status).toBe(400);
+      expect(body).toMatchObject({
+        error: 'invalid_grant',
+        error_description: 'Device code has already been used or is not approved',
+      });
+      expect(mocks.mockCreateIDToken).not.toHaveBeenCalled();
+    });
+
+    it('reports poll metadata failures but preserves the authorization state response', async () => {
+      configureDeviceCode(baseDeviceMetadata(), {
+        updatePollError: new Error('poll write unavailable'),
+      });
+
+      const { response, body } = await requestDeviceToken();
+
+      expect(response.status).toBe(400);
+      expect(body).toMatchObject({ error: 'authorization_pending' });
+      expect(mocks.mockLoggerMethods.error).toHaveBeenCalledWith(
+        'Failed to update poll time',
+        {},
+        expect.any(Error)
+      );
+    });
+
+    it('does not return a partial response when ID token signing fails', async () => {
+      const client = createPublicClient({
+        client_id: clientId,
+        default_resource: 'https://api.example.com',
+      });
+      configureDeviceCode(baseDeviceMetadata({ status: 'approved', sub: 'user-123' }));
+      mocks.mockGetClientCached.mockResolvedValue(client);
+      mocks.mockCreateIDToken.mockRejectedValueOnce(new Error('signing failed'));
+
+      const { response, body } = await requestDeviceToken();
+
+      expect(response.status).toBe(500);
+      expect(body).toMatchObject({
+        error: 'server_error',
+        error_description: 'Failed to create ID token',
+      });
+      expect(mocks.mockCreateAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('does not return a partial response when access token creation fails', async () => {
+      const client = createPublicClient({
+        client_id: clientId,
+        default_resource: 'https://api.example.com',
+      });
+      configureDeviceCode(baseDeviceMetadata({ status: 'approved', sub: 'user-123' }));
+      mocks.mockGetClientCached.mockResolvedValue(client);
+      mocks.mockCreateAccessToken.mockRejectedValueOnce(new Error('access signing failed'));
+
+      const { response, body } = await requestDeviceToken();
+
+      expect(response.status).toBe(500);
+      expect(body).toMatchObject({
+        error: 'server_error',
+        error_description: 'Failed to create access token',
+      });
+      expect(mocks.mockCreateRefreshToken).not.toHaveBeenCalled();
+    });
+
+    it('does not return a partial response when refresh token creation fails', async () => {
+      const client = createPublicClient({
+        client_id: clientId,
+        default_resource: 'https://api.example.com',
+      });
+      configureDeviceCode(baseDeviceMetadata({ status: 'approved', sub: 'user-123' }));
+      mocks.mockGetClientCached.mockResolvedValue(client);
+      mocks.mockCreateRefreshToken.mockRejectedValueOnce(new Error('refresh signing failed'));
+
+      const { response, body } = await requestDeviceToken();
+
+      expect(response.status).toBe(500);
+      expect(body).toMatchObject({
+        error: 'server_error',
+        error_description: 'Failed to create refresh token',
+      });
+    });
+
+    it('issues all tokens once for an approved device code', async () => {
+      const client = createPublicClient({
+        client_id: clientId,
+        default_resource: 'https://api.example.com',
+      });
+      configureDeviceCode(baseDeviceMetadata({ status: 'approved', sub: 'user-123' }));
+      mocks.mockGetClientCached.mockResolvedValue(client);
+
+      const { response, body } = await requestDeviceToken();
+
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        access_token: 'mock-access-token',
+        id_token: 'mock-id-token',
+        refresh_token: 'mock-refresh-token',
+        token_type: 'Bearer',
+        scope: 'openid profile',
+      });
+      expect(mocks.mockCreateAccessToken).toHaveBeenCalledTimes(1);
+      expect(mocks.mockCreateIDToken).toHaveBeenCalledTimes(1);
+      expect(mocks.mockCreateRefreshToken).toHaveBeenCalledTimes(1);
+    });
+  });
+
   // ==========================================================================
   // Direct Auth custom grant
   // ==========================================================================
@@ -3525,6 +4028,113 @@ describe('Client Authentication Tests', () => {
   // ==========================================================================
 
   describe('JWT Bearer Grant Audience', () => {
+    async function requestJWTBearer(overrides: Record<string, string | undefined> = {}) {
+      const body: Record<string, string> = {
+        grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+        assertion: 'valid-assertion',
+      };
+      for (const [key, value] of Object.entries(overrides)) {
+        if (value === undefined) delete body[key];
+        else body[key] = value;
+      }
+      const response = await tokenHandler(
+        createMockContext({ method: 'POST', body, env: mockEnv })
+      );
+      return {
+        response,
+        body: await parseJsonResponse<Record<string, unknown>>(response),
+      };
+    }
+
+    it('requires an assertion and at least one configured trusted issuer', async () => {
+      const missing = await requestJWTBearer({ assertion: undefined });
+      expect(missing.response.status).toBe(400);
+      expect(missing.body).toMatchObject({
+        error: 'invalid_request',
+        error_description: 'Missing required parameter: assertion',
+      });
+
+      mocks.mockParseTrustedIssuers.mockReturnValueOnce(new Map());
+      const unconfigured = await requestJWTBearer();
+      expect(unconfigured.response.status).toBe(500);
+      expect(unconfigured.body).toMatchObject({
+        error: 'server_error',
+        error_description: 'JWT Bearer grant is not configured (no trusted issuers)',
+      });
+      expect(mocks.mockCreateAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('returns validator errors and rejects a claim from an untrusted issuer', async () => {
+      mocks.mockValidateJWTBearerAssertion.mockResolvedValueOnce({
+        valid: false,
+        error: 'invalid_grant',
+        error_description: 'assertion expired',
+      });
+      const invalid = await requestJWTBearer();
+      expect(invalid.response.status).toBe(400);
+      expect(invalid.body).toEqual({
+        error: 'invalid_grant',
+        error_description: 'assertion expired',
+      });
+
+      mocks.mockValidateJWTBearerAssertion.mockResolvedValueOnce({
+        valid: true,
+        claims: { iss: 'https://unknown.example.com', sub: 'service-account' },
+      });
+      const unknown = await requestJWTBearer();
+      expect(unknown.response.status).toBe(400);
+      expect(unknown.body).toMatchObject({
+        error: 'invalid_grant',
+        error_description: 'JWT assertion issuer is not trusted',
+      });
+    });
+
+    it('rejects scopes outside the trusted issuer policy', async () => {
+      mocks.mockParseTrustedIssuers.mockReturnValueOnce(
+        new Map([
+          [
+            'https://service.example.com',
+            {
+              issuer: 'https://service.example.com',
+              jwks_uri: 'https://service.example.com/jwks',
+              default_resource: 'svc://service-api',
+              allowed_scopes: ['api:read'],
+            },
+          ],
+        ])
+      );
+      const result = await requestJWTBearer({ scope: 'api:write' });
+      expect(result.response.status).toBe(400);
+      expect(result.body).toMatchObject({
+        error: 'invalid_scope',
+        error_description: 'Requested scope is not allowed for this issuer',
+      });
+    });
+
+    it('uses assertion scope when request scope is omitted', async () => {
+      mocks.mockValidateJWTBearerAssertion.mockResolvedValueOnce({
+        valid: true,
+        claims: {
+          iss: 'https://service.example.com',
+          sub: 'service-account',
+          scope: 'api:read',
+        },
+      });
+      const result = await requestJWTBearer();
+      expect(result.response.status).toBe(200);
+      expect(result.body.scope).toBe('api:read');
+    });
+
+    it('fails closed when JWT bearer access token creation fails', async () => {
+      mocks.mockCreateAccessToken.mockRejectedValueOnce(new Error('signing failed'));
+      const result = await requestJWTBearer({ scope: 'api:read' });
+      expect(result.response.status).toBe(500);
+      expect(result.body).toMatchObject({
+        error: 'server_error',
+        error_description: 'Failed to create access token',
+      });
+    });
+
     it('should issue JWT bearer access token for an explicit resource target', async () => {
       const response = await tokenHandler(
         createMockContext({
@@ -3722,6 +4332,196 @@ describe('Client Authentication Tests', () => {
   // ==========================================================================
 
   describe('Client Credentials Grant Authentication', () => {
+    function setupM2MClient(overrides: Partial<TestClientMetadata> = {}) {
+      const client = createM2MClient({
+        default_resource: 'svc://m2m-api',
+        allowed_scopes: ['api:read', 'api:write'],
+        ...overrides,
+      });
+      mocks.mockGetClientCached.mockResolvedValue(client);
+      mocks.mockLoadTenantProfileCached.mockResolvedValue({
+        tenant_id: 'default',
+        max_token_ttl_seconds: 1800,
+        allows_client_credentials: true,
+      });
+      return client;
+    }
+
+    async function requestM2M(
+      client: TestClientMetadata,
+      overrides: Record<string, string | undefined> = {},
+      envOverrides: Partial<MockEnv> & { ENABLE_CLIENT_CREDENTIALS?: string } = {}
+    ) {
+      const body: Record<string, string> = {
+        grant_type: 'client_credentials',
+        client_id: client.client_id,
+        client_secret: 'valid-m2m-secret',
+        scope: 'api:read',
+      };
+      for (const [key, value] of Object.entries(overrides)) {
+        if (value === undefined) delete body[key];
+        else body[key] = value;
+      }
+      const response = await tokenHandler(
+        createMockContext({
+          method: 'POST',
+          body,
+          env: {
+            ...mockEnv,
+            ENABLE_CLIENT_CREDENTIALS: 'true',
+            ...envOverrides,
+          },
+        })
+      );
+      return {
+        response,
+        body: await parseJsonResponse<Record<string, unknown>>(response),
+      };
+    }
+
+    it('honors settings overrides and falls back to the environment on settings failure', async () => {
+      const client = setupM2MClient();
+      mocks.mockGetSystemSettingsCached.mockResolvedValueOnce({
+        oidc: { clientCredentials: { enabled: false } },
+      });
+      const disabled = await requestM2M(client);
+      expect(disabled.response.status).toBe(400);
+      expect(disabled.body).toMatchObject({
+        error: 'unsupported_grant_type',
+        error_description: 'Client Credentials grant is not enabled',
+      });
+
+      mocks.mockGetSystemSettingsCached.mockRejectedValueOnce(new Error('settings unavailable'));
+      const fallback = await requestM2M(client);
+      expect(fallback.response.status).toBe(200);
+    });
+
+    it('rejects malformed assertions and Authorization headers before client lookup', async () => {
+      const client = setupM2MClient();
+      mocks.mockParseToken.mockImplementationOnce(() => {
+        throw new Error('malformed assertion');
+      });
+      const assertion = await requestM2M(client, {
+        client_id: undefined,
+        client_secret: undefined,
+        client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+        client_assertion: 'malformed',
+      });
+      expect(assertion.response.status).toBe(401);
+      expect(assertion.body).toMatchObject({
+        error: 'invalid_client',
+        error_description: 'Invalid client_assertion format',
+      });
+
+      mocks.mockParseBasicAuth.mockReturnValueOnce({ success: false, error: 'decode_error' });
+      const basic = await requestM2M(client);
+      expect(basic.response.status).toBe(401);
+      expect(basic.body).toMatchObject({
+        error: 'invalid_client',
+        error_description: 'Invalid Authorization header format',
+      });
+    });
+
+    it('rejects invalid, unknown, and tenant-disallowed M2M clients', async () => {
+      const client = setupM2MClient();
+      mocks.mockValidateClientId.mockReturnValueOnce({ valid: false, error: 'invalid client id' });
+      const invalid = await requestM2M(client);
+      expect(invalid.response.status).toBe(401);
+      expect(invalid.body).toMatchObject({ error_description: 'invalid client id' });
+
+      mocks.mockGetClientCached.mockResolvedValueOnce(null);
+      const unknown = await requestM2M(client);
+      expect(unknown.response.status).toBe(401);
+      expect(unknown.body).toMatchObject({ error_description: 'Client authentication failed' });
+
+      mocks.mockLoadTenantProfileCached.mockResolvedValueOnce({
+        tenant_id: 'default',
+        max_token_ttl_seconds: 1800,
+        allows_client_credentials: false,
+      });
+      const disallowed = await requestM2M(client);
+      expect(disallowed.response.status).toBe(403);
+      expect(disallowed.body).toMatchObject({
+        error: 'unauthorized_client',
+        error_description: 'client_credentials grant is not allowed for this tenant profile',
+      });
+    });
+
+    it('rejects failed private_key_jwt authentication without leaking validator details', async () => {
+      const client = setupM2MClient({ token_endpoint_auth_method: 'private_key_jwt' });
+      mocks.mockParseToken.mockReturnValueOnce({ sub: client.client_id });
+      mocks.mockValidateClientAssertion.mockResolvedValueOnce({
+        valid: false,
+        error_description: 'signature mismatch for credential key',
+      });
+      const result = await requestM2M(client, {
+        client_secret: undefined,
+        client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+        client_assertion: 'header.payload.signature',
+      });
+      expect(result.response.status).toBe(401);
+      expect(result.body).toMatchObject({
+        error: 'invalid_client',
+        error_description: 'Client assertion validation failed',
+      });
+    });
+
+    it('enforces per-client authorization and requested scope intersection', async () => {
+      const unauthorized = setupM2MClient({ client_credentials_allowed: false });
+      const denied = await requestM2M(unauthorized);
+      expect(denied.response.status).toBe(403);
+      expect(denied.body).toMatchObject({
+        error: 'unauthorized_client',
+        error_description: 'Client is not authorized for Client Credentials grant',
+      });
+
+      const scoped = setupM2MClient({ allowed_scopes: ['api:read'] });
+      const invalidScope = await requestM2M(scoped, { scope: 'api:delete' });
+      expect(invalidScope.response.status).toBe(400);
+      expect(invalidScope.body).toMatchObject({
+        error: 'invalid_scope',
+        error_description: 'None of the requested scopes are allowed for this client',
+      });
+    });
+
+    it('rejects invalid DPoP and binds a valid proof to the M2M token', async () => {
+      const client = setupM2MClient();
+      mocks.mockExtractDPoPProof.mockReturnValue('dpop-proof');
+      mocks.mockValidateDPoPProof.mockResolvedValueOnce({
+        valid: false,
+        error_description: 'invalid DPoP signature',
+      });
+      const invalid = await requestM2M(client, { resource: 'svc://m2m-api' });
+      expect(invalid.response.status).toBe(400);
+      expect(mocks.mockCreateAccessToken).not.toHaveBeenCalled();
+
+      mocks.mockValidateDPoPProof.mockResolvedValueOnce({ valid: true, jkt: 'm2m-jkt' });
+      const valid = await requestM2M(client, { resource: 'svc://m2m-api' });
+      expect(valid.response.status).toBe(200);
+      expect(valid.body.token_type).toBe('DPoP');
+      expect(mocks.mockCreateAccessToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sub: `client:${client.client_id}`,
+          cnf: { jkt: 'm2m-jkt' },
+        }),
+        expect.anything(),
+        expect.any(String),
+        1800,
+        expect.any(String)
+      );
+    });
+
+    it('returns no partial M2M response when access token signing fails', async () => {
+      const client = setupM2MClient();
+      mocks.mockCreateAccessToken.mockRejectedValueOnce(new Error('signing failed'));
+      const result = await requestM2M(client);
+      expect(result.response.status).toBe(500);
+      expect(result.body).toMatchObject({
+        error: 'server_error',
+        error_description: 'Failed to create access token',
+      });
+    });
+
     function mockAdminMachineAccess(
       overrides: {
         principalStatus?: string;

--- a/packages/ar-token/src/__tests__/downstream-grant-token-exchange.test.ts
+++ b/packages/ar-token/src/__tests__/downstream-grant-token-exchange.test.ts
@@ -45,6 +45,7 @@ const mocks = vi.hoisted(() => ({
   mockValidateDPoPProof: vi.fn().mockResolvedValue({ valid: true, jkt: 'dpop-jkt' }),
   mockRequireDedicatedAdminDatabaseAdapter: vi.fn().mockReturnValue({}),
   mockResolveElevationGrantSubjectToken: vi.fn(),
+  mockVerifyExternalIdJagSubjectToken: vi.fn(),
 }));
 
 vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
@@ -74,11 +75,23 @@ vi.mock('@authrim/ar-lib-core', async (importOriginal) => {
   };
 });
 
+vi.mock('../external-id-jag-verifier', () => ({
+  verifyExternalIdJagSubjectToken: mocks.mockVerifyExternalIdJagSubjectToken,
+}));
+
 import { tokenHandler } from '../token';
 
 describe('downstream elevation grant token exchange', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.mockGetSystemSettingsCached.mockReset().mockResolvedValue(null);
+    mocks.mockVerifyExternalIdJagSubjectToken.mockReset();
+    mocks.mockVerifyToken.mockReset().mockResolvedValue({});
+    mocks.mockIsTokenRevoked.mockReset().mockResolvedValue(false);
+    mocks.mockCreateAccessToken.mockReset().mockResolvedValue({
+      token: 'downstream-access-token',
+      jti: 'at-jti-1',
+    });
     mocks.mockValidateClientId.mockReturnValue({ valid: true });
     mocks.mockVerifyClientSecretHash.mockResolvedValue(true);
     mocks.mockLoadTenantProfileCached.mockResolvedValue({
@@ -152,6 +165,798 @@ describe('downstream elevation grant token exchange', () => {
         type: 'user',
         id: 'user-1',
       },
+    });
+  });
+
+  describe('RFC 8693 validation matrix', () => {
+    const defaultBody = {
+      grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+      subject_token: 'subject-token',
+      subject_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+      client_id: 'service-client-1',
+      client_secret: 'top-secret',
+      audience: 'https://service.example.com',
+    };
+
+    function request(
+      bodyOverrides: Record<string, unknown> = {},
+      envOverrides: Record<string, unknown> = {}
+    ) {
+      const body: Record<string, unknown> = { ...defaultBody, ...bodyOverrides };
+      for (const [key, value] of Object.entries(body)) {
+        if (value === undefined) delete body[key];
+      }
+      return tokenHandler(
+        createMockContext({
+          method: 'POST',
+          body: body as Record<string, string>,
+          env: {
+            ENABLE_TOKEN_EXCHANGE: 'true',
+            ...envOverrides,
+          },
+        })
+      );
+    }
+
+    async function expectOAuthError(
+      responsePromise: Promise<Response>,
+      status: number,
+      error: string,
+      description: string
+    ) {
+      const response = await responsePromise;
+      const body = await parseJsonResponse<{ error: string; error_description: string }>(response);
+      expect(response.status).toBe(status);
+      expect(body).toEqual({ error, error_description: description });
+    }
+
+    async function createVerificationEnv() {
+      const actual =
+        await vi.importActual<typeof import('@authrim/ar-lib-core')>('@authrim/ar-lib-core');
+      const keySet = await actual.generateKeySet('subject-kid-matrix');
+      mocks.mockParseTokenHeader.mockReturnValue({ alg: 'RS256', kid: 'subject-kid-matrix' });
+      return {
+        KEY_MANAGER: createMockDurableObjectNamespace({
+          rpcMethods: {
+            getActiveKeyWithPrivateRpc: vi.fn().mockResolvedValue({
+              kid: 'subject-kid-matrix',
+              privatePEM: keySet.privatePEM,
+            }),
+            getAllPublicKeysRpc: vi.fn().mockResolvedValue([keySet.publicJWK]),
+          },
+        }),
+        PUBLIC_JWK_JSON: JSON.stringify(keySet.publicJWK),
+      };
+    }
+
+    it('rejects token exchange when both environment and settings disable it', async () => {
+      await expectOAuthError(
+        request({}, { ENABLE_TOKEN_EXCHANGE: 'false' }),
+        400,
+        'unsupported_grant_type',
+        'Token Exchange is not enabled'
+      );
+      expect(mocks.mockGetClientCached).not.toHaveBeenCalled();
+    });
+
+    it('uses cached settings to disable an environment-enabled exchange', async () => {
+      mocks.mockGetSystemSettingsCached.mockResolvedValue({
+        oidc: { tokenExchange: { enabled: false } },
+      });
+      await expectOAuthError(
+        request(),
+        400,
+        'unsupported_grant_type',
+        'Token Exchange is not enabled'
+      );
+    });
+
+    it('falls back to environment configuration when settings lookup fails', async () => {
+      mocks.mockGetSystemSettingsCached.mockRejectedValueOnce(new Error('KV unavailable'));
+      await expectOAuthError(
+        request({ subject_token: undefined }),
+        400,
+        'invalid_request',
+        'subject_token is required'
+      );
+    });
+
+    it('enforces the configured resource parameter limit', async () => {
+      await expectOAuthError(
+        request(
+          { resource: ['https://one.example', 'https://two.example'] },
+          { TOKEN_EXCHANGE_MAX_RESOURCE_PARAMS: '1' }
+        ),
+        400,
+        'invalid_request',
+        'Too many resource parameters (max: 1)'
+      );
+    });
+
+    it('enforces the configured audience parameter limit', async () => {
+      await expectOAuthError(
+        request(
+          { audience: ['service-a', 'service-b'] },
+          { TOKEN_EXCHANGE_MAX_AUDIENCE_PARAMS: '1' }
+        ),
+        400,
+        'invalid_request',
+        'Too many audience parameters (max: 1)'
+      );
+    });
+
+    it('requires both subject token parameters before client lookup', async () => {
+      await expectOAuthError(
+        request({ subject_token: undefined }),
+        400,
+        'invalid_request',
+        'subject_token is required'
+      );
+      await expectOAuthError(
+        request({ subject_token_type: undefined }),
+        400,
+        'invalid_request',
+        'subject_token_type is required'
+      );
+      expect(mocks.mockGetClientCached).not.toHaveBeenCalled();
+    });
+
+    it('rejects disallowed subject token types and refresh tokens even when configured', async () => {
+      await expectOAuthError(
+        request({ subject_token_type: 'urn:ietf:params:oauth:token-type:id_token' }),
+        400,
+        'invalid_request',
+        "subject_token_type 'urn:ietf:params:oauth:token-type:id_token' is not allowed. Allowed types: access_token"
+      );
+
+      await expectOAuthError(
+        request(
+          { subject_token_type: 'urn:ietf:params:oauth:token-type:refresh_token' },
+          { TOKEN_EXCHANGE_ALLOWED_TYPES: 'refresh_token' }
+        ),
+        400,
+        'invalid_request',
+        'refresh_token cannot be used as subject_token for security reasons'
+      );
+    });
+
+    it('rejects malformed Basic credentials instead of falling back to body credentials', async () => {
+      mocks.mockParseBasicAuth.mockReturnValueOnce({
+        success: false,
+        error: 'malformed_credentials',
+      });
+      await expectOAuthError(
+        request(),
+        401,
+        'invalid_client',
+        'Invalid Authorization header format'
+      );
+    });
+
+    it('rejects invalid and unknown clients with non-enumerating errors', async () => {
+      mocks.mockValidateClientId.mockReturnValueOnce({ valid: false, error: 'invalid client id' });
+      await expectOAuthError(request(), 401, 'invalid_client', 'invalid client id');
+
+      mocks.mockGetClientCached.mockResolvedValueOnce(null);
+      await expectOAuthError(request(), 401, 'invalid_client', 'Client authentication failed');
+    });
+
+    it('enforces tenant profile permission before verifying subject tokens', async () => {
+      mocks.mockLoadTenantProfileCached.mockResolvedValueOnce({
+        allows_token_exchange: false,
+        max_token_ttl_seconds: 3600,
+      });
+      await expectOAuthError(
+        request(),
+        403,
+        'unauthorized_client',
+        'token_exchange grant is not allowed for this tenant profile'
+      );
+      expect(mocks.mockParseToken).not.toHaveBeenCalled();
+    });
+
+    it('requires valid confidential client credentials', async () => {
+      mocks.mockVerifyClientSecretHash.mockResolvedValueOnce(false);
+      await expectOAuthError(request(), 401, 'invalid_client', 'Invalid client credentials');
+
+      mocks.mockGetClientCached.mockResolvedValueOnce({
+        client_id: 'service-client-1',
+        tenant_id: 'tenant-a',
+        token_endpoint_auth_method: 'none',
+        token_exchange_allowed: true,
+      });
+      await expectOAuthError(
+        request({ client_secret: undefined }),
+        401,
+        'invalid_client',
+        'Client authentication is required for Token Exchange'
+      );
+    });
+
+    it('enforces per-client token exchange and delegation controls', async () => {
+      mocks.mockGetClientCached.mockResolvedValueOnce({
+        client_id: 'service-client-1',
+        tenant_id: 'tenant-a',
+        client_secret_hash: 'hashed-secret',
+        token_exchange_allowed: false,
+      });
+      await expectOAuthError(
+        request(),
+        403,
+        'unauthorized_client',
+        'Client is not authorized for Token Exchange'
+      );
+
+      mocks.mockGetClientCached.mockResolvedValueOnce({
+        client_id: 'service-client-1',
+        tenant_id: 'tenant-a',
+        client_secret_hash: 'hashed-secret',
+        token_exchange_allowed: true,
+        delegation_mode: 'none',
+      });
+      await expectOAuthError(
+        request(),
+        403,
+        'unauthorized_client',
+        'Token Exchange is disabled for this client'
+      );
+    });
+
+    it('rejects unsupported requested token types before parsing the subject token', async () => {
+      await expectOAuthError(
+        request({ requested_token_type: 'urn:ietf:params:oauth:token-type:refresh_token' }),
+        400,
+        'invalid_request',
+        'Only access_token and id-jag (when enabled) are supported as requested_token_type'
+      );
+      expect(mocks.mockParseToken).not.toHaveBeenCalled();
+    });
+
+    it('rejects malformed subject tokens and tokens without a key identifier', async () => {
+      mocks.mockParseToken.mockImplementationOnce(() => {
+        throw new Error('malformed JWT');
+      });
+      await expectOAuthError(request(), 400, 'invalid_request', 'Invalid subject_token format');
+
+      mocks.mockParseToken.mockReturnValueOnce({ sub: 'user-1', aud: 'service-client-1' });
+      mocks.mockParseTokenHeader.mockReturnValueOnce({ alg: 'RS256' });
+      await expectOAuthError(
+        request(),
+        400,
+        'invalid_grant',
+        'Subject token is missing kid in header'
+      );
+    });
+
+    it('rejects expired, revoked, and cross-audience subject tokens', async () => {
+      const env = await createVerificationEnv();
+      mocks.mockParseToken.mockReturnValueOnce({
+        sub: 'user-1',
+        aud: 'service-client-1',
+        exp: Math.floor(Date.now() / 1000) - 1,
+      });
+      await expectOAuthError(request({}, env), 400, 'invalid_grant', 'Subject token has expired');
+
+      mocks.mockParseToken.mockReturnValueOnce({
+        sub: 'user-1',
+        aud: 'service-client-1',
+        jti: 'revoked-jti',
+      });
+      mocks.mockIsTokenRevoked.mockResolvedValueOnce(true);
+      await expectOAuthError(
+        request({}, env),
+        400,
+        'invalid_grant',
+        'Subject token has been revoked'
+      );
+
+      mocks.mockParseToken.mockReturnValueOnce({
+        sub: 'user-1',
+        aud: 'unrelated-client',
+        client_id: 'issuer-client',
+      });
+      await expectOAuthError(
+        request({}, env),
+        403,
+        'invalid_target',
+        'Client is not authorized to exchange this token'
+      );
+    });
+
+    it.each([
+      [
+        'ftp://service.example.com',
+        "resource 'ftp://service.example.com' must be an absolute URI with http or https scheme",
+      ],
+      [
+        'https://service.example.com/path#fragment',
+        "resource 'https://service.example.com/path#fragment' must not include a fragment component",
+      ],
+      ['not-an-absolute-uri', "resource 'not-an-absolute-uri' must be a valid absolute URI"],
+    ])('rejects invalid resource parameter %s', async (resource, description) => {
+      const env = await createVerificationEnv();
+      mocks.mockParseToken.mockReturnValue({ sub: 'user-1', aud: 'service-client-1' });
+      await expectOAuthError(
+        request({ audience: undefined, resource }, env),
+        400,
+        'invalid_request',
+        description
+      );
+    });
+
+    it('rejects allowed-resource violations after subject authorization', async () => {
+      const env = await createVerificationEnv();
+      mocks.mockParseToken.mockReturnValue({ sub: 'user-1', aud: 'service-client-1' });
+      await expectOAuthError(
+        request({ audience: 'https://disallowed.example.com' }, env),
+        403,
+        'invalid_target',
+        'Requested audience/resource not allowed: https://disallowed.example.com'
+      );
+    });
+
+    it('requires actor_token_type and supports only access tokens as actors', async () => {
+      const env = await createVerificationEnv();
+      mocks.mockParseToken.mockReturnValue({ sub: 'user-1', aud: 'service-client-1' });
+      await expectOAuthError(
+        request({ actor_token: 'actor-token' }, env),
+        400,
+        'invalid_request',
+        'actor_token_type is required when actor_token is provided'
+      );
+      await expectOAuthError(
+        request(
+          {
+            actor_token: 'actor-token',
+            actor_token_type: 'urn:ietf:params:oauth:token-type:id_token',
+          },
+          env
+        ),
+        400,
+        'invalid_request',
+        'Only access_token is supported as actor_token_type'
+      );
+    });
+
+    it('rejects malformed actors and actors without kid or audience', async () => {
+      const env = await createVerificationEnv();
+      const subject = { sub: 'user-1', aud: 'service-client-1' };
+      mocks.mockParseToken.mockReturnValueOnce(subject).mockImplementationOnce(() => {
+        throw new Error('bad actor');
+      });
+      await expectOAuthError(
+        request(
+          {
+            actor_token: 'actor-token',
+            actor_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+          },
+          env
+        ),
+        400,
+        'invalid_request',
+        'Invalid actor_token format'
+      );
+
+      mocks.mockParseToken.mockReturnValueOnce(subject).mockReturnValueOnce({ sub: 'actor-1' });
+      mocks.mockParseTokenHeader
+        .mockReturnValueOnce({ kid: 'subject-kid-matrix' })
+        .mockReturnValueOnce({ alg: 'RS256' });
+      await expectOAuthError(
+        request(
+          {
+            actor_token: 'actor-token',
+            actor_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+          },
+          env
+        ),
+        400,
+        'invalid_grant',
+        'Actor token is missing kid in header'
+      );
+
+      mocks.mockParseToken.mockReturnValueOnce(subject).mockReturnValueOnce({ sub: 'actor-1' });
+      mocks.mockParseTokenHeader.mockReturnValue({ kid: 'subject-kid-matrix' });
+      await expectOAuthError(
+        request(
+          {
+            actor_token: 'actor-token',
+            actor_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+          },
+          env
+        ),
+        400,
+        'invalid_grant',
+        'Actor token must have an audience claim'
+      );
+    });
+
+    it('issues a downgraded delegated token with explicit actor and multiple targets', async () => {
+      const env = await createVerificationEnv();
+      mocks.mockGetClientCached.mockResolvedValueOnce({
+        client_id: 'service-client-1',
+        tenant_id: 'tenant-a',
+        client_secret_hash: 'hashed-secret',
+        token_exchange_allowed: true,
+        delegation_mode: 'delegation',
+        allowed_scopes: ['openid', 'profile_export'],
+        allowed_token_exchange_resources: [
+          'https://service.example.com',
+          'https://backup.example.com',
+        ],
+      });
+      mocks.mockParseToken
+        .mockReturnValueOnce({
+          sub: 'user-1',
+          aud: ['service-client-1'],
+          scope: 'openid profile_export admin',
+          act: { sub: 'prior-actor', client_id: 'prior-client' },
+        })
+        .mockReturnValueOnce({
+          sub: 'actor-1',
+          client_id: 'actor-client',
+          aud: ['service-client-1'],
+        });
+      mocks.mockParseTokenHeader.mockReturnValue({ kid: 'subject-kid-matrix' });
+
+      const response = await request(
+        {
+          scope: 'openid profile_export forbidden',
+          audience: ['https://service.example.com', 'https://backup.example.com'],
+          actor_token: 'actor-token',
+          actor_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+        },
+        env
+      );
+      const body = await parseJsonResponse<Record<string, unknown>>(response);
+
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        access_token: 'downstream-access-token',
+        token_type: 'Bearer',
+        scope: 'openid profile_export',
+      });
+      expect(mocks.mockCreateAccessToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          aud: ['https://service.example.com', 'https://backup.example.com'],
+          scope: 'openid profile_export',
+          act: {
+            sub: 'actor-1',
+            client_id: 'actor-client',
+            act: { sub: 'prior-actor', client_id: 'prior-client' },
+          },
+        }),
+        expect.anything(),
+        expect.any(String),
+        expect.any(Number),
+        'region-jti-1'
+      );
+    });
+
+    it('requires ID-JAG to be enabled before accepting its requested token type', async () => {
+      await expectOAuthError(
+        request({ requested_token_type: 'urn:ietf:params:oauth:token-type:id-jag' }),
+        400,
+        'invalid_request',
+        'ID-JAG token type is not enabled. Enable it via Admin API.'
+      );
+    });
+
+    it('restricts ID-JAG to identity-bearing subject token types', async () => {
+      mocks.mockGetSystemSettingsCached.mockResolvedValue({
+        oidc: {
+          tokenExchange: {
+            enabled: true,
+            allowedSubjectTokenTypes: ['access_token'],
+            idJag: { enabled: true, allowedIssuers: ['https://idp.example.com'] },
+          },
+        },
+      });
+      await expectOAuthError(
+        request({ requested_token_type: 'urn:ietf:params:oauth:token-type:id-jag' }),
+        400,
+        'invalid_request',
+        'ID-JAG requires subject_token_type to be id_token, jwt, or saml2. Got: urn:ietf:params:oauth:token-type:access_token'
+      );
+    });
+
+    it('fails closed when ID-JAG issuer trust is missing or mismatched', async () => {
+      const idJagBody = {
+        requested_token_type: 'urn:ietf:params:oauth:token-type:id-jag',
+        subject_token_type: 'urn:ietf:params:oauth:token-type:id_token',
+      };
+      mocks.mockParseTokenHeader.mockReturnValue({ kid: 'external-kid' });
+
+      mocks.mockGetSystemSettingsCached.mockResolvedValueOnce({
+        oidc: {
+          tokenExchange: {
+            enabled: true,
+            allowedSubjectTokenTypes: ['id_token'],
+            idJag: { enabled: true, allowedIssuers: [] },
+          },
+        },
+      });
+      mocks.mockParseToken.mockReturnValueOnce({ sub: 'user-1' });
+      await expectOAuthError(
+        request(idJagBody),
+        400,
+        'invalid_grant',
+        'Subject token is missing issuer (iss) claim'
+      );
+
+      mocks.mockGetSystemSettingsCached.mockResolvedValueOnce({
+        oidc: {
+          tokenExchange: {
+            enabled: true,
+            allowedSubjectTokenTypes: ['id_token'],
+            idJag: { enabled: true, allowedIssuers: [] },
+          },
+        },
+      });
+      mocks.mockParseToken.mockReturnValueOnce({ sub: 'user-1', iss: 'https://idp.example.com' });
+      await expectOAuthError(
+        request(idJagBody),
+        400,
+        'invalid_grant',
+        'ID-JAG is enabled but no allowed issuers are configured. Configure allowedIssuers via Admin API.'
+      );
+
+      mocks.mockGetSystemSettingsCached.mockResolvedValueOnce({
+        oidc: {
+          tokenExchange: {
+            enabled: true,
+            allowedSubjectTokenTypes: ['id_token'],
+            idJag: { enabled: true, allowedIssuers: ['https://trusted.example.com'] },
+          },
+        },
+      });
+      mocks.mockParseToken.mockReturnValueOnce({ sub: 'user-1', iss: 'https://evil.example.com' });
+      await expectOAuthError(
+        request(idJagBody),
+        400,
+        'invalid_grant',
+        "Subject token issuer 'https://evil.example.com' is not in the allowed issuers list"
+      );
+    });
+
+    it('returns a generic ID-JAG error when external signature verification fails', async () => {
+      mocks.mockGetSystemSettingsCached.mockResolvedValue({
+        oidc: {
+          tokenExchange: {
+            enabled: true,
+            allowedSubjectTokenTypes: ['id_token'],
+            idJag: {
+              enabled: true,
+              allowedIssuers: ['https://idp.example.com'],
+            },
+          },
+        },
+      });
+      mocks.mockParseToken.mockReturnValue({
+        sub: 'user-1',
+        iss: 'https://idp.example.com',
+      });
+      mocks.mockParseTokenHeader.mockReturnValue({ kid: 'external-kid' });
+      mocks.mockVerifyExternalIdJagSubjectToken.mockRejectedValueOnce(
+        new Error('external signature invalid')
+      );
+
+      await expectOAuthError(
+        request({
+          requested_token_type: 'urn:ietf:params:oauth:token-type:id-jag',
+          subject_token_type: 'urn:ietf:params:oauth:token-type:id_token',
+        }),
+        400,
+        'invalid_grant',
+        'Subject token verification failed'
+      );
+    });
+
+    it('issues a short-lived ID-JAG token with preserved authentication context', async () => {
+      const env = await createVerificationEnv();
+      mocks.mockGetSystemSettingsCached.mockResolvedValue({
+        oidc: {
+          tokenExchange: {
+            enabled: true,
+            allowedSubjectTokenTypes: ['id_token'],
+            idJag: {
+              enabled: true,
+              allowedIssuers: ['https://idp.example.com'],
+              maxTokenLifetime: 300,
+              includeTenantClaim: true,
+              requireConfidentialClient: true,
+            },
+          },
+        },
+      });
+      mocks.mockParseToken.mockReturnValue({
+        sub: 'external-user',
+        iss: 'https://idp.example.com',
+      });
+      mocks.mockParseTokenHeader.mockReturnValue({ kid: 'external-kid' });
+      mocks.mockVerifyExternalIdJagSubjectToken.mockResolvedValue({
+        sub: 'external-user',
+        iss: 'https://idp.example.com',
+        aud: 'service-client-1',
+        scope: 'openid profile_export',
+        acr: 'urn:example:loa:2',
+        amr: ['pwd', 'otp'],
+      });
+
+      const response = await request(
+        {
+          requested_token_type: 'urn:ietf:params:oauth:token-type:id-jag',
+          subject_token_type: 'urn:ietf:params:oauth:token-type:id_token',
+        },
+        env
+      );
+      const body = await parseJsonResponse<Record<string, unknown>>(response);
+
+      expect(response.status).toBe(200);
+      expect(body.issued_token_type).toBe('urn:ietf:params:oauth:token-type:id-jag');
+      expect(body.expires_in).toBe(300);
+      expect(mocks.mockCreateAccessToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sub: 'external-user',
+          original_issuer: 'https://idp.example.com',
+          tenant: 'tenant-a',
+          acr: 'urn:example:loa:2',
+          amr: ['pwd', 'otp'],
+        }),
+        expect.anything(),
+        expect.any(String),
+        300,
+        'region-jti-1'
+      );
+    });
+
+    it('rejects actor tokens with invalid signatures, expiry, revocation, or audience', async () => {
+      const env = await createVerificationEnv();
+      const actorRequest = {
+        actor_token: 'actor-token',
+        actor_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+      };
+      const subject = { sub: 'user-1', aud: 'service-client-1' };
+
+      mocks.mockParseToken.mockReturnValueOnce(subject).mockReturnValueOnce({
+        sub: 'actor-1',
+        aud: 'service-client-1',
+      });
+      mocks.mockVerifyToken.mockResolvedValueOnce({}).mockRejectedValueOnce(new Error('bad actor'));
+      await expectOAuthError(
+        request(actorRequest, env),
+        400,
+        'invalid_grant',
+        'Actor token verification failed'
+      );
+
+      mocks.mockParseToken.mockReturnValueOnce(subject).mockReturnValueOnce({
+        sub: 'actor-1',
+        aud: 'service-client-1',
+        exp: Math.floor(Date.now() / 1000) - 1,
+      });
+      await expectOAuthError(
+        request(actorRequest, env),
+        400,
+        'invalid_grant',
+        'Actor token has expired'
+      );
+
+      mocks.mockParseToken.mockReturnValueOnce(subject).mockReturnValueOnce({
+        sub: 'actor-1',
+        aud: 'service-client-1',
+        jti: 'revoked-actor',
+      });
+      mocks.mockIsTokenRevoked.mockResolvedValueOnce(true);
+      await expectOAuthError(
+        request(actorRequest, env),
+        400,
+        'invalid_grant',
+        'Actor token has been revoked'
+      );
+
+      mocks.mockParseToken.mockReturnValueOnce(subject).mockReturnValueOnce({
+        sub: 'actor-1',
+        aud: 'different-client',
+      });
+      await expectOAuthError(
+        request(actorRequest, env),
+        400,
+        'invalid_grant',
+        'Actor token audience does not match requesting client'
+      );
+    });
+
+    it('fails closed when exchanged access token creation fails', async () => {
+      const env = await createVerificationEnv();
+      mocks.mockParseToken.mockReturnValue({ sub: 'user-1', aud: 'service-client-1' });
+      mocks.mockCreateAccessToken.mockRejectedValueOnce(new Error('signing failed'));
+      await expectOAuthError(
+        request({}, env),
+        500,
+        'server_error',
+        'Failed to create access token'
+      );
+    });
+
+    it('rejects invalid DPoP and binds valid DPoP to the exchanged token', async () => {
+      const env = await createVerificationEnv();
+      mocks.mockParseToken.mockReturnValue({ sub: 'user-1', aud: 'service-client-1' });
+      mocks.mockExtractDPoPProof.mockReturnValue('dpop-proof');
+      mocks.mockValidateDPoPProof.mockResolvedValueOnce({
+        valid: false,
+        error_description: 'invalid proof',
+      });
+      const invalidResponse = await request({}, env);
+      expect(invalidResponse.status).toBe(400);
+      expect(mocks.mockCreateAccessToken).not.toHaveBeenCalled();
+
+      mocks.mockValidateDPoPProof.mockResolvedValueOnce({ valid: true, jkt: 'bound-jkt' });
+      const validResponse = await request({}, env);
+      const body = await parseJsonResponse<Record<string, unknown>>(validResponse);
+      expect(validResponse.status).toBe(200);
+      expect(body.token_type).toBe('DPoP');
+      expect(mocks.mockCreateAccessToken).toHaveBeenCalledWith(
+        expect.objectContaining({ cnf: { jkt: 'bound-jkt' } }),
+        expect.anything(),
+        expect.any(String),
+        expect.any(Number),
+        'region-jti-1'
+      );
+    });
+
+    it('supports resource-only and combined resource/audience targets', async () => {
+      const env = await createVerificationEnv();
+      mocks.mockGetClientCached.mockResolvedValue({
+        client_id: 'service-client-1',
+        tenant_id: 'tenant-a',
+        client_secret_hash: 'hashed-secret',
+        token_exchange_allowed: true,
+        delegation_mode: 'impersonation',
+        allowed_scopes: ['openid'],
+        allowed_token_exchange_resources: [
+          'https://service.example.com',
+          'https://resource.example.com',
+        ],
+      });
+      mocks.mockParseToken.mockReturnValue({
+        sub: 'user-1',
+        aud: 'service-client-1',
+        scope: 'openid',
+      });
+
+      const resourceOnly = await request(
+        { audience: undefined, resource: 'https://resource.example.com' },
+        env
+      );
+      expect(resourceOnly.status).toBe(200);
+      expect(mocks.mockCreateAccessToken).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          aud: 'https://resource.example.com',
+          resource: 'https://resource.example.com',
+        }),
+        expect.anything(),
+        expect.any(String),
+        expect.any(Number),
+        'region-jti-1'
+      );
+
+      const both = await request(
+        {
+          audience: 'https://service.example.com',
+          resource: 'https://resource.example.com',
+        },
+        env
+      );
+      expect(both.status).toBe(200);
+      expect(mocks.mockCreateAccessToken).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          aud: ['https://service.example.com', 'https://resource.example.com'],
+        }),
+        expect.anything(),
+        expect.any(String),
+        expect.any(Number),
+        'region-jti-1'
+      );
     });
   });
 

--- a/packages/ar-token/src/__tests__/external-id-jag-verifier.test.ts
+++ b/packages/ar-token/src/__tests__/external-id-jag-verifier.test.ts
@@ -170,4 +170,111 @@ describe('external ID-JAG subject token verification', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  it('requires at least one expected audience', async () => {
+    const signing = await createSigningFixture();
+    const token = await signSubjectToken(signing.privateKey);
+
+    await expect(
+      verifyExternalIdJagSubjectToken({ token, issuer: ISSUER, audiences: [] })
+    ).rejects.toThrow('requires an expected audience');
+  });
+
+  it('rejects missing key identifiers and unsupported signing algorithms before discovery', async () => {
+    const signing = await createSigningFixture();
+    const now = Math.floor(Date.now() / 1000);
+    const withoutKid = await new SignJWT({})
+      .setProtectedHeader({ alg: 'RS256' })
+      .setIssuer(ISSUER)
+      .setSubject('external-user')
+      .setAudience(AUDIENCE)
+      .setExpirationTime(now + 300)
+      .sign(signing.privateKey);
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      verifyExternalIdJagSubjectToken({ token: withoutKid, issuer: ISSUER, audiences: [AUDIENCE] })
+    ).rejects.toThrow('missing kid');
+
+    const unsupported = `${Buffer.from(JSON.stringify({ alg: 'HS256', kid: KID })).toString(
+      'base64url'
+    )}.${Buffer.from('{}').toString('base64url')}.signature`;
+    await expect(
+      verifyExternalIdJagSubjectToken({ token: unsupported, issuer: ISSUER, audiences: [AUDIENCE] })
+    ).rejects.toThrow('unsupported signing algorithm');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [`https://user:password@idp.example.com`, 'credentials'],
+    [`${ISSUER}?tenant=one`, 'query'],
+    [`${ISSUER}#fragment`, 'fragment'],
+  ])('rejects an issuer URL containing %s data', async (issuer) => {
+    const signing = await createSigningFixture();
+    const token = await signSubjectToken(signing.privateKey);
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      verifyExternalIdJagSubjectToken({ token, issuer, audiences: [AUDIENCE] })
+    ).rejects.toThrow(/without credentials, query, or fragment/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [{ issuer: 'https://different.example.com', jwks_uri: JWKS_URI }, /does not match/],
+    [{ issuer: ISSUER }, /missing jwks_uri/],
+  ])('rejects invalid discovery metadata %#', async (discovery, error) => {
+    const signing = await createSigningFixture();
+    const token = await signSubjectToken(signing.privateKey);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => Response.json(discovery))
+    );
+
+    await expect(
+      verifyExternalIdJagSubjectToken({ token, issuer: ISSUER, audiences: [AUDIENCE] })
+    ).rejects.toThrow(error);
+  });
+
+  it.each([
+    [{ not_keys: [] }, /missing keys/],
+    [{ keys: [{ kid: KID }] }, /no usable keys/],
+  ])('rejects invalid JWKS payload %#', async (jwks, error) => {
+    const signing = await createSigningFixture();
+    const token = await signSubjectToken(signing.privateKey);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string | URL | Request) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        return url.includes('openid-configuration')
+          ? Response.json({ issuer: ISSUER, jwks_uri: JWKS_URI })
+          : Response.json(jwks);
+      })
+    );
+
+    await expect(
+      verifyExternalIdJagSubjectToken({ token, issuer: ISSUER, audiences: [AUDIENCE] })
+    ).rejects.toThrow(error);
+  });
+
+  it('refreshes JWKS once and rejects ambiguous or non-verification keys', async () => {
+    const signing = await createSigningFixture();
+    const token = await signSubjectToken(signing.privateKey);
+    const unusable = { ...signing.publicJwk, use: 'enc', key_ops: ['encrypt'], alg: 'RS512' };
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      return url.includes('openid-configuration')
+        ? Response.json({ issuer: ISSUER, jwks_uri: JWKS_URI })
+        : Response.json({ keys: [unusable] });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      verifyExternalIdJagSubjectToken({ token, issuer: ISSUER, audiences: [AUDIENCE] })
+    ).rejects.toThrow('signing key was not found');
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
 });

--- a/packages/ar-token/src/__tests__/issuer.test.ts
+++ b/packages/ar-token/src/__tests__/issuer.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import type { Context } from 'hono';
+import type { Env } from '@authrim/ar-lib-core';
+import { getRequestIssuer } from '../issuer';
+
+function createIssuerContext(tenantId: unknown): Context<{ Bindings: Env }> {
+  return {
+    get: () => tenantId,
+    req: {
+      raw: new Request('https://auth.example.com/token'),
+    },
+    env: {},
+  } as unknown as Context<{ Bindings: Env }>;
+}
+
+describe('request issuer tenant boundary', () => {
+  it.each([undefined, null, '', '   '])('rejects missing tenant context value %#', (tenantId) => {
+    expect(() => getRequestIssuer(createIssuerContext(tenantId))).toThrow(
+      'Request issuer requires tenant context'
+    );
+  });
+
+  it('rejects a context without a tenant getter', () => {
+    const context = {
+      req: { raw: new Request('https://auth.example.com/token') },
+      env: {},
+    } as unknown as Context<{ Bindings: Env }>;
+
+    expect(() => getRequestIssuer(context)).toThrow('Request issuer requires tenant context');
+  });
+
+  it('trims tenant context before issuer resolution', () => {
+    expect(getRequestIssuer(createIssuerContext('  tenant-a  '))).toBe('https://auth.example.com');
+  });
+});

--- a/packages/ar-token/vitest.config.ts
+++ b/packages/ar-token/vitest.config.ts
@@ -14,7 +14,18 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
-      exclude: ['node_modules/', 'test/', 'dist/', '**/*.d.ts', '**/*.config.*', '**/mockData.ts'],
+      exclude: [
+        'node_modules/',
+        'test/',
+        'dist/',
+        '**/__tests__/**',
+        '**/*.d.ts',
+        '**/*.config.*',
+        '**/mockData.ts',
+      ],
+      thresholds: {
+        branches: 75,
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary

- strengthen meaningful negative-path and state-transition coverage across ar-lib-core, ar-management, ar-policy, ar-saml, and ar-token
- cover authorization escalation, cross-tenant access, passkey ownership, account recovery safeguards, redirect validation, SAML logout and metadata handling, and token authentication edge cases
- fix implementation issues exposed by the new tests, including strict IP/CIDR parsing, IPv6 CIDR matching, Hono error-boundary integration, authorization-code shard validation, tenant-scoped checks, and sensitive-value redaction
- raise branch coverage for the prioritized security-sensitive files to approximately 85–96%

## Why

Several security-critical paths had low or zero branch coverage. The added tests assert externally observable security behavior and side effects rather than only executing uncovered lines, so plausible authorization, replay, malformed-input, and tenant-isolation regressions now fail deterministically.

## Impact

The changes reject malformed network and sharded-code inputs more strictly, preserve tenant and ownership boundaries, prevent unsafe account-authenticator transitions, and provide consistent masked error responses through Hono error handlers.

## Validation

- pnpm lint
- pnpm --filter @authrim/ar-lib-core typecheck
- pnpm --filter @authrim/ar-management typecheck
- pnpm --filter @authrim/ar-lib-core test: 4,727 passed
- pnpm --filter @authrim/ar-management test: 3,319 passed, 2 skipped
- package-specific coverage runs for core, management, policy, SAML, and token
- Prettier check
- git diff --check