### PR TITLE
fix(ci): update test environment schema first

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -105,10 +105,10 @@ jobs:
 
       - name: Deploy environment
         run: |
-          pnpm exec tsx packages/setup/src/index.ts deploy \
+          pnpm exec tsx packages/setup/src/index.ts update \
             --env "$AUTHRIM_ENV_NAME" \
-            --source "$GITHUB_WORKSPACE" \
-            --keys-dir "$GITHUB_WORKSPACE/.authrim-keys/$AUTHRIM_ENV_NAME" \
+            --allow-draft-manifest \
+            --all \
             --yes
 
       - name: Validate generated environment


### PR DESCRIPTION
## Summary
- update the existing test environment instead of running initial deployment
- explicitly allow the draft migration manifest used by the develop branch
- apply all pending migration streams before validation and smoke tests

## Root cause
The test deployment failed with `unverified_draft_release_manifest:0.4.0` because the workflow used the initial `deploy` command against an existing environment.

## Validation
- confirmed the workflow diff is limited to the deployment command and its arguments
- matched the repository's documented test-environment update procedure