### PR TITLE
Fix verified rollout recovery across release versions

### DIFF
--- a/packages/setup/src/__tests__/update-release-orchestration.test.ts
+++ b/packages/setup/src/__tests__/update-release-orchestration.test.ts
@@ -14,6 +14,8 @@ import {
   getUiComponentsToUpdate,
   isUpdateSourceLockUnchanged,
   updateLockWithDeploymentsAndVersions,
+  finalizeDeferredInstalledControlReleaseRollout,
+  isVerifiedInstalledRolloutReadyForDeferredCompletion,
   recoverActiveControlReleaseRollout,
   withRecoveredReleaseUpdateState,
   withReleaseUpdateState,
@@ -604,6 +606,174 @@ describe('release update orchestration', () => {
       controlCompletedTargets: 3,
       controlTotalTargets: 3,
     });
+  });
+
+  it('defers completion of a fully migrated installed-version rollout until new Workers verify', async () => {
+    const sourceLock = AuthrimLockSchema.parse({
+      ...lock(),
+      d1: {
+        CONTROL_DB: { id: 'control-database-id', name: 'prod-authrim-control-db' },
+      },
+      workers: {
+        'ar-control': {
+          name: 'prod-ar-control',
+          version: '1.0.0',
+          cloudflareVersionId: '11111111-1111-4111-8111-111111111111',
+        },
+      },
+      releaseUpdate: {
+        targetVersion: '1.0.0',
+        phase: 'verified',
+        manifestChecksum: 'a'.repeat(64),
+        startedAt: '2026-07-21T00:00:00.000Z',
+        updatedAt: '2026-07-21T00:01:00.000Z',
+        appliedTargets: [],
+        manualTargets: [],
+      },
+    });
+    const installedRollout = {
+      operationId: `op_release_rollout_${'6'.repeat(32)}`,
+      sourceVersion: '1.0.0',
+      targetVersion: '1.0.0',
+      releaseId: '1.0.0-draft.abcdef123456',
+      manifestDigest: 'e'.repeat(64),
+      phase: 'awaiting_setup' as const,
+      completedTargets: 3,
+      totalTargets: 3,
+      lastErrorCode: null,
+      updatedAt: 100,
+    };
+
+    const recovered = await recoverActiveControlReleaseRollout({
+      lock: sourceLock,
+      environmentId: 'prod',
+      targetVersion: '1.1.0',
+      manifestChecksum: 'b'.repeat(64),
+      deferVerifiedInstalledRolloutCompletion: true,
+      loadActiveRollout: async () => installedRollout,
+    });
+
+    expect(recovered.lock).toBe(sourceLock);
+    expect(recovered.activeRollout).toBeNull();
+    expect(recovered.installedRolloutToFinalize).toEqual(installedRollout);
+  });
+
+  it('fails closed when an older active rollout lacks complete installed-release evidence', async () => {
+    const verifiedLock = AuthrimLockSchema.parse({
+      ...lock(),
+      d1: {
+        CONTROL_DB: { id: 'control-database-id', name: 'prod-authrim-control-db' },
+      },
+      workers: {
+        'ar-control': {
+          name: 'prod-ar-control',
+          version: '1.0.0',
+          cloudflareVersionId: '11111111-1111-4111-8111-111111111111',
+        },
+      },
+      releaseUpdate: {
+        targetVersion: '1.0.0',
+        phase: 'verified',
+        manifestChecksum: 'a'.repeat(64),
+        startedAt: '2026-07-21T00:00:00.000Z',
+        updatedAt: '2026-07-21T00:01:00.000Z',
+        appliedTargets: [],
+        manualTargets: [],
+      },
+    });
+    const baseRollout = {
+      operationId: `op_release_rollout_${'7'.repeat(32)}`,
+      sourceVersion: '1.0.0',
+      targetVersion: '1.0.0',
+      releaseId: '1.0.0-draft.abcdef123456',
+      manifestDigest: 'e'.repeat(64),
+      phase: 'awaiting_setup' as const,
+      completedTargets: 3,
+      totalTargets: 3,
+      lastErrorCode: null,
+      updatedAt: 100,
+    };
+
+    expect(
+      isVerifiedInstalledRolloutReadyForDeferredCompletion(verifiedLock, {
+        ...baseRollout,
+        phase: 'database_rollout',
+      })
+    ).toBe(false);
+    expect(
+      isVerifiedInstalledRolloutReadyForDeferredCompletion(verifiedLock, {
+        ...baseRollout,
+        completedTargets: 2,
+      })
+    ).toBe(false);
+    expect(
+      isVerifiedInstalledRolloutReadyForDeferredCompletion(
+        AuthrimLockSchema.parse({
+          ...verifiedLock,
+          workers: { 'ar-control': { name: 'prod-ar-control', version: '1.0.0' } },
+        }),
+        baseRollout
+      )
+    ).toBe(false);
+    await expect(
+      recoverActiveControlReleaseRollout({
+        lock: verifiedLock,
+        environmentId: 'prod',
+        targetVersion: '1.1.0',
+        manifestChecksum: 'b'.repeat(64),
+        deferVerifiedInstalledRolloutCompletion: false,
+        loadActiveRollout: async () => baseRollout,
+      })
+    ).rejects.toThrow('release_rollout_active_target_mismatch');
+  });
+
+  it('revalidates and finalizes a deferred installed rollout only after verification begins', async () => {
+    const rollout = {
+      operationId: `op_release_rollout_${'8'.repeat(32)}`,
+      sourceVersion: '1.0.0',
+      targetVersion: '1.0.0',
+      releaseId: '1.0.0-draft.abcdef123456',
+      manifestDigest: 'f'.repeat(64),
+      phase: 'awaiting_setup' as const,
+      completedTargets: 3,
+      totalTargets: 3,
+      lastErrorCode: null,
+      updatedAt: 100,
+    };
+    const calls: string[] = [];
+
+    await finalizeDeferredInstalledControlReleaseRollout({
+      controlDatabaseId: 'control-database-id',
+      environmentId: 'prod',
+      rollout,
+      getStatus: async () => {
+        calls.push('get');
+        return rollout;
+      },
+      beginVerification: async () => {
+        calls.push('begin');
+        return { ...rollout, phase: 'verifying' };
+      },
+      complete: async () => {
+        calls.push('complete');
+        return { ...rollout, phase: 'completed' };
+      },
+    });
+
+    expect(calls).toEqual(['get', 'begin', 'complete']);
+
+    await expect(
+      finalizeDeferredInstalledControlReleaseRollout({
+        controlDatabaseId: 'control-database-id',
+        environmentId: 'prod',
+        rollout,
+        getStatus: async () => ({
+          ...rollout,
+          phase: 'completed',
+          completedTargets: 2,
+        }),
+      })
+    ).rejects.toThrow('release_rollout_deferred_completed_state_inconsistent');
   });
 
   it('fails closed instead of adopting an unrelated active rollout', () => {

--- a/packages/setup/src/cli/commands/update.ts
+++ b/packages/setup/src/cli/commands/update.ts
@@ -163,18 +163,38 @@ export async function recoverActiveControlReleaseRollout(input: {
   environmentId: string;
   targetVersion: string;
   manifestChecksum: string;
+  deferVerifiedInstalledRolloutCompletion?: boolean;
   loadActiveRollout?: (input: {
     controlDatabaseId: string;
     environmentId: string;
   }) => Promise<ReleaseRolloutHandoffStatus | null>;
-}): Promise<{ lock: AuthrimLock; activeRollout: ReleaseRolloutHandoffStatus | null }> {
+}): Promise<{
+  lock: AuthrimLock;
+  activeRollout: ReleaseRolloutHandoffStatus | null;
+  installedRolloutToFinalize: ReleaseRolloutHandoffStatus | null;
+}> {
   const controlDatabase = input.lock.d1.CONTROL_DB;
-  if (!controlDatabase) return { lock: input.lock, activeRollout: null };
+  if (!controlDatabase) {
+    return { lock: input.lock, activeRollout: null, installedRolloutToFinalize: null };
+  }
   const activeRollout = await (input.loadActiveRollout ?? getActiveReleaseRolloutHandoffStatus)({
     controlDatabaseId: controlDatabase.id,
     environmentId: input.environmentId,
   });
-  if (!activeRollout) return { lock: input.lock, activeRollout: null };
+  if (!activeRollout) {
+    return { lock: input.lock, activeRollout: null, installedRolloutToFinalize: null };
+  }
+  if (
+    activeRollout.targetVersion !== input.targetVersion &&
+    input.deferVerifiedInstalledRolloutCompletion === true &&
+    isVerifiedInstalledRolloutReadyForDeferredCompletion(input.lock, activeRollout)
+  ) {
+    return {
+      lock: input.lock,
+      activeRollout: null,
+      installedRolloutToFinalize: activeRollout,
+    };
+  }
   return {
     lock: withRecoveredReleaseUpdateState(input.lock, {
       targetVersion: input.targetVersion,
@@ -182,7 +202,92 @@ export async function recoverActiveControlReleaseRollout(input: {
       activeRollout,
     }),
     activeRollout,
+    installedRolloutToFinalize: null,
   };
+}
+
+export function isVerifiedInstalledRolloutReadyForDeferredCompletion(
+  lock: AuthrimLock,
+  activeRollout: ReleaseRolloutHandoffStatus
+): boolean {
+  const installedVersion = lock.productVersion;
+  const release = lock.releaseUpdate;
+  const workers = Object.values(lock.workers ?? {});
+  return Boolean(
+    installedVersion &&
+    activeRollout.targetVersion === installedVersion &&
+    (activeRollout.sourceVersion === null ||
+      activeRollout.sourceVersion === installedVersion ||
+      activeRollout.sourceVersion === release?.previousProductVersion) &&
+    (activeRollout.phase === 'awaiting_setup' || activeRollout.phase === 'verifying') &&
+    activeRollout.completedTargets === activeRollout.totalTargets &&
+    activeRollout.lastErrorCode === null &&
+    release?.targetVersion === installedVersion &&
+    release.phase === 'verified' &&
+    workers.length > 0 &&
+    workers.every(
+      (worker) => worker.version === installedVersion && Boolean(worker.cloudflareVersionId)
+    )
+  );
+}
+
+export async function finalizeDeferredInstalledControlReleaseRollout(input: {
+  controlDatabaseId: string;
+  environmentId: string;
+  rollout: ReleaseRolloutHandoffStatus | null;
+  getStatus?: typeof getReleaseRolloutHandoffStatus;
+  beginVerification?: typeof beginReleaseRolloutVerification;
+  complete?: typeof completeReleaseRolloutHandoff;
+}): Promise<void> {
+  if (!input.rollout) return;
+  const getStatus = input.getStatus ?? getReleaseRolloutHandoffStatus;
+  const beginVerification = input.beginVerification ?? beginReleaseRolloutVerification;
+  const complete = input.complete ?? completeReleaseRolloutHandoff;
+  let current = await getStatus({
+    controlDatabaseId: input.controlDatabaseId,
+    environmentId: input.environmentId,
+    operationId: input.rollout.operationId,
+  });
+  if (
+    current.operationId !== input.rollout.operationId ||
+    current.targetVersion !== input.rollout.targetVersion ||
+    current.manifestDigest !== input.rollout.manifestDigest
+  ) {
+    throw new Error('release_rollout_deferred_identity_mismatch');
+  }
+  if (current.phase === 'completed') {
+    if (current.completedTargets !== current.totalTargets || current.lastErrorCode !== null) {
+      throw new Error('release_rollout_deferred_completed_state_inconsistent');
+    }
+    return;
+  }
+  if (
+    current.completedTargets !== current.totalTargets ||
+    current.lastErrorCode !== null ||
+    (current.phase !== 'awaiting_setup' && current.phase !== 'verifying')
+  ) {
+    throw new Error(`release_rollout_deferred_completion_not_ready:${current.phase}`);
+  }
+  if (current.phase === 'awaiting_setup') {
+    current = await beginVerification({
+      controlDatabaseId: input.controlDatabaseId,
+      environmentId: input.environmentId,
+      operationId: input.rollout.operationId,
+      actorId: 'setup:update',
+    });
+  }
+  if (current.phase !== 'verifying') {
+    throw new Error(`release_rollout_deferred_verification_conflict:${current.phase}`);
+  }
+  const completed = await complete({
+    controlDatabaseId: input.controlDatabaseId,
+    environmentId: input.environmentId,
+    operationId: input.rollout.operationId,
+    actorId: 'setup:update',
+  });
+  if (completed.phase !== 'completed') {
+    throw new Error(`release_rollout_deferred_completion_conflict:${completed.phase}`);
+  }
 }
 
 // =============================================================================
@@ -1260,12 +1365,20 @@ export async function updateCommand(options: UpdateCommandOptions): Promise<void
     environmentId: env,
     targetVersion: productVersion,
     manifestChecksum,
+    deferVerifiedInstalledRolloutCompletion: controlManagedStreamIds.length === 0,
   });
   workingLock = recoveredRollout.lock;
   if (recoveredRollout.activeRollout) {
     console.log(
       chalk.yellow(
         `  Recovered active Control release rollout ${recoveredRollout.activeRollout.operationId} (${recoveredRollout.activeRollout.phase}).`
+      )
+    );
+  }
+  if (recoveredRollout.installedRolloutToFinalize) {
+    console.log(
+      chalk.yellow(
+        `  Preserving verified ${recoveredRollout.installedRolloutToFinalize.targetVersion} Control rollout ${recoveredRollout.installedRolloutToFinalize.operationId} until the new Worker release is verified.`
       )
     );
   }
@@ -1706,6 +1819,11 @@ export async function updateCommand(options: UpdateCommandOptions): Promise<void
           controlDatabaseId: controlDatabase.id,
           environmentId: env,
           operationId: workingLock.releaseUpdate?.controlOperationId,
+        });
+        await finalizeDeferredInstalledControlReleaseRollout({
+          controlDatabaseId: controlDatabase.id,
+          environmentId: env,
+          rollout: recoveredRollout.installedRolloutToFinalize,
         });
       }
       workingLock = withReleaseUpdateState(workingLock, {
@@ -2182,6 +2300,11 @@ export async function updateCommand(options: UpdateCommandOptions): Promise<void
           controlDatabaseId: controlDatabase.id,
           environmentId: env,
           operationId: workingLock.releaseUpdate?.controlOperationId,
+        });
+        await finalizeDeferredInstalledControlReleaseRollout({
+          controlDatabaseId: controlDatabase.id,
+          environmentId: env,
+          rollout: recoveredRollout.installedRolloutToFinalize,
         });
       }
       workingLock = withReleaseUpdateState(workingLock, {


### PR DESCRIPTION
## Summary

- detect a fully migrated Control rollout for the already verified installed version during a newer Worker-only update
- preserve the existing mutation fence until the new Worker and UI deployments pass visibility and HTTP verification
- finalize the prior rollout only after revalidating its immutable operation identity, target counts, phase, and error state
- keep mismatched, incomplete, blocked, or schema-changing transitions fail-closed

## Regression coverage

- verified installed-version rollout deferral
- missing deployment evidence, incomplete target progress, and unsafe phase rejection
- ordered awaiting-setup to verifying to completed transition
- inconsistent completed-state rejection

## Validation

- `pnpm --filter @authrim/setup exec vitest run src/__tests__/update-release-orchestration.test.ts src/__tests__/release-rollout-handoff.test.ts`
- `pnpm --filter @authrim/setup typecheck`
- `pnpm --filter @authrim/setup lint`
- `pnpm exec prettier --check packages/setup/src/cli/commands/update.ts packages/setup/src/__tests__/update-release-orchestration.test.ts`
- `pnpm --filter @authrim/setup exec vitest run src/__tests__/semantic-baseline-migrations.test.ts` (with Docker access)

## Release impact

- no migration, release manifest, checksum, or package version changes
- fixes the develop deployment failure `release_rollout_active_target_mismatch:0.4.0:0.4.1`
