### PR TITLE
Preserve Wrangler inventory output in CI

### DIFF
--- a/packages/setup/src/__tests__/cloudflare-r2.test.ts
+++ b/packages/setup/src/__tests__/cloudflare-r2.test.ts
@@ -1832,6 +1832,7 @@ Version(s):  (100%) 22222222-2222-4222-8222-222222222222
       versionId: '22222222-2222-4222-8222-222222222222',
       source: 'Upload',
     });
+    expect(execaMock.mock.calls[0]?.[2]?.env?.WRANGLER_LOG).toBe('log');
   });
 
   it('retries transient Worker deployment inventory failures', async () => {

--- a/packages/setup/src/__tests__/deploy.test.ts
+++ b/packages/setup/src/__tests__/deploy.test.ts
@@ -1820,10 +1820,24 @@ describe('resolveExistingWorkerComponents', () => {
     ).rejects.toThrow('401 authentication failed');
   });
 
+  it('does not treat successful but empty Wrangler inventory output as an absent Worker', async () => {
+    const rootDir = createTempRoot();
+    vi.mocked(execa).mockResolvedValue({
+      ...successfulCommandResult(),
+      stdout: '',
+    } as Awaited<ReturnType<typeof execa>>);
+
+    await expect(
+      resolveExistingWorkerComponents({ env: 'test', rootDir }, ['ar-auth'])
+    ).rejects.toThrow('invalid deployment JSON');
+  });
+
   it('uses the dedicated Workers token for inventory without exposing it in arguments', async () => {
     const rootDir = createTempRoot();
     const previousWorkersToken = process.env.CLOUDFLARE_WORKERS_API_TOKEN;
+    const previousWranglerLog = process.env.WRANGLER_LOG;
     process.env.CLOUDFLARE_WORKERS_API_TOKEN = 'dedicated-workers-token';
+    process.env.WRANGLER_LOG = 'warn';
     vi.mocked(execa).mockResolvedValue({
       ...successfulCommandResult(),
       stdout: JSON.stringify([{ id: 'active-auth' }]),
@@ -1836,9 +1850,12 @@ describe('resolveExistingWorkerComponents', () => {
       const [, args, commandOptions] = vi.mocked(execa).mock.calls[0]!;
       expect(args).not.toContain('dedicated-workers-token');
       expect(commandOptions?.env?.CLOUDFLARE_API_TOKEN).toBe('dedicated-workers-token');
+      expect(commandOptions?.env?.WRANGLER_LOG).toBe('log');
     } finally {
       if (previousWorkersToken === undefined) delete process.env.CLOUDFLARE_WORKERS_API_TOKEN;
       else process.env.CLOUDFLARE_WORKERS_API_TOKEN = previousWorkersToken;
+      if (previousWranglerLog === undefined) delete process.env.WRANGLER_LOG;
+      else process.env.WRANGLER_LOG = previousWranglerLog;
     }
   });
 
@@ -1978,6 +1995,9 @@ describe('deployWorkerGradually', () => {
     vi.mocked(execa).mockImplementation(async (_command, args, options) => {
       const commandArgs = [...(args ?? [])];
       if (commandArgs.includes('deployments') && commandArgs.includes('list')) {
+        if (commandArgs.includes('--json')) {
+          expect(options?.env?.WRANGLER_LOG).toBe('log');
+        }
         return {
           ...successfulCommandResult(),
           stdout: JSON.stringify([

--- a/packages/setup/src/core/cloudflare.ts
+++ b/packages/setup/src/core/cloudflare.ts
@@ -10653,7 +10653,11 @@ export async function getWorkerDeployments(name: string): Promise<WorkerDeployme
   const maxAttempts = process.env.NODE_ENV === 'test' ? 2 : 4;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
-      const { stdout, stderr } = await wrangler(['deployments', 'list', '--name', name]);
+      const { stdout, stderr } = await wrangler(['deployments', 'list', '--name', name], {
+        // This output is parsed below. A process-wide WRANGLER_LOG=warn suppresses successful
+        // Wrangler output entirely, so force the machine-consumer level for this subprocess.
+        env: { WRANGLER_LOG: 'log' },
+      });
 
       // Check if worker doesn't exist
       if (isWorkerInventoryNotFoundError(stderr)) {

--- a/packages/setup/src/core/deploy.ts
+++ b/packages/setup/src/core/deploy.ts
@@ -2456,7 +2456,14 @@ async function readWorkerTrafficSnapshot(
           '--env',
           options.env,
         ],
-        { cwd: context.packageDir, reject: true, cancelSignal: options.signal }
+        {
+          cwd: context.packageDir,
+          reject: true,
+          cancelSignal: options.signal,
+          // Machine-readable Wrangler output is emitted at the `log` level. A process-wide
+          // WRANGLER_LOG=warn (used by CI) otherwise turns a successful response into empty stdout.
+          env: { WRANGLER_LOG: 'log' },
+        }
       )
   );
   const deployments = JSON.parse(String(deploymentsResult.stdout)) as WranglerDeploymentListItem[];
@@ -3746,7 +3753,11 @@ async function cloudflareWorkerHasActiveDeployment(
         cwd,
         reject: false as const,
         cancelSignal: options.signal,
-        ...(workersToken ? { env: { CLOUDFLARE_API_TOKEN: workersToken } } : {}),
+        env: {
+          // Keep --json machine-readable even when the parent process reduces Wrangler logging.
+          WRANGLER_LOG: 'log',
+          ...(workersToken ? { CLOUDFLARE_API_TOKEN: workersToken } : {}),
+        },
       };
       const result = await execa(
         'pnpm',
@@ -3755,7 +3766,7 @@ async function cloudflareWorkerHasActiveDeployment(
       );
       if (result.exitCode === 0) {
         try {
-          const deployments = JSON.parse(String(result.stdout || '[]')) as unknown;
+          const deployments = JSON.parse(String(result.stdout)) as unknown;
           if (!Array.isArray(deployments)) {
             throw new Error(`Wrangler returned invalid deployment JSON for ${workerName}`);
           }
@@ -3789,7 +3800,7 @@ async function cloudflareWorkerHasActiveDeployment(
       );
       if (versionResult.exitCode === 0) {
         try {
-          const version = JSON.parse(String(versionResult.stdout || '{}')) as { id?: unknown };
+          const version = JSON.parse(String(versionResult.stdout)) as { id?: unknown };
           if (version.id !== expected) {
             throw new Error(`Worker version identity mismatch for ${workerName}`);
           }


### PR DESCRIPTION
## Summary

- force the Wrangler log level required for parsed deployment and version output
- cover existing Worker detection, staged traffic snapshots, and readiness deployment readback
- reject successful commands with empty inventory output instead of treating them as absent resources
- add regression coverage for the GitHub Actions WRANGLER_LOG=warn environment

## Root cause

Wrangler emits its JSON and deployment-list output through the log channel. The deployment workflow sets WRANGLER_LOG=warn, which allowed Wrangler to exit successfully while returning empty stdout. Existing Worker detection interpreted the empty deployment list as no Worker, then exact-version verification interpreted its empty output as malformed JSON.

## Validation

- pnpm exec vitest run packages/setup/src/__tests__/deploy.test.ts packages/setup/src/__tests__/cloudflare-r2.test.ts packages/setup/src/__tests__/worker-readiness.test.ts
- pnpm --filter @authrim/setup typecheck
- pnpm --filter @authrim/setup lint
- Prettier checks for all changed files
- reproduced the failure mode with WRANGLER_LOG=warn and verified WRANGLER_LOG=log returns the exact version JSON
