### PR TITLE
Fix existing Worker detection during Setup updates

### DIFF
--- a/packages/setup/src/__tests__/deploy.test.ts
+++ b/packages/setup/src/__tests__/deploy.test.ts
@@ -28,6 +28,7 @@ import {
   nodeVersionSatisfiesEngine,
   reconcileWorkerCronTriggers,
   resolveExistingWorkerComponents,
+  resolveMissingUiWorkerBindingTargets,
   updateLockWithDeployments,
   type DeployOptions,
   type WorkerDeploymentLeaseCoordinator,
@@ -1817,6 +1818,149 @@ describe('resolveExistingWorkerComponents', () => {
     await expect(
       resolveExistingWorkerComponents({ env: 'test', rootDir }, ['ar-auth'])
     ).rejects.toThrow('401 authentication failed');
+  });
+
+  it('uses the dedicated Workers token for inventory without exposing it in arguments', async () => {
+    const rootDir = createTempRoot();
+    const previousWorkersToken = process.env.CLOUDFLARE_WORKERS_API_TOKEN;
+    process.env.CLOUDFLARE_WORKERS_API_TOKEN = 'dedicated-workers-token';
+    vi.mocked(execa).mockResolvedValue({
+      ...successfulCommandResult(),
+      stdout: JSON.stringify([{ id: 'active-auth' }]),
+    } as Awaited<ReturnType<typeof execa>>);
+
+    try {
+      await expect(
+        resolveExistingWorkerComponents({ env: 'test', rootDir }, ['ar-auth'])
+      ).resolves.toEqual(['ar-auth']);
+      const [, args, commandOptions] = vi.mocked(execa).mock.calls[0]!;
+      expect(args).not.toContain('dedicated-workers-token');
+      expect(commandOptions?.env?.CLOUDFLARE_API_TOKEN).toBe('dedicated-workers-token');
+    } finally {
+      if (previousWorkersToken === undefined) delete process.env.CLOUDFLARE_WORKERS_API_TOKEN;
+      else process.env.CLOUDFLARE_WORKERS_API_TOKEN = previousWorkersToken;
+    }
+  });
+
+  it('verifies an exact locked Worker version when deployment inventory is empty', async () => {
+    const rootDir = createTempRoot();
+    const expectedVersionId = '11111111-1111-4111-8111-111111111111';
+    vi.mocked(execa)
+      .mockResolvedValueOnce({
+        ...successfulCommandResult(),
+        stdout: JSON.stringify([]),
+      } as Awaited<ReturnType<typeof execa>>)
+      .mockResolvedValueOnce({
+        ...successfulCommandResult(),
+        stdout: JSON.stringify({ id: expectedVersionId }),
+      } as Awaited<ReturnType<typeof execa>>);
+
+    await expect(
+      resolveExistingWorkerComponents(
+        {
+          env: 'test',
+          rootDir,
+          expectedWorkerVersionIds: { 'ar-auth': expectedVersionId },
+        },
+        ['ar-auth']
+      )
+    ).resolves.toEqual(['ar-auth']);
+    expect(vi.mocked(execa).mock.calls[1]?.[1]).toEqual([
+      'exec',
+      'wrangler',
+      'versions',
+      'view',
+      expectedVersionId,
+      '--name',
+      'test-ar-auth',
+      '--json',
+    ]);
+  });
+
+  it('fails closed when exact locked Worker version verification is malformed or mismatched', async () => {
+    const rootDir = createTempRoot();
+    vi.mocked(execa)
+      .mockResolvedValueOnce({
+        ...successfulCommandResult(),
+        stdout: JSON.stringify([]),
+      } as Awaited<ReturnType<typeof execa>>)
+      .mockResolvedValueOnce({
+        ...successfulCommandResult(),
+        stdout: JSON.stringify({ id: 'different-version' }),
+      } as Awaited<ReturnType<typeof execa>>);
+
+    await expect(
+      resolveExistingWorkerComponents(
+        {
+          env: 'test',
+          rootDir,
+          expectedWorkerVersionIds: {
+            'ar-auth': '11111111-1111-4111-8111-111111111111',
+          },
+        },
+        ['ar-auth']
+      )
+    ).rejects.toThrow('invalid or mismatched version JSON');
+  });
+
+  it('treats an exact locked Worker version as absent only after confirmed not-found readback', async () => {
+    const rootDir = createTempRoot();
+    vi.mocked(execa)
+      .mockResolvedValueOnce({
+        ...successfulCommandResult(),
+        stdout: JSON.stringify([]),
+      } as Awaited<ReturnType<typeof execa>>)
+      .mockResolvedValueOnce({
+        ...successfulCommandResult(),
+        exitCode: 1,
+        stderr: 'Worker version not found [code: 10007]',
+      } as Awaited<ReturnType<typeof execa>>);
+
+    await expect(
+      resolveExistingWorkerComponents(
+        {
+          env: 'test',
+          rootDir,
+          expectedWorkerVersionIds: {
+            'ar-auth': '11111111-1111-4111-8111-111111111111',
+          },
+        },
+        ['ar-auth']
+      )
+    ).resolves.toEqual([]);
+  });
+
+  it('uses exact locked UI versions before deciding placeholder binding targets are missing', async () => {
+    const rootDir = createTempRoot();
+    const loginVersionId = '11111111-1111-4111-8111-111111111111';
+    const adminVersionId = '22222222-2222-4222-8222-222222222222';
+    vi.mocked(execa).mockImplementation(async (_command, args) => {
+      if (args?.includes('deployments')) {
+        return {
+          ...successfulCommandResult(),
+          stdout: JSON.stringify([]),
+        } as Awaited<ReturnType<typeof execa>>;
+      }
+      const expected = args?.[args.indexOf('view') + 1];
+      return {
+        ...successfulCommandResult(),
+        stdout: JSON.stringify({ id: expected }),
+      } as Awaited<ReturnType<typeof execa>>;
+    });
+
+    await expect(
+      resolveMissingUiWorkerBindingTargets(
+        {
+          env: 'test',
+          rootDir,
+          expectedWorkerVersionIds: {
+            'ar-login-ui': loginVersionId,
+            'ar-admin-ui': adminVersionId,
+          },
+        },
+        { loginUi: true, adminUi: true }
+      )
+    ).resolves.toEqual({ loginUi: false, adminUi: false });
   });
 });
 

--- a/packages/setup/src/cli/commands/deploy.ts
+++ b/packages/setup/src/cli/commands/deploy.ts
@@ -2943,6 +2943,12 @@ export async function deployCommand(options: DeployCommandOptions): Promise<void
       existingComponents: CORE_WORKER_COMPONENTS.filter(
         (component) => currentLock.workers?.[component] !== undefined
       ),
+      expectedWorkerVersionIds: Object.fromEntries(
+        Object.entries(currentLock.workers ?? {}).map(([component, worker]) => [
+          component,
+          worker.cloudflareVersionId,
+        ])
+      ),
       secrets: deploymentSecrets,
       automaticProvisioning: automaticProvisioning && pendingControlTokenBootstrap === null,
       cloudflareAccountId: config.cloudflare?.accountId,

--- a/packages/setup/src/cli/commands/update.ts
+++ b/packages/setup/src/cli/commands/update.ts
@@ -2019,6 +2019,12 @@ export async function updateCommand(options: UpdateCommandOptions): Promise<void
       existingComponents: CORE_WORKER_COMPONENTS.filter(
         (component) => workingLock.workers?.[component] !== undefined
       ),
+      expectedWorkerVersionIds: Object.fromEntries(
+        Object.entries(workingLock.workers ?? {}).map(([component, worker]) => [
+          component,
+          worker.cloudflareVersionId,
+        ])
+      ),
       secrets: deploymentSecrets,
       deploymentLease: {
         controlDatabaseId: deploymentControlDatabase.id,

--- a/packages/setup/src/core/deploy.ts
+++ b/packages/setup/src/core/deploy.ts
@@ -281,6 +281,8 @@ export interface DeployOptions {
   deploymentStrategy?: 'auto' | 'direct' | 'staged';
   /** Worker entries already known to exist remotely, normally sourced from authrim.lock. */
   existingComponents?: readonly WorkerComponent[];
+  /** Exact immutable Worker version IDs used to verify an existing deployment when inventory is empty. */
+  expectedWorkerVersionIds?: Readonly<Record<string, string | undefined>>;
   /** Secret values keyed by Wrangler secret name. Only each Worker's allow-list is written. */
   secrets?: Readonly<Record<string, string>>;
   /** Whether ar-control must receive scoped Cloudflare provisioning tokens. */
@@ -3731,43 +3733,84 @@ async function cloudflareWorkerHasActiveDeployment(
   workerName: string,
   cwd: string,
   options: DeployOptions,
-  throttle: DeploymentThrottle
+  throttle: DeploymentThrottle,
+  expectedVersionId?: string
 ): Promise<boolean> {
   return runWithAdaptiveRetry(
     `Checking Worker deployment ${workerName}`,
     options,
     throttle,
     async () => {
+      const workersToken = process.env.CLOUDFLARE_WORKERS_API_TOKEN?.trim();
+      const commandOptions = {
+        cwd,
+        reject: false as const,
+        cancelSignal: options.signal,
+        ...(workersToken ? { env: { CLOUDFLARE_API_TOKEN: workersToken } } : {}),
+      };
       const result = await execa(
         'pnpm',
         ['exec', 'wrangler', 'deployments', 'list', '--name', workerName, '--json'],
-        {
-          cwd,
-          reject: false,
-          cancelSignal: options.signal,
-        }
+        commandOptions
       );
       if (result.exitCode === 0) {
         try {
           const deployments = JSON.parse(String(result.stdout || '[]')) as unknown;
-          return Array.isArray(deployments) && deployments.length > 0;
+          if (!Array.isArray(deployments)) {
+            throw new Error(`Wrangler returned invalid deployment JSON for ${workerName}`);
+          }
+          if (deployments.length > 0) return true;
         } catch {
           throw new Error(`Wrangler returned invalid deployment JSON for ${workerName}`);
         }
+      } else {
+        const errorText = getErrorText({
+          message: String(result.stderr || result.stdout || 'Unknown Wrangler error'),
+          stderr: result.stderr,
+          stdout: result.stdout,
+        });
+        if (!/does not exist|not found|\b10007\b|\b404\b/i.test(errorText)) {
+          const commandError = new Error(errorText) as Error & {
+            stderr?: unknown;
+            stdout?: unknown;
+          };
+          commandError.stderr = result.stderr;
+          commandError.stdout = result.stdout;
+          throw commandError;
+        }
       }
 
-      const errorText = getErrorText({
-        message: String(result.stderr || result.stdout || 'Unknown Wrangler error'),
-        stderr: result.stderr,
-        stdout: result.stdout,
-      });
-      if (/does not exist|not found|\b10007\b|\b404\b/i.test(errorText)) {
-        return false;
+      const expected = expectedVersionId?.trim();
+      if (!expected) return false;
+      const versionResult = await execa(
+        'pnpm',
+        ['exec', 'wrangler', 'versions', 'view', expected, '--name', workerName, '--json'],
+        commandOptions
+      );
+      if (versionResult.exitCode === 0) {
+        try {
+          const version = JSON.parse(String(versionResult.stdout || '{}')) as { id?: unknown };
+          if (version.id !== expected) {
+            throw new Error(`Worker version identity mismatch for ${workerName}`);
+          }
+          return true;
+        } catch {
+          throw new Error(`Wrangler returned invalid or mismatched version JSON for ${workerName}`);
+        }
       }
-      const commandError = new Error(errorText) as Error & { stderr?: unknown; stdout?: unknown };
-      commandError.stderr = result.stderr;
-      commandError.stdout = result.stdout;
-      throw commandError;
+      const versionErrorText = getErrorText({
+        message: String(versionResult.stderr || versionResult.stdout || 'Unknown Wrangler error'),
+        stderr: versionResult.stderr,
+        stdout: versionResult.stdout,
+      });
+      if (/does not exist|not found|\b10007\b|\b404\b/i.test(versionErrorText)) return false;
+      const versionError = new Error(versionErrorText) as Error & {
+        stderr?: unknown;
+        stdout?: unknown;
+      };
+      versionError.stderr = versionResult.stderr;
+      versionError.stdout = versionResult.stdout;
+      throw versionError;
     }
   );
 }
@@ -3788,7 +3831,8 @@ export async function resolveMissingUiWorkerBindingTargets(
           `${options.env}-ar-login-ui`,
           options.rootDir,
           options,
-          throttle
+          throttle,
+          options.expectedWorkerVersionIds?.['ar-login-ui']
         )
       : Promise.resolve(true),
     enabled.adminUi
@@ -3796,7 +3840,8 @@ export async function resolveMissingUiWorkerBindingTargets(
           `${options.env}-ar-admin-ui`,
           options.rootDir,
           options,
-          throttle
+          throttle,
+          options.expectedWorkerVersionIds?.['ar-admin-ui']
         )
       : Promise.resolve(true),
   ]);
@@ -3818,7 +3863,8 @@ export async function resolveExistingWorkerComponents(
       getWorkerName(options.env, component),
       join(options.rootDir, 'packages', component),
       options,
-      throttle
+      throttle,
+      options.expectedWorkerVersionIds?.[component]
     ),
   }));
   return components.filter((component) => results.get(component)?.exists === true);

--- a/packages/setup/src/index.ts
+++ b/packages/setup/src/index.ts
@@ -714,6 +714,12 @@ program
             existingComponents: WORKER_COMPONENTS.filter(
               (component) => upgradeLock?.workers?.[component] !== undefined
             ),
+            expectedWorkerVersionIds: Object.fromEntries(
+              Object.entries(upgradeLock?.workers ?? {}).map(([component, worker]) => [
+                component,
+                worker.cloudflareVersionId,
+              ])
+            ),
             secrets,
             cleanupLegacyStaticSecrets: true,
             deployConfigLockProof: deployConfigLock?.proof,

--- a/packages/setup/src/web/api.ts
+++ b/packages/setup/src/web/api.ts
@@ -3141,6 +3141,12 @@ export function createApiRoutes(): Hono {
           existingComponents: WORKER_COMPONENTS.filter(
             (component) => lock.workers?.[component] !== undefined
           ),
+          expectedWorkerVersionIds: Object.fromEntries(
+            Object.entries(lock.workers ?? {}).map(([component, worker]) => [
+              component,
+              worker.cloudflareVersionId,
+            ])
+          ),
           cleanupLegacyStaticSecrets: true,
           deployConfigLockProof: deployConfigLock.proof,
           onProgress: addProgress,
@@ -3443,6 +3449,12 @@ export function createApiRoutes(): Hono {
           deploymentStrategy: 'auto' as const,
           existingComponents: WORKER_COMPONENTS.filter(
             (component) => lock.workers?.[component] !== undefined
+          ),
+          expectedWorkerVersionIds: Object.fromEntries(
+            Object.entries(lock.workers ?? {}).map(([component, worker]) => [
+              component,
+              worker.cloudflareVersionId,
+            ])
           ),
           deployConfigLockProof: deployConfigLock.proof,
           onProgress: addProgress,
@@ -4624,6 +4636,11 @@ export function createApiRoutes(): Hono {
                 dryRun: false,
                 concurrency: 2,
                 existingComponents: locallyRecordedComponents,
+                expectedWorkerVersionIds: Object.fromEntries(
+                  Object.entries(existingDeploymentLock?.workers ?? {}).map(
+                    ([component, worker]) => [component, worker.cloudflareVersionId]
+                  )
+                ),
                 onProgress: addProgress,
               },
               WORKER_COMPONENTS
@@ -5159,7 +5176,16 @@ export function createApiRoutes(): Hono {
           ? dryRun
             ? enabledUiBindingTargets
             : await resolveMissingUiWorkerBindingTargets(
-                { env, rootDir: resolve(rootDir), onProgress: addProgress },
+                {
+                  env,
+                  rootDir: resolve(rootDir),
+                  expectedWorkerVersionIds: Object.fromEntries(
+                    Object.entries(existingDeploymentLock?.workers ?? {}).map(
+                      ([component, worker]) => [component, worker.cloudflareVersionId]
+                    )
+                  ),
+                  onProgress: addProgress,
+                },
                 enabledUiBindingTargets
               )
           : { loginUi: false, adminUi: false };
@@ -8754,6 +8780,12 @@ export function createApiRoutes(): Hono {
           existingComponents: WORKER_COMPONENTS.filter(
             (component) => lock!.workers?.[component] !== undefined
           ),
+          expectedWorkerVersionIds: Object.fromEntries(
+            Object.entries(lock!.workers ?? {}).map(([component, worker]) => [
+              component,
+              worker.cloudflareVersionId,
+            ])
+          ),
           secrets: deploymentSecrets,
           cleanupLegacyStaticSecrets: true,
           deployConfigLockProof: deployConfigLock.proof,
@@ -8776,7 +8808,12 @@ export function createApiRoutes(): Hono {
           componentsToUpdate.includes('ar-router')
         ) {
           const missingUiBindingTargets = await resolveMissingUiWorkerBindingTargets(
-            { env, rootDir: resolve(rootDir), onProgress: addProgress },
+            {
+              env,
+              rootDir: resolve(rootDir),
+              expectedWorkerVersionIds: workerDeployOptions.expectedWorkerVersionIds,
+              onProgress: addProgress,
+            },
             {
               loginUi: config.components.loginUi ?? true,
               adminUi: config.components.adminUi ?? true,
@@ -9612,6 +9649,12 @@ export function createApiRoutes(): Hono {
             existingComponents: WORKER_COMPONENTS.filter(
               (component) => componentLock?.workers?.[component] !== undefined
             ),
+            expectedWorkerVersionIds: Object.fromEntries(
+              Object.entries(componentLock?.workers ?? {}).map(([component, worker]) => [
+                component,
+                worker.cloudflareVersionId,
+              ])
+            ),
             secrets: deploymentSecrets,
             cleanupLegacyStaticSecrets: true,
             deployConfigLockProof: deployConfigLock?.proof,
@@ -9693,7 +9736,12 @@ export function createApiRoutes(): Hono {
 
           if (!dryRun && componentName === 'ar-router') {
             const missingUiBindingTargets = await resolveMissingUiWorkerBindingTargets(
-              { env, rootDir, onProgress: addProgress },
+              {
+                env,
+                rootDir,
+                expectedWorkerVersionIds: componentDeployOptions.expectedWorkerVersionIds,
+                onProgress: addProgress,
+              },
               {
                 loginUi: cfg?.components?.loginUi ?? true,
                 adminUi: cfg?.components?.adminUi ?? true,


### PR DESCRIPTION
## Summary

- use the dedicated Workers API token for Wrangler Worker inventory without exposing it in command arguments
- verify exact immutable Worker version IDs from the environment lock when deployment inventory is empty
- pass locked Worker identities through CLI, Web Setup, resume, UI binding-target, and focused deployment paths
- fail closed on malformed, mismatched, or unauthorized version readback

## Root cause

The develop deployment supplied the new scoped D1 and Workers tokens, but existing Worker inventory still ran under the generic API token. GitHub Actions consequently classified all existing Workers and both UI Workers as missing, redeployed UI placeholders, and entered the initial Control bootstrap path, which failed with initial_control_bootstrap_config_missing.

## Validation

- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm --filter @authrim/setup test (2,517/2,518 passed in the sandbox; the Docker-backed PostgreSQL test was rerun with Docker access)
- pnpm --filter @authrim/setup exec vitest run src/__tests__/semantic-baseline-migrations.test.ts (14/14 passed)
- focused deployment, Web update, CLI initial deployment, and CI secret-wiring tests (253/253 passed)