### PR TITLE
fix(saml): harden signature and metadata validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,74 +56,34 @@ npx @authrim/setup
 
 ## Quick Start
 
-### Option 1: Using the published setup package (Recommended)
+### Published setup package (Recommended)
 
 ```bash
-# Interactive setup from npm
 npx @authrim/setup
-
-# Or CLI mode for terminal-based setup
+# Terminal-based setup
 npx @authrim/setup --cli
 ```
 
-The setup package can download the Authrim source into a local project directory before provisioning and deployment.
+The local Web UI guides you through Cloudflare authentication, resource provisioning, key generation,
+Worker deployment, optional UI deployment, and initial admin creation.
 
-The setup wizard will guide you through:
-- Cloudflare authentication
-- Resource provisioning (D1, KV, Queues, R2)
-- Key generation
-- Standard API capability deployment, including SAML IdP, Device Flow / CIBA, and VC SD-JWT
-- Optional Admin UI and Login UI deployment
-- Tenant discovery, including domain, email-domain, and WAYF-style tenant selection modes
-- Worker deployment
-- Initial admin creation
-
-### Option 2: Clone the source and run the setup tool
-
-Use this path when you want to inspect or modify the source code while still using the setup workflow.
+### From source
 
 ```bash
-# 1. Clone and install
 git clone https://github.com/sgrastar/authrim.git
 cd authrim
 pnpm install
-
-# 2. Launch the local setup tool
 pnpm run setup
 ```
-
-The local setup command runs the same setup package from the workspace source.
-
-### Option 3: Scripted Setup (Development)
-
-```bash
-# 1. Clone and install
-git clone https://github.com/sgrastar/authrim.git
-cd authrim
-pnpm install
-
-# 2. Initialize a dev environment from the current setup implementation
-pnpm run setup:init --env=dev --cli
-
-# Optional: deploy or inspect the generated environment from source
-pnpm run setup:deploy --env=dev
-pnpm run setup:info --env=dev
-
-# 3. Run locally
-pnpm run dev
-# → http://localhost:8787/.well-known/openid-configuration
-```
-
-The setup command creates `.authrim/dev`, generates keys, provisions current Cloudflare resources
-including D1, KV, Queues, and R2, writes generated Wrangler configuration, applies the current root
-migration set, and keeps optional Admin UI / Login UI deployment settings aligned with the setup
-configuration.
 
 📚 **Full guides:** [Development](./docs/getting-started/development.md) | [Deployment](./docs/getting-started/deployment.md) | [Testing](./docs/getting-started/testing.md) | [Setup CLI](./packages/setup/README.md)
 
 ## Performance
 
-K6 Cloud distributed load testing in December 2025 validated Authrim's current sharded Workers architecture under representative OIDC workloads.
+### OIDC benchmarks (December 2025)
+
+K6 Cloud distributed load testing in December 2025 validated the sharded Workers architecture in
+use at that time under representative OIDC workloads.
 
 Observed benchmark results include:
 
@@ -131,14 +91,96 @@ Observed benchmark results include:
 - Full 5-step OAuth login flow: **150 logins/sec** with P95 around 756ms
 - CPU time: typically **1-4ms** in the tested scenarios
 
-Capacity depends on workload shape, Cloudflare plan limits, storage usage, and sharding configuration.
+[View the December 2025 reports](./load-testing/reports/Dec2025/)
 
-[View detailed reports](./load-testing/reports/Dec2025/)
+### SCIM attribute updates (August 2026)
 
-## Approximate Cloudflare Cost (Reference Only)
+An August 2026 test of mapped `displayName` updates found:
 
-⚠️ The following table is a **rough reference only**.  
-Actual costs depend on request volume, CPU time, and usage of KV / D1 / R2.
+- Individual PATCH: approximately **13 successful updates/sec** near a 14/sec offer; a no-drop
+  14/sec run was not demonstrated.
+- Bulk PATCH: **30 updates/sec** completed successfully in a one-minute trial, with P95 request
+  latency around 111.5 seconds due to queueing.
+- Provisional operating guidance remains **10 updates/sec** until longer soak testing is complete.
+
+[View the August 2026 SCIM report](./load-testing/reports/Aug2026/scim-attribute-update.md)
+
+Capacity depends on workload shape, Cloudflare plan limits, storage usage, sharding configuration,
+and test duration. These results are benchmark evidence, not an SLA.
+
+---
+
+## Current Status
+
+Authrim is currently pre-1.0. Core protocol and platform capabilities are implemented, but production hardening is still in progress.
+
+**Target release window:** Summer/Fall 2026
+
+| Area                             | Implementation    | Operational maturity | Notes                                                                                                                                                                                                             |
+| -------------------------------- | ----------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OpenID Provider                  | Complete          | Ready                | Certified OpenID Provider and Logout profiles                                                                                                                                                                     |
+| OAuth/OIDC advanced profiles     | Complete          | In progress          | PAR, DPoP, JAR, JARM, JWE, claims policy, token exchange, session management, introspection, and revocation                                                                                                        |
+| FAPI profiles                    | Complete          | In progress          | FAPI 2.0 Final DPoP, Client Credentials, Message Signing, and RP Suite plans completed without functional failures; formal certification publication is planned                                                   |
+| SAML 2.0 IdP/SP                  | Hardening active  | In progress          | Tenant-scoped IdP/SP endpoints, metadata import/export, configurable entityIDs, signing certificate rollover, encryption options, SSO/SLO correlation, and Admin UI operations                                   |
+| SCIM 2.0                         | Inbound complete  | In progress          | Users, Groups, and Bulk receiver with Mapping Set-based writes; outbound provisioning is out of scope                                                                                                             |
+| Authentication                   | Complete          | In progress          | Passkey, email code, social login, anonymous login and upgrade, Direct Auth, device flow, and CIBA                                                                                                                 |
+| CIBA                             | Complete          | In progress          | Backchannel authentication, approval, polling, and request storage; FAPI-CIBA private-key Poll/Ping Suite plans completed without functional failures                                                            |
+| Native SSO                       | Complete          | In progress          | `device_secret`, `ds_hash`, DPoP-bound token exchange, token revocation/introspection, and device management                                                                                                       |
+| Authorization                    | Complete          | In progress          | RBAC, ABAC, ReBAC, token embedding, real-time check API, and authorization update push                                                                                                                             |
+| Identity Hub                     | Complete          | In progress          | External IdP integration, account linking, identity stitching, and tenant discovery                                                                                                                               |
+| Account lifecycle and governance | Baseline complete | In progress          | Durable account lifecycle, identifier replacement, support context, legal holds, retention controls, and email delivery history                                                                                   |
+| VC/DID                           | Partial           | Experimental         | OpenID4VCI/OpenID4VP endpoint baselines and did:web/did:key support exist; official Final and HAIP Suite plans currently have known failures                                                                      |
+| JavaScript SDKs                  | Complete          | In progress          | Core, web, server, and SvelteKit packages                                                                                                                                                                         |
+| Admin/Login UI                   | Basic complete    | In progress          | Admin operations cover identity, SAML, storage, logging, governance, and Control Plane surfaces; Login UI production-flow hardening continues                                                                     |
+| Unified Control Plane            | Basic complete    | In progress          | Signed Runtime Registry and Lookup routes resolve single- or multi-shard D1 assignments with `shared_pool` or `tenant_exclusive` placement                                                                         |
+| Setup and release updates        | Baseline complete | In progress          | Setup and Control include resumable database-before-Worker release-operation paths; end-to-end production validation and deployment documentation continue                                                       |
+| Runtime storage profiles         | Basic complete    | In progress          | Setup-managed D1/R2 inventory and Hyperdrive-backed user core, PII, custom/extension, and audit paths exist; control-plane storage remains D1/KV-biased                                                          |
+| Multi-tenancy isolation          | Baseline complete | In progress          | Tenant-scoped issuer routing, storage access, admin boundaries, job artifacts, and regression coverage are in place                                                                                               |
+| Logging and operational evidence | Basic complete    | In progress          | Structured runtime logs, admin/user audit logs, sensitive-detail chunks, delivery events, exports, DLQ replay, retention jobs, and storage-destination controls are implemented                                  |
+| Security, QA, and validation     | Active            | In progress          | Security regression matrices and internal review remediation are active; a formal external audit and penetration test have not yet been completed                                                                 |
+
+[View the detailed roadmap](./docs/ROADMAP.md) and [feature matrix](./docs/FEATURES.md).
+
+---
+
+## Technical Stack
+
+### Backend (API)
+
+| Layer          | Technology                             | Version               | Purpose                                                                    |
+| ------------- | ------------------------- | -------- | ---------------------------------- |
+| **Runtime**    | Cloudflare Workers                     | -                     | Global edge deployment                                                     |
+| **Framework**  | Hono                                   | 4.13.x                | Fast, lightweight web framework                                            |
+| **Language**   | TypeScript                             | 5.9.x                 | Type-safe development                                                      |
+| **Build**      | Turbo + pnpm                           | 2.9.x / 9.x           | Monorepo, parallel builds, caching                                         |
+| **Deployment** | Wrangler                               | 4.110.x               | Workers deployment and local runtime                                       |
+| **Storage**    | KV / D1 / Durable Objects / Hyperdrive | -                     | Cloudflare-native persistence with external database paths where supported |
+| **Crypto**     | JOSE                                   | 6.2.x                 | JWT/JWS/JWE/JWK (RS256, ES256)                                             |
+| **WebAuthn**   | SimpleWebAuthn                         | 13.2.x                | Passkey authentication                                                     |
+| **SAML**       | xmldom + xml-crypto + pako             | 0.8.x / 6.1.x / 2.1.x | SAML 2.0 XML processing, signatures, and bindings                          |
+| **Email**      | Cloudflare Email Sending               | -                     | Workers `send_email` binding for transactional email                       |
+| **Email**      | Resend                                 | 6.8.x                 | Magic Link, OTP delivery                                                   |
+| **Testing**    | Vitest + Playwright                    | 4.1.x / 1.57.x        | Unit, integration, and E2E tests                                           |
+
+### Frontend (UI)
+
+| Layer          | Technology                                         | Version            | Purpose                                                     |
+| -------------- | ------------------------ | --------- | ------------------------------ |
+| **Framework**  | SvelteKit + Svelte                                 | 2.70.x / 5.56.x    | Modern reactive framework                                   |
+| **Deployment** | Cloudflare Workers static assets                   | -                  | UI Workers and global edge delivery                         |
+| **Build**      | Vite                                               | 7.3.x              | UI build and dev server                                     |
+| **CSS**        | UnoCSS                                             | 66.6.x             | Utility-first CSS                                           |
+| **Components** | Melt UI                                            | 0.86.x             | Headless, accessible components                             |
+| **Icons**      | UnoCSS preset-icons + Iconify Heroicons / Phosphor | 66.6.x / 1.2.x     | Utility icon classes and selectable Login UI provider icons |
+| **i18n**       | typesafe-i18n                                      | 5.26.x             | Type-safe internationalization                              |
+| **WebAuthn**   | SimpleWebAuthn Browser                             | 13.2.x             | Client-side passkey support                                 |
+| **Testing**    | Vitest + Testing Library                           | 4.1.x / 5.2.x-next | Component tests                                             |
+
+## Approximate Cloudflare Cost (December 2025 Reference)
+
+⚠️ The following estimates use the workload assumptions and Cloudflare pricing considered for the
+December 2025 benchmark. They are historical reference values, not current quotes. Actual costs
+depend on request volume, CPU time, and usage of KV, D1, Durable Objects, and R2.
 
 | Product Scale                   | Users (Total) | Est. CF Cost | Notes                                |
 | ------------------------------- | ------------: | -----------: | ------------------------------------ |
@@ -151,16 +193,16 @@ Actual costs depend on request volume, CPU time, and usage of KV / D1 / R2.
 | High-traffic consumer service   |           ~5M | ~$150–300/mo | Heavy auth traffic                   |
 | Large-scale platform            |          ~10M | ~$300–600/mo | 150 login/sec tested                 |
 
-### Assumptions
+### December 2025 assumptions
 
-- Workers Paid plan ($5/month)
+- Workers Paid plan base fee used in the estimate: $5/month
 - Optimized request patterns (caching, batching)
 - Typical authentication flows (OIDC, token refresh)
 - Excludes large R2 storage and excessive KV/D1 writes
 - Assumes ~20% DAU with weekly logins
 - Authrim scales primarily with **requests and CPU time**, not with user count
 
-### Verified by Load Testing (Dec 2025)
+### December 2025 benchmark estimate
 
 | Metric                 | Value                 | Cost         |
 | ---------------------- | --------------------- | ------------ |
@@ -171,100 +213,17 @@ Actual costs depend on request volume, CPU time, and usage of KV / D1 / R2.
 | Base fee               | —                     | $5.00 (6%)   |
 | **Total (excl. tax)**  | **≈ 5M users equiv.** | **$79.78**   |
 
-**Request-to-User conversion:**
+**Request-to-user conversion used in the estimate:**
 
 - 1 OIDC login ≈ 4 requests (authorize → token → userinfo → discovery)
 - 18M requests ≈ 4.5M logins/month
 - With 20% DAU and weekly login assumption → **~5M total users equivalent**
 
-> Infrastructure cost only (self-hosted). No vendor fees. See [Cloudflare pricing](https://developers.cloudflare.com/workers/platform/pricing/) for details.
-
----
-
-## Current Status
-
-Authrim is currently pre-1.0. Core protocol and platform capabilities are implemented, but production hardening is still in progress.
-
-**Target release window:** Summer/Fall 2026
-
-| Area                                      | Status                                                                                                                                                  |
-| ----- | ------ |
-| Core OIDC/OAuth implementation            | Implemented                                                                                                                                             |
-| FAPI profiles                             | Implemented; official Final OP/RP Suite plans completed without functional failures; formal certification publication planned                           |
-| CIBA                                      | Implemented; FAPI-CIBA private-key Poll/Ping Suite plans completed without functional failures                                                          |
-| SAML 2.0 IdP/SP                           | Active; implementation substantially complete with local entity metadata, signing rollover, and Admin UI operations                                     |
-| SCIM 2.0 | Inbound provisioning implemented; outbound provisioning is out of scope |
-| RBAC / ABAC / ReBAC policy engine         | Implemented                                                                                                                                             |
-| Identity Hub and external IdP integration | Implemented                                                                                                                                             |
-| Passkey / email auth / local auth         | Implemented; production flow hardening in progress                                                                                                      |
-| VC/DID                                    | Partial; OpenID4VCI/OpenID4VP endpoint baselines exist, but official Final and HAIP conformance gaps remain                                             |
-| JavaScript SDKs                           | Implemented                                                                                                                                             |
-| Setup tooling                             | Implemented; production deployment docs in progress                                                                                                     |
-| UI consolidation                          | Active; Admin/Login/setup flows are being polished against the current Workers deployment model                                                         |
-| Security, QA, and validation              | Active; internal review remediation landed for selected management authorization, CIBA, setup-token, WebAuthn, OTP, VCI, device-flow, and SCIM findings |
-| Storage portability                       | Implementation baseline complete; validation active                                                                                                     |
-| Multi-tenant isolation                    | Implementation baseline complete; validation active                                                                                                     |
-| Operational logging and evidence          | Implementation baseline complete; validation active                                                                                                     |
-
-[View detailed roadmap](./docs/ROADMAP.md)
-
----
-
-## Technical Stack
-
-### Backend (API)
-
-| Layer          | Technology                             | Version               | Purpose                                                                    |
-| ------------- | ------------------------- | -------- | ---------------------------------- |
-| **Runtime**    | Cloudflare Workers                     | -                     | Global edge deployment                                                     |
-| **Framework**  | Hono                                   | 4.12.x                | Fast, lightweight web framework                                            |
-| **Language**   | TypeScript                             | 5.9.x                 | Type-safe development                                                      |
-| **Build**      | Turbo + pnpm                           | 2.7.x / 9.x           | Monorepo, parallel builds, caching                                         |
-| **Deployment** | Wrangler                               | 4.59.x                | Workers deployment and local runtime                                       |
-| **Storage**    | KV / D1 / Durable Objects / Hyperdrive | -                     | Cloudflare-native persistence with external database paths where supported |
-| **Crypto**     | JOSE                                   | 6.1.x                 | JWT/JWS/JWE/JWK (RS256, ES256)                                             |
-| **WebAuthn**   | SimpleWebAuthn                         | 13.2.x                | Passkey authentication                                                     |
-| **SAML**       | xmldom + xml-crypto + pako             | 0.8.x / 6.1.x / 2.1.x | SAML 2.0 XML processing, signatures, and bindings                          |
-| **Email**      | Cloudflare Email Sending               | -                     | Workers `send_email` binding for transactional email                       |
-| **Email**      | Resend                                 | 6.8.x                 | Magic Link, OTP delivery                                                   |
-| **Testing**    | Vitest + Playwright                    | 4.0.x / 1.57.x        | Unit, integration, and E2E tests                                           |
-
-### Frontend (UI)
-
-| Layer          | Technology                                         | Version            | Purpose                                                     |
-| -------------- | ------------------------ | --------- | ------------------------------ |
-| **Framework**  | SvelteKit + Svelte                                 | 2.53.x / 5.53.x    | Modern reactive framework                                   |
-| **Deployment** | Cloudflare Workers static assets                   | -                  | UI Workers and global edge delivery                         |
-| **Build**      | Vite                                               | 7.3.x              | UI build and dev server                                     |
-| **CSS**        | UnoCSS                                             | 66.6.x             | Utility-first CSS                                           |
-| **Components** | Melt UI                                            | 0.86.x             | Headless, accessible components                             |
-| **Icons**      | UnoCSS preset-icons + Iconify Heroicons / Phosphor | 66.6.x / 1.2.x     | Utility icon classes and selectable Login UI provider icons |
-| **i18n**       | typesafe-i18n                                      | 5.26.x             | Type-safe internationalization                              |
-| **WebAuthn**   | SimpleWebAuthn Browser                             | 13.2.x             | Client-side passkey support                                 |
-| **Testing**    | Vitest + Testing Library                           | 4.0.x / 5.2.x-next | Component tests                                             |
-
-## Features
-
-| Area                             | Implementation    | Operational maturity | Notes                                                                                                                                                                                                             |
-| --- | --- | --- | --- |
-| OpenID Provider                  | Complete          | Ready                | Certified OpenID Provider and Logout profiles                                                                                                                                                                     |
-| OAuth/OIDC advanced profiles     | Complete          | In progress          | PAR, DPoP, JAR, JARM, JWE, claims policy, token exchange                                                                                                                                                          |
-| FAPI profiles                    | Complete          | In progress          | FAPI 2.0 Final DPoP, Client Credentials, Message Signing, and RP Suite plans completed without functional failures; formal certification publication is planned                                                   |
-| SAML 2.0 IdP/SP                  | Hardening active  | In progress          | Tenant-scoped IdP/SP endpoints, metadata import/export, configurable entityIDs, interactive login redirect policy, signing certificate subject/rollover, encryption options, SSO/SLO correlation, and DR planning |
-| SCIM 2.0 | Inbound complete | In progress | Users, Groups, and Bulk receiver; outbound provisioning is out of scope |
-| Authentication                   | Complete          | In progress          | Passkey, email code, social login, Direct Auth, device flow, CIBA                                                                                                                                                 |
-| CIBA                             | Complete          | In progress          | Backchannel authentication, approval, polling, and request storage paths; FAPI-CIBA private-key Poll/Ping Suite plans completed without functional failures                                                       |
-| Native SSO                       | Complete          | In progress          | `device_secret`, `ds_hash`, and DPoP-bound token exchange support                                                                                                                                                 |
-| Authorization                    | Complete          | In progress          | RBAC, ABAC, ReBAC, token embedding, real-time check API                                                                                                                                                           |
-| Identity Hub                     | Complete          | In progress          | External IdP integration, account linking, identity stitching                                                                                                                                                     |
-| VC/DID                           | Partial           | Experimental         | OpenID4VCI/OpenID4VP endpoint baselines and did:web/did:key support exist; official Final and HAIP Suite plans currently have known failures                                                                      |
-| SDKs                             | Complete          | In progress          | Core, web, server, and SvelteKit packages                                                                                                                                                                         |
-| Admin/Login UI                   | Basic complete    | In progress          | Admin UI includes SAML entity info, database connections, storage destinations, logging controls, and tenant discovery settings; Login UI supports configured provider logos/icons                                |
-| Runtime storage profiles         | Basic complete    | In progress          | Runtime profiles, setup-managed D1/R2 inventory, tenant D1 assignment visibility, and Hyperdrive-backed user core, PII, custom/extension, and audit paths exist; control-plane storage remains D1/KV-biased       |
-| Multi-tenancy isolation          | Baseline complete | In progress          | Tenant-scoped issuer routing, storage access, admin boundaries, job artifacts, and regression coverage are in place                                                                                               |
-| Logging and operational evidence | Basic complete    | In progress          | Structured runtime logs, admin/user audit logs, diagnostic detail, sensitive detail chunks, delivery events, DLQ replay, and storage-destination controls are implemented                                         |
-
-See [Feature Matrix](./docs/FEATURES.md) for a more detailed capability and SDK overview.
+> Infrastructure cost only (self-hosted). Check the current Cloudflare pricing for
+> [Workers](https://developers.cloudflare.com/workers/platform/pricing/),
+> [D1](https://developers.cloudflare.com/d1/platform/pricing/),
+> [Workers KV](https://developers.cloudflare.com/kv/platform/pricing/), and
+> [R2](https://developers.cloudflare.com/r2/pricing/) before estimating a deployment.
 
 ---
 
@@ -295,15 +254,3 @@ See [LICENSE](./LICENSE) for details.
 - **Issues**: [Report bugs](https://github.com/sgrastar/authrim/issues)
 - **Discussions**: [Feature requests](https://github.com/sgrastar/authrim/discussions)
 - **Email**: yuta@sgrastar.org
-
----
-
-> **Authrim** — _Identity & Access at the edge of everywhere_
->
-> **Status:** Pre-1.0 | Target release window: Summer/Fall 2026 | Production hardening and OpenID4VC Final/HAIP interoperability work in progress
->
-> _A self-hosted Identity & Access Platform for modern applications._
->
-> ```bash
-> npx @authrim/setup
-> ```

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
       "devalue": "^5.8.1",
       "minimatch@<3.1.4": "3.1.4",
       "minimatch@>=9.0.0 <9.0.7": "9.0.7",
-      "@xmldom/xmldom": "^0.8.13",
+      "@xmldom/xmldom": "^0.8.15",
       "dompurify": "3.4.13",
       "nanoid@<3.3.18": "3.3.18",
       "nanoid@>=4.0.0 <5.1.16": "5.1.16",

--- a/packages/ar-saml/openapi/saml.openapi.yaml
+++ b/packages/ar-saml/openapi/saml.openapi.yaml
@@ -246,7 +246,7 @@ paths:
         - adminBearer: []
         - adminSessionCookie: []
       requestBody:
-        $ref: "#/components/requestBodies/SAMLMetadataInput"
+        $ref: "#/components/requestBodies/SAMLAggregateMetadataInput"
       responses:
         "200":
           $ref: "#/components/responses/SAMLMetadataPreview"
@@ -657,6 +657,15 @@ components:
             $ref: "#/components/schemas/SAMLMetadataInput"
           example:
             metadataUrl: https://idp.example.com/metadata.xml
+    SAMLAggregateMetadataInput:
+      required: true
+      description: The JSON request body is limited to 12 MiB; inline aggregate XML is limited to 10 MiB.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/SAMLAggregateMetadataInput"
+          example:
+            metadataUrl: https://federation.example.com/aggregate-metadata.xml
     SAMLTrustCertificatePreview:
       required: true
       content:
@@ -1088,6 +1097,7 @@ components:
           format: uri
         metadataXml:
           type: string
+          maxLength: 1048576
         nameIdFormat:
           type: string
         metadataNameIdFormats:
@@ -1151,6 +1161,7 @@ components:
           format: uri
         metadataXml:
           type: string
+          maxLength: 1048576
         samlProfile:
           type: string
         attributePresetId:
@@ -1259,6 +1270,20 @@ components:
       properties:
         metadataXml:
           type: string
+          maxLength: 1048576
+        metadataUrl:
+          type: string
+          format: uri
+        samlProfile:
+          type: string
+        attributePresetId:
+          type: string
+    SAMLAggregateMetadataInput:
+      type: object
+      properties:
+        metadataXml:
+          type: string
+          maxLength: 10485760
         metadataUrl:
           type: string
           format: uri

--- a/packages/ar-saml/package.json
+++ b/packages/ar-saml/package.json
@@ -16,10 +16,11 @@
   "dependencies": {
     "@authrim/ar-lib-core": "workspace:*",
     "@authrim/ar-lib-field-mapping": "workspace:*",
-    "@xmldom/xmldom": "^0.8.13",
+    "@xmldom/xmldom": "^0.8.15",
     "hono": "4.13.2",
     "jose": "^6.2.9",
     "pako": "^2.1.0",
+    "saxes": "6.0.0",
     "xml-crypto": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/ar-saml/src/__tests__/saml-integration.test.ts
+++ b/packages/ar-saml/src/__tests__/saml-integration.test.ts
@@ -99,6 +99,9 @@ vi.mock('../admin/providers', () => ({
 
 vi.mock('../common/signature', () => ({
   verifyXmlSignature: vi.fn(),
+  verifyXmlSignatureAndGetReferences: vi.fn((xml: string) => [
+    { uri: /\bReference URI="([^"]+)"/.exec(xml)?.[1] ?? '', xml },
+  ]),
   verifyRedirectBindingSignature: vi.fn().mockResolvedValue(true),
   hasSignature: vi.fn((xml: string) => xml.includes('<ds:Signature')),
   signXml: vi.fn((xml: string) => xml), // Pass through
@@ -501,22 +504,32 @@ function createMockLogoutResponse(
     issuer?: string;
     statusCode?: string;
     inResponseTo?: string;
+    includeSignature?: boolean;
   } = {}
 ): string {
   const {
     issuer = 'https://idp.example.com',
     statusCode = 'urn:oasis:names:tc:SAML:2.0:status:Success',
     inResponseTo = '_request_123',
+    includeSignature = true,
   } = options;
+  const responseId = `_response_${Date.now()}`;
+  const signature = includeSignature
+    ? `<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <ds:SignedInfo><ds:Reference URI="#${responseId}"/></ds:SignedInfo>
+    <ds:SignatureValue>test-signature</ds:SignatureValue>
+  </ds:Signature>`
+    : '';
 
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <samlp:LogoutResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
   xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
-  ID="_response_${Date.now()}"
+  ID="${responseId}"
   Version="2.0"
   IssueInstant="${new Date().toISOString()}"
   InResponseTo="${inResponseTo}">
   <saml:Issuer>${issuer}</saml:Issuer>
+  ${signature}
   <samlp:Status>
     <samlp:StatusCode Value="${statusCode}"/>
   </samlp:Status>

--- a/packages/ar-saml/src/admin/__tests__/aggregate-metadata.test.ts
+++ b/packages/ar-saml/src/admin/__tests__/aggregate-metadata.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
+  AGGREGATE_METADATA_FETCH_LIMIT_BYTES,
   extractEntityDescriptorXml,
+  extractEntityDescriptorXmls,
   fingerprintCertificateSha256,
   isAggregateMetadata,
   parseAggregateMetadata,
+  verifyAggregateMetadata,
   verifyAggregateMetadataSignature,
 } from '../aggregate-metadata';
 import { signXml } from '../../common/signature';
@@ -158,8 +161,93 @@ describe('SAML aggregate metadata', () => {
     expect(xml).not.toContain('https://idp.example.test/idp');
   });
 
-  it('permits unsigned aggregate metadata in warn mode but records the trust profile decision', () => {
-    const summary = verifyAggregateMetadataSignature(
+  it('extracts multiple selected entities in one streaming pass', () => {
+    const entities = extractEntityDescriptorXmls(aggregateXml, [
+      'https://idp.example.test/idp',
+      'https://sp.example.test/sp',
+    ]);
+
+    expect(entities).toHaveLength(2);
+    expect(entities.get('https://idp.example.test/idp')).toContain('Example IdP');
+    expect(entities.get('https://sp.example.test/sp')).toContain('AssertionConsumerService');
+  });
+
+  it('rejects expired and malformed aggregate root validUntil values', () => {
+    expect(() =>
+      parseAggregateMetadata(aggregateXml.replace('2030-01-01T00:00:00Z', '2000-01-01T00:00:00Z'))
+    ).toThrow('Invalid aggregate metadata: expired validUntil');
+    expect(() =>
+      parseAggregateMetadata(aggregateXml.replace('2030-01-01T00:00:00Z', 'not-a-date'))
+    ).toThrow('Invalid aggregate metadata: invalid validUntil');
+
+    expect(() =>
+      parseAggregateMetadata(
+        aggregateXml.replace(
+          '<md:EntitiesDescriptor Name="nested">',
+          '<md:EntitiesDescriptor Name="nested" validUntil="2000-01-01T00:00:00Z">'
+        )
+      )
+    ).toThrow('Invalid aggregate metadata: expired validUntil');
+  });
+
+  it('rejects aggregate processing instructions and excessive nesting before DOM parsing', () => {
+    expect(() =>
+      parseAggregateMetadata(
+        aggregateXml.replace('<md:EntityDescriptor', '<?unsafe x?>\n<md:EntityDescriptor')
+      )
+    ).toThrow('SAML metadata processing instructions are not allowed');
+
+    const deeplyNested = `<md:EntitiesDescriptor xmlns:md="${'urn:oasis:names:tc:SAML:2.0:metadata'}" ID="_deep">${'<md:EntitiesDescriptor>'.repeat(64)}<md:EntityDescriptor entityID="https://sp.example.test/sp"/>${'</md:EntitiesDescriptor>'.repeat(64)}</md:EntitiesDescriptor>`;
+    expect(() => parseAggregateMetadata(deeplyNested)).toThrow(
+      'Aggregate metadata exceeds maximum depth'
+    );
+  });
+
+  it('rejects aggregate XML above the configured byte limit', () => {
+    const oversized = `<md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" ID="_large"><md:EntityDescriptor entityID="https://sp.example.test/sp"><!--${'x'.repeat(
+      AGGREGATE_METADATA_FETCH_LIMIT_BYTES
+    )}--></md:EntityDescriptor></md:EntitiesDescriptor>`;
+    expect(() => parseAggregateMetadata(oversized)).toThrow(
+      'Aggregate metadata exceeds maximum size'
+    );
+  });
+
+  it('rejects an oversized root Signature before DOM signature parsing', async () => {
+    const oversizedSignature = `<md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" ID="_signature_limit"><ds:Signature><ds:Object>${'x'.repeat(
+      128 * 1024
+    )}</ds:Object></ds:Signature><md:EntityDescriptor entityID="https://sp.example.test/sp"/></md:EntitiesDescriptor>`;
+
+    await expect(
+      verifyAggregateMetadataSignature(
+        oversizedSignature,
+        'https://metadata.example.test/aggregate.xml',
+        [],
+        'strict'
+      )
+    ).rejects.toThrow('Aggregate signature exceeds maximum size');
+  });
+
+  it('accepts federation-sized XML without creating a DOM for the aggregate document', () => {
+    const entities = Array.from(
+      { length: 500 },
+      (_, index) =>
+        `<md:EntityDescriptor entityID="https://sp${index}.example.test/sp"><md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:Extensions><label>${'x'.repeat(
+          700
+        )}</label></md:Extensions><md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://sp${index}.example.test/acs" index="0"/></md:SPSSODescriptor></md:EntityDescriptor>`
+    ).join('');
+    const largeAggregate = `<md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" ID="_large_federation">${entities}</md:EntitiesDescriptor>`;
+
+    const parsed = parseAggregateMetadata(largeAggregate);
+    expect(new TextEncoder().encode(largeAggregate).byteLength).toBeGreaterThan(256 * 1024);
+    expect(parsed.entities).toHaveLength(500);
+    expect(parsed.entities[499]).toMatchObject({
+      entityId: 'https://sp499.example.test/sp',
+      acsUrl: 'https://sp499.example.test/acs',
+    });
+  });
+
+  it('permits unsigned aggregate metadata in warn mode but records the trust profile decision', async () => {
+    const summary = await verifyAggregateMetadataSignature(
       aggregateXml,
       'https://metadata.example.test/aggregate.xml',
       [
@@ -182,8 +270,8 @@ describe('SAML aggregate metadata', () => {
     expect(summary.error).toBe('Aggregate metadata root is not signed');
   });
 
-  it('rejects unsigned aggregate metadata in strict mode', () => {
-    expect(() =>
+  it('rejects unsigned aggregate metadata in strict mode', async () => {
+    await expect(
       verifyAggregateMetadataSignature(
         aggregateXml,
         'https://metadata.example.test/aggregate.xml',
@@ -201,24 +289,24 @@ describe('SAML aggregate metadata', () => {
         ],
         'strict'
       )
-    ).toThrow('Aggregate metadata root is not signed');
+    ).rejects.toThrow('Aggregate metadata root is not signed');
   });
 
-  it('records disabled aggregate metadata signature verification explicitly', () => {
-    expect(
+  it('records disabled aggregate metadata signature verification explicitly', async () => {
+    await expect(
       verifyAggregateMetadataSignature(
         aggregateXml,
         'https://metadata.example.test/aggregate.xml',
         [],
         'disabled'
       )
-    ).toMatchObject({
+    ).resolves.toMatchObject({
       status: 'skipped',
       policy: 'disabled',
     });
   });
 
-  it('verifies signed aggregate metadata with a matching trust profile', () => {
+  it('verifies signed aggregate metadata with a matching trust profile', async () => {
     const signedXml = signXml(signableAggregateXml, {
       privateKey: testPrivateKey,
       certificate: testCertificate,
@@ -226,7 +314,7 @@ describe('SAML aggregate metadata', () => {
       signatureLocation: 'prepend',
     });
 
-    const summary = verifyAggregateMetadataSignature(
+    const summary = await verifyAggregateMetadataSignature(
       signedXml,
       'https://metadata.example.test/aggregate.xml',
       [
@@ -259,7 +347,7 @@ describe('SAML aggregate metadata', () => {
     });
   });
 
-  it('does not match uploaded aggregate metadata to URL-bound trust profiles without a URL', () => {
+  it('returns only the validated signed reference for downstream aggregate processing', async () => {
     const signedXml = signXml(signableAggregateXml, {
       privateKey: testPrivateKey,
       certificate: testCertificate,
@@ -267,7 +355,88 @@ describe('SAML aggregate metadata', () => {
       signatureLocation: 'prepend',
     });
 
-    expect(() =>
+    const result = await verifyAggregateMetadata(
+      signedXml,
+      'https://metadata.example.test/aggregate.xml',
+      [
+        {
+          id: 'profile-1',
+          tenantId: 'default',
+          name: 'Example federation',
+          metadataUrlPatterns: ['https://metadata.example.test/*'],
+          certificates: [
+            {
+              id: 'cert-1',
+              certificate: testCertificate,
+              fingerprintSha256: 'test-fingerprint',
+              createdAt: 1,
+            },
+          ],
+          enabled: true,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      'strict'
+    );
+
+    expect(result.verification.status).toBe('verified');
+    expect(result.aggregate.metadataXml).not.toContain('<Signature');
+    expect(result.aggregate.metadataXml).not.toContain('<ds:Signature');
+    expect(result.aggregate.entities).toHaveLength(1);
+  });
+
+  it('verifies federation-style default namespaces with inherited extension prefixes', async () => {
+    const federationXml = `<EntitiesDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui" ID="_default_ns"><EntityDescriptor entityID="https://idp.example.test/idp"><IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><Extensions><mdui:UIInfo><mdui:DisplayName xml:lang="en">Default Namespace IdP</mdui:DisplayName></mdui:UIInfo></Extensions><SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.example.test/sso"/></IDPSSODescriptor></EntityDescriptor></EntitiesDescriptor>`;
+    const signedXml = signXml(federationXml, {
+      privateKey: testPrivateKey,
+      certificate: testCertificate,
+      referenceUri: '#_default_ns',
+      signatureLocation: 'prepend',
+    });
+
+    const result = await verifyAggregateMetadata(
+      signedXml,
+      undefined,
+      [
+        {
+          id: 'profile-1',
+          tenantId: 'default',
+          name: 'Offline federation',
+          metadataUrlPatterns: ['*'],
+          certificates: [
+            {
+              id: 'cert-1',
+              certificate: testCertificate,
+              fingerprintSha256: 'test-fingerprint',
+              createdAt: 1,
+            },
+          ],
+          enabled: true,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      'strict'
+    );
+
+    expect(result.verification.status).toBe('verified');
+    expect(result.aggregate.entities[0]).toMatchObject({
+      entityId: 'https://idp.example.test/idp',
+      displayName: 'Default Namespace IdP',
+      ssoUrl: 'https://idp.example.test/sso',
+    });
+  });
+
+  it('does not match uploaded aggregate metadata to URL-bound trust profiles without a URL', async () => {
+    const signedXml = signXml(signableAggregateXml, {
+      privateKey: testPrivateKey,
+      certificate: testCertificate,
+      referenceUri: '#_signed_aggregate',
+      signatureLocation: 'prepend',
+    });
+
+    await expect(
       verifyAggregateMetadataSignature(
         signedXml,
         undefined,
@@ -292,10 +461,10 @@ describe('SAML aggregate metadata', () => {
         ],
         'strict'
       )
-    ).toThrow('No matching federation trust profile');
+    ).rejects.toThrow('No matching federation trust profile');
   });
 
-  it('allows uploaded aggregate metadata only when the trust profile explicitly uses *', () => {
+  it('allows uploaded aggregate metadata only when the trust profile explicitly uses *', async () => {
     const signedXml = signXml(signableAggregateXml, {
       privateKey: testPrivateKey,
       certificate: testCertificate,
@@ -303,7 +472,7 @@ describe('SAML aggregate metadata', () => {
       signatureLocation: 'prepend',
     });
 
-    const summary = verifyAggregateMetadataSignature(
+    const summary = await verifyAggregateMetadataSignature(
       signedXml,
       undefined,
       [
@@ -331,7 +500,7 @@ describe('SAML aggregate metadata', () => {
     expect(summary.status).toBe('verified');
   });
 
-  it('rejects aggregate signatures with more than one Reference', () => {
+  it('rejects aggregate signatures with more than one Reference', async () => {
     const signedXml = signXml(signableAggregateXml, {
       privateKey: testPrivateKey,
       certificate: testCertificate,
@@ -342,7 +511,7 @@ describe('SAML aggregate metadata', () => {
       '<Reference xmlns="http://www.w3.org/2000/09/xmldsig#" URI="#unexpected"><DigestValue>ignored</DigestValue></Reference>$&'
     );
 
-    expect(() =>
+    await expect(
       verifyAggregateMetadataSignature(
         signedXml,
         'https://metadata.example.test/aggregate.xml',
@@ -367,12 +536,48 @@ describe('SAML aggregate metadata', () => {
         ],
         'strict'
       )
-    ).toThrow(
+    ).rejects.toThrow(
       'Aggregate signature reference does not exclusively cover the root EntitiesDescriptor'
     );
   });
 
-  it('rejects tampered signed aggregate metadata in strict mode', () => {
+  it('rejects a Reference moved outside the signed SignedInfo element', async () => {
+    const signedXml = signXml(signableAggregateXml, {
+      privateKey: testPrivateKey,
+      certificate: testCertificate,
+      referenceUri: '#_signed_aggregate',
+      signatureLocation: 'prepend',
+    });
+    const reference = signedXml.match(/<Reference\b[\s\S]*?<\/Reference>/)?.[0];
+    expect(reference).toBeDefined();
+    const decoyXml = signedXml
+      .replace(reference!, '')
+      .replace('</Signature>', `<Object>${reference}</Object></Signature>`);
+
+    await expect(
+      verifyAggregateMetadataSignature(
+        decoyXml,
+        'https://metadata.example.test/aggregate.xml',
+        [
+          {
+            id: 'profile-1',
+            tenantId: 'default',
+            name: 'Example federation',
+            metadataUrlPatterns: ['https://metadata.example.test/*'],
+            certificates: [],
+            enabled: true,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ],
+        'strict'
+      )
+    ).rejects.toThrow(
+      'Aggregate signature reference does not exclusively cover the root EntitiesDescriptor'
+    );
+  });
+
+  it('rejects tampered signed aggregate metadata in strict mode', async () => {
     const signedXml = signXml(signableAggregateXml, {
       privateKey: testPrivateKey,
       certificate: testCertificate,
@@ -380,7 +585,7 @@ describe('SAML aggregate metadata', () => {
       signatureLocation: 'prepend',
     }).replace('https://sp.example.test/acs', 'https://sp.example.test/tampered');
 
-    expect(() =>
+    await expect(
       verifyAggregateMetadataSignature(
         signedXml,
         'https://metadata.example.test/aggregate.xml',
@@ -405,10 +610,10 @@ describe('SAML aggregate metadata', () => {
         ],
         'strict'
       )
-    ).toThrow('Aggregate metadata signature could not be verified');
+    ).rejects.toThrow('Aggregate metadata signature could not be verified');
   });
 
-  it('rejects aggregate metadata signed by an unknown certificate in strict mode', () => {
+  it('rejects aggregate metadata signed by an unknown certificate in strict mode', async () => {
     const signedXml = signXml(signableAggregateXml, {
       privateKey: testPrivateKey,
       certificate: testCertificate,
@@ -416,7 +621,7 @@ describe('SAML aggregate metadata', () => {
       signatureLocation: 'prepend',
     });
 
-    expect(() =>
+    await expect(
       verifyAggregateMetadataSignature(
         signedXml,
         'https://metadata.example.test/aggregate.xml',
@@ -441,7 +646,7 @@ describe('SAML aggregate metadata', () => {
         ],
         'strict'
       )
-    ).toThrow('Aggregate metadata signature could not be verified');
+    ).rejects.toThrow('Aggregate metadata signature could not be verified');
   });
 
   it('rejects invalid trust certificate PEM before fingerprinting', async () => {

--- a/packages/ar-saml/src/admin/__tests__/aggregate-provider-api.test.ts
+++ b/packages/ar-saml/src/admin/__tests__/aggregate-provider-api.test.ts
@@ -216,6 +216,7 @@ function createAggregateStoreNamespace(input: {
 
 function createContext(input: {
   body?: unknown;
+  rawRequest?: Request;
   params?: Record<string, string>;
   query?: Record<string, string | undefined>;
   tenantId?: string;
@@ -224,6 +225,7 @@ function createContext(input: {
 }) {
   return {
     req: {
+      raw: input.rawRequest,
       json: async () => input.body,
       header: () => undefined,
       query: (name: string) => input.query?.[name],
@@ -294,6 +296,40 @@ describe('SAML aggregate provider API', () => {
       'https://metadata.example.test/aggregate.xml',
       expect.objectContaining({ maxResponseSize: 10 * 1024 * 1024 })
     );
+  });
+
+  it('rejects an oversized aggregate preview request before buffering its JSON body', async () => {
+    const response = await handlePreviewMetadata(
+      createContext({
+        rawRequest: new Request('https://authrim.example.test/api/admin/saml-metadata/preview', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': String(12 * 1024 * 1024 + 1),
+          },
+          body: '{}',
+        }),
+      })
+    );
+    const body = (await response.json()) as { error_description: string };
+
+    expect(response.status).toBe(400);
+    expect(body.error_description).toContain('request body exceeds size limit');
+    expect(mocks.safeFetchText).not.toHaveBeenCalled();
+  });
+
+  it('rejects oversized single-entity XML received through the aggregate preview endpoint', async () => {
+    const oversizedSingleMetadata = singleSPMetadata.replace(
+      '</md:EntityDescriptor>',
+      `<md:Extensions>${'x'.repeat(1024 * 1024)}</md:Extensions></md:EntityDescriptor>`
+    );
+    const response = await handlePreviewMetadata(
+      createContext({ body: { metadataXml: oversizedSingleMetadata } }) as never
+    );
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error_description?: string };
+    expect(body.error_description).toContain('Single-entity SAML metadata exceeds size limit');
   });
 
   it('loads normalized SAML federation trust sources during aggregate preview', async () => {

--- a/packages/ar-saml/src/admin/aggregate-metadata.ts
+++ b/packages/ar-saml/src/admin/aggregate-metadata.ts
@@ -6,22 +6,35 @@ import type {
   SAMLMetadataVerificationPolicy,
   SAMLMetadataVerificationSummary,
 } from '@authrim/ar-lib-core';
-import { SignedXml } from 'xml-crypto';
+import { SaxesParser, type SaxesTagNS } from 'saxes';
+import { ExclusiveCanonicalization } from 'xml-crypto';
 import {
   parseXml,
-  serializeXml,
   findElement,
   findElements,
-  findDirectChildElement,
   getAttribute,
   getTextContent,
 } from '../common/xml-utils';
 import { DIGEST_ALGORITHMS, SAML_NAMESPACES, SIGNATURE_ALGORITHMS } from '../common/constants';
-import type { SignedXmlWithErrors } from '../common/types';
+import { importPublicKeyFromCertificate } from '../common/signature';
 import { SAMLMetadataValidationError } from './errors';
 
 export const SINGLE_METADATA_FETCH_LIMIT_BYTES = 1024 * 1024;
 export const AGGREGATE_METADATA_FETCH_LIMIT_BYTES = 10 * 1024 * 1024;
+
+const AGGREGATE_XML_LIMITS = {
+  maxBytes: AGGREGATE_METADATA_FETCH_LIMIT_BYTES,
+  maxElements: 100_000,
+  maxAttributes: 200_000,
+  maxDepth: 64,
+  maxEntities: 10_000,
+} as const;
+
+const AGGREGATE_SIGNATURE_LIMITS = {
+  maxBytes: 128 * 1024,
+  maxElements: 512,
+  maxAttributes: 1024,
+} as const;
 
 export interface ParsedAggregateMetadata {
   metadataXml: string;
@@ -30,58 +43,104 @@ export interface ParsedAggregateMetadata {
   entities: SAMLMetadataEntitySummary[];
 }
 
+export interface VerifiedAggregateMetadata {
+  aggregate: ParsedAggregateMetadata;
+  verification: SAMLMetadataVerificationSummary;
+}
+
+interface ScannedAggregateMetadata {
+  rootId: string;
+  rootIdOccurrences: number;
+  validUntil?: string;
+  rootSignatureXml?: string;
+  entityCount: number;
+  entityXml: string[];
+}
+
+interface PreparedAggregateSignature {
+  signedReference: string;
+  signedInfo: Uint8Array;
+  signatureValue: Uint8Array;
+}
+
 export function isAggregateMetadata(xml: string): boolean {
-  const doc = parseXml(xml);
-  const root = doc.documentElement;
-  return root?.namespaceURI === SAML_NAMESPACES.MD && root.localName === 'EntitiesDescriptor';
+  if (utf8ByteLength(xml) > AGGREGATE_XML_LIMITS.maxBytes) {
+    throw new SAMLMetadataValidationError('Aggregate metadata exceeds maximum size');
+  }
+  let rootIsAggregate = false;
+  let depth = 0;
+  let elementCount = 0;
+  let attributeCount = 0;
+  const parser = new SaxesParser({ xmlns: true });
+  parser.on('doctype', () => {
+    throw new SAMLMetadataValidationError(
+      'XML security error: DOCTYPE declarations are not allowed'
+    );
+  });
+  parser.on('processinginstruction', () => {
+    throw new SAMLMetadataValidationError('SAML metadata processing instructions are not allowed');
+  });
+  parser.on('opentag', (tag) => {
+    depth++;
+    elementCount++;
+    attributeCount += Object.keys(tag.attributes).length;
+    if (depth > AGGREGATE_XML_LIMITS.maxDepth) {
+      throw new SAMLMetadataValidationError('SAML metadata exceeds maximum depth');
+    }
+    if (elementCount > AGGREGATE_XML_LIMITS.maxElements) {
+      throw new SAMLMetadataValidationError('SAML metadata exceeds maximum element count');
+    }
+    if (attributeCount > AGGREGATE_XML_LIMITS.maxAttributes) {
+      throw new SAMLMetadataValidationError('SAML metadata exceeds maximum attribute count');
+    }
+    if (depth === 1) {
+      rootIsAggregate = tag.uri === SAML_NAMESPACES.MD && tag.local === 'EntitiesDescriptor';
+    }
+  });
+  parser.on('closetag', () => {
+    depth--;
+  });
+  try {
+    parser.write(xml).close();
+  } catch (error) {
+    throw toAggregateValidationError(error);
+  }
+  return rootIsAggregate;
 }
 
 export function parseAggregateMetadata(xml: string): ParsedAggregateMetadata {
-  const doc = parseXml(xml);
-  const root = doc.documentElement;
-  if (
-    !root ||
-    root.namespaceURI !== SAML_NAMESPACES.MD ||
-    root.localName !== 'EntitiesDescriptor'
-  ) {
-    throw new SAMLMetadataValidationError('Invalid aggregate metadata: missing EntitiesDescriptor');
-  }
-
-  const rootId = getAttribute(root, 'ID');
-  if (!rootId) {
-    throw new SAMLMetadataValidationError('Invalid aggregate metadata: missing root ID');
-  }
-
-  const entities = findElements(root, SAML_NAMESPACES.MD, 'EntityDescriptor').map((entity) =>
-    summarizeEntityDescriptor(entity)
-  );
-  if (entities.length === 0) {
-    throw new SAMLMetadataValidationError(
-      'Invalid aggregate metadata: no EntityDescriptor entries'
-    );
-  }
-
-  return {
-    metadataXml: xml,
-    rootId,
-    validUntil: getAttribute(root, 'validUntil') || undefined,
-    entities,
-  };
+  return buildParsedAggregateMetadata(xml, scanAggregateMetadata(xml));
 }
 
 export function extractEntityDescriptorXml(xml: string, entityId: string): string {
-  const doc = parseXml(xml);
-  const entities = findElements(doc, SAML_NAMESPACES.MD, 'EntityDescriptor');
-  const entity = entities.find((candidate) => getAttribute(candidate, 'entityID') === entityId);
-  if (!entity) {
+  const entities = extractEntityDescriptorXmls(xml, [entityId]);
+  const entityXml = entities.get(entityId);
+  if (!entityXml) {
     throw new SAMLMetadataValidationError(
       `Aggregate metadata does not contain entityID: ${entityId}`
     );
   }
+  return entityXml;
+}
 
-  const clone = entity.cloneNode(true) as Element;
-  copyNamespaceDeclarations(entity, clone);
-  return serializeXml(clone);
+export function extractEntityDescriptorXmls(
+  xml: string,
+  entityIds: Iterable<string>
+): Map<string, string> {
+  const requestedEntityIds = new Set(entityIds);
+  if (requestedEntityIds.size === 0) {
+    return new Map();
+  }
+  const scan = scanAggregateMetadata(xml, requestedEntityIds);
+  const results = new Map<string, string>();
+  for (const entityXml of scan.entityXml) {
+    const entity = parseEntityDescriptor(entityXml);
+    const entityId = getAttribute(entity, 'entityID');
+    if (entityId && requestedEntityIds.has(entityId) && !results.has(entityId)) {
+      results.set(entityId, entityXml);
+    }
+  }
+  return results;
 }
 
 export function resolveAggregateSignaturePolicy(env: Env): SAMLMetadataVerificationPolicy {
@@ -101,21 +160,33 @@ export function resolveAggregateSignaturePolicy(env: Env): SAMLMetadataVerificat
   return isProduction ? 'strict' : 'warn';
 }
 
-export function verifyAggregateMetadataSignature(
+export async function verifyAggregateMetadataSignature(
   xml: string,
   metadataUrl: string | undefined,
   trustProfiles: SAMLFederationTrustProfile[],
   policy: SAMLMetadataVerificationPolicy
-): SAMLMetadataVerificationSummary {
+): Promise<SAMLMetadataVerificationSummary> {
+  return (await verifyAggregateMetadata(xml, metadataUrl, trustProfiles, policy)).verification;
+}
+
+export async function verifyAggregateMetadata(
+  xml: string,
+  metadataUrl: string | undefined,
+  trustProfiles: SAMLFederationTrustProfile[],
+  policy: SAMLMetadataVerificationPolicy
+): Promise<VerifiedAggregateMetadata> {
+  const scan = scanAggregateMetadata(xml, undefined, false);
   if (policy === 'disabled') {
     return {
-      status: 'skipped',
-      policy,
-      warnings: ['Aggregate metadata signature verification is disabled.'],
+      aggregate: parseAggregateMetadata(xml),
+      verification: {
+        status: 'skipped',
+        policy,
+        warnings: ['Aggregate metadata signature verification is disabled.'],
+      },
     };
   }
 
-  const aggregate = parseAggregateMetadata(xml);
   const matchingProfiles = trustProfiles.filter(
     (profile) => profile.enabled && metadataUrlMatchesProfile(metadataUrl, profile)
   );
@@ -125,26 +196,21 @@ export function verifyAggregateMetadataSignature(
     const summary: SAMLMetadataVerificationSummary = {
       status: policy === 'strict' ? 'failed' : 'unverified',
       policy,
-      signedElementId: aggregate.rootId,
+      signedElementId: scan.rootId,
       warnings: ['No enabled federation trust profile matched this metadata URL.'],
       error: 'No matching federation trust profile',
     };
     if (policy === 'strict') {
       throw new SAMLMetadataValidationError(summary.error!);
     }
-    return summary;
+    return { aggregate: parseAggregateMetadata(xml), verification: summary };
   }
 
-  const rootSignature = findDirectChildElement(
-    parseXml(xml).documentElement,
-    SAML_NAMESPACES.DS,
-    'Signature'
-  );
-  if (!rootSignature) {
+  if (!scan.rootSignatureXml) {
     const summary: SAMLMetadataVerificationSummary = {
       status: policy === 'strict' ? 'failed' : 'unverified',
       policy,
-      signedElementId: aggregate.rootId,
+      signedElementId: scan.rootId,
       trustProfileId: matchingProfiles[0]?.id,
       trustProfileName: matchingProfiles[0]?.name,
       warnings: ['Aggregate metadata root is not signed.'],
@@ -153,20 +219,25 @@ export function verifyAggregateMetadataSignature(
     if (policy === 'strict') {
       throw new SAMLMetadataValidationError(summary.error!);
     }
-    return summary;
+    return { aggregate: parseAggregateMetadata(xml), verification: summary };
   }
 
-  const referenceUris = Array.from(
-    rootSignature.getElementsByTagNameNS(SAML_NAMESPACES.DS, 'Reference')
-  )
+  const signatureNode = parseXml(scan.rootSignatureXml).documentElement;
+  const signedInfo = getSingleDirectDsigChild(signatureNode, 'SignedInfo');
+  const references = getDirectDsigChildren(signedInfo, 'Reference');
+  const referenceUris = references
     .map((reference) => getAttribute(reference as Element, 'URI'))
     .filter((uri): uri is string => Boolean(uri));
 
-  if (referenceUris.length !== 1 || referenceUris[0] !== `#${aggregate.rootId}`) {
+  if (
+    references.length !== 1 ||
+    referenceUris.length !== 1 ||
+    referenceUris[0] !== `#${scan.rootId}`
+  ) {
     const summary: SAMLMetadataVerificationSummary = {
       status: policy === 'strict' ? 'failed' : 'unverified',
       policy,
-      signedElementId: aggregate.rootId,
+      signedElementId: scan.rootId,
       trustProfileId: matchingProfiles[0]?.id,
       trustProfileName: matchingProfiles[0]?.name,
       warnings: [
@@ -177,21 +248,36 @@ export function verifyAggregateMetadataSignature(
     if (policy === 'strict') {
       throw new SAMLMetadataValidationError(summary.error!);
     }
-    return summary;
+    return { aggregate: parseAggregateMetadata(xml), verification: summary };
+  }
+
+  let prepared: PreparedAggregateSignature | undefined;
+  try {
+    prepared = await prepareAggregateSignature(xml, scan);
+  } catch (error) {
+    warnings.push(error instanceof Error ? error.message : 'Signature verification failed');
   }
 
   for (const profile of matchingProfiles) {
     for (const certificate of profile.certificates) {
+      if (!prepared) break;
       try {
-        verifyRootAggregateSignature(xml, aggregate.rootId, certificate.certificate);
+        await verifyPreparedAggregateSignature(prepared, certificate.certificate);
+        const verifiedAggregate = parseAggregateMetadata(prepared.signedReference);
+        if (verifiedAggregate.rootId !== scan.rootId) {
+          throw new Error('Verified aggregate root ID does not match the received document');
+        }
         return {
-          status: 'verified',
-          policy,
-          trustProfileId: profile.id,
-          trustProfileName: profile.name,
-          certificateFingerprintSha256: certificate.fingerprintSha256,
-          signedElementId: aggregate.rootId,
-          verifiedAt: Date.now(),
+          aggregate: verifiedAggregate,
+          verification: {
+            status: 'verified',
+            policy,
+            trustProfileId: profile.id,
+            trustProfileName: profile.name,
+            certificateFingerprintSha256: certificate.fingerprintSha256,
+            signedElementId: scan.rootId,
+            verifiedAt: Date.now(),
+          },
         };
       } catch (error) {
         warnings.push(error instanceof Error ? error.message : 'Signature verification failed');
@@ -202,7 +288,7 @@ export function verifyAggregateMetadataSignature(
   const summary: SAMLMetadataVerificationSummary = {
     status: policy === 'strict' ? 'failed' : 'unverified',
     policy,
-    signedElementId: aggregate.rootId,
+    signedElementId: scan.rootId,
     trustProfileId: matchingProfiles[0]?.id,
     trustProfileName: matchingProfiles[0]?.name,
     warnings: warnings.slice(0, 5),
@@ -211,7 +297,7 @@ export function verifyAggregateMetadataSignature(
   if (policy === 'strict') {
     throw new SAMLMetadataValidationError(summary.error!);
   }
-  return summary;
+  return { aggregate: parseAggregateMetadata(xml), verification: summary };
 }
 
 export async function fingerprintCertificateSha256(certificate: string): Promise<string> {
@@ -349,104 +435,573 @@ function isHttpsUrl(value: string): boolean {
   }
 }
 
-function verifyRootAggregateSignature(xml: string, rootId: string, certificateOrKey: string): void {
-  const doc = parseXml(xml);
-  const signatureNode = findDirectChildElement(
-    doc.documentElement,
-    SAML_NAMESPACES.DS,
-    'Signature'
-  );
-  if (!signatureNode) {
+async function prepareAggregateSignature(
+  xml: string,
+  scan: ScannedAggregateMetadata
+): Promise<PreparedAggregateSignature> {
+  if (!scan.rootSignatureXml) {
     throw new Error('Aggregate metadata root is not signed');
   }
-  const references = signatureNode.getElementsByTagNameNS(SAML_NAMESPACES.DS, 'Reference');
+  const signatureNode = parseXml(scan.rootSignatureXml).documentElement;
+  const signedInfo = getSingleDirectDsigChild(signatureNode, 'SignedInfo');
+  const references = getDirectDsigChildren(signedInfo, 'Reference');
   if (references.length !== 1) {
     throw new Error('Aggregate signature must contain exactly one Reference');
   }
 
   const referenceUri = references[0]?.getAttribute('URI');
-  if (referenceUri !== `#${rootId}`) {
+  if (referenceUri !== `#${scan.rootId}`) {
     throw new Error(
-      `Aggregate signature Reference URI "${referenceUri}" does not match root "#${rootId}"`
+      `Aggregate signature Reference URI "${referenceUri}" does not match root "#${scan.rootId}"`
     );
   }
 
-  const referencedElements = findElementsById(doc, rootId);
-  if (referencedElements.length !== 1) {
+  if (scan.rootIdOccurrences !== 1) {
     throw new Error(
-      `Aggregate signature expected exactly one element with ID "${rootId}", found ${referencedElements.length}`
+      `Aggregate signature expected exactly one element with ID "${scan.rootId}", found ${scan.rootIdOccurrences}`
     );
   }
 
-  const signatureMethod = signatureNode.getElementsByTagNameNS(
-    SAML_NAMESPACES.DS,
-    'SignatureMethod'
-  )[0];
-  if (signatureMethod?.getAttribute('Algorithm') === SIGNATURE_ALGORITHMS.RSA_SHA1) {
-    throw new Error('SHA-1 signature algorithm is not allowed');
+  const canonicalizationMethod = getSingleDirectDsigChild(signedInfo, 'CanonicalizationMethod');
+  if (
+    canonicalizationMethod.getAttribute('Algorithm') !== 'http://www.w3.org/2001/10/xml-exc-c14n#'
+  ) {
+    throw new Error('Aggregate SignedInfo canonicalization must use exclusive C14N');
   }
 
-  const digestMethod = references[0]?.getElementsByTagNameNS(SAML_NAMESPACES.DS, 'DigestMethod')[0];
-  if (digestMethod?.getAttribute('Algorithm') === DIGEST_ALGORITHMS.SHA1) {
-    throw new Error('SHA-1 digest algorithm is not allowed');
+  const signatureMethod = getSingleDirectDsigChild(signedInfo, 'SignatureMethod');
+  if (signatureMethod.getAttribute('Algorithm') !== SIGNATURE_ALGORITHMS.RSA_SHA256) {
+    throw new Error('Aggregate signature algorithm must be RSA-SHA256');
   }
 
-  const signature = new SignedXml();
-  signature.publicCert = certificateOrKey;
-  signature.loadSignature(signatureNode);
-  if (!signature.checkSignature(xml)) {
-    const errors = (signature as unknown as SignedXmlWithErrors).validationErrors || [];
-    throw new Error(`Signature verification failed: ${errors.join(', ')}`);
+  const digestMethod = getSingleDirectDsigChild(references[0]!, 'DigestMethod');
+  if (digestMethod.getAttribute('Algorithm') !== DIGEST_ALGORITHMS.SHA256) {
+    throw new Error('Aggregate digest algorithm must be SHA-256');
+  }
+
+  const transformsElement = getSingleDirectDsigChild(references[0]!, 'Transforms');
+  const transforms = getDirectDsigChildren(transformsElement, 'Transform').map((transform) =>
+    transform.getAttribute('Algorithm')
+  );
+  if (
+    transforms.length !== 2 ||
+    transforms[0] !== 'http://www.w3.org/2000/09/xmldsig#enveloped-signature' ||
+    transforms[1] !== 'http://www.w3.org/2001/10/xml-exc-c14n#'
+  ) {
+    throw new Error(
+      'Aggregate signature transforms must be enveloped-signature followed by exclusive C14N'
+    );
+  }
+
+  if (signatureNode.getElementsByTagNameNS('*', 'InclusiveNamespaces').length > 0) {
+    throw new Error('Aggregate signature InclusiveNamespaces is not supported');
+  }
+
+  const digestValue = getRequiredElementText(
+    getSingleDirectDsigChild(references[0]!, 'DigestValue'),
+    'DigestValue'
+  );
+  const signatureValue = decodeBase64(
+    getRequiredElementText(
+      getSingleDirectDsigChild(signatureNode, 'SignatureValue'),
+      'SignatureValue'
+    ),
+    'SignatureValue'
+  );
+  const signedInfoCanonical = new ExclusiveCanonicalization().process(signedInfo, {});
+  const signedReference = canonicalizeAggregateReference(xml);
+  const actualDigest = new Uint8Array(
+    await crypto.subtle.digest('SHA-256', new TextEncoder().encode(signedReference))
+  );
+  if (encodeBase64(actualDigest) !== digestValue.replace(/\s+/g, '')) {
+    throw new Error('Aggregate metadata reference digest is invalid');
+  }
+
+  return {
+    signedReference,
+    signedInfo: new TextEncoder().encode(signedInfoCanonical),
+    signatureValue,
+  };
+}
+
+async function verifyPreparedAggregateSignature(
+  prepared: PreparedAggregateSignature,
+  certificate: string
+): Promise<void> {
+  const publicKey = await importPublicKeyFromCertificate(certificate);
+  const valid = await crypto.subtle.verify(
+    'RSASSA-PKCS1-v1_5',
+    publicKey,
+    toArrayBuffer(prepared.signatureValue),
+    toArrayBuffer(prepared.signedInfo)
+  );
+  if (!valid) {
+    throw new Error('Aggregate SignedInfo signature is invalid');
   }
 }
 
-function findElementsById(doc: Document, id: string): Element[] {
-  const results: Element[] = [];
+function canonicalizeAggregateReference(xml: string): string {
+  let depth = 0;
+  let skippedSignatureDepth: number | undefined;
+  const output: string[] = [];
+  const renderedNamespaces: Array<Map<string, string>> = [];
+  const parser = new SaxesParser({ xmlns: true });
 
-  function traverse(node: Node): void {
-    if (node.nodeType === 1 && (node as Element).getAttribute('ID') === id) {
-      results.push(node as Element);
-    }
-    if (!node.childNodes) {
+  parser.on('doctype', () => {
+    throw new SAMLMetadataValidationError(
+      'XML security error: DOCTYPE declarations are not allowed'
+    );
+  });
+  parser.on('processinginstruction', () => {
+    throw new SAMLMetadataValidationError('SAML metadata processing instructions are not allowed');
+  });
+  parser.on('opentag', (tag) => {
+    depth++;
+    const inherited = new Map(renderedNamespaces[renderedNamespaces.length - 1] ?? []);
+    renderedNamespaces.push(inherited);
+
+    if (
+      skippedSignatureDepth === undefined &&
+      depth === 2 &&
+      tag.uri === SAML_NAMESPACES.DS &&
+      tag.local === 'Signature'
+    ) {
+      skippedSignatureDepth = depth;
       return;
     }
-    for (let i = 0; i < node.childNodes.length; i++) {
-      traverse(node.childNodes[i]!);
+    if (skippedSignatureDepth !== undefined) return;
+
+    output.push(serializeExclusiveCanonicalOpenTag(tag, inherited));
+  });
+  parser.on('text', (text) => {
+    if (skippedSignatureDepth === undefined && depth > 0) {
+      output.push(escapeCanonicalText(text));
+    }
+  });
+  parser.on('cdata', (text) => {
+    if (skippedSignatureDepth === undefined && depth > 0) {
+      output.push(escapeCanonicalText(text));
+    }
+  });
+  parser.on('closetag', (tag) => {
+    if (skippedSignatureDepth === undefined) {
+      output.push(`</${tag.name}>`);
+    } else if (skippedSignatureDepth === depth) {
+      skippedSignatureDepth = undefined;
+    }
+    renderedNamespaces.pop();
+    depth--;
+  });
+
+  try {
+    parser.write(xml).close();
+  } catch (error) {
+    throw toAggregateValidationError(error);
+  }
+  return output.join('');
+}
+
+function serializeExclusiveCanonicalOpenTag(
+  tag: SaxesTagNS,
+  renderedNamespaces: Map<string, string>
+): string {
+  const namespacesToRender = new Map<string, string>();
+  if (tag.prefix) {
+    if (renderedNamespaces.get(tag.prefix) !== tag.uri) {
+      namespacesToRender.set(tag.prefix, tag.uri);
+    }
+  } else if ((renderedNamespaces.get('') ?? '') !== tag.uri) {
+    namespacesToRender.set('', tag.uri);
+  }
+
+  const attributes = Object.values(tag.attributes).filter(
+    (attribute) => attribute.prefix !== 'xmlns' && attribute.name !== 'xmlns'
+  );
+  for (const attribute of attributes) {
+    if (
+      attribute.prefix &&
+      attribute.prefix !== 'xml' &&
+      renderedNamespaces.get(attribute.prefix) !== attribute.uri
+    ) {
+      namespacesToRender.set(attribute.prefix, attribute.uri);
     }
   }
 
-  traverse(doc);
-  return results;
+  const namespaceXml = Array.from(namespacesToRender)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([prefix, uri]) => {
+      renderedNamespaces.set(prefix, uri);
+      const name = prefix ? `xmlns:${prefix}` : 'xmlns';
+      return ` ${name}="${escapeCanonicalAttribute(uri)}"`;
+    })
+    .join('');
+  const attributeXml = attributes
+    .sort((left, right) => {
+      const leftKey = `${left.uri || ''}\u0000${left.local}`;
+      const rightKey = `${right.uri || ''}\u0000${right.local}`;
+      return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+    })
+    .map((attribute) => ` ${attribute.name}="${escapeCanonicalAttribute(attribute.value)}"`)
+    .join('');
+
+  return `<${tag.name}${namespaceXml}${attributeXml}>`;
 }
 
-function copyNamespaceDeclarations(source: Element, target: Element): void {
-  let current: Element | null = source;
-  while (current) {
-    for (let i = 0; i < current.attributes.length; i++) {
-      const attr = current.attributes[i];
-      if (
-        (attr.name === 'xmlns' || attr.name.startsWith('xmlns:')) &&
-        !hasAttributeNamed(target, attr.name)
-      ) {
-        target.setAttribute(attr.name, attr.value);
+function escapeCanonicalText(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\r/g, '&#xD;');
+}
+
+function escapeCanonicalAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/"/g, '&quot;')
+    .replace(/\t/g, '&#x9;')
+    .replace(/\n/g, '&#xA;')
+    .replace(/\r/g, '&#xD;');
+}
+
+function getRequiredElementText(element: Element, localName: string): string {
+  const value = getTextContent(element)?.trim();
+  if (!value) {
+    throw new Error(`Aggregate signature ${localName} is empty`);
+  }
+  return value;
+}
+
+function getSingleDirectDsigChild(parent: Element, localName: string): Element {
+  const children = getDirectDsigChildren(parent, localName);
+  if (children.length !== 1) {
+    throw new Error(`Aggregate signature must contain exactly one direct ${localName}`);
+  }
+  return children[0]!;
+}
+
+function getDirectDsigChildren(parent: Element, localName: string): Element[] {
+  const children: Element[] = [];
+  for (let index = 0; index < parent.childNodes.length; index++) {
+    const child = parent.childNodes[index];
+    if (child?.nodeType !== 1 || (child as Element).localName !== localName) continue;
+    const element = child as Element;
+    if (element.namespaceURI !== SAML_NAMESPACES.DS) {
+      throw new Error(`Aggregate signature ${localName} must use the XMLDSig namespace`);
+    }
+    children.push(element);
+  }
+  return children;
+}
+
+function decodeBase64(value: string, field: string): Uint8Array {
+  const normalized = value.replace(/\s+/g, '');
+  if (!normalized || !/^[A-Za-z0-9+/]+={0,2}$/.test(normalized)) {
+    throw new Error(`Aggregate signature ${field} is not valid base64`);
+  }
+  try {
+    return Uint8Array.from(atob(normalized), (character) => character.charCodeAt(0));
+  } catch {
+    throw new Error(`Aggregate signature ${field} is not valid base64`);
+  }
+}
+
+function encodeBase64(value: Uint8Array): string {
+  let binary = '';
+  for (const byte of value) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function toArrayBuffer(value: Uint8Array): ArrayBuffer {
+  return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength) as ArrayBuffer;
+}
+
+function buildParsedAggregateMetadata(
+  xml: string,
+  scan: ScannedAggregateMetadata
+): ParsedAggregateMetadata {
+  assertAggregateMetadataIsCurrent(scan.validUntil);
+  const entities = scan.entityXml.map((entityXml) =>
+    summarizeEntityDescriptor(parseEntityDescriptor(entityXml))
+  );
+  if (entities.length === 0) {
+    throw new SAMLMetadataValidationError(
+      'Invalid aggregate metadata: no EntityDescriptor entries'
+    );
+  }
+  return {
+    metadataXml: xml,
+    rootId: scan.rootId,
+    validUntil: scan.validUntil,
+    entities,
+  };
+}
+
+function parseEntityDescriptor(xml: string): Element {
+  if (utf8ByteLength(xml) > SINGLE_METADATA_FETCH_LIMIT_BYTES) {
+    throw new SAMLMetadataValidationError(
+      'Invalid aggregate metadata: EntityDescriptor exceeds size limit'
+    );
+  }
+  const root = parseXml(xml).documentElement;
+  if (root.namespaceURI !== SAML_NAMESPACES.MD || root.localName !== 'EntityDescriptor') {
+    throw new SAMLMetadataValidationError('Invalid aggregate metadata: invalid EntityDescriptor');
+  }
+  return root;
+}
+
+function scanAggregateMetadata(
+  xml: string,
+  requestedEntityIds?: ReadonlySet<string>,
+  captureEntities = true
+): ScannedAggregateMetadata {
+  if (utf8ByteLength(xml) > AGGREGATE_XML_LIMITS.maxBytes) {
+    throw new SAMLMetadataValidationError('Aggregate metadata exceeds maximum size');
+  }
+
+  let depth = 0;
+  let elementCount = 0;
+  let attributeCount = 0;
+  let entityCount = 0;
+  let rootId = '';
+  let validUntil: string | undefined;
+  let rootIdOccurrences = 0;
+  let captureEntityDepth: number | undefined;
+  let captureEntity = false;
+  let entityBuffer: string[] = [];
+  let captureSignatureDepth: number | undefined;
+  let signatureBuffer: string[] = [];
+  let signatureBytes = 0;
+  let signatureElementCount = 0;
+  let signatureAttributeCount = 0;
+  let rootSignatureXml: string | undefined;
+  const entityXml: string[] = [];
+  const namespaceStack: Array<Record<string, string>> = [];
+  const parser = new SaxesParser({ xmlns: true });
+
+  const appendSignatureChunk = (chunk: string): void => {
+    signatureBytes += utf8ByteLength(chunk);
+    if (signatureBytes > AGGREGATE_SIGNATURE_LIMITS.maxBytes) {
+      throw new SAMLMetadataValidationError('Aggregate signature exceeds maximum size');
+    }
+    signatureBuffer.push(chunk);
+  };
+
+  const countSignatureElement = (tag: SaxesTagNS): void => {
+    signatureElementCount++;
+    signatureAttributeCount += Object.keys(tag.attributes).length;
+    if (signatureElementCount > AGGREGATE_SIGNATURE_LIMITS.maxElements) {
+      throw new SAMLMetadataValidationError('Aggregate signature exceeds maximum element count');
+    }
+    if (signatureAttributeCount > AGGREGATE_SIGNATURE_LIMITS.maxAttributes) {
+      throw new SAMLMetadataValidationError('Aggregate signature exceeds maximum attribute count');
+    }
+  };
+
+  parser.on('doctype', () => {
+    throw new SAMLMetadataValidationError(
+      'XML security error: DOCTYPE declarations are not allowed'
+    );
+  });
+  parser.on('processinginstruction', () => {
+    throw new SAMLMetadataValidationError('SAML metadata processing instructions are not allowed');
+  });
+  parser.on('opentag', (tag) => {
+    depth++;
+    const inScopeNamespaces = {
+      ...(namespaceStack[namespaceStack.length - 1] ?? {}),
+      ...tag.ns,
+    };
+    namespaceStack.push(inScopeNamespaces);
+    elementCount++;
+    attributeCount += Object.keys(tag.attributes).length;
+    if (depth > AGGREGATE_XML_LIMITS.maxDepth) {
+      throw new SAMLMetadataValidationError('Aggregate metadata exceeds maximum depth');
+    }
+    if (elementCount > AGGREGATE_XML_LIMITS.maxElements) {
+      throw new SAMLMetadataValidationError('Aggregate metadata exceeds maximum element count');
+    }
+    if (attributeCount > AGGREGATE_XML_LIMITS.maxAttributes) {
+      throw new SAMLMetadataValidationError('Aggregate metadata exceeds maximum attribute count');
+    }
+
+    const id = getSaxesAttribute(tag, 'ID');
+    if (depth === 1) {
+      if (tag.uri !== SAML_NAMESPACES.MD || tag.local !== 'EntitiesDescriptor') {
+        throw new SAMLMetadataValidationError(
+          'Invalid aggregate metadata: missing EntitiesDescriptor'
+        );
+      }
+      rootId = id ?? '';
+      if (!rootId) {
+        throw new SAMLMetadataValidationError('Invalid aggregate metadata: missing root ID');
+      }
+      validUntil = getSaxesAttribute(tag, 'validUntil');
+    }
+    if (tag.uri === SAML_NAMESPACES.MD && tag.local === 'EntitiesDescriptor') {
+      assertAggregateMetadataIsCurrent(getSaxesAttribute(tag, 'validUntil'));
+    }
+    if (id === rootId && rootId) {
+      rootIdOccurrences++;
+    }
+
+    if (
+      captureEntityDepth === undefined &&
+      tag.uri === SAML_NAMESPACES.MD &&
+      tag.local === 'EntityDescriptor'
+    ) {
+      entityCount++;
+      if (entityCount > AGGREGATE_XML_LIMITS.maxEntities) {
+        throw new SAMLMetadataValidationError('Aggregate metadata exceeds maximum entity count');
+      }
+      const entityId = getSaxesAttribute(tag, 'entityID') ?? '';
+      captureEntity = captureEntities && (!requestedEntityIds || requestedEntityIds.has(entityId));
+      captureEntityDepth = depth;
+      entityBuffer = [];
+    } else if (
+      captureEntityDepth !== undefined &&
+      tag.uri === SAML_NAMESPACES.MD &&
+      tag.local === 'EntityDescriptor'
+    ) {
+      throw new SAMLMetadataValidationError('Invalid aggregate metadata: nested EntityDescriptor');
+    }
+
+    if (captureEntity && captureEntityDepth !== undefined) {
+      entityBuffer.push(
+        serializeSaxesOpenTag(tag, depth === captureEntityDepth ? inScopeNamespaces : undefined)
+      );
+    }
+
+    if (
+      captureSignatureDepth === undefined &&
+      depth === 2 &&
+      tag.uri === SAML_NAMESPACES.DS &&
+      tag.local === 'Signature'
+    ) {
+      if (rootSignatureXml) {
+        throw new SAMLMetadataValidationError(
+          'Invalid aggregate metadata: multiple root signatures'
+        );
+      }
+      captureSignatureDepth = depth;
+      signatureBuffer = [];
+      signatureBytes = 0;
+      signatureElementCount = 0;
+      signatureAttributeCount = 0;
+      countSignatureElement(tag);
+      appendSignatureChunk(serializeSaxesOpenTag(tag, inScopeNamespaces));
+    } else if (captureSignatureDepth !== undefined && depth > captureSignatureDepth) {
+      countSignatureElement(tag);
+      appendSignatureChunk(serializeSaxesOpenTag(tag));
+    }
+  });
+  parser.on('text', (text) => {
+    const escaped = escapeXmlText(text);
+    if (captureEntity) entityBuffer.push(escaped);
+    if (captureSignatureDepth !== undefined) appendSignatureChunk(escaped);
+  });
+  parser.on('cdata', (text) => {
+    const escaped = escapeXmlText(text);
+    if (captureEntity) entityBuffer.push(escaped);
+    if (captureSignatureDepth !== undefined) appendSignatureChunk(escaped);
+  });
+  parser.on('closetag', (tag) => {
+    if (captureEntity && captureEntityDepth !== undefined) {
+      entityBuffer.push(`</${tag.name}>`);
+    }
+    if (captureSignatureDepth !== undefined) {
+      appendSignatureChunk(`</${tag.name}>`);
+    }
+
+    if (captureEntityDepth === depth) {
+      if (captureEntity) {
+        entityXml.push(entityBuffer.join(''));
+      }
+      captureEntityDepth = undefined;
+      captureEntity = false;
+      entityBuffer = [];
+    }
+    if (captureSignatureDepth === depth) {
+      rootSignatureXml = signatureBuffer.join('');
+      captureSignatureDepth = undefined;
+      signatureBuffer = [];
+    }
+    namespaceStack.pop();
+    depth--;
+  });
+
+  try {
+    parser.write(xml).close();
+  } catch (error) {
+    throw toAggregateValidationError(error);
+  }
+
+  if (!rootId) {
+    throw new SAMLMetadataValidationError('Invalid aggregate metadata: missing EntitiesDescriptor');
+  }
+  if (entityCount === 0) {
+    throw new SAMLMetadataValidationError(
+      'Invalid aggregate metadata: no EntityDescriptor entries'
+    );
+  }
+  return { rootId, rootIdOccurrences, validUntil, rootSignatureXml, entityCount, entityXml };
+}
+
+function serializeSaxesOpenTag(
+  tag: SaxesTagNS,
+  inScopeNamespaces?: Readonly<Record<string, string>>
+): string {
+  const attributes = Object.values(tag.attributes);
+  const existingNames = new Set(attributes.map((attribute) => attribute.name));
+  const serializedAttributes = attributes.map(
+    (attribute) => ` ${attribute.name}="${escapeXmlAttribute(attribute.value)}"`
+  );
+
+  if (inScopeNamespaces) {
+    for (const [prefix, uri] of Object.entries(inScopeNamespaces)) {
+      if (prefix === 'xml') continue;
+      const name = prefix ? `xmlns:${prefix}` : 'xmlns';
+      if (!existingNames.has(name)) {
+        serializedAttributes.push(` ${name}="${escapeXmlAttribute(uri)}"`);
       }
     }
-    current = current.parentNode?.nodeType === 1 ? (current.parentNode as Element) : null;
   }
+  return `<${tag.name}${serializedAttributes.join('')}>`;
+}
 
-  if (!hasAttributeNamed(target, 'xmlns')) {
-    target.setAttribute('xmlns', SAML_NAMESPACES.MD);
+function getSaxesAttribute(tag: SaxesTagNS, name: string): string | undefined {
+  return Object.values(tag.attributes).find((attribute) => attribute.name === name)?.value;
+}
+
+function escapeXmlText(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function escapeXmlAttribute(value: string): string {
+  return escapeXmlText(value).replace(/"/g, '&quot;').replace(/\r/g, '&#13;');
+}
+
+function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function assertAggregateMetadataIsCurrent(validUntil: string | undefined, now = Date.now()): void {
+  if (!validUntil) return;
+  const expiresAt = Date.parse(validUntil);
+  if (!Number.isFinite(expiresAt)) {
+    throw new SAMLMetadataValidationError('Invalid aggregate metadata: invalid validUntil');
   }
-  if (!hasAttributeNamed(target, 'xmlns:ds')) {
-    target.setAttribute('xmlns:ds', SAML_NAMESPACES.DS);
+  if (expiresAt <= now) {
+    throw new SAMLMetadataValidationError('Invalid aggregate metadata: expired validUntil');
   }
 }
 
-function hasAttributeNamed(element: Element, name: string): boolean {
-  for (let i = 0; i < element.attributes.length; i++) {
-    if (element.attributes[i]?.name === name) {
-      return true;
-    }
-  }
-  return serializeXml(element).includes(`${name}=`);
+function toAggregateValidationError(error: unknown): SAMLMetadataValidationError {
+  if (error instanceof SAMLMetadataValidationError) return error;
+  return new SAMLMetadataValidationError(
+    error instanceof Error
+      ? `Invalid aggregate metadata: ${error.message}`
+      : 'Invalid aggregate metadata'
+  );
 }

--- a/packages/ar-saml/src/admin/providers.ts
+++ b/packages/ar-saml/src/admin/providers.ts
@@ -54,6 +54,7 @@ import {
   createAuditLog,
   hasAdminPermission,
   bumpAuthenticationMethodsCacheRevision,
+  readRequestJsonWithLimit,
 } from '@authrim/ar-lib-core';
 import {
   parseXml,
@@ -81,12 +82,12 @@ import {
   AGGREGATE_METADATA_FETCH_LIMIT_BYTES,
   SINGLE_METADATA_FETCH_LIMIT_BYTES,
   extractEntityDescriptorXml,
+  extractEntityDescriptorXmls,
   fingerprintCertificateSha256,
   getLogoUrl,
   isAggregateMetadata,
-  parseAggregateMetadata,
   resolveAggregateSignaturePolicy,
-  verifyAggregateMetadataSignature,
+  verifyAggregateMetadata,
 } from './aggregate-metadata';
 import {
   getSAMLNextSigningCertificates,
@@ -126,6 +127,8 @@ import {
 import { resolveSAMLMetadataSigningMode, shouldSignSAMLMetadata } from '../common/metadata-signing';
 
 type AdminSAMLContext = Context<{ Bindings: Env }>;
+const SINGLE_METADATA_REQUEST_LIMIT_BYTES = 2 * 1024 * 1024;
+const AGGREGATE_METADATA_REQUEST_LIMIT_BYTES = 12 * 1024 * 1024;
 type AdminSAMLAuthContext = Context<{
   Bindings: Env;
   Variables: { adminAuth?: AdminAuthContext };
@@ -1202,7 +1205,10 @@ export async function handlePreviewMetadata(c: AdminSAMLContext): Promise<Respon
       return forbidden;
     }
 
-    const body = (await c.req.json()) as SAMLMetadataPreviewRequest;
+    const body = await readSAMLAdminJsonWithLimit<SAMLMetadataPreviewRequest>(
+      c,
+      AGGREGATE_METADATA_REQUEST_LIMIT_BYTES
+    );
     const resolvedMetadata = await resolveMetadataImportInput(c, body, {
       maxResponseSize: AGGREGATE_METADATA_FETCH_LIMIT_BYTES,
     });
@@ -1212,10 +1218,9 @@ export async function handlePreviewMetadata(c: AdminSAMLContext): Promise<Respon
 
     if (metadataIsAggregateOrThrow(resolvedMetadata.metadataXml)) {
       const tenantId = resolveSAMLTenantIdFromContext(c);
-      const aggregate = parseAggregateMetadata(resolvedMetadata.metadataXml);
       const policy = resolveAggregateSignaturePolicy(c.env);
       const trustProfiles = await listFederationTrustProfiles(c.env, tenantId);
-      const verification = verifyAggregateMetadataSignature(
+      const { aggregate, verification } = await verifyAggregateMetadata(
         resolvedMetadata.metadataXml,
         resolvedMetadata.metadataUrl,
         trustProfiles,
@@ -1225,7 +1230,7 @@ export async function handlePreviewMetadata(c: AdminSAMLContext): Promise<Respon
       const preview = await storeAggregatePreview(c.env, {
         previewId,
         tenantId,
-        metadataXml: resolvedMetadata.metadataXml,
+        metadataXml: aggregate.metadataXml,
         metadataUrl: resolvedMetadata.metadataUrl,
         entities: aggregate.entities,
         verification,
@@ -1240,6 +1245,8 @@ export async function handlePreviewMetadata(c: AdminSAMLContext): Promise<Respon
         verification,
       });
     }
+
+    assertSingleMetadataSize(resolvedMetadata.metadataXml);
 
     let providerType: 'saml_idp' | 'saml_sp';
     let config: SAMLIdPConfig | SAMLSPConfig;
@@ -1470,7 +1477,10 @@ export async function handleCreateProvider(c: AdminSAMLContext): Promise<Respons
       return forbidden;
     }
 
-    const body = (await c.req.json()) as SAMLProviderCreateRequest;
+    const body = await readSAMLAdminJsonWithLimit<SAMLProviderCreateRequest>(
+      c,
+      SINGLE_METADATA_REQUEST_LIMIT_BYTES
+    );
 
     const hasMetadataInput = Boolean(body.metadataXml || body.metadataUrl);
 
@@ -1730,7 +1740,10 @@ export async function handleUpdateProvider(c: AdminSAMLContext): Promise<Respons
       return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
     }
 
-    const body = (await c.req.json()) as SAMLProviderUpdateRequest;
+    const body = await readSAMLAdminJsonWithLimit<SAMLProviderUpdateRequest>(
+      c,
+      SINGLE_METADATA_REQUEST_LIMIT_BYTES
+    );
     const existingConfig = JSON.parse(existing.config_json);
 
     // Merge config updates
@@ -1892,7 +1905,10 @@ export async function handleImportMetadata(c: AdminSAMLContext): Promise<Respons
       return createErrorResponse(c, AR_ERROR_CODES.ADMIN_RESOURCE_NOT_FOUND);
     }
 
-    const body = (await c.req.json()) as MetadataImportRequest;
+    const body = await readSAMLAdminJsonWithLimit<MetadataImportRequest>(
+      c,
+      SINGLE_METADATA_REQUEST_LIMIT_BYTES
+    );
 
     const resolvedMetadata = await resolveMetadataImportInput(c, body, {
       maxResponseSize: SINGLE_METADATA_FETCH_LIMIT_BYTES,
@@ -2078,16 +2094,17 @@ export async function handleRefreshMetadata(c: AdminSAMLContext): Promise<Respon
       }
       const policy = resolveAggregateSignaturePolicy(c.env);
       const trustProfiles = await listFederationTrustProfiles(c.env, tenantId);
-      const verification = verifyAggregateMetadataSignature(
+      const verified = await verifyAggregateMetadata(
         fetchedMetadataXml,
         metadataUrl,
         trustProfiles,
         policy
       );
       metadataXml = extractEntityDescriptorXml(
-        fetchedMetadataXml,
+        verified.aggregate.metadataXml,
         aggregateImport.aggregateEntityId
       );
+      const verification = verified.verification;
       aggregateImport = {
         ...aggregateImport,
         aggregateSourceUrl: metadataUrl,
@@ -2648,6 +2665,12 @@ function metadataIsAggregateOrThrow(metadataXml: string): boolean {
   }
 }
 
+function assertSingleMetadataSize(metadataXml: string): void {
+  if (new TextEncoder().encode(metadataXml).byteLength > SINGLE_METADATA_FETCH_LIMIT_BYTES) {
+    throw new SAMLMetadataValidationError('Single-entity SAML metadata exceeds size limit');
+  }
+}
+
 function toSAMLMetadataValidationError(error: unknown): SAMLMetadataValidationError {
   if (error instanceof SAMLMetadataValidationError) {
     return error;
@@ -2676,6 +2699,10 @@ async function resolveMetadataImportInput(
   options: { maxResponseSize?: number } = {}
 ): Promise<{ metadataXml: string; metadataUrl?: string } | Response> {
   if (input.metadataXml) {
+    const maxResponseSize = options.maxResponseSize ?? SINGLE_METADATA_FETCH_LIMIT_BYTES;
+    if (new TextEncoder().encode(input.metadataXml).byteLength > maxResponseSize) {
+      return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE);
+    }
     return { metadataXml: input.metadataXml };
   }
 
@@ -2703,6 +2730,23 @@ async function resolveMetadataImportInput(
     return { metadataXml, metadataUrl: input.metadataUrl };
   } catch {
     return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE);
+  }
+}
+
+async function readSAMLAdminJsonWithLimit<T>(c: AdminSAMLContext, maxBytes: number): Promise<T> {
+  try {
+    // Hono always exposes the raw Request in production. The fallback keeps direct unit-handler
+    // contexts usable without weakening the deployed request-body limit.
+    if (c.req.raw instanceof Request) {
+      return await readRequestJsonWithLimit<T>(c.req.raw, maxBytes);
+    }
+    return (await c.req.json()) as T;
+  } catch (error) {
+    throw new SAMLMetadataValidationError(
+      error instanceof Error && error.message.includes('maximum size')
+        ? 'SAML metadata request body exceeds size limit'
+        : 'Invalid SAML metadata request body'
+    );
   }
 }
 
@@ -3107,10 +3151,15 @@ async function processAggregateBatchCreate(
         .filter((key): key is string => Boolean(key))
     );
 
+    const extractedEntities = extractEntityDescriptorXmls(preview.metadataXml, input.entityIds);
+
     let successfulImports = 0;
     for (const entityId of input.entityIds) {
       try {
-        const metadataXml = extractEntityDescriptorXml(preview.metadataXml, entityId);
+        const metadataXml = extractedEntities.get(entityId);
+        if (!metadataXml) {
+          throw new Error(`Aggregate metadata does not contain entityID: ${entityId}`);
+        }
         const providerType = input.providerType ?? detectSAMLMetadataProviderType(metadataXml);
         if (providerType !== 'saml_idp' && providerType !== 'saml_sp') {
           throw new Error('Unsupported SAML metadata role');

--- a/packages/ar-saml/src/common/__tests__/redirect-binding.test.ts
+++ b/packages/ar-saml/src/common/__tests__/redirect-binding.test.ts
@@ -23,7 +23,11 @@ import {
   type LogoutResponseOptions,
 } from '../slo-messages';
 import { SAML_MESSAGE_LIMITS } from '../message-limits';
-import { signRedirectBinding, verifyRedirectBindingSignature } from '../signature';
+import {
+  parseRedirectBindingSignatureInput,
+  signRedirectBinding,
+  verifyRedirectBindingSignature,
+} from '../signature';
 
 // Test private key (same as signature-security.test.ts)
 const testPrivateKey = `-----BEGIN PRIVATE KEY-----
@@ -407,6 +411,68 @@ describe('HTTP-Redirect Binding - SAML 2.0 Bindings Section 3.4', () => {
   });
 
   describe('Invalid Input Handling', () => {
+    it('rejects duplicate signed query parameters', () => {
+      expect(() =>
+        parseRedirectBindingSignatureInput(
+          '?SAMLRequest=first&SAMLRequest=second&SigAlg=algorithm&Signature=value',
+          'SAMLRequest'
+        )
+      ).toThrow('Duplicate HTTP-Redirect parameter: SAMLRequest');
+    });
+
+    it('rejects a query containing both request and response messages', () => {
+      expect(() =>
+        parseRedirectBindingSignatureInput(
+          '?SAMLRequest=request&SAMLResponse=response&SigAlg=algorithm&Signature=value',
+          'SAMLRequest'
+        )
+      ).toThrow('HTTP-Redirect message cannot contain both SAMLRequest and SAMLResponse');
+    });
+
+    it('preserves signed encodings and decodes only signature metadata', () => {
+      expect(
+        parseRedirectBindingSignatureInput(
+          'SAMLRequest=a%2Bb&RelayState=&SigAlg=urn%3Atest&Signature=c%2Bd',
+          'SAMLRequest'
+        )
+      ).toEqual({
+        samlMessage: 'a%2Bb',
+        relayState: '',
+        sigAlg: 'urn:test',
+        signature: 'c+d',
+      });
+    });
+
+    it('allows an unsigned message without optional Redirect parameters', () => {
+      expect(parseRedirectBindingSignatureInput('?SAMLRequest=value&&', 'SAMLRequest')).toEqual({
+        samlMessage: 'value',
+      });
+    });
+
+    it.each(['RelayState', 'SigAlg', 'Signature'])('rejects duplicate %s parameters', (name) => {
+      expect(() =>
+        parseRedirectBindingSignatureInput(
+          `?SAMLRequest=value&${name}=first&${name}=second`,
+          'SAMLRequest'
+        )
+      ).toThrow(`Duplicate HTTP-Redirect parameter: ${name}`);
+    });
+
+    it('rejects a missing message parameter', () => {
+      expect(() => parseRedirectBindingSignatureInput('?RelayState=value', 'SAMLResponse')).toThrow(
+        'Missing SAMLResponse parameter'
+      );
+    });
+
+    it('rejects malformed percent encoding in names and values', () => {
+      expect(() => parseRedirectBindingSignatureInput('?%ZZ=value', 'SAMLRequest')).toThrow(
+        'Malformed HTTP-Redirect query encoding'
+      );
+      expect(() =>
+        parseRedirectBindingSignatureInput('?SAMLRequest=value&SigAlg=%ZZ', 'SAMLRequest')
+      ).toThrow('Malformed HTTP-Redirect query encoding');
+    });
+
     it('should reject invalid base64 encoding', () => {
       expect(() => parseLogoutRequestRedirect('not-valid-base64!!!')).toThrow();
     });

--- a/packages/ar-saml/src/common/__tests__/signature-security.test.ts
+++ b/packages/ar-saml/src/common/__tests__/signature-security.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   signXml,
   verifyXmlSignature,
+  verifyXmlSignatureAndGetReferences,
   hasSignature,
   extractCertificateFromSignature,
 } from '../signature';
@@ -769,6 +770,128 @@ describe('XSW Attack Protection - Enhanced', () => {
           certificateOrKey: testCertificate,
         })
       ).toThrow('XSW Protection: Reference URI must be a fragment identifier or empty');
+    });
+  });
+
+  describe('authenticated reference consumption', () => {
+    it('returns the canonicalized XML that was actually digest-verified', () => {
+      const xml = createTestSAMLResponse('_verified_reference');
+      const signedXml = signXml(xml, {
+        privateKey: testPrivateKey,
+        certificate: testCertificate,
+        referenceUri: '#_verified_reference',
+      });
+
+      const references = verifyXmlSignatureAndGetReferences(signedXml, {
+        certificateOrKey: testCertificate,
+        expectedId: '_verified_reference',
+        strictXswProtection: true,
+      });
+
+      expect(references).toHaveLength(1);
+      expect(references[0]?.uri).toBe('#_verified_reference');
+      expect(references[0]?.xml).toContain('<samlp:Response');
+      expect(references[0]?.xml).toContain('<saml:NameID>user@example.com</saml:NameID>');
+    });
+
+    it('rejects the processing-instruction canonicalization authentication bypass', () => {
+      const xml = createTestSAMLResponse('_pi_bypass').replace(
+        'user@example.com',
+        'not-an-admin@example.com'
+      );
+      const signedXml = signXml(xml, {
+        privateKey: testPrivateKey,
+        certificate: testCertificate,
+        referenceUri: '#_pi_bypass',
+      });
+      const bypassXml = signedXml.replace(
+        '<saml:NameID>not-an-admin@example.com</saml:NameID>',
+        '<saml:NameID><?p not-an-?>admin@example.com</saml:NameID>'
+      );
+
+      expect(() =>
+        verifyXmlSignatureAndGetReferences(bypassXml, {
+          certificateOrKey: testCertificate,
+          expectedId: '_pi_bypass',
+          strictXswProtection: true,
+        })
+      ).toThrow('SAML XML processing instructions are not allowed');
+    });
+
+    it.each([
+      [
+        (xml: string) =>
+          xml.replace(
+            'Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"',
+            'Algorithm="http://www.w3.org/TR/1999/REC-xpath-19991116"'
+          ),
+        'Unsupported XML signature transform',
+      ],
+      [
+        (xml: string) =>
+          xml.replace(
+            '</Transforms>',
+            '<Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></Transforms>'
+          ),
+        'XML signature Reference uses too many transforms',
+      ],
+      [
+        (xml: string) =>
+          xml.replace(
+            '<DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>',
+            '<DigestMethod/>'
+          ),
+        'DigestMethod Algorithm is required',
+      ],
+      [
+        (xml: string) =>
+          xml.replace(
+            'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+            'urn:unsupported:signature'
+          ),
+        'Unsupported signature algorithm',
+      ],
+      [
+        (xml: string) =>
+          xml.replace(
+            '<CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>',
+            '<CanonicalizationMethod Algorithm="urn:unsupported:c14n"/>'
+          ),
+        'Unsupported canonicalization algorithm',
+      ],
+    ])('rejects unsupported XML signature structure %#', (manipulate, expectedError) => {
+      const signedXml = signXml(createTestSAMLResponse('_structure'), {
+        privateKey: testPrivateKey,
+        certificate: testCertificate,
+        referenceUri: '#_structure',
+      });
+      expect(() =>
+        verifyXmlSignatureAndGetReferences(manipulate(signedXml), {
+          certificateOrKey: testCertificate,
+          expectedId: '_structure',
+          strictXswProtection: true,
+        })
+      ).toThrow(expectedError);
+    });
+
+    it('rejects namespace-decoy DigestMethod elements before cryptographic verification', () => {
+      const signedXml = signXml(createTestSAMLResponse('_namespace_decoy'), {
+        privateKey: testPrivateKey,
+        certificate: testCertificate,
+        referenceUri: '#_namespace_decoy',
+      });
+      const decoyXml = signedXml.replace(
+        '<DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>',
+        '<DigestMethod xmlns="" Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"><ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/></DigestMethod>'
+      );
+
+      expect(() =>
+        verifyXmlSignatureAndGetReferences(decoyXml, {
+          certificateOrKey: testCertificate,
+          expectedId: '_namespace_decoy',
+          strictXswProtection: true,
+        })
+      ).toThrow('DigestMethod must use the XMLDSig namespace');
     });
   });
 });

--- a/packages/ar-saml/src/common/message-limits.ts
+++ b/packages/ar-saml/src/common/message-limits.ts
@@ -2,12 +2,12 @@ import * as pako from 'pako';
 import { base64Decode, base64DecodeToBytes } from './xml-utils';
 
 export const SAML_MESSAGE_LIMITS = {
-  postBodyBytes: 3 * 1024 * 1024,
-  postEncodedChars: 2 * 1024 * 1024,
-  postDecodedChars: 768 * 1024,
+  postBodyBytes: 512 * 1024,
+  postEncodedChars: 384 * 1024,
+  postDecodedChars: 256 * 1024,
   redirectEncodedChars: 128 * 1024,
   redirectCompressedBytes: 64 * 1024,
-  redirectInflatedChars: 512 * 1024,
+  redirectInflatedChars: 256 * 1024,
 } as const;
 
 type PostBindingRequestLike =

--- a/packages/ar-saml/src/common/signature.ts
+++ b/packages/ar-saml/src/common/signature.ts
@@ -11,10 +11,15 @@
  */
 
 import { SignedXml } from 'xml-crypto';
-import { SIGNATURE_ALGORITHMS, DIGEST_ALGORITHMS, CANONICALIZATION_ALGORITHMS } from './constants';
-import { parseXml, serializeXml } from './xml-utils';
+import {
+  SIGNATURE_ALGORITHMS,
+  DIGEST_ALGORITHMS,
+  CANONICALIZATION_ALGORITHMS,
+  SAML_NAMESPACES,
+} from './constants';
+import { parseSAMLXml, parseXml } from './xml-utils';
 import type { XMLNode, XMLElement, SignedXmlWithErrors } from './types';
-import { NodeType, isElementNode } from './types';
+import { isElementNode } from './types';
 import { assertCertificateCurrentlyValid, extractSubjectPublicKeyInfo } from './x509';
 
 // =============================================================================
@@ -94,6 +99,20 @@ export interface VerifyOptions {
   allowSha1SignatureAlgorithm?: boolean;
   /** Allow deprecated SHA-1 DigestMethod. Only use for explicit legacy SP opt-in. */
   allowSha1DigestAlgorithm?: boolean;
+}
+
+export interface VerifiedXmlReference {
+  /** Fragment URI from ds:Reference, for example #_assertion_id. */
+  uri: string;
+  /** Canonicalized bytes whose digest was verified by xml-crypto. */
+  xml: string;
+}
+
+export interface RedirectBindingSignatureInput {
+  samlMessage: string;
+  relayState?: string;
+  signature?: string;
+  sigAlg?: string;
 }
 
 /**
@@ -199,6 +218,18 @@ function resolveSignatureReferenceXPath(referenceUri: string): string {
  * @see https://www.usenix.org/conference/usenixsecurity12/technical-sessions/presentation/somorovsky
  */
 export function verifyXmlSignature(xml: string, options: VerifyOptions): boolean {
+  verifyXmlSignatureAndGetReferences(xml, options);
+  return true;
+}
+
+/**
+ * Verify XML signatures and return only the authenticated reference bytes.
+ * Callers must parse these values instead of continuing to consume the original DOM.
+ */
+export function verifyXmlSignatureAndGetReferences(
+  xml: string,
+  options: VerifyOptions
+): VerifiedXmlReference[] {
   const {
     certificateOrKey,
     expectedId,
@@ -209,7 +240,7 @@ export function verifyXmlSignature(xml: string, options: VerifyOptions): boolean
 
   assertCertificateCurrentlyValid(certificateOrKey);
 
-  const doc = parseXml(xml);
+  const doc = parseSAMLXml(xml);
 
   // Find Signature element
   const signatures = doc.getElementsByTagNameNS('http://www.w3.org/2000/09/xmldsig#', 'Signature');
@@ -217,9 +248,13 @@ export function verifyXmlSignature(xml: string, options: VerifyOptions): boolean
     throw new Error('No signature found in XML');
   }
 
+  const verifiedReferences: VerifiedXmlReference[] = [];
+
   // Verify each signature
   for (let i = 0; i < signatures.length; i++) {
     const signatureNode = signatures[i];
+    const signedInfo = getSingleDirectXmlDsigChild(signatureNode, 'SignedInfo');
+    getSingleDirectXmlDsigChild(signatureNode, 'SignatureValue');
 
     // ==========================================================================
     // SECURITY CHECKS BEFORE SIGNATURE VERIFICATION
@@ -228,10 +263,7 @@ export function verifyXmlSignature(xml: string, options: VerifyOptions): boolean
     // ==========================================================================
 
     // 1. Check that Reference exists and has valid URI
-    const references = signatureNode.getElementsByTagNameNS(
-      'http://www.w3.org/2000/09/xmldsig#',
-      'Reference'
-    );
+    const references = getDirectXmlDsigChildren(signedInfo, 'Reference');
     if (references.length === 0) {
       throw new Error('No Reference found in signature');
     }
@@ -282,11 +314,12 @@ export function verifyXmlSignature(xml: string, options: VerifyOptions): boolean
         throw new Error('XSW Protection: Reference URI is required in strict mode');
       }
 
-      const digestMethod = reference.getElementsByTagNameNS(
-        'http://www.w3.org/2000/09/xmldsig#',
-        'DigestMethod'
-      )[0];
+      const digestMethod = getSingleDirectXmlDsigChild(reference, 'DigestMethod');
+      getSingleDirectXmlDsigChild(reference, 'DigestValue');
       const digestAlgorithm = digestMethod?.getAttribute('Algorithm');
+      if (!digestAlgorithm) {
+        throw new Error('DigestMethod Algorithm is required');
+      }
       if (digestAlgorithm === DIGEST_ALGORITHMS.SHA1 && !allowSha1DigestAlgorithm) {
         throw new Error('SHA-1 digest algorithm is not allowed');
       }
@@ -322,17 +355,27 @@ export function verifyXmlSignature(xml: string, options: VerifyOptions): boolean
       }
     }
 
-    // 5. Check signature algorithm (reject SHA-1) BEFORE verification
-    const signatureMethod = signatureNode.getElementsByTagNameNS(
-      'http://www.w3.org/2000/09/xmldsig#',
-      'SignatureMethod'
-    )[0];
-    if (signatureMethod) {
-      const algorithm = signatureMethod.getAttribute('Algorithm');
-      if (algorithm === SIGNATURE_ALGORITHMS.RSA_SHA1 && !allowSha1SignatureAlgorithm) {
-        throw new Error('SHA-1 signature algorithm is not allowed');
-      }
+    for (let referenceIndex = 0; referenceIndex < references.length; referenceIndex++) {
+      validateReferenceTransforms(references[referenceIndex]!);
     }
+
+    // 5. Check signature algorithm (reject SHA-1) BEFORE verification
+    const signatureMethod = getSingleDirectXmlDsigChild(signedInfo, 'SignatureMethod');
+    const signatureAlgorithm = signatureMethod?.getAttribute('Algorithm');
+    if (!signatureAlgorithm) {
+      throw new Error('SignatureMethod Algorithm is required');
+    }
+    if (signatureAlgorithm === SIGNATURE_ALGORITHMS.RSA_SHA1 && !allowSha1SignatureAlgorithm) {
+      throw new Error('SHA-1 signature algorithm is not allowed');
+    }
+    if (
+      signatureAlgorithm !== SIGNATURE_ALGORITHMS.RSA_SHA256 &&
+      !(allowSha1SignatureAlgorithm && signatureAlgorithm === SIGNATURE_ALGORITHMS.RSA_SHA1)
+    ) {
+      throw new Error(`Unsupported signature algorithm: ${signatureAlgorithm}`);
+    }
+
+    validateCanonicalizationMethod(signedInfo);
 
     // ==========================================================================
     // CRYPTOGRAPHIC SIGNATURE VERIFICATION
@@ -354,16 +397,95 @@ export function verifyXmlSignature(xml: string, options: VerifyOptions): boolean
       const errors = sigWithErrors.validationErrors || [];
       throw new Error(`Signature verification failed: ${errors.join(', ')}`);
     }
+
+    const signedReferences = sig.getSignedReferences();
+    if (signedReferences.length !== referenceUris.length) {
+      throw new Error('Signature verification did not return every signed reference');
+    }
+    for (let referenceIndex = 0; referenceIndex < signedReferences.length; referenceIndex++) {
+      const signedReference = signedReferences[referenceIndex];
+      const uri = referenceUris[referenceIndex];
+      if (signedReference === undefined || uri === undefined) {
+        throw new Error('Signature verification returned an incomplete signed reference');
+      }
+      verifiedReferences.push({ uri, xml: signedReference });
+    }
   }
 
-  return true;
+  return verifiedReferences;
+}
+
+function validateReferenceTransforms(reference: Element): void {
+  const allowedTransforms = new Set([
+    'http://www.w3.org/2000/09/xmldsig#enveloped-signature',
+    CANONICALIZATION_ALGORITHMS.EXCLUSIVE_C14N,
+    CANONICALIZATION_ALGORITHMS.EXCLUSIVE_C14N_WITH_COMMENTS,
+  ]);
+  const transformsElement = getSingleDirectXmlDsigChild(reference, 'Transforms');
+  const transforms = getDirectXmlDsigChildren(transformsElement, 'Transform');
+  if (transforms.length > 2) {
+    throw new Error('XML signature Reference uses too many transforms');
+  }
+  if (transforms.length !== 2) {
+    throw new Error('XML signature Reference must use exactly two transforms');
+  }
+  for (let index = 0; index < transforms.length; index++) {
+    const algorithm = transforms[index]?.getAttribute('Algorithm');
+    if (!algorithm || !allowedTransforms.has(algorithm)) {
+      throw new Error(`Unsupported XML signature transform: ${algorithm || 'missing'}`);
+    }
+  }
+  if (
+    transforms[0]?.getAttribute('Algorithm') !==
+      'http://www.w3.org/2000/09/xmldsig#enveloped-signature' ||
+    (transforms[1]?.getAttribute('Algorithm') !== CANONICALIZATION_ALGORITHMS.EXCLUSIVE_C14N &&
+      transforms[1]?.getAttribute('Algorithm') !==
+        CANONICALIZATION_ALGORITHMS.EXCLUSIVE_C14N_WITH_COMMENTS)
+  ) {
+    throw new Error(
+      'XML signature transforms must be enveloped-signature followed by exclusive C14N'
+    );
+  }
+}
+
+function validateCanonicalizationMethod(signedInfo: Element): void {
+  const method = getSingleDirectXmlDsigChild(signedInfo, 'CanonicalizationMethod');
+  const algorithm = method.getAttribute('Algorithm');
+  if (
+    algorithm !== CANONICALIZATION_ALGORITHMS.EXCLUSIVE_C14N &&
+    algorithm !== CANONICALIZATION_ALGORITHMS.EXCLUSIVE_C14N_WITH_COMMENTS
+  ) {
+    throw new Error(`Unsupported canonicalization algorithm: ${algorithm || 'missing'}`);
+  }
+}
+
+function getSingleDirectXmlDsigChild(parent: Element, localName: string): Element {
+  const children = getDirectXmlDsigChildren(parent, localName);
+  if (children.length !== 1) {
+    throw new Error(`XML signature must contain exactly one direct ${localName}`);
+  }
+  return children[0]!;
+}
+
+function getDirectXmlDsigChildren(parent: Element, localName: string): Element[] {
+  const children: Element[] = [];
+  for (let index = 0; index < parent.childNodes.length; index++) {
+    const child = parent.childNodes[index];
+    if (child?.nodeType !== 1 || (child as Element).localName !== localName) continue;
+    const element = child as Element;
+    if (element.namespaceURI !== SAML_NAMESPACES.DS) {
+      throw new Error(`XML signature ${localName} must use the XMLDSig namespace`);
+    }
+    children.push(element);
+  }
+  return children;
 }
 
 /**
  * Check if XML document has a signature
  */
 export function hasSignature(xml: string): boolean {
-  const doc = parseXml(xml);
+  const doc = parseSAMLXml(xml);
   const signatures = doc.getElementsByTagNameNS('http://www.w3.org/2000/09/xmldsig#', 'Signature');
   return signatures.length > 0;
 }
@@ -493,7 +615,7 @@ export async function verifyRedirectBindingSignature(
   // Rebuild the signed string (must match exactly what was signed)
   // Per SAML 2.0 Bindings Section 3.4.4.1, the signed string uses URL-encoded values
   let signInput = `${samlParam}=${samlValue}`;
-  if (relayState) {
+  if (relayState !== undefined) {
     signInput += `&RelayState=${relayState}`;
   }
   signInput += `&SigAlg=${encodeURIComponent(sigAlg)}`;
@@ -512,6 +634,63 @@ export async function verifyRedirectBindingSignature(
   const isValid = await crypto.subtle.verify('RSASSA-PKCS1-v1_5', publicKey, signatureBytes, data);
 
   return isValid;
+}
+
+/**
+ * Extract exactly one copy of each signed HTTP-Redirect binding parameter while
+ * preserving the original URL encoding used in the signature input.
+ */
+export function parseRedirectBindingSignatureInput(
+  search: string,
+  samlParam: 'SAMLRequest' | 'SAMLResponse'
+): RedirectBindingSignatureInput {
+  const query = search.startsWith('?') ? search.slice(1) : search;
+  const values = new Map<string, string[]>();
+  for (const part of query.split('&')) {
+    if (!part) continue;
+    const separator = part.indexOf('=');
+    const rawName = separator >= 0 ? part.slice(0, separator) : part;
+    const rawValue = separator >= 0 ? part.slice(separator + 1) : '';
+    const name = decodeRedirectQueryComponent(rawName);
+    const existing = values.get(name) ?? [];
+    existing.push(rawValue);
+    values.set(name, existing);
+  }
+
+  for (const name of [samlParam, 'RelayState', 'SigAlg', 'Signature']) {
+    if ((values.get(name)?.length ?? 0) > 1) {
+      throw new Error(`Duplicate HTTP-Redirect parameter: ${name}`);
+    }
+  }
+  const oppositeParam = samlParam === 'SAMLRequest' ? 'SAMLResponse' : 'SAMLRequest';
+  if ((values.get(oppositeParam)?.length ?? 0) > 0) {
+    throw new Error('HTTP-Redirect message cannot contain both SAMLRequest and SAMLResponse');
+  }
+
+  const samlMessage = values.get(samlParam)?.[0];
+  if (samlMessage === undefined) {
+    throw new Error(`Missing ${samlParam} parameter`);
+  }
+
+  const relayState = values.get('RelayState')?.[0];
+  const rawSignature = values.get('Signature')?.[0];
+  const rawSigAlg = values.get('SigAlg')?.[0];
+  return {
+    samlMessage,
+    ...(relayState !== undefined ? { relayState } : {}),
+    ...(rawSignature !== undefined
+      ? { signature: decodeRedirectQueryComponent(rawSignature) }
+      : {}),
+    ...(rawSigAlg !== undefined ? { sigAlg: decodeRedirectQueryComponent(rawSigAlg) } : {}),
+  };
+}
+
+function decodeRedirectQueryComponent(value: string): string {
+  try {
+    return decodeURIComponent(value.replace(/\+/g, ' '));
+  } catch {
+    throw new Error('Malformed HTTP-Redirect query encoding');
+  }
 }
 
 /**
@@ -538,7 +717,7 @@ async function importPrivateKeyPem(pem: string): Promise<CryptoKey> {
 /**
  * Import public key from X.509 certificate PEM
  */
-async function importPublicKeyFromCertificate(
+export async function importPublicKeyFromCertificate(
   pem: string,
   options: { hash?: 'SHA-1' | 'SHA-256' } = {}
 ): Promise<CryptoKey> {

--- a/packages/ar-saml/src/common/slo-messages.ts
+++ b/packages/ar-saml/src/common/slo-messages.ts
@@ -13,7 +13,7 @@ import {
   appendChild,
   addNamespaceDeclarations,
   serializeXml,
-  parseXml,
+  parseSAMLXml,
   findDirectChildElement,
   findDirectChildElements,
   base64Encode,
@@ -251,7 +251,7 @@ export function parseLogoutRequestRedirect(samlRequestEncoded: string): ParsedLo
  * Parse LogoutRequest XML
  */
 export function parseLogoutRequestXml(xml: string): ParsedLogoutRequest {
-  const doc = parseXml(xml);
+  const doc = parseSAMLXml(xml);
   const logoutRequestElement = doc.documentElement;
 
   if (
@@ -352,7 +352,7 @@ export function parseLogoutResponseRedirect(samlResponseEncoded: string): Parsed
  * Parse LogoutResponse XML
  */
 export function parseLogoutResponseXml(xml: string): ParsedLogoutResponse {
-  const doc = parseXml(xml);
+  const doc = parseSAMLXml(xml);
   const logoutResponseElement = doc.documentElement;
 
   if (

--- a/packages/ar-saml/src/common/xml-utils.test.ts
+++ b/packages/ar-saml/src/common/xml-utils.test.ts
@@ -4,6 +4,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   parseXml,
+  parseSAMLXml,
+  SAML_XML_LIMITS,
   serializeXml,
   createDocument,
   createElement,
@@ -36,6 +38,48 @@ describe('XML Utilities', () => {
     it('should throw on invalid XML', () => {
       const xml = '<root><unclosed>';
       expect(() => parseXml(xml)).toThrow();
+    });
+  });
+
+  describe('parseSAMLXml security limits', () => {
+    it('allows an XML declaration but rejects processing instructions in the message', () => {
+      expect(() => parseSAMLXml('<?xml version="1.0"?><root/>')).not.toThrow();
+      expect(() => parseSAMLXml('<root><?hidden admin?></root>')).toThrow(
+        'SAML XML processing instructions are not allowed'
+      );
+    });
+
+    it('rejects oversized protocol XML before DOM parsing', () => {
+      const xml = `<root>${'a'.repeat(SAML_XML_LIMITS.maxChars)}</root>`;
+      expect(() => parseSAMLXml(xml)).toThrow('SAML XML exceeds maximum size');
+    });
+
+    it('rejects deeply nested protocol XML', () => {
+      const depth = SAML_XML_LIMITS.maxDepth + 1;
+      const xml = `${'<n>'.repeat(depth)}${'</n>'.repeat(depth)}`;
+      expect(() => parseSAMLXml(xml)).toThrow('SAML XML exceeds maximum depth');
+    });
+
+    it('rejects excessive markup before DOM parsing', () => {
+      const xml = `<root>${'<n/>'.repeat(SAML_XML_LIMITS.maxMarkupTokens)}</root>`;
+      expect(() => parseSAMLXml(xml)).toThrow('SAML XML exceeds maximum markup complexity');
+    });
+
+    it('rejects an excessive number of attributes', () => {
+      const attributes = Array.from(
+        { length: SAML_XML_LIMITS.maxAttributes + 1 },
+        (_, index) => ` a${index}="x"`
+      ).join('');
+      expect(() => parseSAMLXml(`<root${attributes}/>`)).toThrow(
+        'SAML XML exceeds maximum attribute count'
+      );
+    });
+
+    it('rejects an excessive number of DOM nodes', () => {
+      const fragments = 'x<![CDATA[x]]>'.repeat(Math.ceil(SAML_XML_LIMITS.maxNodes / 2));
+      expect(() => parseSAMLXml(`<root>${fragments}</root>`)).toThrow(
+        'SAML XML exceeds maximum node count'
+      );
     });
   });
 

--- a/packages/ar-saml/src/common/xml-utils.ts
+++ b/packages/ar-saml/src/common/xml-utils.ts
@@ -8,6 +8,14 @@
 import { DOMParser, XMLSerializer, DOMImplementation } from '@xmldom/xmldom';
 import { SAML_NAMESPACES } from './constants';
 
+export const SAML_XML_LIMITS = {
+  maxChars: 256 * 1024,
+  maxMarkupTokens: 8192,
+  maxNodes: 8192,
+  maxDepth: 64,
+  maxAttributes: 8192,
+} as const;
+
 // Re-export types from xmldom for use in other modules
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type XMLDocument = ReturnType<DOMParser['parseFromString']>;
@@ -101,6 +109,79 @@ export function parseXml(xmlString: string): XMLDocument {
   }
 
   return doc;
+}
+
+/**
+ * Parse an untrusted SAML protocol message with resource and syntax limits.
+ *
+ * Processing instructions are forbidden after the optional XML declaration.
+ * xml-crypto canonicalization and DOM text extraction do not preserve the same
+ * processing-instruction semantics, so accepting them could make the verified
+ * bytes differ from the values consumed by protocol code.
+ */
+export function parseSAMLXml(xmlString: string): XMLDocument {
+  if (xmlString.length > SAML_XML_LIMITS.maxChars) {
+    throw new Error('SAML XML exceeds maximum size');
+  }
+
+  const markupTokens = countOccurrences(xmlString, '<');
+  if (markupTokens > SAML_XML_LIMITS.maxMarkupTokens) {
+    throw new Error('SAML XML exceeds maximum markup complexity');
+  }
+
+  const withoutDeclaration = xmlString.replace(/^\uFEFF?\s*<\?xml(?:\s[^?]*?)?\?>/i, '');
+  if (withoutDeclaration.includes('<?')) {
+    throw new Error('SAML XML processing instructions are not allowed');
+  }
+
+  const doc = parseXml(xmlString);
+  validateSAMLDocumentBudget(doc);
+  return doc;
+}
+
+function countOccurrences(value: string, character: string): number {
+  let count = 0;
+  for (let index = 0; index < value.length; index++) {
+    if (value[index] === character) {
+      count++;
+    }
+  }
+  return count;
+}
+
+function validateSAMLDocumentBudget(doc: XMLDocument): void {
+  const stack: Array<{ node: Node; depth: number }> = [{ node: doc, depth: 0 }];
+  let nodeCount = 0;
+  let attributeCount = 0;
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) continue;
+
+    nodeCount++;
+    if (nodeCount > SAML_XML_LIMITS.maxNodes) {
+      throw new Error('SAML XML exceeds maximum node count');
+    }
+    if (current.depth > SAML_XML_LIMITS.maxDepth) {
+      throw new Error('SAML XML exceeds maximum depth');
+    }
+
+    if (current.node.nodeType === 1) {
+      attributeCount += (current.node as Element).attributes?.length ?? 0;
+      if (attributeCount > SAML_XML_LIMITS.maxAttributes) {
+        throw new Error('SAML XML exceeds maximum attribute count');
+      }
+    }
+
+    const children = current.node.childNodes;
+    if (!children) continue;
+    for (let index = children.length - 1; index >= 0; index--) {
+      const child = children[index];
+      if (child) {
+        stack.push({ node: child, depth: current.depth + 1 });
+      }
+    }
+  }
 }
 
 /**

--- a/packages/ar-saml/src/idp/__tests__/authn-request-signature.test.ts
+++ b/packages/ar-saml/src/idp/__tests__/authn-request-signature.test.ts
@@ -92,6 +92,24 @@ describe('validateSAMLAuthnRequestSignature', () => {
     });
   });
 
+  it('returns authenticated references for signed POST AuthnRequest processing', async () => {
+    const references = [{ uri: '#_request123', xml: '<AuthnRequest ID="_request123" />' }];
+    await expect(
+      validateSAMLAuthnRequestSignature(
+        {
+          authnRequest,
+          spConfig: { ...baseSpConfig, authnRequestSignaturePolicy: 'required' },
+          binding: 'post',
+          xml: '<AuthnRequest><Signature /></AuthnRequest>',
+        },
+        {
+          hasSignature: () => true,
+          verifyXmlSignatureAndGetReferences: vi.fn(() => references),
+        }
+      )
+    ).resolves.toEqual(references);
+  });
+
   it('tries rollover certificates when verifying signed POST AuthnRequest', async () => {
     const verifyXmlSignature = vi.fn((_xml, options) => options.certificateOrKey === 'sp-next');
 

--- a/packages/ar-saml/src/idp/__tests__/logout-request-signature.test.ts
+++ b/packages/ar-saml/src/idp/__tests__/logout-request-signature.test.ts
@@ -86,6 +86,24 @@ describe('validateSAMLLogoutRequestSignature', () => {
     );
   });
 
+  it('returns authenticated references for signed POST LogoutRequest processing', async () => {
+    const references = [{ uri: '#_logout123', xml: '<LogoutRequest ID="_logout123" />' }];
+    await expect(
+      validateSAMLLogoutRequestSignature(
+        {
+          logoutRequest,
+          spConfig: { ...baseSpConfig, logoutRequestSignaturePolicy: 'required' },
+          binding: 'post',
+          xml: '<LogoutRequest><Signature /></LogoutRequest>',
+        },
+        {
+          hasSignature: () => true,
+          verifyXmlSignatureAndGetReferences: vi.fn(() => references),
+        }
+      )
+    ).resolves.toEqual(references);
+  });
+
   it('tries rollover certificates when verifying signed POST LogoutRequest', async () => {
     const verifyXmlSignature = vi.fn((_xml, options) => options.certificateOrKey === 'sp-next');
 

--- a/packages/ar-saml/src/idp/__tests__/logout-response-signature.test.ts
+++ b/packages/ar-saml/src/idp/__tests__/logout-response-signature.test.ts
@@ -87,6 +87,26 @@ describe('validateSAMLLogoutResponseSignature', () => {
     );
   });
 
+  it('returns authenticated references for signed POST LogoutResponse processing', async () => {
+    const references = [
+      { uri: '#_logout_response123', xml: '<LogoutResponse ID="_logout_response123" />' },
+    ];
+    await expect(
+      validateSAMLLogoutResponseSignature(
+        {
+          logoutResponse,
+          spConfig: { ...baseSpConfig, logoutResponseSignaturePolicy: 'required' },
+          binding: 'post',
+          xml: '<LogoutResponse><Signature /></LogoutResponse>',
+        },
+        {
+          hasSignature: () => true,
+          verifyXmlSignatureAndGetReferences: vi.fn(() => references),
+        }
+      )
+    ).resolves.toEqual(references);
+  });
+
   it('verifies signed Redirect LogoutResponse over raw query parameter values', async () => {
     const verifyRedirectBindingSignature = vi.fn(async () => true);
 

--- a/packages/ar-saml/src/idp/__tests__/sso-handler.test.ts
+++ b/packages/ar-saml/src/idp/__tests__/sso-handler.test.ts
@@ -315,6 +315,7 @@ describe('IdP SSO handler policy boundaries', () => {
   });
 
   it.each([
+    ['not-a-date', undefined],
     [new Date(Date.now() + 10 * 60_000).toISOString(), undefined],
     [new Date(Date.now() - 30 * 60_000).toISOString(), undefined],
     [new Date().toISOString(), 'https://attacker.example/sso'],

--- a/packages/ar-saml/src/idp/authn-request-signature.ts
+++ b/packages/ar-saml/src/idp/authn-request-signature.ts
@@ -3,6 +3,8 @@ import {
   hasSignature,
   verifyRedirectBindingSignature,
   verifyXmlSignature,
+  verifyXmlSignatureAndGetReferences,
+  type VerifiedXmlReference,
 } from '../common/signature';
 import { DIGEST_ALGORITHMS, SAML_NAMESPACES, SIGNATURE_ALGORITHMS } from '../common/constants';
 import { getAttribute, parseXml } from '../common/xml-utils';
@@ -28,6 +30,7 @@ export interface SAMLAuthnRequestSignatureValidationInput {
 export interface SAMLAuthnRequestSignatureVerifiers {
   hasSignature?: (xml: string) => boolean;
   verifyXmlSignature?: typeof verifyXmlSignature;
+  verifyXmlSignatureAndGetReferences?: typeof verifyXmlSignatureAndGetReferences;
   verifyRedirectBindingSignature?: typeof verifyRedirectBindingSignature;
 }
 
@@ -53,11 +56,11 @@ export class SAMLAuthnRequestSignatureValidationError extends Error {
 export async function validateSAMLAuthnRequestSignature(
   input: SAMLAuthnRequestSignatureValidationInput,
   verifiers: SAMLAuthnRequestSignatureVerifiers = {}
-): Promise<void> {
+): Promise<VerifiedXmlReference[] | undefined> {
   const policy = input.spConfig.authnRequestSignaturePolicy ?? 'optional';
 
   if (policy === 'disabled') {
-    return;
+    return undefined;
   }
 
   const requestIsSigned = isAuthnRequestSigned(input, verifiers.hasSignature ?? hasSignature);
@@ -69,7 +72,7 @@ export async function validateSAMLAuthnRequestSignature(
         'Signed AuthnRequest is required for this Service Provider'
       );
     }
-    return;
+    return undefined;
   }
 
   const certificates = getSPVerificationCertificates(input.spConfig);
@@ -87,7 +90,7 @@ export async function validateSAMLAuthnRequestSignature(
       certificates,
       verifiers.verifyRedirectBindingSignature ?? verifyRedirectBindingSignature
     );
-    return;
+    return undefined;
   }
 
   validateXmlSignatureAlgorithms(input.xml, input.spConfig);
@@ -100,7 +103,10 @@ export async function validateSAMLAuthnRequestSignature(
   const allowSha1DigestAlgorithm =
     input.spConfig.authnRequestLegacyAlgorithmPolicy === 'explicit_opt_in' &&
     (input.spConfig.acceptedAuthnRequestDigestAlgorithms ?? []).includes(DIGEST_ALGORITHMS.SHA1);
-  const verifier = verifiers.verifyXmlSignature ?? verifyXmlSignature;
+  const verifier = verifiers.verifyXmlSignature;
+  const referenceVerifier =
+    verifiers.verifyXmlSignatureAndGetReferences ??
+    (verifier ? undefined : verifyXmlSignatureAndGetReferences);
   let lastError: unknown;
   for (const certificate of certificates) {
     const verifyOptions: Parameters<typeof verifyXmlSignature>[1] = {
@@ -116,8 +122,11 @@ export async function validateSAMLAuthnRequestSignature(
     }
 
     try {
-      if (verifier(input.xml, verifyOptions)) {
-        return;
+      if (referenceVerifier) {
+        return referenceVerifier(input.xml, verifyOptions);
+      }
+      if (verifier?.(input.xml, verifyOptions)) {
+        return undefined;
       }
     } catch (error) {
       lastError = error;

--- a/packages/ar-saml/src/idp/logout-request-signature.ts
+++ b/packages/ar-saml/src/idp/logout-request-signature.ts
@@ -4,6 +4,8 @@ import {
   hasSignature,
   verifyRedirectBindingSignature,
   verifyXmlSignature,
+  verifyXmlSignatureAndGetReferences,
+  type VerifiedXmlReference,
 } from '../common/signature';
 import { DIGEST_ALGORITHMS, SAML_NAMESPACES, SIGNATURE_ALGORITHMS } from '../common/constants';
 import { getAttribute, parseXml } from '../common/xml-utils';
@@ -24,6 +26,7 @@ export interface SAMLLogoutRequestSignatureValidationInput {
 export interface SAMLLogoutRequestSignatureVerifiers {
   hasSignature?: (xml: string) => boolean;
   verifyXmlSignature?: typeof verifyXmlSignature;
+  verifyXmlSignatureAndGetReferences?: typeof verifyXmlSignatureAndGetReferences;
   verifyRedirectBindingSignature?: typeof verifyRedirectBindingSignature;
 }
 
@@ -49,11 +52,11 @@ export class SAMLLogoutRequestSignatureValidationError extends Error {
 export async function validateSAMLLogoutRequestSignature(
   input: SAMLLogoutRequestSignatureValidationInput,
   verifiers: SAMLLogoutRequestSignatureVerifiers = {}
-): Promise<void> {
+): Promise<VerifiedXmlReference[] | undefined> {
   const policy = input.spConfig.logoutRequestSignaturePolicy ?? 'required';
 
   if (policy === 'disabled') {
-    return;
+    return undefined;
   }
 
   const requestIsSigned = isLogoutRequestSigned(input, verifiers.hasSignature ?? hasSignature);
@@ -64,7 +67,7 @@ export async function validateSAMLLogoutRequestSignature(
         'Signed LogoutRequest is required for this Service Provider'
       );
     }
-    return;
+    return undefined;
   }
 
   const certificates = getSPVerificationCertificates(input.spConfig);
@@ -82,27 +85,32 @@ export async function validateSAMLLogoutRequestSignature(
       certificates,
       verifiers.verifyRedirectBindingSignature ?? verifyRedirectBindingSignature
     );
-    return;
+    return undefined;
   }
 
   validateXmlSignatureAlgorithms(input.xml, input.spConfig);
 
-  const verifier = verifiers.verifyXmlSignature ?? verifyXmlSignature;
+  const verifier = verifiers.verifyXmlSignature;
+  const referenceVerifier =
+    verifiers.verifyXmlSignatureAndGetReferences ??
+    (verifier ? undefined : verifyXmlSignatureAndGetReferences);
   let lastError: unknown;
   for (const certificate of certificates) {
     try {
-      if (
-        verifier(input.xml, {
-          certificateOrKey: certificate,
-          expectedId: input.logoutRequest.id,
-          strictXswProtection: true,
-          ...(shouldAllowSha1XmlSignature(input.spConfig)
-            ? { allowSha1SignatureAlgorithm: true }
-            : {}),
-          ...(shouldAllowSha1XmlDigest(input.spConfig) ? { allowSha1DigestAlgorithm: true } : {}),
-        })
-      ) {
-        return;
+      const verifyOptions = {
+        certificateOrKey: certificate,
+        expectedId: input.logoutRequest.id,
+        strictXswProtection: true,
+        ...(shouldAllowSha1XmlSignature(input.spConfig)
+          ? { allowSha1SignatureAlgorithm: true }
+          : {}),
+        ...(shouldAllowSha1XmlDigest(input.spConfig) ? { allowSha1DigestAlgorithm: true } : {}),
+      };
+      if (referenceVerifier) {
+        return referenceVerifier(input.xml, verifyOptions);
+      }
+      if (verifier?.(input.xml, verifyOptions)) {
+        return undefined;
       }
     } catch (error) {
       lastError = error;

--- a/packages/ar-saml/src/idp/logout-response-signature.ts
+++ b/packages/ar-saml/src/idp/logout-response-signature.ts
@@ -4,6 +4,8 @@ import {
   hasSignature,
   verifyRedirectBindingSignature,
   verifyXmlSignature,
+  verifyXmlSignatureAndGetReferences,
+  type VerifiedXmlReference,
 } from '../common/signature';
 import { DIGEST_ALGORITHMS, SAML_NAMESPACES, SIGNATURE_ALGORITHMS } from '../common/constants';
 import { getAttribute, parseXml } from '../common/xml-utils';
@@ -24,6 +26,7 @@ export interface SAMLLogoutResponseSignatureValidationInput {
 export interface SAMLLogoutResponseSignatureVerifiers {
   hasSignature?: (xml: string) => boolean;
   verifyXmlSignature?: typeof verifyXmlSignature;
+  verifyXmlSignatureAndGetReferences?: typeof verifyXmlSignatureAndGetReferences;
   verifyRedirectBindingSignature?: typeof verifyRedirectBindingSignature;
 }
 
@@ -49,11 +52,11 @@ export class SAMLLogoutResponseSignatureValidationError extends Error {
 export async function validateSAMLLogoutResponseSignature(
   input: SAMLLogoutResponseSignatureValidationInput,
   verifiers: SAMLLogoutResponseSignatureVerifiers = {}
-): Promise<void> {
+): Promise<VerifiedXmlReference[] | undefined> {
   const policy = input.spConfig.logoutResponseSignaturePolicy ?? 'optional';
 
   if (policy === 'disabled') {
-    return;
+    return undefined;
   }
 
   const responseIsSigned = isLogoutResponseSigned(input, verifiers.hasSignature ?? hasSignature);
@@ -64,7 +67,7 @@ export async function validateSAMLLogoutResponseSignature(
         'Signed LogoutResponse is required for this Service Provider'
       );
     }
-    return;
+    return undefined;
   }
 
   const certificates = getSPVerificationCertificates(input.spConfig);
@@ -82,27 +85,32 @@ export async function validateSAMLLogoutResponseSignature(
       certificates,
       verifiers.verifyRedirectBindingSignature ?? verifyRedirectBindingSignature
     );
-    return;
+    return undefined;
   }
 
   validateXmlSignatureAlgorithms(input.xml, input.spConfig);
 
-  const verifier = verifiers.verifyXmlSignature ?? verifyXmlSignature;
+  const verifier = verifiers.verifyXmlSignature;
+  const referenceVerifier =
+    verifiers.verifyXmlSignatureAndGetReferences ??
+    (verifier ? undefined : verifyXmlSignatureAndGetReferences);
   let lastError: unknown;
   for (const certificate of certificates) {
     try {
-      if (
-        verifier(input.xml, {
-          certificateOrKey: certificate,
-          expectedId: input.logoutResponse.id,
-          strictXswProtection: true,
-          ...(shouldAllowSha1XmlSignature(input.spConfig)
-            ? { allowSha1SignatureAlgorithm: true }
-            : {}),
-          ...(shouldAllowSha1XmlDigest(input.spConfig) ? { allowSha1DigestAlgorithm: true } : {}),
-        })
-      ) {
-        return;
+      const verifyOptions = {
+        certificateOrKey: certificate,
+        expectedId: input.logoutResponse.id,
+        strictXswProtection: true,
+        ...(shouldAllowSha1XmlSignature(input.spConfig)
+          ? { allowSha1SignatureAlgorithm: true }
+          : {}),
+        ...(shouldAllowSha1XmlDigest(input.spConfig) ? { allowSha1DigestAlgorithm: true } : {}),
+      };
+      if (referenceVerifier) {
+        return referenceVerifier(input.xml, verifyOptions);
+      }
+      if (verifier?.(input.xml, verifyOptions)) {
+        return undefined;
       }
     } catch (error) {
       lastError = error;

--- a/packages/ar-saml/src/idp/slo.ts
+++ b/packages/ar-saml/src/idp/slo.ts
@@ -46,7 +46,11 @@ import {
 } from '../common/message-limits';
 import { generateSAMLId, nowAsDateTime } from '../common/xml-utils';
 import { STATUS_CODES, DEFAULTS, NAMEID_FORMATS } from '../common/constants';
-import { signRedirectBinding, signXml } from '../common/signature';
+import {
+  parseRedirectBindingSignatureInput,
+  signRedirectBinding,
+  signXml,
+} from '../common/signature';
 import { getSAMLIdPSigningMaterial } from '../common/idp-signing';
 import { getSPConfig } from '../admin/providers';
 import {
@@ -211,6 +215,7 @@ async function handleRedirectBinding(
   assertSAMLRelayStateSize(relayState);
 
   if (samlRequest) {
+    const redirectSignature = parseRedirectBindingSignatureInput(url.search, 'SAMLRequest');
     const xml = parseSAMLLogoutMessage(() =>
       inflateRedirectBindingMessage(samlRequest, 'SAML LogoutRequest')
     );
@@ -219,14 +224,10 @@ async function handleRedirectBinding(
       relayState,
       binding: 'redirect',
       xml,
-      redirectSignature: {
-        samlMessage: getRawQueryParam(url.search, 'SAMLRequest') ?? encodeURIComponent(samlRequest),
-        relayState: getRawQueryParam(url.search, 'RelayState'),
-        signature: url.searchParams.get('Signature') || undefined,
-        sigAlg: url.searchParams.get('SigAlg') || undefined,
-      },
+      redirectSignature,
     });
   } else if (samlResponse) {
+    const redirectSignature = parseRedirectBindingSignatureInput(url.search, 'SAMLResponse');
     const xml = parseSAMLLogoutMessage(() =>
       inflateRedirectBindingMessage(samlResponse, 'SAML LogoutResponse')
     );
@@ -235,13 +236,7 @@ async function handleRedirectBinding(
       relayState,
       binding: 'redirect',
       xml,
-      redirectSignature: {
-        samlMessage:
-          getRawQueryParam(url.search, 'SAMLResponse') ?? encodeURIComponent(samlResponse),
-        relayState: getRawQueryParam(url.search, 'RelayState'),
-        signature: url.searchParams.get('Signature') || undefined,
-        sigAlg: url.searchParams.get('SigAlg') || undefined,
-      },
+      redirectSignature,
     });
   } else {
     return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_REQUIRED_FIELD, {
@@ -260,7 +255,8 @@ async function processLogoutRequest(
   input: ParsedLogoutRequestInput
 ): Promise<Response> {
   const log = getLogger(c).module('SAML-IDP');
-  const { logoutRequest, relayState, binding } = input;
+  let { logoutRequest } = input;
+  const { relayState, binding } = input;
   const tenantId = resolveSAMLTenantIdFromContext(c);
   const { idpEntityId } = await getSAMLLocalEntityIds(env, tenantId);
 
@@ -282,13 +278,35 @@ async function processLogoutRequest(
   }
 
   try {
-    await validateSAMLLogoutRequestSignature({
+    const verifiedReferences = await validateSAMLLogoutRequestSignature({
       logoutRequest,
       spConfig,
       binding: input.binding,
       xml: input.xml,
       redirectSignature: input.redirectSignature,
     });
+    if (binding === 'post' && verifiedReferences) {
+      const signedRequest = verifiedReferences.find(
+        (reference) => reference.uri === `#${logoutRequest.id}`
+      );
+      if (!signedRequest) {
+        throw new SAMLLogoutRequestSignatureValidationError(
+          'logout_request_invalid_signature',
+          'Signed LogoutRequest reference is missing'
+        );
+      }
+      const authenticatedRequest = parseLogoutRequestXml(signedRequest.xml);
+      if (
+        authenticatedRequest.id !== logoutRequest.id ||
+        authenticatedRequest.issuer !== logoutRequest.issuer
+      ) {
+        throw new SAMLLogoutRequestSignatureValidationError(
+          'logout_request_invalid_signature',
+          'Signed LogoutRequest does not match the routed request'
+        );
+      }
+      logoutRequest = authenticatedRequest;
+    }
   } catch (error) {
     if (error instanceof SAMLLogoutRequestSignatureValidationError) {
       log.warn('SAML LogoutRequest signature policy failed', {
@@ -422,7 +440,8 @@ async function processLogoutResponse(
   input: ParsedLogoutResponseInput
 ): Promise<Response> {
   const log = getLogger(c).module('SAML-IDP');
-  const { logoutResponse, relayState } = input;
+  let { logoutResponse } = input;
+  const { relayState } = input;
   const tenantId = resolveSAMLTenantIdFromContext(c);
   let outboundLogoutRequest: SAMLOutboundLogoutRequestRecord | undefined;
 
@@ -438,13 +457,35 @@ async function processLogoutResponse(
       spEntityId: spConfig.entityId,
       inResponseTo: logoutResponse.inResponseTo,
     });
-    await validateSAMLLogoutResponseSignature({
+    const verifiedReferences = await validateSAMLLogoutResponseSignature({
       logoutResponse,
       spConfig,
       binding: input.binding,
       xml: input.xml,
       redirectSignature: input.redirectSignature,
     });
+    if (input.binding === 'post' && verifiedReferences) {
+      const signedResponse = verifiedReferences.find(
+        (reference) => reference.uri === `#${logoutResponse.id}`
+      );
+      if (!signedResponse) {
+        throw new SAMLLogoutResponseSignatureValidationError(
+          'logout_response_invalid_signature',
+          'Signed LogoutResponse reference is missing'
+        );
+      }
+      const authenticatedResponse = parseLogoutResponseXml(signedResponse.xml);
+      if (
+        authenticatedResponse.id !== logoutResponse.id ||
+        authenticatedResponse.issuer !== logoutResponse.issuer
+      ) {
+        throw new SAMLLogoutResponseSignatureValidationError(
+          'logout_response_invalid_signature',
+          'Signed LogoutResponse does not match the routed response'
+        );
+      }
+      logoutResponse = authenticatedResponse;
+    }
     await deleteSAMLOutboundLogoutRequest(env.STATE_STORE, {
       tenantId,
       requestId: outboundLogoutRequest.requestId,
@@ -570,23 +611,26 @@ function validateLogoutResponseDestination(
  */
 function validateLogoutRequest(logoutRequest: ParsedLogoutRequest, issuerUrl: string): void {
   // Check request is not expired
-  const issueInstant = new Date(logoutRequest.issueInstant);
-  const now = new Date();
+  const issueInstantMs = Date.parse(logoutRequest.issueInstant);
+  if (!Number.isFinite(issueInstantMs)) {
+    throw new SAMLLogoutMessageValidationError();
+  }
+  const nowMs = Date.now();
   const skewMs = DEFAULTS.CLOCK_SKEW_SECONDS * 1000;
   const maxAge = DEFAULTS.REQUEST_VALIDITY_SECONDS * 1000;
 
-  if (issueInstant.getTime() > now.getTime() + skewMs) {
+  if (issueInstantMs > nowMs + skewMs) {
     throw new SAMLLogoutMessageValidationError();
   }
 
-  if (now.getTime() - issueInstant.getTime() > maxAge + skewMs) {
+  if (nowMs - issueInstantMs > maxAge + skewMs) {
     throw new SAMLLogoutMessageValidationError();
   }
 
   // Check NotOnOrAfter if present
   if (logoutRequest.notOnOrAfter) {
-    const notOnOrAfter = new Date(logoutRequest.notOnOrAfter);
-    if (now.getTime() > notOnOrAfter.getTime() + skewMs) {
+    const notOnOrAfterMs = Date.parse(logoutRequest.notOnOrAfter);
+    if (!Number.isFinite(notOnOrAfterMs) || nowMs >= notOnOrAfterMs + skewMs) {
       throw new SAMLLogoutMessageValidationError();
     }
   }
@@ -1421,11 +1465,4 @@ async function storeIdPLogoutRequestState(
     transactionId: options.transactionId,
     ttlSeconds: DEFAULTS.REQUEST_VALIDITY_SECONDS,
   });
-}
-
-function getRawQueryParam(search: string, name: string): string | undefined {
-  const prefix = `${name}=`;
-  const query = search.startsWith('?') ? search.slice(1) : search;
-  const match = query.split('&').find((part) => part.startsWith(prefix));
-  return match ? match.slice(prefix.length) : undefined;
 }

--- a/packages/ar-saml/src/idp/sso.ts
+++ b/packages/ar-saml/src/idp/sso.ts
@@ -37,7 +37,7 @@ import {
   filterSamlAttributesByDestinationConsentWithStatus,
 } from '@authrim/ar-lib-core';
 import {
-  parseXml,
+  parseSAMLXml,
   findDirectChildElement,
   getAttribute,
   getTextContent,
@@ -111,6 +111,7 @@ import { buildSAMLPostBindingResponse } from '../common/post-binding-form';
 import { getSAMLLocalEntityIds } from '../common/entity-id';
 import { assertSAMLRelayStateSize } from '../common/relay-state';
 import { isAllowedIdPSSODestination } from './shibboleth-compat';
+import { parseRedirectBindingSignatureInput } from '../common/signature';
 
 interface AuthenticatedSAMLSession {
   userId: string;
@@ -151,7 +152,8 @@ export async function handleIdPSSO(c: Context<{ Bindings: Env }>): Promise<Respo
       parsedInput = await parsePostBinding(c);
     }
 
-    const { authnRequest, relayState } = parsedInput;
+    let { authnRequest } = parsedInput;
+    const { relayState } = parsedInput;
 
     // Validate AuthnRequest
     await validateAuthnRequest(authnRequest, issuerUrl);
@@ -164,13 +166,36 @@ export async function handleIdPSSO(c: Context<{ Bindings: Env }>): Promise<Respo
 
     try {
       if (!parsedInput.storedRequestValidated) {
-        await validateSAMLAuthnRequestSignature({
+        const verifiedReferences = await validateSAMLAuthnRequestSignature({
           authnRequest,
           spConfig,
           binding: parsedInput.binding,
           xml: parsedInput.xml,
           redirectSignature: parsedInput.redirectSignature,
         });
+        if (parsedInput.binding === 'post' && verifiedReferences) {
+          const signedRequest = verifiedReferences.find(
+            (reference) => reference.uri === `#${authnRequest.id}`
+          );
+          if (!signedRequest) {
+            throw new SAMLAuthnRequestSignatureValidationError(
+              'authn_request_invalid_signature',
+              'Signed AuthnRequest reference is missing'
+            );
+          }
+          const authenticatedRequest = parseAuthnRequestXml(signedRequest.xml);
+          if (
+            authenticatedRequest.id !== authnRequest.id ||
+            authenticatedRequest.issuer !== authnRequest.issuer
+          ) {
+            throw new SAMLAuthnRequestSignatureValidationError(
+              'authn_request_invalid_signature',
+              'Signed AuthnRequest does not match the routed request'
+            );
+          }
+          authnRequest = authenticatedRequest;
+          await validateAuthnRequest(authnRequest, issuerUrl);
+        }
       }
       validateSAMLResponseProtocolBinding(authnRequest);
       resolveSAMLResponseDestination(authnRequest, spConfig);
@@ -951,18 +976,14 @@ async function parseRedirectBinding(c: Context<{ Bindings: Env }>): Promise<{
 
   // Decode: URL decode -> Base64 decode -> Inflate (deflate decompress)
   const inflated = inflateRedirectBindingMessage(samlRequest, 'SAML AuthnRequest');
+  const redirectSignature = parseRedirectBindingSignatureInput(url.search, 'SAMLRequest');
 
   return {
     authnRequest: parseAuthnRequestXml(inflated),
     relayState,
     binding: 'redirect',
     xml: inflated,
-    redirectSignature: {
-      samlMessage: getRawQueryParam(url.search, 'SAMLRequest') ?? encodeURIComponent(samlRequest),
-      relayState: getRawQueryParam(url.search, 'RelayState'),
-      signature: url.searchParams.get('Signature') || undefined,
-      sigAlg: url.searchParams.get('SigAlg') || undefined,
-    },
+    redirectSignature,
   };
 }
 
@@ -1053,18 +1074,11 @@ async function parsePostBinding(c: Context<{ Bindings: Env }>): Promise<{
   };
 }
 
-function getRawQueryParam(search: string, name: string): string | undefined {
-  const prefix = `${name}=`;
-  const query = search.startsWith('?') ? search.slice(1) : search;
-  const match = query.split('&').find((part) => part.startsWith(prefix));
-  return match ? match.slice(prefix.length) : undefined;
-}
-
 /**
  * Parse AuthnRequest XML into structured data
  */
 export function parseAuthnRequestXml(xml: string): SAMLAuthnRequest {
-  const doc = parseXml(xml);
+  const doc = parseSAMLXml(xml);
   const authnRequestElement = doc.documentElement;
 
   if (
@@ -1145,16 +1159,19 @@ async function validateAuthnRequest(
   issuerUrl: string
 ): Promise<void> {
   // Check request is not expired (allow clock skew)
-  const issueInstant = new Date(authnRequest.issueInstant);
-  const now = new Date();
+  const issueInstantMs = Date.parse(authnRequest.issueInstant);
+  if (!Number.isFinite(issueInstantMs)) {
+    throw new Error('AuthnRequest IssueInstant is invalid');
+  }
+  const nowMs = Date.now();
   const skewMs = DEFAULTS.CLOCK_SKEW_SECONDS * 1000;
   const maxAge = DEFAULTS.REQUEST_VALIDITY_SECONDS * 1000;
 
-  if (issueInstant.getTime() > now.getTime() + skewMs) {
+  if (issueInstantMs > nowMs + skewMs) {
     throw new Error('AuthnRequest IssueInstant is in the future');
   }
 
-  if (now.getTime() - issueInstant.getTime() > maxAge + skewMs) {
+  if (nowMs - issueInstantMs > maxAge + skewMs) {
     throw new Error('AuthnRequest has expired');
   }
 

--- a/packages/ar-saml/src/sp/__tests__/conditions.test.ts
+++ b/packages/ar-saml/src/sp/__tests__/conditions.test.ts
@@ -62,6 +62,9 @@ vi.mock('../../admin/providers', () => ({
 
 vi.mock('../../common/signature', () => ({
   verifyXmlSignature: vi.fn().mockReturnValue(true),
+  verifyXmlSignatureAndGetReferences: vi.fn((xml: string) => [
+    { uri: `#${/\bID="([^"]+)"/.exec(xml)?.[1]}`, xml },
+  ]),
   hasSignature: vi.fn((xml: string) => xml.includes('<ds:Signature')),
 }));
 
@@ -184,6 +187,7 @@ function createSAMLResponseWithConditions(options: {
   notBefore?: string | null;
   notOnOrAfter?: string | null;
   audiences?: string[];
+  audienceRestrictions?: string[][];
   includeConditions?: boolean;
   includeOneTimeUse?: boolean;
   includeProxyRestriction?: boolean;
@@ -198,18 +202,21 @@ function createSAMLResponseWithConditions(options: {
     notBefore = new Date(Date.now() - 60000).toISOString(),
     notOnOrAfter = new Date(Date.now() + 300000).toISOString(),
     audiences = ['https://auth.example.com/saml/sp/metadata'],
+    audienceRestrictions = [audiences],
     includeConditions = true,
     includeOneTimeUse = false,
     includeProxyRestriction = false,
     proxyCount = 0,
   } = options;
 
-  const audienceRestriction =
-    audiences.length > 0
-      ? `<saml:AudienceRestriction>
-        ${audiences.map((a) => `<saml:Audience>${a}</saml:Audience>`).join('\n        ')}
+  const audienceRestriction = audienceRestrictions
+    .filter((restriction) => restriction.length > 0)
+    .map(
+      (restriction) => `<saml:AudienceRestriction>
+        ${restriction.map((audience) => `<saml:Audience>${audience}</saml:Audience>`).join('\n        ')}
       </saml:AudienceRestriction>`
-      : '';
+    )
+    .join('\n');
 
   const oneTimeUse = includeOneTimeUse ? '<saml:OneTimeUse/>' : '';
   const proxyRestriction = includeProxyRestriction
@@ -511,6 +518,19 @@ describe('Conditions Validation - SAML 2.0 Core Section 2.5', () => {
       const res = await callACS(samlResponse);
 
       expect(res.status).toBe(302);
+    });
+
+    it('should require every AudienceRestriction to allow our SP', async () => {
+      const samlResponse = createSAMLResponseWithConditions({
+        audienceRestrictions: [
+          ['https://auth.example.com/saml/sp/metadata'],
+          ['https://other-sp.example.com/sp'],
+        ],
+      });
+
+      const res = await callACS(samlResponse);
+
+      expect(res.status).toBeGreaterThanOrEqual(400);
     });
 
     it('should reject assertion with empty AudienceRestriction', async () => {

--- a/packages/ar-saml/src/sp/__tests__/logout-request-signature.test.ts
+++ b/packages/ar-saml/src/sp/__tests__/logout-request-signature.test.ts
@@ -85,6 +85,24 @@ describe('validateSAMLIdPLogoutRequestSignature', () => {
     );
   });
 
+  it('returns authenticated references for signed IdP POST LogoutRequest processing', async () => {
+    const references = [{ uri: '#_logout123', xml: '<LogoutRequest ID="_logout123" />' }];
+    await expect(
+      validateSAMLIdPLogoutRequestSignature(
+        {
+          logoutRequest,
+          idpConfig: baseIdPConfig,
+          binding: 'post',
+          xml: '<LogoutRequest><Signature /></LogoutRequest>',
+        },
+        {
+          hasSignature: () => true,
+          verifyXmlSignatureAndGetReferences: vi.fn(() => references),
+        }
+      )
+    ).resolves.toEqual(references);
+  });
+
   it('verifies signed Redirect LogoutRequest over raw query parameter values', async () => {
     const verifyRedirectBindingSignature = vi.fn(async () => true);
 

--- a/packages/ar-saml/src/sp/__tests__/slo-handler.test.ts
+++ b/packages/ar-saml/src/sp/__tests__/slo-handler.test.ts
@@ -72,6 +72,10 @@ vi.mock('../../common/signature', async (importOriginal) => {
     ...actual,
     hasSignature: vi.fn((xml: string) => xml.includes('<Signature')),
     verifyXmlSignature: mocks.verify,
+    verifyXmlSignatureAndGetReferences: vi.fn((xml: string, options: unknown) => {
+      mocks.verify(xml, options);
+      return [{ uri: `#${/\bID="([^"]+)"/.exec(xml)?.[1]}`, xml }];
+    }),
     signXml: vi.fn((xml: string) => xml),
   };
 });
@@ -136,12 +140,14 @@ function environment(withState = true) {
 function requestXml(
   options: {
     issueInstant?: string;
+    notOnOrAfter?: string;
     destination?: string;
     sessionIndex?: string;
   } = {}
 ) {
   return `<samlp:LogoutRequest xmlns:samlp="${SAML_NAMESPACES.SAML2P}" xmlns:saml="${SAML_NAMESPACES.SAML2}"
     ID="_logout" IssueInstant="${options.issueInstant ?? new Date().toISOString()}"
+    ${options.notOnOrAfter ? `NotOnOrAfter="${options.notOnOrAfter}"` : ''}
     ${options.destination ? `Destination="${options.destination}"` : ''}>
     <saml:Issuer>https://idp.example.test/entity</saml:Issuer>
     <saml:NameID>user@example.test</saml:NameID>
@@ -152,10 +158,11 @@ function requestXml(
 function responseXml(
   options: { statusCode?: string; inResponseTo?: string; signature?: boolean } = {}
 ) {
+  const signature = options.signature ?? true;
   return `<samlp:LogoutResponse xmlns:samlp="${SAML_NAMESPACES.SAML2P}" xmlns:saml="${SAML_NAMESPACES.SAML2}"
     ID="_response" IssueInstant="${new Date().toISOString()}" InResponseTo="${options.inResponseTo ?? '_outbound'}">
     <saml:Issuer>https://idp.example.test/entity</saml:Issuer>
-    ${options.signature ? '<Signature />' : ''}
+    ${signature ? '<Signature />' : ''}
     <samlp:Status><samlp:StatusCode Value="${options.statusCode ?? STATUS_CODES.SUCCESS}"/></samlp:Status>
   </samlp:LogoutResponse>`;
 }
@@ -218,10 +225,23 @@ describe('SP SLO handler policy boundaries', () => {
   it.each([
     [new Date(Date.now() + 10 * 60_000).toISOString(), undefined],
     [new Date(Date.now() - 30 * 60_000).toISOString(), undefined],
+    ['not-a-date', undefined],
     [new Date().toISOString(), 'https://attacker.example.test/slo'],
   ])('rejects invalid request timing or destination', async (issueInstant, destination) => {
     await expectValidationError(
       await post('SAMLRequest', requestXml({ issueInstant, destination }))
+    );
+  });
+
+  it('rejects an invalid or expired LogoutRequest NotOnOrAfter', async () => {
+    await expectValidationError(
+      await post('SAMLRequest', requestXml({ notOnOrAfter: 'not-a-date' }))
+    );
+    await expectValidationError(
+      await post(
+        'SAMLRequest',
+        requestXml({ notOnOrAfter: new Date(Date.now() - 10 * 60_000).toISOString() })
+      )
     );
   });
 
@@ -291,6 +311,12 @@ describe('SP SLO handler policy boundaries', () => {
     const response = await post('SAMLResponse', responseXml({ signature: true }));
     await expectValidationError(response);
     expect(mocks.verify).toHaveBeenCalled();
+    expect(mocks.consumeOutbound).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsigned POST LogoutResponse before consuming correlation state', async () => {
+    const response = await post('SAMLResponse', responseXml({ signature: false }));
+    await expectValidationError(response);
     expect(mocks.consumeOutbound).not.toHaveBeenCalled();
   });
 

--- a/packages/ar-saml/src/sp/__tests__/subject-confirmation.test.ts
+++ b/packages/ar-saml/src/sp/__tests__/subject-confirmation.test.ts
@@ -63,6 +63,9 @@ vi.mock('../../admin/providers', () => ({
 
 vi.mock('../../common/signature', () => ({
   verifyXmlSignature: vi.fn().mockReturnValue(true),
+  verifyXmlSignatureAndGetReferences: vi.fn((xml: string) => [
+    { uri: `#${/\bID="([^"]+)"/.exec(xml)?.[1]}`, xml },
+  ]),
   hasSignature: vi.fn((xml: string) => xml.includes('<ds:Signature')),
 }));
 

--- a/packages/ar-saml/src/sp/acs.ts
+++ b/packages/ar-saml/src/sp/acs.ts
@@ -42,7 +42,7 @@ import { executeRuntimeMapping } from '@authrim/ar-lib-field-mapping/runtime';
 import type { SourceValueEnvelope } from '@authrim/ar-lib-field-mapping/contract';
 import { resolveSAMLTenantIdFromContext } from '../common/tenant';
 import {
-  parseXml,
+  parseSAMLXml,
   getAttribute,
   getTextContent,
   findDirectChildElement,
@@ -53,7 +53,11 @@ import {
   parsePostBindingFormDataWithLimit,
 } from '../common/message-limits';
 import { SAML_NAMESPACES, STATUS_CODES, DEFAULTS } from '../common/constants';
-import { verifyXmlSignature, hasSignature } from '../common/signature';
+import {
+  verifyXmlSignatureAndGetReferences,
+  hasSignature,
+  type VerifiedXmlReference,
+} from '../common/signature';
 import { getIdPConfigByEntityId } from '../admin/providers';
 import { getSAMLLocalEntityIds } from '../common/entity-id';
 import { assertSAMLRelayStateSize, SAMLRelayStateTooLargeError } from '../common/relay-state';
@@ -101,25 +105,38 @@ export async function handleSPACS(c: Context<{ Bindings: Env }>): Promise<Respon
     const responseXml = decodePostBindingMessage(samlResponse, 'SAML Response');
 
     // Parse and validate Response
-    const { responseId, issuer, assertion, inResponseTo } = parseAndValidateResponse(
-      responseXml,
-      issuerUrl,
-      spEntityId
-    );
-    auditProviderId = issuer;
+    const preliminaryResponse = parseAndValidateResponse(responseXml, issuerUrl, spEntityId);
+    auditProviderId = preliminaryResponse.issuer;
 
     // Get IdP configuration
-    const idpConfig = await getIdPConfigByEntityId(env, tenantId, issuer);
+    const idpConfig = await getIdPConfigByEntityId(env, tenantId, preliminaryResponse.issuer);
     if (!idpConfig) {
       return createErrorResponse(c, AR_ERROR_CODES.SAML_INVALID_RESPONSE);
     }
 
+    let verifiedResponse: ParsedResponse;
     try {
-      validateSAMLResponseSignature(responseXml, idpConfig, responseId, assertion.id);
+      const verifiedReferences = validateSAMLResponseSignature(
+        responseXml,
+        idpConfig,
+        preliminaryResponse.responseId,
+        preliminaryResponse.assertion.id
+      );
+      verifiedResponse = parseVerifiedSAMLResponse(
+        preliminaryResponse,
+        verifiedReferences,
+        issuerUrl,
+        spEntityId
+      );
+      if (verifiedResponse.issuer !== preliminaryResponse.issuer) {
+        throw new Error('Verified SAML Response Issuer does not match the routed IdP');
+      }
     } catch (error) {
       log.error('Signature verification failed', {}, error as Error);
       return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE);
     }
+
+    const { issuer, assertion, inResponseTo } = verifiedResponse;
 
     // Validate InResponseTo (if we sent an AuthnRequest)
     let validatedRequest: SAMLRequestData | null = null;
@@ -517,6 +534,7 @@ interface ParsedResponse {
 interface ParsedSAMLAssertion extends SAMLAssertion {
   subjectConfirmationData: {
     notOnOrAfter: string;
+    inResponseTo?: string;
   };
 }
 
@@ -528,7 +546,7 @@ function parseAndValidateResponse(
   issuerUrl: string,
   spEntityId: string
 ): ParsedResponse {
-  const doc = parseXml(xml);
+  const doc = parseSAMLXml(xml);
 
   const responseElement = doc.documentElement;
   if (
@@ -700,14 +718,20 @@ function parseAssertion(
       SAML_NAMESPACES.SAML2,
       'AudienceRestriction'
     );
-    const audienceElements = audienceRestrictionElements.flatMap((audienceRestriction) =>
+    const audienceGroups = audienceRestrictionElements.map((audienceRestriction) =>
       findDirectChildElements(audienceRestriction, SAML_NAMESPACES.SAML2, 'Audience')
+        .map((audience) => getTextContent(audience) || '')
+        .filter(Boolean)
     );
-    const audiences = audienceElements.map((el) => getTextContent(el) || '').filter(Boolean);
+    const audiences = audienceGroups.flat();
 
-    // Validate audience
+    // Audience values within one restriction are alternatives (OR), while separate
+    // AudienceRestriction elements are cumulative (AND).
     const expectedAudience = spEntityId;
-    if (audiences.length === 0 || !audiences.includes(expectedAudience)) {
+    if (
+      audienceGroups.length === 0 ||
+      audienceGroups.some((group) => !group.includes(expectedAudience))
+    ) {
       // SECURITY: Do not expose endpoint URLs in error message
       throw new Error('Invalid Audience in SAML Assertion');
     }
@@ -945,7 +969,10 @@ function validateSubjectConfirmation(
     }
   }
 
-  return { notOnOrAfter };
+  return {
+    notOnOrAfter,
+    inResponseTo: subjectConfirmationInResponseTo || undefined,
+  };
 }
 
 /**
@@ -1050,8 +1077,11 @@ function validateSAMLResponseSignature(
   idpConfig: SAMLIdPConfig,
   responseId: string,
   assertionId: string
-): void {
-  if (!idpConfig.certificate) {
+): VerifiedXmlReference[] {
+  const certificates = Array.from(
+    new Set([idpConfig.certificate, ...(idpConfig.certificates ?? [])].filter(Boolean))
+  );
+  if (certificates.length === 0) {
     throw new Error('IdP certificate is required to verify SAML Response signatures');
   }
 
@@ -1059,31 +1089,80 @@ function validateSAMLResponseSignature(
     throw new Error('Signed SAML Response or Assertion is required for configured IdP');
   }
 
-  verifyXmlSignature(xml, {
-    certificateOrKey: idpConfig.certificate,
-    strictXswProtection: true,
-  });
-
-  const signedReferences = getSignatureReferenceUris(xml);
-  if (!signedReferences.has(`#${responseId}`) && !signedReferences.has(`#${assertionId}`)) {
-    throw new Error('SAML signature does not cover the processed Response or Assertion');
-  }
-}
-
-function getSignatureReferenceUris(xml: string): Set<string> {
-  const doc = parseXml(xml);
-  const signatures = doc.getElementsByTagNameNS(SAML_NAMESPACES.DS, 'Signature');
-  const uris = new Set<string>();
-  for (let i = 0; i < signatures.length; i++) {
-    const references = signatures[i].getElementsByTagNameNS(SAML_NAMESPACES.DS, 'Reference');
-    for (let j = 0; j < references.length; j++) {
-      const uri = getAttribute(references[j], 'URI');
-      if (uri) {
-        uris.add(uri);
-      }
+  let verifiedReferences: VerifiedXmlReference[] | undefined;
+  let lastError: unknown;
+  for (const certificate of certificates) {
+    try {
+      verifiedReferences = verifyXmlSignatureAndGetReferences(xml, {
+        certificateOrKey: certificate,
+        strictXswProtection: true,
+      });
+      break;
+    } catch (error) {
+      lastError = error;
     }
   }
-  return uris;
+  if (!verifiedReferences) {
+    throw lastError instanceof Error ? lastError : new Error('SAML signature verification failed');
+  }
+
+  if (
+    !verifiedReferences.some(
+      (reference) => reference.uri === `#${responseId}` || reference.uri === `#${assertionId}`
+    )
+  ) {
+    throw new Error('SAML signature does not cover the processed Response or Assertion');
+  }
+
+  return verifiedReferences;
+}
+
+function parseVerifiedSAMLResponse(
+  preliminary: ParsedResponse,
+  verifiedReferences: VerifiedXmlReference[],
+  issuerUrl: string,
+  spEntityId: string
+): ParsedResponse {
+  const signedResponse = verifiedReferences.find(
+    (reference) => reference.uri === `#${preliminary.responseId}`
+  );
+  if (signedResponse) {
+    return parseAndValidateResponse(signedResponse.xml, issuerUrl, spEntityId);
+  }
+
+  const signedAssertion = verifiedReferences.find(
+    (reference) => reference.uri === `#${preliminary.assertion.id}`
+  );
+  if (!signedAssertion) {
+    throw new Error('SAML signature does not contain the processed Assertion');
+  }
+
+  const doc = parseSAMLXml(signedAssertion.xml);
+  const assertionElement = doc.documentElement;
+  if (
+    !assertionElement ||
+    assertionElement.namespaceURI !== SAML_NAMESPACES.SAML2 ||
+    assertionElement.localName !== 'Assertion'
+  ) {
+    throw new Error('Signed SAML reference is not an Assertion');
+  }
+
+  const assertion = parseAssertion(
+    assertionElement,
+    issuerUrl,
+    spEntityId,
+    preliminary.inResponseTo
+  );
+  if (assertion.id !== preliminary.assertion.id || assertion.issuer !== preliminary.issuer) {
+    throw new Error('Signed Assertion does not match the routed SAML Response');
+  }
+
+  return {
+    responseId: preliminary.responseId,
+    issuer: assertion.issuer,
+    inResponseTo: assertion.subjectConfirmationData.inResponseTo,
+    assertion,
+  };
 }
 
 function parseSAMLDateTimeMs(value: string, label: string): number {

--- a/packages/ar-saml/src/sp/logout-request-signature.ts
+++ b/packages/ar-saml/src/sp/logout-request-signature.ts
@@ -4,6 +4,8 @@ import {
   hasSignature,
   verifyRedirectBindingSignature,
   verifyXmlSignature,
+  verifyXmlSignatureAndGetReferences,
+  type VerifiedXmlReference,
 } from '../common/signature';
 import { DIGEST_ALGORITHMS, SAML_NAMESPACES, SIGNATURE_ALGORITHMS } from '../common/constants';
 import { getAttribute, parseXml } from '../common/xml-utils';
@@ -20,6 +22,7 @@ export interface SAMLIdPLogoutRequestSignatureValidationInput {
 export interface SAMLIdPLogoutRequestSignatureVerifiers {
   hasSignature?: (xml: string) => boolean;
   verifyXmlSignature?: typeof verifyXmlSignature;
+  verifyXmlSignatureAndGetReferences?: typeof verifyXmlSignatureAndGetReferences;
   verifyRedirectBindingSignature?: typeof verifyRedirectBindingSignature;
 }
 
@@ -45,11 +48,11 @@ export class SAMLIdPLogoutRequestSignatureValidationError extends Error {
 export async function validateSAMLIdPLogoutRequestSignature(
   input: SAMLIdPLogoutRequestSignatureValidationInput,
   verifiers: SAMLIdPLogoutRequestSignatureVerifiers = {}
-): Promise<void> {
+): Promise<VerifiedXmlReference[] | undefined> {
   const policy = resolveLogoutRequestSignaturePolicy(input.idpConfig);
 
   if (policy === 'disabled') {
-    return;
+    return undefined;
   }
 
   const requestIsSigned = isLogoutRequestSigned(input, verifiers.hasSignature ?? hasSignature);
@@ -60,7 +63,7 @@ export async function validateSAMLIdPLogoutRequestSignature(
         'Signed IdP LogoutRequest is required'
       );
     }
-    return;
+    return undefined;
   }
 
   const certificates = getIdPVerificationCertificates(input.idpConfig);
@@ -78,27 +81,32 @@ export async function validateSAMLIdPLogoutRequestSignature(
       certificates,
       verifiers.verifyRedirectBindingSignature ?? verifyRedirectBindingSignature
     );
-    return;
+    return undefined;
   }
 
   validateXmlSignatureAlgorithms(input.xml, input.idpConfig);
 
-  const verifier = verifiers.verifyXmlSignature ?? verifyXmlSignature;
+  const verifier = verifiers.verifyXmlSignature;
+  const referenceVerifier =
+    verifiers.verifyXmlSignatureAndGetReferences ??
+    (verifier ? undefined : verifyXmlSignatureAndGetReferences);
   let lastError: unknown;
   for (const certificate of certificates) {
     try {
-      if (
-        verifier(input.xml, {
-          certificateOrKey: certificate,
-          expectedId: input.logoutRequest.id,
-          strictXswProtection: true,
-          ...(shouldAllowSha1XmlSignature(input.idpConfig)
-            ? { allowSha1SignatureAlgorithm: true }
-            : {}),
-          ...(shouldAllowSha1XmlDigest(input.idpConfig) ? { allowSha1DigestAlgorithm: true } : {}),
-        })
-      ) {
-        return;
+      const verifyOptions = {
+        certificateOrKey: certificate,
+        expectedId: input.logoutRequest.id,
+        strictXswProtection: true,
+        ...(shouldAllowSha1XmlSignature(input.idpConfig)
+          ? { allowSha1SignatureAlgorithm: true }
+          : {}),
+        ...(shouldAllowSha1XmlDigest(input.idpConfig) ? { allowSha1DigestAlgorithm: true } : {}),
+      };
+      if (referenceVerifier) {
+        return referenceVerifier(input.xml, verifyOptions);
+      }
+      if (verifier?.(input.xml, verifyOptions)) {
+        return undefined;
       }
     } catch (error) {
       lastError = error;

--- a/packages/ar-saml/src/sp/slo.ts
+++ b/packages/ar-saml/src/sp/slo.ts
@@ -30,8 +30,7 @@ import {
   recordHybridUserSessionRevocationEpoch,
 } from '@authrim/ar-lib-core';
 import {
-  parseLogoutResponsePost,
-  parseLogoutResponseRedirect,
+  parseLogoutResponseXml,
   parseLogoutRequestXml,
   buildLogoutResponse,
   buildLogoutRequest,
@@ -44,9 +43,20 @@ import {
   inflateRedirectBindingMessage,
   parsePostBindingFormDataWithLimit,
 } from '../common/message-limits';
-import { base64Decode, generateSAMLId, nowAsDateTime } from '../common/xml-utils';
-import { STATUS_CODES, DEFAULTS } from '../common/constants';
-import { signXml, verifyXmlSignature, hasSignature } from '../common/signature';
+import { generateSAMLId, nowAsDateTime } from '../common/xml-utils';
+import {
+  DIGEST_ALGORITHMS,
+  SIGNATURE_ALGORITHMS,
+  STATUS_CODES,
+  DEFAULTS,
+} from '../common/constants';
+import {
+  signXml,
+  verifyRedirectBindingSignature,
+  verifyXmlSignatureAndGetReferences,
+  hasSignature,
+  parseRedirectBindingSignatureInput,
+} from '../common/signature';
 import { getSAMLSigningMaterial, getSAMLSigningPolicy } from '../common/saml-signing-keys';
 import { getIdPConfigByEntityId } from '../admin/providers';
 import { findActiveSamlUserByEmail, getSamlUserNameIdById } from '../common/user-store';
@@ -122,8 +132,16 @@ async function handlePostBinding(
       xml,
     });
   } else if (samlResponse) {
-    const logoutResponse = parseSAMLLogoutMessage(() => parseLogoutResponsePost(samlResponse));
-    return processLogoutResponse(c, env, logoutResponse, relayState, samlResponse);
+    const xml = parseSAMLLogoutMessage(() =>
+      decodePostBindingMessage(samlResponse, 'SAML LogoutResponse')
+    );
+    const logoutResponse = parseSAMLLogoutMessage(() => parseLogoutResponseXml(xml));
+    return processLogoutResponse(c, env, {
+      logoutResponse,
+      relayState,
+      binding: 'post',
+      xml,
+    });
   } else {
     return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_REQUIRED_FIELD, {
       variables: { field: 'SAMLRequest or SAMLResponse' },
@@ -146,6 +164,7 @@ async function handleRedirectBinding(
   assertSAMLRelayStateSize(relayState);
 
   if (samlRequest) {
+    const redirectSignature = parseRedirectBindingSignatureInput(url.search, 'SAMLRequest');
     const xml = parseSAMLLogoutMessage(() =>
       inflateRedirectBindingMessage(samlRequest, 'SAML LogoutRequest')
     );
@@ -155,16 +174,21 @@ async function handleRedirectBinding(
       relayState,
       binding: 'redirect',
       xml,
-      redirectSignature: {
-        samlMessage: getRawQueryParam(url.search, 'SAMLRequest') ?? encodeURIComponent(samlRequest),
-        relayState: getRawQueryParam(url.search, 'RelayState'),
-        signature: url.searchParams.get('Signature') || undefined,
-        sigAlg: url.searchParams.get('SigAlg') || undefined,
-      },
+      redirectSignature,
     });
   } else if (samlResponse) {
-    const logoutResponse = parseSAMLLogoutMessage(() => parseLogoutResponseRedirect(samlResponse));
-    return processLogoutResponse(c, env, logoutResponse, relayState);
+    const redirectSignature = parseRedirectBindingSignatureInput(url.search, 'SAMLResponse');
+    const xml = parseSAMLLogoutMessage(() =>
+      inflateRedirectBindingMessage(samlResponse, 'SAML LogoutResponse')
+    );
+    const logoutResponse = parseSAMLLogoutMessage(() => parseLogoutResponseXml(xml));
+    return processLogoutResponse(c, env, {
+      logoutResponse,
+      relayState,
+      binding: 'redirect',
+      xml,
+      redirectSignature,
+    });
   } else {
     return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_REQUIRED_FIELD, {
       variables: { field: 'SAMLRequest or SAMLResponse' },
@@ -190,7 +214,8 @@ async function processLogoutRequest(
   input: ParsedIdPLogoutRequestInput
 ): Promise<Response> {
   const log = getLogger(c).module('SAML-SP');
-  const { logoutRequest, relayState, binding } = input;
+  let { logoutRequest } = input;
+  const { relayState, binding } = input;
 
   // Get IdP configuration
   const idpConfig = await getIdPConfigByEntityId(
@@ -205,13 +230,35 @@ async function processLogoutRequest(
   }
 
   try {
-    await validateSAMLIdPLogoutRequestSignature({
+    const verifiedReferences = await validateSAMLIdPLogoutRequestSignature({
       logoutRequest,
       idpConfig,
       binding,
       xml: input.xml,
       redirectSignature: input.redirectSignature,
     });
+    if (binding === 'post' && verifiedReferences) {
+      const signedRequest = verifiedReferences.find(
+        (reference) => reference.uri === `#${logoutRequest.id}`
+      );
+      if (!signedRequest) {
+        throw new SAMLIdPLogoutRequestSignatureValidationError(
+          'idp_logout_request_invalid_signature',
+          'Signed LogoutRequest reference is missing'
+        );
+      }
+      const authenticatedRequest = parseLogoutRequestXml(signedRequest.xml);
+      if (
+        authenticatedRequest.id !== logoutRequest.id ||
+        authenticatedRequest.issuer !== logoutRequest.issuer
+      ) {
+        throw new SAMLIdPLogoutRequestSignatureValidationError(
+          'idp_logout_request_invalid_signature',
+          'Signed LogoutRequest does not match the routed request'
+        );
+      }
+      logoutRequest = authenticatedRequest;
+    }
   } catch (error) {
     if (error instanceof SAMLIdPLogoutRequestSignatureValidationError) {
       log.warn('IdP LogoutRequest signature policy failed', {
@@ -250,24 +297,23 @@ async function processLogoutRequest(
   );
 }
 
-function getRawQueryParam(search: string, name: string): string | undefined {
-  const prefix = `${name}=`;
-  const query = search.startsWith('?') ? search.slice(1) : search;
-  const match = query.split('&').find((part) => part.startsWith(prefix));
-  return match ? match.slice(prefix.length) : undefined;
-}
-
 /**
  * Process LogoutResponse from IdP (for SP-initiated logout)
  */
 async function processLogoutResponse(
   c: Context<{ Bindings: Env }>,
   env: Env,
-  logoutResponse: ParsedLogoutResponse,
-  relayState: string | null,
-  samlBase64?: string
+  input: {
+    logoutResponse: ParsedLogoutResponse;
+    relayState: string | null;
+    binding: 'post' | 'redirect';
+    xml: string;
+    redirectSignature?: SAMLRedirectSignatureInput;
+  }
 ): Promise<Response> {
   const log = getLogger(c).module('SAML-SP');
+  let { logoutResponse } = input;
+  let { relayState } = input;
 
   const tenantId = resolveSAMLTenantIdFromContext(c);
 
@@ -278,22 +324,97 @@ async function processLogoutResponse(
     return createErrorResponse(c, AR_ERROR_CODES.SAML_INVALID_RESPONSE);
   }
 
-  // Verify signature if present
-  if (samlBase64) {
-    const decodedXml = base64Decode(samlBase64);
-    if (hasSignature(decodedXml)) {
-      try {
-        // Use expectedId and strictXswProtection to prevent XSW attacks
-        verifyXmlSignature(decodedXml, {
-          certificateOrKey: idpConfig.certificate,
-          expectedId: logoutResponse.id,
-          strictXswProtection: true,
-        });
-      } catch (error) {
-        log.error('LogoutResponse signature verification failed', {}, error as Error);
-        return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE);
+  try {
+    const certificates = Array.from(
+      new Set([idpConfig.certificate, ...(idpConfig.certificates ?? [])].filter(Boolean))
+    );
+    if (input.binding === 'post') {
+      if (!hasSignature(input.xml)) {
+        throw new Error('Signed HTTP-POST LogoutResponse is required');
+      }
+      let lastError: unknown;
+      let authenticatedResponse: ParsedLogoutResponse | undefined;
+      for (const certificate of certificates) {
+        try {
+          const references = verifyXmlSignatureAndGetReferences(input.xml, {
+            certificateOrKey: certificate,
+            expectedId: logoutResponse.id,
+            strictXswProtection: true,
+            ...(idpConfig.logoutRequestLegacyAlgorithmPolicy === 'explicit_opt_in' &&
+            idpConfig.acceptedLogoutRequestSignatureAlgorithms?.includes(
+              SIGNATURE_ALGORITHMS.RSA_SHA1
+            )
+              ? { allowSha1SignatureAlgorithm: true }
+              : {}),
+            ...(idpConfig.logoutRequestLegacyAlgorithmPolicy === 'explicit_opt_in' &&
+            idpConfig.acceptedLogoutRequestDigestAlgorithms?.includes(DIGEST_ALGORITHMS.SHA1)
+              ? { allowSha1DigestAlgorithm: true }
+              : {}),
+          });
+          const signedResponse = references.find(
+            (reference) => reference.uri === `#${logoutResponse.id}`
+          );
+          if (!signedResponse) {
+            throw new Error('Signed LogoutResponse reference is missing');
+          }
+          authenticatedResponse = parseLogoutResponseXml(signedResponse.xml);
+          break;
+        } catch (error) {
+          lastError = error;
+        }
+      }
+      if (
+        !authenticatedResponse ||
+        authenticatedResponse.id !== logoutResponse.id ||
+        authenticatedResponse.issuer !== logoutResponse.issuer
+      ) {
+        throw lastError instanceof Error
+          ? lastError
+          : new Error('Signed LogoutResponse does not match the routed response');
+      }
+      logoutResponse = authenticatedResponse;
+    } else if (input.binding === 'redirect') {
+      const redirectSignature = input.redirectSignature;
+      if (
+        !redirectSignature?.samlMessage ||
+        !redirectSignature.signature ||
+        !redirectSignature.sigAlg
+      ) {
+        throw new Error('Signed HTTP-Redirect LogoutResponse is required');
+      }
+      const acceptedSignatureAlgorithms =
+        idpConfig.logoutRequestLegacyAlgorithmPolicy === 'explicit_opt_in'
+          ? (idpConfig.acceptedLogoutRequestSignatureAlgorithms ?? [
+              SIGNATURE_ALGORITHMS.RSA_SHA256,
+            ])
+          : [SIGNATURE_ALGORITHMS.RSA_SHA256];
+      let verified = false;
+      let lastError: unknown;
+      for (const certificate of certificates) {
+        try {
+          verified = await verifyRedirectBindingSignature(
+            'SAMLResponse',
+            redirectSignature.samlMessage,
+            redirectSignature.relayState,
+            redirectSignature.signature,
+            redirectSignature.sigAlg,
+            certificate,
+            { acceptedSignatureAlgorithms }
+          );
+          if (verified) break;
+        } catch (error) {
+          lastError = error;
+        }
+      }
+      if (!verified) {
+        throw lastError instanceof Error
+          ? lastError
+          : new Error('Invalid HTTP-Redirect LogoutResponse signature');
       }
     }
+  } catch (error) {
+    log.error('LogoutResponse signature verification failed', {}, error as Error);
+    return createErrorResponse(c, AR_ERROR_CODES.VALIDATION_INVALID_VALUE);
   }
 
   try {
@@ -365,17 +486,27 @@ async function processLogoutResponse(
  */
 function validateLogoutRequest(logoutRequest: ParsedLogoutRequest, issuerUrl: string): void {
   // Check request is not expired
-  const issueInstant = new Date(logoutRequest.issueInstant);
-  const now = new Date();
+  const issueInstantMs = Date.parse(logoutRequest.issueInstant);
+  if (!Number.isFinite(issueInstantMs)) {
+    throw new SAMLLogoutMessageValidationError();
+  }
+  const nowMs = Date.now();
   const skewMs = DEFAULTS.CLOCK_SKEW_SECONDS * 1000;
   const maxAge = DEFAULTS.REQUEST_VALIDITY_SECONDS * 1000;
 
-  if (issueInstant.getTime() > now.getTime() + skewMs) {
+  if (issueInstantMs > nowMs + skewMs) {
     throw new SAMLLogoutMessageValidationError();
   }
 
-  if (now.getTime() - issueInstant.getTime() > maxAge + skewMs) {
+  if (nowMs - issueInstantMs > maxAge + skewMs) {
     throw new SAMLLogoutMessageValidationError();
+  }
+
+  if (logoutRequest.notOnOrAfter) {
+    const notOnOrAfterMs = Date.parse(logoutRequest.notOnOrAfter);
+    if (!Number.isFinite(notOnOrAfterMs) || nowMs >= notOnOrAfterMs + skewMs) {
+      throw new SAMLLogoutMessageValidationError();
+    }
   }
 
   // Validate Destination if present

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ overrides:
   devalue: ^5.8.1
   minimatch@<3.1.4: 3.1.4
   minimatch@>=9.0.0 <9.0.7: 9.0.7
-  '@xmldom/xmldom': ^0.8.13
+  '@xmldom/xmldom': ^0.8.15
   dompurify: 3.4.13
   nanoid@<3.3.18: 3.3.18
   nanoid@>=4.0.0 <5.1.16: 5.1.16
@@ -830,8 +830,8 @@ importers:
         specifier: workspace:*
         version: link:../ar-lib-field-mapping
       '@xmldom/xmldom':
-        specifier: ^0.8.13
-        version: 0.8.13
+        specifier: ^0.8.15
+        version: 0.8.15
       hono:
         specifier: 4.13.2
         version: 4.13.2
@@ -841,6 +841,9 @@ importers:
       pako:
         specifier: ^2.1.0
         version: 2.1.0
+      saxes:
+        specifier: 6.0.0
+        version: 6.0.0
       xml-crypto:
         specifier: ^6.0.0
         version: 6.1.2
@@ -3286,10 +3289,9 @@ packages:
     resolution: {integrity: sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q==}
     engines: {node: '>= 16'}
 
-  '@xmldom/xmldom@0.8.13':
-    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+  '@xmldom/xmldom@0.8.15':
+    resolution: {integrity: sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
 
   '@xyflow/svelte@1.5.0':
     resolution: {integrity: sha512-kHJVwMtabN7xthDJqLvx5wGT5qjOAVV90J9a26geDS51lrGsGb7CCxNRiZCMuVDlRkczGVIy9dkqdph6FL4slQ==}
@@ -8808,7 +8810,7 @@ snapshots:
 
   '@xmldom/is-dom-node@1.0.1': {}
 
-  '@xmldom/xmldom@0.8.13': {}
+  '@xmldom/xmldom@0.8.15': {}
 
   '@xyflow/svelte@1.5.0(svelte@5.56.3(@typescript-eslint/types@8.53.1))':
     dependencies:
@@ -12025,7 +12027,7 @@ snapshots:
   xml-crypto@6.1.2:
     dependencies:
       '@xmldom/is-dom-node': 1.0.1
-      '@xmldom/xmldom': 0.8.13
+      '@xmldom/xmldom': 0.8.15
       xpath: 0.0.33
 
   xml-name-validator@5.0.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,7 +36,7 @@ overrides:
   'devalue': '^5.8.1'
   'minimatch@<3.1.4': '3.1.4'
   'minimatch@>=9.0.0 <9.0.7': '9.0.7'
-  '@xmldom/xmldom': '^0.8.13'
+  '@xmldom/xmldom': '^0.8.15'
   'dompurify': '3.4.13'
   'nanoid@<3.3.18': '3.3.18'
   'nanoid@>=4.0.0 <5.1.16': '5.1.16'

--- a/test/integration/saml-enterprise-academic-profiles.test.ts
+++ b/test/integration/saml-enterprise-academic-profiles.test.ts
@@ -478,9 +478,9 @@ describe('academic and research federation profiles', () => {
     ).toBe('eduPersonScopedAffiliation');
   });
 
-  it('fails closed for an unsigned eduGAIN-style aggregate under strict trust policy', () => {
+  it('fails closed for an unsigned eduGAIN-style aggregate under strict trust policy', async () => {
     expect.hasAssertions();
-    expect(() =>
+    await expect(
       verifyAggregateMetadataSignature(
         ACADEMIC_AGGREGATE_METADATA,
         'https://metadata.example.edu/edugain.xml',
@@ -495,12 +495,12 @@ describe('academic and research federation profiles', () => {
         ],
         'strict'
       )
-    ).toThrow('Aggregate metadata root is not signed');
+    ).rejects.toThrow('Aggregate metadata root is not signed');
   });
 
-  it('marks an unsigned aggregate unverified rather than trusted under warn policy', () => {
+  it('marks an unsigned aggregate unverified rather than trusted under warn policy', async () => {
     expect.hasAssertions();
-    const result = verifyAggregateMetadataSignature(
+    const result = await verifyAggregateMetadataSignature(
       ACADEMIC_AGGREGATE_METADATA,
       'https://metadata.example.edu/edugain.xml',
       [


### PR DESCRIPTION
## Summary

- harden SAML XML signature verification so ACS and SLO consumers process only the exact verified signed references
- enforce strict XMLDSig hierarchy, namespace, transform, algorithm, certificate, destination, recipient, time, audience, and replay validation
- require signed SP LogoutResponse messages for both HTTP-POST and HTTP-Redirect bindings
- add bounded SAX processing for federation aggregate metadata instead of building a DOM for the complete document
- enforce aggregate, entity, XML structure, signature-subtree, fetch, and request-body resource limits
- validate aggregate expiration throughout nested EntitiesDescriptor elements and keep batch entity extraction to one SAX pass
- update the SAML OpenAPI limits, dependencies, regression coverage, and README documentation

## Federation metadata behavior

- aggregate document limit: 10 MiB
- individual EntityDescriptor limit: 1 MiB
- up to 100,000 elements, 200,000 attributes, depth 64, and 10,000 entities
- root Signature subtree limit: 128 KiB, 512 elements, and 1,024 attributes
- verified against a 5.65 MiB GakuNin aggregate containing 650 entities

The implementation retains the bounded XML string needed for verification and storage, but avoids constructing a DOM for the full aggregate. Selected entities are extracted in a single SAX pass and parsed individually.

## Compatibility notes

- unsigned LogoutResponse messages are rejected
- XML processing instructions other than the XML declaration are rejected
- unsupported or legacy XMLDSig algorithms and non-profile transforms fail closed
- aggregates above 10 MiB and individual entities above 1 MiB are rejected

## Validation

- `pnpm --filter @authrim/ar-saml test -- --coverage` — 68 files, 915 tests
- `pnpm --filter @authrim/ar-saml typecheck`
- `pnpm lint`
- `pnpm exec prettier --check packages/ar-saml/src packages/ar-saml/package.json`
- `pnpm openapi:validate`
- `pnpm openapi:routes -- --fail-on-missing`
- `pnpm audit --prod --audit-level=high`
- `git diff --check`
- security diff review completed; four Low-severity omissions identified and remediated
