### PR TITLE
fix(management): persist guest deletion audit retries

### DIFF
--- a/migrations/core/d1/004_guest_deletion_audit_outbox.sql
+++ b/migrations/core/d1/004_guest_deletion_audit_outbox.sql
@@ -1,0 +1,26 @@
+-- Durable reconciliation for guest deletion completion audits.
+-- No account foreign key: the task must survive account deletion.
+CREATE TABLE guest_deletion_audit_outbox (
+  audit_id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  operation_id TEXT NOT NULL,
+  actor_user_id TEXT NOT NULL,
+  ip_address TEXT NOT NULL,
+  user_agent TEXT NOT NULL,
+  metadata_json TEXT NOT NULL CHECK (json_valid(metadata_json) AND length(metadata_json) <= 4096),
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'retry', 'succeeded')),
+  attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+  next_attempt_at INTEGER NOT NULL,
+  last_error_code TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  succeeded_at INTEGER,
+  UNIQUE (tenant_id, operation_id),
+  CHECK ((status = 'succeeded' AND succeeded_at IS NOT NULL) OR
+         (status <> 'succeeded' AND succeeded_at IS NULL))
+);
+
+CREATE INDEX idx_guest_deletion_audit_outbox_due
+  ON guest_deletion_audit_outbox (tenant_id, status, next_attempt_at, created_at);

--- a/migrations/core/postgresql/004_guest_deletion_audit_outbox.sql
+++ b/migrations/core/postgresql/004_guest_deletion_audit_outbox.sql
@@ -1,0 +1,26 @@
+-- Durable reconciliation for guest deletion completion audits.
+-- No account foreign key: the task must survive account deletion.
+CREATE TABLE guest_deletion_audit_outbox (
+  audit_id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  operation_id TEXT NOT NULL,
+  actor_user_id TEXT NOT NULL,
+  ip_address TEXT NOT NULL,
+  user_agent TEXT NOT NULL,
+  metadata_json TEXT NOT NULL CHECK (length(metadata_json) <= 4096),
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'retry', 'succeeded')),
+  attempt_count BIGINT NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+  next_attempt_at BIGINT NOT NULL,
+  last_error_code TEXT,
+  created_at BIGINT NOT NULL,
+  updated_at BIGINT NOT NULL,
+  succeeded_at BIGINT,
+  UNIQUE (tenant_id, operation_id),
+  CHECK ((status = 'succeeded' AND succeeded_at IS NOT NULL) OR
+         (status <> 'succeeded' AND succeeded_at IS NULL))
+);
+
+CREATE INDEX idx_guest_deletion_audit_outbox_due
+  ON guest_deletion_audit_outbox (tenant_id, status, next_attempt_at, created_at);

--- a/migrations/release-manifest.draft.json
+++ b/migrations/release-manifest.draft.json
@@ -27,6 +27,10 @@
             {
               "path": "003_account_registration_state.sql",
               "checksum": "6eddca50b137cc1dd45d26109ee1579e672f899fae2a2ba7ebaa7931e54f6dc1"
+            },
+            {
+              "path": "004_guest_deletion_audit_outbox.sql",
+              "checksum": "cf3721b57c9f805be91dcc9c9d91fb9dd00febd3c927bf4554dfeecf4a277ecb"
             }
           ]
         },
@@ -104,6 +108,10 @@
             {
               "path": "003_account_registration_state.sql",
               "checksum": "8e1b46d59e61fd735415868df395b97dc6feac1a454fdcf1d88581c1fd706a4f"
+            },
+            {
+              "path": "004_guest_deletion_audit_outbox.sql",
+              "checksum": "cbd29fa6bbe4b211d6bffff90d645034225a0e21cc9d3546fbd9726a7a99b49b"
             }
           ]
         },
@@ -152,6 +160,10 @@
         {
           "path": "003_account_registration_state.sql",
           "checksum": "6eddca50b137cc1dd45d26109ee1579e672f899fae2a2ba7ebaa7931e54f6dc1"
+        },
+        {
+          "path": "004_guest_deletion_audit_outbox.sql",
+          "checksum": "cf3721b57c9f805be91dcc9c9d91fb9dd00febd3c927bf4554dfeecf4a277ecb"
         }
       ]
     },
@@ -257,6 +269,10 @@
         {
           "path": "003_account_registration_state.sql",
           "checksum": "8e1b46d59e61fd735415868df395b97dc6feac1a454fdcf1d88581c1fd706a4f"
+        },
+        {
+          "path": "004_guest_deletion_audit_outbox.sql",
+          "checksum": "cbd29fa6bbe4b211d6bffff90d645034225a0e21cc9d3546fbd9726a7a99b49b"
         }
       ]
     },

--- a/packages/ar-lib-core/src/repositories/__tests__/guest-lifecycle.test.ts
+++ b/packages/ar-lib-core/src/repositories/__tests__/guest-lifecycle.test.ts
@@ -120,16 +120,28 @@ describe.each(['d1', 'postgresql'])('guest lifecycle conditional SQL (%s schema)
   it('records an explicit administrator deletion independently of retention', async () => {
     await repository.enroll({ ...enrollment, deletionAfterDays: null });
     expect(
-      await repository.beginAdministrativeDeletion('guest-1', 'admin-delete-1', 2000, 2000001)
+      await repository.beginAdministrativeDeletion(
+        'guest-1',
+        'admin-delete-1',
+        2000,
+        '{"schemaVersion":1}',
+        2000001
+      )
     ).toBe(true);
     expect(await repository.get('guest-1')).toMatchObject({
       phase: 'deleting',
       deletion_operation_id: 'admin-delete-1',
+      deletion_route_json: '{"schemaVersion":1}',
       deletion_started_at_ms: 2000001,
     });
-    expect(await repository.beginAdministrativeDeletion('guest-1', 'admin-delete-2', 2001)).toBe(
-      false
-    );
+    expect(
+      await repository.beginAdministrativeDeletion(
+        'guest-1',
+        'admin-delete-2',
+        2001,
+        '{"schemaVersion":1}'
+      )
+    ).toBe(false);
     expect(await repository.completeDeletion('guest-1', 'admin-delete-2', 2002)).toBe(false);
     expect(await repository.completeDeletion('guest-1', 'admin-delete-1', 2002)).toBe(true);
     expect(await repository.get('guest-1')).toMatchObject({

--- a/packages/ar-lib-core/src/repositories/__tests__/guest-lifecycle.test.ts
+++ b/packages/ar-lib-core/src/repositories/__tests__/guest-lifecycle.test.ts
@@ -117,6 +117,28 @@ describe.each(['d1', 'postgresql'])('guest lifecycle conditional SQL (%s schema)
     expect(await repository.beginDeletion('guest-1', 'delete', 999999999)).toBe(false);
   });
 
+  it('records an explicit administrator deletion independently of retention', async () => {
+    await repository.enroll({ ...enrollment, deletionAfterDays: null });
+    expect(
+      await repository.beginAdministrativeDeletion('guest-1', 'admin-delete-1', 2000, 2000001)
+    ).toBe(true);
+    expect(await repository.get('guest-1')).toMatchObject({
+      phase: 'deleting',
+      deletion_operation_id: 'admin-delete-1',
+      deletion_started_at_ms: 2000001,
+    });
+    expect(await repository.beginAdministrativeDeletion('guest-1', 'admin-delete-2', 2001)).toBe(
+      false
+    );
+    expect(await repository.completeDeletion('guest-1', 'admin-delete-2', 2002)).toBe(false);
+    expect(await repository.completeDeletion('guest-1', 'admin-delete-1', 2002)).toBe(true);
+    expect(await repository.get('guest-1')).toMatchObject({
+      phase: 'deleted',
+      deletion_operation_id: 'admin-delete-1',
+      deleted_at: 2002,
+    });
+  });
+
   it('acquires the hold once, rejects deletion during it, and expires at its exact boundary', async () => {
     await repository.enroll(enrollment);
     expect(await repository.acquireHold('guest-1', 87400, 10)).toMatchObject({

--- a/packages/ar-lib-core/src/repositories/guest-lifecycle.ts
+++ b/packages/ar-lib-core/src/repositories/guest-lifecycle.ts
@@ -200,6 +200,29 @@ export class GuestLifecycleRepository {
     return result.rowsAffected === 1;
   }
 
+  /**
+   * Claim an explicit administrator deletion without applying the retention deadline.
+   * The caller must perform its legal-hold check before invoking this transition.
+   */
+  async beginAdministrativeDeletion(
+    userId: string,
+    operationId: string,
+    now: number,
+    startedAtMs = now * 1000
+  ): Promise<boolean> {
+    const result = await this.db.execute(
+      `UPDATE guest_account_lifecycle SET phase = 'deleting', deletion_operation_id = ?,
+        deletion_route_json = NULL, deletion_started_at_ms = ?, revision = revision + 1,
+        updated_at = ?
+       WHERE tenant_id = ? AND user_id = ? AND phase = 'active'
+       AND EXISTS (SELECT 1 FROM identity_accounts
+         WHERE tenant_id = ? AND legacy_user_id = ? AND account_type = 'user'
+           AND registration_state = 'guest' AND deleted_at IS NULL)`,
+      [operationId, startedAtMs, now, this.tenantId, userId, this.tenantId, userId]
+    );
+    return result.rowsAffected === 1;
+  }
+
   async completeDeletion(userId: string, operationId: string, now: number): Promise<boolean> {
     const result = await this.db.execute(
       `UPDATE guest_account_lifecycle SET phase = 'deleted', deleted_at = ?,

--- a/packages/ar-lib-core/src/repositories/guest-lifecycle.ts
+++ b/packages/ar-lib-core/src/repositories/guest-lifecycle.ts
@@ -208,17 +208,19 @@ export class GuestLifecycleRepository {
     userId: string,
     operationId: string,
     now: number,
+    routeJson: string,
     startedAtMs = now * 1000
   ): Promise<boolean> {
+    if (!routeJson) throw new Error('guest_administrative_deletion_route_required');
     const result = await this.db.execute(
       `UPDATE guest_account_lifecycle SET phase = 'deleting', deletion_operation_id = ?,
-        deletion_route_json = NULL, deletion_started_at_ms = ?, revision = revision + 1,
+        deletion_route_json = ?, deletion_started_at_ms = ?, revision = revision + 1,
         updated_at = ?
        WHERE tenant_id = ? AND user_id = ? AND phase = 'active'
        AND EXISTS (SELECT 1 FROM identity_accounts
          WHERE tenant_id = ? AND legacy_user_id = ? AND account_type = 'user'
            AND registration_state = 'guest' AND deleted_at IS NULL)`,
-      [operationId, startedAtMs, now, this.tenantId, userId, this.tenantId, userId]
+      [operationId, routeJson, startedAtMs, now, this.tenantId, userId, this.tenantId, userId]
     );
     return result.rowsAffected === 1;
   }

--- a/packages/ar-lib-core/src/services/audit/__tests__/audit-service-routing.test.ts
+++ b/packages/ar-lib-core/src/services/audit/__tests__/audit-service-routing.test.ts
@@ -152,6 +152,42 @@ describe('AuditService routing', () => {
     );
   });
 
+  it('preserves a supplied event timestamp in primary and fanout records', async () => {
+    const createdAt = 1_779_321_600_123;
+    const auditProfile: AuditProfile = {
+      id: 'audit-profile-1',
+      kind: 'audit',
+      label: 'Primary + Fanout',
+      primary: { type: 'd1', bindingRef: 'DB', dataset: 'event_log' },
+      archive: { type: 'r2', bucketRef: 'DIAGNOSTIC_LOGS', prefix: 'audit/' },
+      sinks: [],
+      archiveFailureMode: 'gate_cleanup',
+      sinkFailureMode: 'retry_until_ttl',
+    };
+    const queue = createMockQueue();
+    const service = new AuditService({
+      coreSource,
+      piiSource,
+      r2Bucket,
+      auditQueue: queue,
+      resolveAuditProfile: vi.fn().mockResolvedValue(auditProfile),
+    });
+
+    await service.logEvent('tenant-a', {
+      createdAt,
+      eventType: 'user.deleted',
+      eventCategory: 'user',
+      result: 'success',
+    });
+
+    expect(queue.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timestamp: createdAt,
+        entries: [expect.objectContaining({ createdAt })],
+      })
+    );
+  });
+
   it('supports archive-only audit profiles by skipping the primary write and queueing fanout', async () => {
     const auditProfile: AuditProfile = {
       id: 'archive-only',

--- a/packages/ar-lib-core/src/services/audit/__tests__/audit-service-routing.test.ts
+++ b/packages/ar-lib-core/src/services/audit/__tests__/audit-service-routing.test.ts
@@ -190,6 +190,49 @@ describe('AuditService routing', () => {
     expect(queue.send).toHaveBeenCalledOnce();
   });
 
+  it('retries gated fanout after the primary insert succeeded but queue delivery failed', async () => {
+    const auditProfile: AuditProfile = {
+      id: 'audit-profile-gated-retry',
+      kind: 'audit',
+      label: 'Gated fanout retry',
+      primary: { type: 'd1', bindingRef: 'DB', dataset: 'event_log' },
+      archive: { type: 'r2', bucketRef: 'DIAGNOSTIC_LOGS', prefix: 'audit/' },
+      sinks: [{ type: 'logpush', destinationRef: 'workers-logpush' }],
+      archiveFailureMode: 'gate_cleanup',
+      sinkFailureMode: 'retry_until_ttl',
+    };
+    const coreAdapter = createMockDatabaseAdapter('core-adapter');
+    vi.mocked(coreAdapter.execute)
+      .mockResolvedValueOnce({ success: true, rowsAffected: 1 })
+      .mockResolvedValueOnce({ success: true, rowsAffected: 0 });
+    const queue = createMockQueue();
+    vi.mocked(queue.send)
+      .mockRejectedValueOnce(new Error('queue unavailable'))
+      .mockResolvedValueOnce(undefined);
+    const service = new AuditService({
+      coreSource: coreAdapter,
+      piiSource,
+      r2Bucket,
+      auditQueue: queue,
+      resolveAuditProfile: vi.fn().mockResolvedValue(auditProfile),
+    });
+    const event = {
+      id: 'stable-gated-event-id',
+      createdAt: 1_725_000_000_000,
+      eventType: 'user.deleted',
+      eventCategory: 'user' as const,
+      result: 'success' as const,
+      requireDurableFanout: true,
+    };
+
+    await expect(service.logEvent('tenant-a', event)).rejects.toThrow('audit_fanout_queue_failed');
+    await expect(service.logEvent('tenant-a', event)).resolves.toBeUndefined();
+
+    expect(coreAdapter.execute).toHaveBeenCalledTimes(2);
+    expect(queue.send).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(queue.send).mock.calls[0][0]).toEqual(vi.mocked(queue.send).mock.calls[1][0]);
+  });
+
   it('preserves a supplied event timestamp in primary and fanout records', async () => {
     const createdAt = 1_779_321_600_123;
     const auditProfile: AuditProfile = {

--- a/packages/ar-lib-core/src/services/audit/__tests__/audit-service-routing.test.ts
+++ b/packages/ar-lib-core/src/services/audit/__tests__/audit-service-routing.test.ts
@@ -152,6 +152,44 @@ describe('AuditService routing', () => {
     );
   });
 
+  it('does not enqueue fanout again when a stable event ID already exists in D1', async () => {
+    const auditProfile: AuditProfile = {
+      id: 'audit-profile-idempotent',
+      kind: 'audit',
+      label: 'Idempotent fanout',
+      primary: { type: 'd1', bindingRef: 'DB', dataset: 'event_log' },
+      archive: { type: 'r2', bucketRef: 'DIAGNOSTIC_LOGS', prefix: 'audit/' },
+      sinks: [{ type: 'logpush', destinationRef: 'workers-logpush' }],
+      archiveFailureMode: 'gate_cleanup',
+      sinkFailureMode: 'retry_until_ttl',
+    };
+    const coreAdapter = createMockDatabaseAdapter('core-adapter');
+    vi.mocked(coreAdapter.execute)
+      .mockResolvedValueOnce({ success: true, rowsAffected: 1 })
+      .mockResolvedValueOnce({ success: true, rowsAffected: 0 });
+    const queue = createMockQueue();
+    const service = new AuditService({
+      coreSource: coreAdapter,
+      piiSource,
+      r2Bucket,
+      auditQueue: queue,
+      resolveAuditProfile: vi.fn().mockResolvedValue(auditProfile),
+    });
+    const event = {
+      id: 'stable-event-id',
+      createdAt: 1_725_000_000_000,
+      eventType: 'user.deleted',
+      eventCategory: 'user' as const,
+      result: 'success' as const,
+    };
+
+    await service.logEvent('tenant-a', event);
+    await service.logEvent('tenant-a', event);
+
+    expect(coreAdapter.execute).toHaveBeenCalledTimes(2);
+    expect(queue.send).toHaveBeenCalledOnce();
+  });
+
   it('preserves a supplied event timestamp in primary and fanout records', async () => {
     const createdAt = 1_779_321_600_123;
     const auditProfile: AuditProfile = {

--- a/packages/ar-lib-core/src/services/audit/__tests__/audit-service-routing.test.ts
+++ b/packages/ar-lib-core/src/services/audit/__tests__/audit-service-routing.test.ts
@@ -163,6 +163,7 @@ describe('AuditService routing', () => {
       sinks: [],
       archiveFailureMode: 'gate_cleanup',
       sinkFailureMode: 'retry_until_ttl',
+      retention: { primaryDays: 3, archiveDays: 30 },
     };
     const queue = createMockQueue();
     const service = new AuditService({
@@ -183,7 +184,12 @@ describe('AuditService routing', () => {
     expect(queue.send).toHaveBeenCalledWith(
       expect.objectContaining({
         timestamp: createdAt,
-        entries: [expect.objectContaining({ createdAt })],
+        entries: [
+          expect.objectContaining({
+            createdAt,
+            retentionUntil: createdAt + 3 * 24 * 60 * 60 * 1000,
+          }),
+        ],
       })
     );
   });

--- a/packages/ar-lib-core/src/services/audit/__tests__/audit-service-routing.test.ts
+++ b/packages/ar-lib-core/src/services/audit/__tests__/audit-service-routing.test.ts
@@ -269,6 +269,37 @@ describe('AuditService routing', () => {
     );
   });
 
+  it('rejects archive-only writes when fanout cannot be queued durably', async () => {
+    const auditProfile: AuditProfile = {
+      id: 'archive-only',
+      kind: 'audit',
+      label: 'Archive Only',
+      primary: null,
+      archive: { type: 'r2', bucketRef: 'DIAGNOSTIC_LOGS', prefix: 'audit/' },
+      sinks: [],
+      archiveFailureMode: 'gate_cleanup',
+      sinkFailureMode: 'best_effort',
+    };
+    const queue = createMockQueue();
+    vi.mocked(queue.send).mockRejectedValueOnce(new Error('queue unavailable'));
+    const service = new AuditService({
+      coreSource,
+      piiSource,
+      r2Bucket,
+      auditQueue: queue,
+      resolveAuditProfile: vi.fn().mockResolvedValue(auditProfile),
+    });
+
+    await expect(
+      service.logEvent('tenant-a', {
+        id: 'stable-archive-only-event',
+        eventType: 'user.deleted',
+        eventCategory: 'user',
+        result: 'success',
+      })
+    ).rejects.toThrow('audit_fanout_queue_failed');
+  });
+
   it('applies runtime delivery-plan overrides for routing fanout and retention', async () => {
     const now = Date.now();
     vi.spyOn(Date, 'now').mockReturnValue(now);

--- a/packages/ar-lib-core/src/services/audit/__tests__/logging-catalog-store.test.ts
+++ b/packages/ar-lib-core/src/services/audit/__tests__/logging-catalog-store.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SqlLogChunkCatalogStore } from '../logging-catalog-store';
+
+function createAdapter() {
+  return {
+    query: vi.fn().mockResolvedValue([]),
+    queryOne: vi.fn(),
+    execute: vi.fn().mockResolvedValue({ rowsAffected: 1 }),
+    transaction: vi.fn(),
+    batch: vi.fn().mockResolvedValue([]),
+    isHealthy: vi.fn().mockResolvedValue({ healthy: true, latencyMs: 1 }),
+    getType: vi.fn().mockReturnValue('mock'),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('SqlLogChunkCatalogStore writer leases', () => {
+  it('persists a pending writer lease and restores it from the catalog row', async () => {
+    const adapter = createAdapter();
+    adapter.queryOne.mockResolvedValue({
+      id: 'obj_stable',
+      tenant_key: 'tk_123',
+      log_type: 'audit',
+      plane: 'archive',
+      surface: null,
+      object_key: 'logs/obj_stable.jsonl.gz',
+      object_kind: 'chunk',
+      status: 'pending',
+      record_count: 1,
+      byte_count: 0,
+      checksum_sha256: null,
+      compression: 'gzip_block',
+      encryption_scope: 'tenant:tk_123:audit:archive',
+      key_version: 1,
+      created_at: 1_700_000_000_000,
+      committed_at: 1_700_000_060_000,
+    });
+    const store = new SqlLogChunkCatalogStore(adapter);
+
+    await expect(
+      store.createPendingObject({
+        id: 'obj_stable',
+        tenantKey: 'tk_123',
+        logType: 'audit',
+        plane: 'archive',
+        objectKey: 'logs/obj_stable.jsonl.gz',
+        objectKind: 'chunk',
+        status: 'pending',
+        recordCount: 1,
+        byteCount: 0,
+        compression: 'gzip_block',
+        encryptionScope: 'tenant:tk_123:audit:archive',
+        keyVersion: 1,
+        createdAt: 1_700_000_000_000,
+        claimLeaseUntil: 1_700_000_060_000,
+      })
+    ).resolves.toBe(true);
+    expect((adapter.execute.mock.calls[0]?.[1] as unknown[])[15]).toBe(1_700_000_060_000);
+    await expect(store.getObject('obj_stable')).resolves.toEqual(
+      expect.objectContaining({
+        status: 'pending',
+        claimLeaseUntil: 1_700_000_060_000,
+        committedAt: undefined,
+      })
+    );
+  });
+
+  it('atomically reclaims only an expired pending writer lease', async () => {
+    const adapter = createAdapter();
+    const store = new SqlLogChunkCatalogStore(adapter);
+
+    await expect(
+      store.reclaimExpiredPendingObject('obj_stable', 1_700_000_060_001, 1_700_000_120_001)
+    ).resolves.toBe(true);
+    expect(adapter.execute).toHaveBeenCalledWith(
+      expect.stringContaining('(committed_at IS NULL OR committed_at <= ?)'),
+      [1_700_000_120_001, 'obj_stable', 1_700_000_060_001]
+    );
+  });
+});

--- a/packages/ar-lib-core/src/services/audit/__tests__/operational-logs.test.ts
+++ b/packages/ar-lib-core/src/services/audit/__tests__/operational-logs.test.ts
@@ -141,6 +141,14 @@ describe('operational-logs', () => {
         });
         return { rowsAffected: 1 };
       }
+      if (
+        sql.includes('INSERT INTO log_object_catalog') ||
+        sql.includes('INSERT INTO log_chunk_record_index') ||
+        sql.includes('UPDATE log_object_catalog') ||
+        sql.includes('UPDATE log_chunk_record_index')
+      ) {
+        return { rowsAffected: 1 };
+      }
       return { rowsAffected: 0 };
     }),
     queryOne: vi.fn(async (sql: string, params: unknown[]) => {

--- a/packages/ar-lib-core/src/services/audit/__tests__/queue-consumer-delivery-payload.test.ts
+++ b/packages/ar-lib-core/src/services/audit/__tests__/queue-consumer-delivery-payload.test.ts
@@ -723,18 +723,86 @@ describe('logging delivery queue consumer', () => {
       })
     );
     expect(adminDb.execute).toHaveBeenCalledWith(
-      expect.stringContaining('INSERT INTO logging_delivery_events'),
-      expect.arrayContaining([
-        'tk_123',
-        'dest_1',
-        'operational',
-        'external_sink',
-        'critical',
-        'delivered',
-      ])
+      expect.stringContaining("SET status = 'delivered'"),
+      expect.arrayContaining([1])
     );
     expect(message.ack).toHaveBeenCalledOnce();
     expect(message.retry).not.toHaveBeenCalled();
+  });
+
+  it('claims a stable HTTP batch delivery before POST and skips duplicate queue messages', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 202,
+      headers: { get: vi.fn().mockReturnValue(null) },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const bucket = {
+      get: vi.fn().mockResolvedValue(
+        await createEncryptedArchivePayloadObject('payloads/batch_dedup.json', 'tk_123', {
+          records: [{ id: 'evt_1' }],
+        })
+      ),
+      delete: vi.fn().mockResolvedValue(undefined),
+    } as unknown as R2Bucket;
+    const adminDb = createAdminDbAdapter();
+    const deliveryClaims = new Map<string, string>();
+    adminDb.execute.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      if (sql.includes('INSERT INTO logging_delivery_events')) {
+        const id = String(params[0]);
+        if (deliveryClaims.has(id)) return { rowsAffected: 0 };
+        deliveryClaims.set(id, 'retrying');
+        return { rowsAffected: 1 };
+      }
+      if (sql.includes('UPDATE logging_delivery_events')) {
+        const id = String(params[4] ?? params[10] ?? params[1]);
+        if (sql.includes("SET status = 'delivered'") && deliveryClaims.get(id) === 'retrying') {
+          deliveryClaims.set(id, 'delivered');
+          return { rowsAffected: 1 };
+        }
+        return { rowsAffected: 0 };
+      }
+      return { rowsAffected: 1 };
+    });
+    const payload = {
+      payload_type: 'http_sink_batch',
+      schema_version: 1,
+      payload_id: 'qpl_dedup_1',
+      tenant_key: 'tk_123',
+      lane: 'critical',
+      created_at: 1779148800000,
+      destination_id: 'dest_1',
+      endpoint_url: 'https://collector.example/logs',
+      log_type: 'operational',
+      plane: 'external_sink',
+      batch_id: 'batch_dedup',
+      record_count: 1,
+      body_object_ref: 'r2://payloads/batch_dedup.json',
+    };
+    const messages = [createMessage(payload), createMessage(payload)];
+
+    await processLoggingDeliveryQueue(
+      { messages, queue: 'LOGGING_DELIVERY_QUEUE' } as unknown as MessageBatch<unknown>,
+      {
+        DB: {} as D1Database,
+        DB_PII: {} as D1Database,
+        DB_ADMIN: adminDb,
+        AUDIT_ARCHIVE: bucket,
+        OBJECT_ENCRYPTION_ROOT_KEY: ROOT_KEY,
+      }
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(bucket.get).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://collector.example/logs',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-Authrim-Delivery': 'qpl_dedup_1' }),
+      })
+    );
+    for (const message of messages) {
+      expect(message.ack).toHaveBeenCalledOnce();
+      expect(message.retry).not.toHaveBeenCalled();
+    }
   });
 
   it('rejects oversized HTTP sink body objects before reading R2 text', async () => {
@@ -832,8 +900,8 @@ describe('logging delivery queue consumer', () => {
       })
     );
     expect(adminDb.execute).toHaveBeenCalledWith(
-      expect.stringContaining('INSERT INTO logging_delivery_events'),
-      expect.arrayContaining(['delivered'])
+      expect.stringContaining("SET status = 'delivered'"),
+      expect.any(Array)
     );
     expect(JSON.stringify(adminDb.execute.mock.calls)).not.toContain('runtime-token');
     expect(message.ack).toHaveBeenCalledOnce();
@@ -898,10 +966,10 @@ describe('logging delivery queue consumer', () => {
       })
     );
     expect(JSON.stringify(adminDb.execute.mock.calls)).not.toContain('runtime-hmac-secret');
-    const eventInsert = adminDb.execute.mock.calls.find(([sql]) =>
-      String(sql).includes('INSERT INTO logging_delivery_events')
+    const eventCompletion = adminDb.execute.mock.calls.find(([sql]) =>
+      String(sql).includes("SET status = 'delivered'")
     );
-    const metadata = JSON.parse((eventInsert?.[1] as unknown[])[13] as string) as {
+    const metadata = JSON.parse((eventCompletion?.[1] as unknown[])[3] as string) as {
       redacted_headers: Record<string, string>;
     };
     expect(metadata.redacted_headers['X-Authrim-Signature-256']).toBe('[redacted]');
@@ -961,10 +1029,10 @@ describe('logging delivery queue consumer', () => {
         }),
       })
     );
-    const eventInsert = adminDb.execute.mock.calls.find(([sql]) =>
-      String(sql).includes('INSERT INTO logging_delivery_events')
+    const eventCompletion = adminDb.execute.mock.calls.find(([sql]) =>
+      String(sql).includes("SET status = 'delivered'")
     );
-    const metadata = JSON.parse((eventInsert?.[1] as unknown[])[13] as string) as {
+    const metadata = JSON.parse((eventCompletion?.[1] as unknown[])[3] as string) as {
       redacted_headers: Record<string, string>;
     };
     expect(metadata.redacted_headers['X-Webhook-Signature']).toBe('[redacted]');
@@ -1014,18 +1082,8 @@ describe('logging delivery queue consumer', () => {
       })
     );
     expect(adminDb.execute).toHaveBeenCalledWith(
-      expect.stringContaining('INSERT INTO logging_delivery_events'),
-      expect.arrayContaining([
-        'tk_123',
-        'dest_1',
-        'audit',
-        'external_sink',
-        'critical',
-        'delivered',
-        1,
-        null,
-        'chk_1',
-      ])
+      expect.stringContaining("SET status = 'delivered'"),
+      expect.arrayContaining([1, 'chk_1'])
     );
     expect(message.ack).toHaveBeenCalledOnce();
     expect(message.retry).not.toHaveBeenCalled();
@@ -1164,8 +1222,8 @@ describe('logging delivery queue consumer', () => {
       }
     );
 
-    const eventCall = adminDb.execute.mock.calls.find(([sql]) =>
-      String(sql).includes('INSERT INTO logging_delivery_events')
+    const eventCall = adminDb.execute.mock.calls.find(([, params]) =>
+      (params as unknown[] | undefined)?.includes('http_sink_delivery_failed')
     );
     expect(eventCall?.[1]).toEqual(
       expect.arrayContaining([

--- a/packages/ar-lib-core/src/services/audit/__tests__/queue-consumer-fanout.test.ts
+++ b/packages/ar-lib-core/src/services/audit/__tests__/queue-consumer-fanout.test.ts
@@ -126,6 +126,24 @@ describe('audit queue consumer fanout', () => {
       ...createAdminDbAdapter(),
       queryOne: vi.fn().mockResolvedValue({ tenant_key: 't_registry_archive' }),
     };
+    const deliveryEventIds = new Set<string>();
+    const adminDb = {
+      ...createAdminDbAdapter(),
+      execute: vi.fn().mockImplementation(async (sql: string, params: unknown[] = []) => {
+        if (sql.includes('INSERT INTO logging_delivery_events')) {
+          const id = String(params[0]);
+          if (deliveryEventIds.has(id)) {
+            return { rowsAffected: 0 };
+          }
+          deliveryEventIds.add(id);
+          return { rowsAffected: 1 };
+        }
+        if (sql.includes('SET tenant_key =')) {
+          return { rowsAffected: 0 };
+        }
+        return { rowsAffected: 1 };
+      }),
+    };
     const body: AuditQueueMessage = {
       type: 'event_log',
       tenantId: 'tenant-registry-a',
@@ -158,6 +176,7 @@ describe('audit queue consumer fanout', () => {
       {
         DB: coreDb,
         DB_PII: {} as D1Database,
+        DB_ADMIN: adminDb,
         AUDIT_ARCHIVE: bucket,
         OBJECT_ENCRYPTION_ROOT_KEY: ROOT_KEY,
       } as unknown as Parameters<typeof processAuditQueue>[1]
@@ -170,6 +189,7 @@ describe('audit queue consumer fanout', () => {
       {
         DB: coreDb,
         DB_PII: {} as D1Database,
+        DB_ADMIN: adminDb,
         AUDIT_ARCHIVE: bucket,
         OBJECT_ENCRYPTION_ROOT_KEY: ROOT_KEY,
       } as unknown as Parameters<typeof processAuditQueue>[1]
@@ -207,6 +227,11 @@ describe('audit queue consumer fanout', () => {
     expect(consoleLogSpy).toHaveBeenCalledWith(
       expect.stringContaining('"schema":"authrim.audit.v1"')
     );
+    expect(
+      consoleLogSpy.mock.calls.filter(([line]) =>
+        String(line).includes('"schema":"authrim.audit.v1"')
+      )
+    ).toHaveLength(1);
     expect(message.ack).toHaveBeenCalledOnce();
     expect(message.retry).not.toHaveBeenCalled();
     expect(replayedMessage.ack).toHaveBeenCalledOnce();

--- a/packages/ar-lib-core/src/services/audit/__tests__/queue-consumer-fanout.test.ts
+++ b/packages/ar-lib-core/src/services/audit/__tests__/queue-consumer-fanout.test.ts
@@ -126,10 +126,10 @@ describe('audit queue consumer fanout', () => {
       ...createAdminDbAdapter(),
       queryOne: vi.fn().mockResolvedValue({ tenant_key: 't_registry_archive' }),
     };
-    const message = createMessage({
+    const body: AuditQueueMessage = {
       type: 'event_log',
       tenantId: 'tenant-registry-a',
-      timestamp: Date.now(),
+      timestamp: 1_725_000_000_000,
       entries: [
         {
           id: 'evt-1',
@@ -139,7 +139,7 @@ describe('audit queue consumer fanout', () => {
           result: 'success',
           severity: 'info',
           detailsJson: JSON.stringify({ requestHeaders: { authorization: 'Bearer secret' } }),
-          createdAt: Date.now(),
+          createdAt: 1_725_000_000_000,
         },
       ],
       fanout: {
@@ -149,10 +149,24 @@ describe('audit queue consumer fanout', () => {
         archiveFailureMode: 'gate_cleanup',
         sinkFailureMode: 'retry_until_ttl',
       },
-    });
+    };
+    const message = createMessage(body);
+    const replayedMessage = createMessage(body);
 
     await processAuditQueue(
       { messages: [message], queue: 'AUDIT_QUEUE' } as unknown as MessageBatch<AuditQueueMessage>,
+      {
+        DB: coreDb,
+        DB_PII: {} as D1Database,
+        AUDIT_ARCHIVE: bucket,
+        OBJECT_ENCRYPTION_ROOT_KEY: ROOT_KEY,
+      } as unknown as Parameters<typeof processAuditQueue>[1]
+    );
+    await processAuditQueue(
+      {
+        messages: [replayedMessage],
+        queue: 'AUDIT_QUEUE',
+      } as unknown as MessageBatch<AuditQueueMessage>,
       {
         DB: coreDb,
         DB_PII: {} as D1Database,
@@ -167,6 +181,7 @@ describe('audit queue consumer fanout', () => {
     expect(archiveKey).toContain('.jsonl.gz');
     expect(archiveKey).toContain('/t_registry_archive/');
     expect(archiveKey).not.toContain('/tenant-registry-a/');
+    expect((bucket.put as unknown as ReturnType<typeof vi.fn>).mock.calls[1]?.[0]).toBe(archiveKey);
     const archiveBody = (bucket.put as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[1];
     const archiveRecord = await decodeFirstChunkRecord({
       bytes: archiveBody as Uint8Array,
@@ -194,6 +209,8 @@ describe('audit queue consumer fanout', () => {
     );
     expect(message.ack).toHaveBeenCalledOnce();
     expect(message.retry).not.toHaveBeenCalled();
+    expect(replayedMessage.ack).toHaveBeenCalledOnce();
+    expect(replayedMessage.retry).not.toHaveBeenCalled();
   });
 
   it('encrypts audit archive chunks when object encryption root key is configured', async () => {
@@ -295,7 +312,6 @@ describe('audit queue consumer fanout', () => {
         DB_PII: {} as D1Database,
       } as unknown as Parameters<typeof processAuditQueue>[1]
     );
-
     expect(message.retry).toHaveBeenCalledOnce();
     expect(message.ack).not.toHaveBeenCalled();
   });
@@ -562,10 +578,10 @@ describe('audit queue consumer fanout', () => {
     } as unknown as R2Bucket;
     const deliveryQueue = { send: vi.fn().mockResolvedValue(undefined) };
     const adminDb = createAdminDbAdapter();
-    const message = createMessage({
+    const body: AuditQueueMessage = {
       type: 'event_log',
       tenantId: 'tenant-a',
-      timestamp: Date.now(),
+      timestamp: 1_725_000_000_000,
       entries: [
         {
           id: 'evt-1',
@@ -574,7 +590,7 @@ describe('audit queue consumer fanout', () => {
           eventCategory: 'auth',
           result: 'success',
           severity: 'info',
-          createdAt: Date.now(),
+          createdAt: 1_725_000_000_000,
         },
       ],
       fanout: {
@@ -590,10 +606,26 @@ describe('audit queue consumer fanout', () => {
         archiveFailureMode: 'best_effort',
         sinkFailureMode: 'retry_until_ttl',
       },
-    });
+    };
+    const message = createMessage(body);
+    const replayedMessage = createMessage(body);
 
     await processAuditQueue(
       { messages: [message], queue: 'AUDIT_QUEUE' } as unknown as MessageBatch<AuditQueueMessage>,
+      {
+        DB: {} as D1Database,
+        DB_PII: {} as D1Database,
+        DB_ADMIN: adminDb,
+        AUDIT_ARCHIVE: payloadBucket,
+        OBJECT_ENCRYPTION_ROOT_KEY: ROOT_KEY,
+        LOGGING_DELIVERY_QUEUE: deliveryQueue,
+      } as unknown as Parameters<typeof processAuditQueue>[1]
+    );
+    await processAuditQueue(
+      {
+        messages: [replayedMessage],
+        queue: 'AUDIT_QUEUE',
+      } as unknown as MessageBatch<AuditQueueMessage>,
       {
         DB: {} as D1Database,
         DB_PII: {} as D1Database,
@@ -619,6 +651,9 @@ describe('audit queue consumer fanout', () => {
       /^logging-delivery-payloads\/v1\/t_[^/]+\/\d{4}\/\d{2}\/\d{2}\/\d{2}\/qpl_[^/]+\.json$/
     );
     expect(payloadObjectKey).not.toContain('[object Object]');
+    expect((payloadBucket.put as unknown as ReturnType<typeof vi.fn>).mock.calls[1]?.[0]).toBe(
+      payloadObjectKey
+    );
     expect(deliveryQueue.send).toHaveBeenCalledWith(
       expect.objectContaining({
         payload_type: 'http_sink_batch',
@@ -637,6 +672,17 @@ describe('audit queue consumer fanout', () => {
     );
     expect(message.ack).toHaveBeenCalledOnce();
     expect(message.retry).not.toHaveBeenCalled();
+    expect(replayedMessage.ack).toHaveBeenCalledOnce();
+    expect(replayedMessage.retry).not.toHaveBeenCalled();
+    const firstPayload = (deliveryQueue.send as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0];
+    const replayedPayload = (deliveryQueue.send as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[1]?.[0];
+    expect(replayedPayload).toMatchObject({
+      payload_id: firstPayload.payload_id,
+      batch_id: firstPayload.batch_id,
+      body_object_ref: firstPayload.body_object_ref,
+    });
   });
 
   it('retries explicit HTTP admin destinations when no delivery queue is bound', async () => {

--- a/packages/ar-lib-core/src/services/audit/__tests__/queue-consumer-fanout.test.ts
+++ b/packages/ar-lib-core/src/services/audit/__tests__/queue-consumer-fanout.test.ts
@@ -127,9 +127,55 @@ describe('audit queue consumer fanout', () => {
       queryOne: vi.fn().mockResolvedValue({ tenant_key: 't_registry_archive' }),
     };
     const deliveryEventIds = new Set<string>();
+    const catalogObjects = new Map<string, Record<string, unknown>>();
     const adminDb = {
       ...createAdminDbAdapter(),
+      queryOne: vi.fn().mockImplementation(async (sql: string, params: unknown[] = []) => {
+        if (sql.includes('FROM log_object_catalog')) {
+          return catalogObjects.get(String(params[0])) ?? null;
+        }
+        return null;
+      }),
       execute: vi.fn().mockImplementation(async (sql: string, params: unknown[] = []) => {
+        if (sql.includes('INSERT INTO log_object_catalog')) {
+          const id = String(params[0]);
+          if (catalogObjects.has(id)) {
+            return { rowsAffected: 0 };
+          }
+          catalogObjects.set(id, {
+            id,
+            tenant_key: params[1],
+            log_type: params[2],
+            plane: params[3],
+            surface: params[4],
+            object_key: params[5],
+            object_kind: params[6],
+            status: params[7],
+            record_count: params[8],
+            byte_count: params[9],
+            checksum_sha256: params[10],
+            compression: params[11],
+            encryption_scope: params[12],
+            key_version: params[13],
+            created_at: params[14],
+            committed_at: params[15],
+          });
+          return { rowsAffected: 1 };
+        }
+        if (sql.includes("SET status = 'committed'")) {
+          const id = String(params[3]);
+          const row = catalogObjects.get(id);
+          if (row) {
+            catalogObjects.set(id, {
+              ...row,
+              status: 'committed',
+              byte_count: params[0],
+              checksum_sha256: params[1],
+              committed_at: params[2],
+            });
+          }
+          return { rowsAffected: row ? 1 : 0 };
+        }
         if (sql.includes('INSERT INTO logging_delivery_events')) {
           const id = String(params[0]);
           if (deliveryEventIds.has(id)) {
@@ -201,7 +247,7 @@ describe('audit queue consumer fanout', () => {
     expect(archiveKey).toContain('.jsonl.gz');
     expect(archiveKey).toContain('/t_registry_archive/');
     expect(archiveKey).not.toContain('/tenant-registry-a/');
-    expect((bucket.put as unknown as ReturnType<typeof vi.fn>).mock.calls[1]?.[0]).toBe(archiveKey);
+    expect(bucket.put).toHaveBeenCalledOnce();
     const archiveBody = (bucket.put as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[1];
     const archiveRecord = await decodeFirstChunkRecord({
       bytes: archiveBody as Uint8Array,

--- a/packages/ar-lib-core/src/services/audit/__tests__/queue-consumer-fanout.test.ts
+++ b/packages/ar-lib-core/src/services/audit/__tests__/queue-consumer-fanout.test.ts
@@ -238,6 +238,96 @@ describe('audit queue consumer fanout', () => {
     expect(replayedMessage.retry).not.toHaveBeenCalled();
   });
 
+  it('retains the Logpush claim when completion persistence fails after emission', async () => {
+    const coreDb = {
+      ...createAdminDbAdapter(),
+      queryOne: vi.fn().mockResolvedValue({ tenant_key: 't_registry_logpush' }),
+    };
+    const deliveryEventIds = new Set<string>();
+    const adminDb = {
+      ...createAdminDbAdapter(),
+      execute: vi.fn().mockImplementation(async (sql: string, params: unknown[] = []) => {
+        if (sql.includes('INSERT INTO logging_delivery_events')) {
+          const id = String(params[0]);
+          if (deliveryEventIds.has(id)) {
+            return { rowsAffected: 0 };
+          }
+          deliveryEventIds.add(id);
+          return { rowsAffected: 1 };
+        }
+        if (sql.includes("SET status = 'delivered'")) {
+          throw new Error('admin database unavailable');
+        }
+        if (sql.includes('SET tenant_key =')) {
+          return { rowsAffected: 0 };
+        }
+        if (sql.includes('DELETE FROM logging_delivery_events')) {
+          deliveryEventIds.delete(String(params[0]));
+          return { rowsAffected: 1 };
+        }
+        return { rowsAffected: 1 };
+      }),
+    };
+    const body: AuditQueueMessage = {
+      type: 'event_log',
+      tenantId: 'tenant-registry-logpush',
+      timestamp: 1_725_000_000_000,
+      entries: [
+        {
+          id: 'evt-logpush-completion-pending',
+          tenantId: 'tenant-registry-logpush',
+          eventType: 'user.deleted',
+          eventCategory: 'user',
+          result: 'success',
+          severity: 'info',
+          createdAt: 1_725_000_000_000,
+        },
+      ],
+      fanout: {
+        auditProfileId: 'audit-profile-logpush',
+        archives: [],
+        sinks: [{ type: 'logpush', destinationRef: 'workers-logpush' }],
+        archiveFailureMode: 'best_effort',
+        sinkFailureMode: 'retry_until_ttl',
+      },
+    };
+    const message = createMessage(body);
+    const replayedMessage = createMessage(body);
+    const env = {
+      DB: coreDb,
+      DB_PII: {} as D1Database,
+      DB_ADMIN: adminDb,
+    } as unknown as Parameters<typeof processAuditQueue>[1];
+
+    await processAuditQueue(
+      { messages: [message], queue: 'AUDIT_QUEUE' } as unknown as MessageBatch<AuditQueueMessage>,
+      env
+    );
+    await processAuditQueue(
+      {
+        messages: [replayedMessage],
+        queue: 'AUDIT_QUEUE',
+      } as unknown as MessageBatch<AuditQueueMessage>,
+      env
+    );
+
+    expect(
+      consoleLogSpy.mock.calls.filter(([line]) =>
+        String(line).includes('evt-logpush-completion-pending')
+      )
+    ).toHaveLength(1);
+    expect(message.retry).toHaveBeenCalledOnce();
+    expect(replayedMessage.ack).toHaveBeenCalledOnce();
+    expect(adminDb.execute).toHaveBeenCalledWith(
+      expect.stringContaining("error_class = 'delivery_emission_uncertain'"),
+      expect.any(Array)
+    );
+    expect(adminDb.execute).not.toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM logging_delivery_events'),
+      expect.anything()
+    );
+  });
+
   it('encrypts audit archive chunks when object encryption root key is configured', async () => {
     const bucket = {
       put: vi.fn().mockResolvedValue(undefined),

--- a/packages/ar-lib-core/src/services/audit/__tests__/queue-consumer-fanout.test.ts
+++ b/packages/ar-lib-core/src/services/audit/__tests__/queue-consumer-fanout.test.ts
@@ -483,6 +483,7 @@ describe('audit queue consumer fanout', () => {
       status: 200,
     });
     vi.stubGlobal('fetch', fetchMock);
+    const adminDb = createAdminDbAdapter();
 
     const message = createMessage({
       type: 'event_log',
@@ -519,6 +520,7 @@ describe('audit queue consumer fanout', () => {
       {
         DB: {} as D1Database,
         DB_PII: {} as D1Database,
+        DB_ADMIN: adminDb,
       } as unknown as Parameters<typeof processAuditQueue>[1]
     );
 
@@ -543,6 +545,7 @@ describe('audit queue consumer fanout', () => {
       status: 202,
     });
     vi.stubGlobal('fetch', fetchMock);
+    const adminDb = createAdminDbAdapter();
 
     const message = createMessage({
       type: 'event_log',
@@ -579,6 +582,7 @@ describe('audit queue consumer fanout', () => {
       {
         DB: {} as D1Database,
         DB_PII: {} as D1Database,
+        DB_ADMIN: adminDb,
         AUDIT_HTTP_TOKEN: 'sink-secret',
       } as unknown as Parameters<typeof processAuditQueue>[1]
     );
@@ -642,13 +646,95 @@ describe('audit queue consumer fanout', () => {
     );
 
     expect(adminDb.execute).toHaveBeenCalledWith(
-      expect.stringContaining('INSERT INTO logging_delivery_events'),
-      expect.arrayContaining(['audit', 'external_sink', 'critical', 'delivered'])
+      expect.stringContaining("'delivery_in_progress'"),
+      expect.arrayContaining(['audit', 'external_sink', 'critical'])
     );
-    const params = adminDb.execute.mock.calls[0]?.[1] as unknown[];
-    expect(params[13]).toContain('"http_status":200');
+    expect(adminDb.execute).toHaveBeenCalledWith(
+      expect.stringContaining("SET status = 'delivered'"),
+      expect.any(Array)
+    );
+    const completion = adminDb.execute.mock.calls.find(([sql]) =>
+      String(sql).includes("SET status = 'delivered'")
+    );
+    expect(String((completion?.[1] as unknown[])[3])).toContain('"http_status":200');
     expect(message.ack).toHaveBeenCalledOnce();
     expect(message.retry).not.toHaveBeenCalled();
+  });
+
+  it('claims direct HTTP audit delivery before POST and skips a duplicate fanout', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: vi.fn().mockReturnValue(null) },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const adminDb = createAdminDbAdapter();
+    const deliveryClaims = new Map<string, string>();
+    adminDb.execute.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      if (sql.includes('INSERT INTO logging_delivery_events')) {
+        const id = String(params[0]);
+        if (deliveryClaims.has(id)) return { rowsAffected: 0 };
+        deliveryClaims.set(id, 'retrying');
+        return { rowsAffected: 1 };
+      }
+      if (sql.includes("SET status = 'delivered'")) {
+        const id = String(params[4]);
+        if (deliveryClaims.get(id) !== 'retrying') return { rowsAffected: 0 };
+        deliveryClaims.set(id, 'delivered');
+        return { rowsAffected: 1 };
+      }
+      if (sql.includes('UPDATE logging_delivery_events')) {
+        return { rowsAffected: 0 };
+      }
+      return { rowsAffected: 1 };
+    });
+    const body: AuditQueueMessage = {
+      type: 'event_log',
+      tenantId: 'tenant-a',
+      timestamp: 1_725_000_000_000,
+      entries: [
+        {
+          id: 'evt-dedup',
+          tenantId: 'tenant-a',
+          eventType: 'auth.login',
+          eventCategory: 'auth',
+          result: 'success',
+          severity: 'info',
+          createdAt: 1_725_000_000_000,
+        },
+      ],
+      fanout: {
+        auditProfileId: 'audit-profile-http',
+        archives: [],
+        sinks: [{ type: 'http', url: 'https://example.com/audit' }],
+        archiveFailureMode: 'best_effort',
+        sinkFailureMode: 'retry_until_ttl',
+      },
+    };
+    const messages = [createMessage(body), createMessage(body)];
+
+    await processAuditQueue(
+      { messages, queue: 'AUDIT_QUEUE' } as unknown as MessageBatch<AuditQueueMessage>,
+      {
+        DB: {} as D1Database,
+        DB_PII: {} as D1Database,
+        DB_ADMIN: adminDb,
+      } as unknown as Parameters<typeof processAuditQueue>[1]
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/audit',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-Authrim-Delivery': expect.stringMatching(/^tenant-a:/),
+        }),
+      })
+    );
+    for (const message of messages) {
+      expect(message.ack).toHaveBeenCalledOnce();
+      expect(message.retry).not.toHaveBeenCalled();
+    }
   });
 
   it('enqueues committed archive chunks for explicit admin destinations', async () => {

--- a/packages/ar-lib-core/src/services/audit/audit-service.ts
+++ b/packages/ar-lib-core/src/services/audit/audit-service.ts
@@ -470,12 +470,18 @@ export class AuditService implements IAuditService {
           error: sanitizeErrorMessage(String(queueError)),
           tenantId,
         });
+        if (!deliveryPlan.primary) {
+          throw new Error('audit_fanout_queue_failed');
+        }
       }
     } else if (fanout && !this.auditQueue && shouldFanout) {
       this.logger.warn('audit_fanout_skipped_without_queue', {
         tenantId,
         auditProfileId: deliveryPlan.auditProfileId,
       });
+      if (!deliveryPlan.primary) {
+        throw new Error('audit_fanout_queue_unavailable');
+      }
     }
   }
 

--- a/packages/ar-lib-core/src/services/audit/audit-service.ts
+++ b/packages/ar-lib-core/src/services/audit/audit-service.ts
@@ -227,14 +227,13 @@ export class AuditService implements IAuditService {
     tenantId: string,
     plan: AuditDeliveryPlan,
     entry: EventLogEntry
-  ): Promise<void> {
+  ): Promise<boolean> {
     if (!plan.primary) {
-      return;
+      return true;
     }
 
     if (this.isD1PrimaryTarget(plan.primary)) {
-      await this.directInsertEventLog(entry);
-      return;
+      return this.directInsertEventLog(entry);
     }
 
     const adapter = this.resolvePrimaryAdapter
@@ -246,13 +245,14 @@ export class AuditService implements IAuditService {
         targetType: plan.primary.type,
         auditProfileId: plan.auditProfileId,
       });
-      return;
+      return true;
     }
 
     const result = await adapter.writeEventLog(entry);
     if (!result.success) {
       throw new Error(result.errorMessage ?? 'audit_primary_event_write_failed');
     }
+    return result.entriesWritten > 0;
   }
 
   private async writePrimaryPIILog(
@@ -452,11 +452,11 @@ export class AuditService implements IAuditService {
       createdAt,
     };
 
-    await this.writePrimaryEventLog(tenantId, deliveryPlan, entry);
+    const shouldFanout = await this.writePrimaryEventLog(tenantId, deliveryPlan, entry);
 
     const fanout = this.buildFanoutPlan(deliveryPlan);
 
-    if (fanout && this.auditQueue) {
+    if (fanout && this.auditQueue && shouldFanout) {
       try {
         await this.auditQueue.send({
           type: 'event_log',
@@ -471,7 +471,7 @@ export class AuditService implements IAuditService {
           tenantId,
         });
       }
-    } else if (fanout && !this.auditQueue) {
+    } else if (fanout && !this.auditQueue && shouldFanout) {
       this.logger.warn('audit_fanout_skipped_without_queue', {
         tenantId,
         auditProfileId: deliveryPlan.auditProfileId,
@@ -482,8 +482,8 @@ export class AuditService implements IAuditService {
   /**
    * Direct insert to event_log table.
    */
-  private async directInsertEventLog(entry: EventLogEntry): Promise<void> {
-    await this.coreAdapter.execute(
+  private async directInsertEventLog(entry: EventLogEntry): Promise<boolean> {
+    const result = await this.coreAdapter.execute(
       `INSERT INTO event_log (
         id, tenant_id, event_type, event_category, result, severity,
         error_code, error_message, anonymized_user_id, client_id,
@@ -512,6 +512,7 @@ export class AuditService implements IAuditService {
         entry.id,
       ]
     );
+    return result.rowsAffected > 0;
   }
 
   /**

--- a/packages/ar-lib-core/src/services/audit/audit-service.ts
+++ b/packages/ar-lib-core/src/services/audit/audit-service.ts
@@ -455,8 +455,16 @@ export class AuditService implements IAuditService {
     const shouldFanout = await this.writePrimaryEventLog(tenantId, deliveryPlan, entry);
 
     const fanout = this.buildFanoutPlan(deliveryPlan);
+    const hasGatedFanout =
+      (deliveryPlan.archives.length > 0 && deliveryPlan.archiveFailureMode === 'gate_cleanup') ||
+      (deliveryPlan.sinks.length > 0 && deliveryPlan.sinkFailureMode === 'retry_until_ttl');
+    const requiresDurableFanout =
+      !deliveryPlan.primary || (params.requireDurableFanout === true && hasGatedFanout);
+    // A failed durable fanout is replayed with the same event ID. The primary insert then reports
+    // zero rows, so gated delivery must still retry; downstream fanout IDs remain idempotent.
+    const shouldQueueFanout = shouldFanout || requiresDurableFanout;
 
-    if (fanout && this.auditQueue && shouldFanout) {
+    if (fanout && this.auditQueue && shouldQueueFanout) {
       try {
         await this.auditQueue.send({
           type: 'event_log',
@@ -470,16 +478,16 @@ export class AuditService implements IAuditService {
           error: sanitizeErrorMessage(String(queueError)),
           tenantId,
         });
-        if (!deliveryPlan.primary) {
+        if (requiresDurableFanout) {
           throw new Error('audit_fanout_queue_failed');
         }
       }
-    } else if (fanout && !this.auditQueue && shouldFanout) {
+    } else if (fanout && !this.auditQueue && shouldQueueFanout) {
       this.logger.warn('audit_fanout_skipped_without_queue', {
         tenantId,
         auditProfileId: deliveryPlan.auditProfileId,
       });
-      if (!deliveryPlan.primary) {
+      if (requiresDurableFanout) {
         throw new Error('audit_fanout_queue_unavailable');
       }
     }

--- a/packages/ar-lib-core/src/services/audit/audit-service.ts
+++ b/packages/ar-lib-core/src/services/audit/audit-service.ts
@@ -383,7 +383,10 @@ export class AuditService implements IAuditService {
       auditProfile,
     });
     const entryId = params.id ?? crypto.randomUUID();
-    const createdAt = Date.now();
+    const createdAt = params.createdAt ?? Date.now();
+    if (!Number.isSafeInteger(createdAt) || createdAt < 0) {
+      throw new Error('audit_event_created_at_invalid');
+    }
     const retentionUntil = calculateRetentionUntil(
       this.resolveRetentionDays(auditProfile, config, 'event', deliveryPlan.retentionDays)
     );

--- a/packages/ar-lib-core/src/services/audit/audit-service.ts
+++ b/packages/ar-lib-core/src/services/audit/audit-service.ts
@@ -387,8 +387,13 @@ export class AuditService implements IAuditService {
     if (!Number.isSafeInteger(createdAt) || createdAt < 0) {
       throw new Error('audit_event_created_at_invalid');
     }
+    const createdAtDate = new Date(createdAt);
+    if (!Number.isFinite(createdAtDate.getTime())) {
+      throw new Error('audit_event_created_at_invalid');
+    }
     const retentionUntil = calculateRetentionUntil(
-      this.resolveRetentionDays(auditProfile, config, 'event', deliveryPlan.retentionDays)
+      this.resolveRetentionDays(auditProfile, config, 'event', deliveryPlan.retentionDays),
+      createdAtDate
     );
 
     // Sanitize details if provided

--- a/packages/ar-lib-core/src/services/audit/logging-catalog-store.ts
+++ b/packages/ar-lib-core/src/services/audit/logging-catalog-store.ts
@@ -38,8 +38,8 @@ export class SqlLogChunkCatalogStore implements LogChunkCatalogStore {
     this.adapter = ensureDatabaseAdapter(db, 'logging-chunk-catalog');
   }
 
-  async createPendingObject(row: LogObjectCatalogRow): Promise<void> {
-    await this.adapter.execute(
+  async createPendingObject(row: LogObjectCatalogRow): Promise<boolean> {
+    const result = await this.adapter.execute(
       `INSERT INTO log_object_catalog (
         id, tenant_key, log_type, plane, surface, object_key, object_kind, status,
         record_count, byte_count, checksum_sha256, compression, encryption_scope,
@@ -66,6 +66,58 @@ export class SqlLogChunkCatalogStore implements LogChunkCatalogStore {
         null,
       ]
     );
+    // Only an explicit conflict result loses the claim. Some compatible executors do not expose
+    // affected-row metadata, so preserve their historical single-writer behavior.
+    return result.rowsAffected !== 0;
+  }
+
+  async getObject(id: string): Promise<LogObjectCatalogRow | null> {
+    const row = await this.adapter.queryOne<{
+      id: string;
+      tenant_key: string;
+      log_type: LogObjectCatalogRow['logType'];
+      plane: LogObjectCatalogRow['plane'];
+      surface: string | null;
+      object_key: string;
+      object_kind: 'chunk';
+      status: LogObjectCatalogRow['status'];
+      record_count: number | string;
+      byte_count: number | string;
+      checksum_sha256: string | null;
+      compression: LogObjectCatalogRow['compression'];
+      encryption_scope: string | null;
+      key_version: number | string | null;
+      created_at: number | string;
+      committed_at: number | string | null;
+    }>(
+      `SELECT id, tenant_key, log_type, plane, surface, object_key, object_kind, status,
+              record_count, byte_count, checksum_sha256, compression, encryption_scope,
+              key_version, created_at, committed_at
+       FROM log_object_catalog
+       WHERE id = ?`,
+      [id]
+    );
+    if (!row) {
+      return null;
+    }
+    return {
+      id: row.id,
+      tenantKey: row.tenant_key,
+      logType: row.log_type,
+      plane: row.plane,
+      surface: row.surface ?? undefined,
+      objectKey: row.object_key,
+      objectKind: row.object_kind,
+      status: row.status,
+      recordCount: Number(row.record_count),
+      byteCount: Number(row.byte_count),
+      checksumSha256: row.checksum_sha256 ?? undefined,
+      compression: row.compression,
+      encryptionScope: row.encryption_scope ?? undefined,
+      keyVersion: row.key_version === null ? undefined : Number(row.key_version),
+      createdAt: Number(row.created_at),
+      committedAt: row.committed_at === null ? undefined : Number(row.committed_at),
+    };
   }
 
   async createPendingRecordIndexes(rows: LogChunkRecordIndexRow[]): Promise<void> {

--- a/packages/ar-lib-core/src/services/audit/logging-catalog-store.ts
+++ b/packages/ar-lib-core/src/services/audit/logging-catalog-store.ts
@@ -120,6 +120,18 @@ export class SqlLogChunkCatalogStore implements LogChunkCatalogStore {
     };
   }
 
+  async reclaimOrphanObject(id: string): Promise<boolean> {
+    const result = await this.adapter.execute(
+      `UPDATE log_object_catalog
+       SET status = 'pending',
+           checksum_sha256 = NULL,
+           committed_at = NULL
+       WHERE id = ? AND status = 'orphan_candidate'`,
+      [id]
+    );
+    return result.rowsAffected > 0;
+  }
+
   async createPendingRecordIndexes(rows: LogChunkRecordIndexRow[]): Promise<void> {
     if (rows.length === 0) {
       return;
@@ -134,7 +146,21 @@ export class SqlLogChunkCatalogStore implements LogChunkCatalogStore {
           line_number, block_offset, block_length, record_offset, record_length,
           event_at, index_profile, indexed_fields, status, created_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT(tenant_key, log_type, plane, record_id) DO NOTHING`,
+        ON CONFLICT(tenant_key, log_type, plane, record_id) DO UPDATE SET
+          surface = excluded.surface,
+          object_catalog_id = excluded.object_catalog_id,
+          chunk_id = excluded.chunk_id,
+          line_number = excluded.line_number,
+          block_offset = excluded.block_offset,
+          block_length = excluded.block_length,
+          record_offset = excluded.record_offset,
+          record_length = excluded.record_length,
+          event_at = excluded.event_at,
+          index_profile = excluded.index_profile,
+          indexed_fields = excluded.indexed_fields,
+          status = 'pending',
+          created_at = excluded.created_at
+        WHERE log_chunk_record_index.status = 'deleted'`,
           params: [
             row.recordId,
             row.tenantKey,

--- a/packages/ar-lib-core/src/services/audit/logging-catalog-store.ts
+++ b/packages/ar-lib-core/src/services/audit/logging-catalog-store.ts
@@ -62,7 +62,9 @@ export class SqlLogChunkCatalogStore implements LogChunkCatalogStore {
         row.encryptionScope ?? null,
         row.keyVersion ?? null,
         row.createdAt,
-        row.committedAt ?? null,
+        // committed_at is otherwise unused while status=pending, so it carries the bounded
+        // writer lease without requiring a second coordination table or schema transition.
+        row.status === 'pending' ? (row.claimLeaseUntil ?? null) : (row.committedAt ?? null),
         null,
       ]
     );
@@ -116,18 +118,42 @@ export class SqlLogChunkCatalogStore implements LogChunkCatalogStore {
       encryptionScope: row.encryption_scope ?? undefined,
       keyVersion: row.key_version === null ? undefined : Number(row.key_version),
       createdAt: Number(row.created_at),
-      committedAt: row.committed_at === null ? undefined : Number(row.committed_at),
+      committedAt:
+        row.status === 'committed' && row.committed_at !== null
+          ? Number(row.committed_at)
+          : undefined,
+      claimLeaseUntil:
+        // See createPendingObject: for pending rows this column is the writer lease deadline.
+        row.status === 'pending' && row.committed_at !== null
+          ? Number(row.committed_at)
+          : undefined,
     };
   }
 
-  async reclaimOrphanObject(id: string): Promise<boolean> {
+  async reclaimOrphanObject(id: string, claimLeaseUntil: number): Promise<boolean> {
     const result = await this.adapter.execute(
       `UPDATE log_object_catalog
        SET status = 'pending',
            checksum_sha256 = NULL,
-           committed_at = NULL
+           committed_at = ?
        WHERE id = ? AND status = 'orphan_candidate'`,
-      [id]
+      [claimLeaseUntil, id]
+    );
+    return result.rowsAffected > 0;
+  }
+
+  async reclaimExpiredPendingObject(
+    id: string,
+    now: number,
+    claimLeaseUntil: number
+  ): Promise<boolean> {
+    const result = await this.adapter.execute(
+      `UPDATE log_object_catalog
+       SET committed_at = ?
+       WHERE id = ?
+         AND status = 'pending'
+         AND (committed_at IS NULL OR committed_at <= ?)`,
+      [claimLeaseUntil, id, now]
     );
     return result.rowsAffected > 0;
   }

--- a/packages/ar-lib-core/src/services/audit/queue-consumer.ts
+++ b/packages/ar-lib-core/src/services/audit/queue-consumer.ts
@@ -1807,8 +1807,10 @@ async function processFanoutMessage(
       }
     }
 
+    let sinkEmitted = false;
     try {
       await deliverSinkTarget(sink, body, env);
+      sinkEmitted = true;
       if (logpushClaimed && deliveryEventStore) {
         await deliveryEventStore.completeClaim({
           id: deliveredEventId,
@@ -1835,7 +1837,7 @@ async function processFanoutMessage(
         });
       }
     } catch (error) {
-      if (logpushClaimed && deliveryEventStore) {
+      if (logpushClaimed && deliveryEventStore && !sinkEmitted) {
         try {
           await deliveryEventStore.releaseClaim(deliveredEventId);
         } catch (releaseError) {
@@ -1845,6 +1847,20 @@ async function processFanoutMessage(
             error: sanitizeErrorMessage(String(releaseError)),
           });
         }
+      } else if (logpushClaimed && sinkEmitted) {
+        try {
+          await deliveryEventStore?.preserveEmittedClaim(deliveredEventId);
+        } catch (preserveError) {
+          logger.warn('audit_logpush_emitted_claim_preservation_failed', {
+            tenantId: body.tenantId,
+            auditProfileId: fanout.auditProfileId,
+            error: sanitizeErrorMessage(String(preserveError)),
+          });
+        }
+        logger.warn('audit_logpush_delivery_completion_pending', {
+          tenantId: body.tenantId,
+          auditProfileId: fanout.auditProfileId,
+        });
       }
       const status = deliveryStatusForFailure(sinkFailureMode);
       const errorClass = deliveryErrorClass(error, 'sink_delivery_failed');

--- a/packages/ar-lib-core/src/services/audit/queue-consumer.ts
+++ b/packages/ar-lib-core/src/services/audit/queue-consumer.ts
@@ -614,6 +614,7 @@ interface RuntimeCredentialCacheEntry {
 }
 
 const RUNTIME_CREDENTIAL_CACHE_TTL_MS = 60_000;
+const LOGPUSH_DELIVERY_CLAIM_LEASE_MS = 60_000;
 const runtimeCredentialCache = new Map<string, RuntimeCredentialCacheEntry>();
 const tenantKeyCache = new Map<string, string>();
 
@@ -1763,23 +1764,90 @@ async function processFanoutMessage(
       continue;
     }
 
+    const deliveryMetadata = targetMetadata(sink, fanout, body);
+    const deliveredEventId = await createAuditFanoutStableLoggingId(
+      'lde',
+      body,
+      `${stablePurpose}:delivered`
+    );
+    let logpushClaimed = false;
+    if (sink.type === 'logpush') {
+      if (!deliveryEventStore) {
+        if (sinkFailureMode === 'retry_until_ttl') {
+          throw new Error('logging_delivery_claim_store_unavailable');
+        }
+      } else {
+        const claimNow = Date.now();
+        try {
+          logpushClaimed = await deliveryEventStore.claimEvent({
+            id: deliveredEventId,
+            tenantKey,
+            destinationId,
+            logType,
+            plane: 'external_sink',
+            lane,
+            attemptCount,
+            metadata: deliveryMetadata,
+            now: claimNow,
+            leaseUntil: claimNow + LOGPUSH_DELIVERY_CLAIM_LEASE_MS,
+          });
+        } catch (error) {
+          logger.warn('audit_logpush_delivery_claim_failed', {
+            tenantId: body.tenantId,
+            auditProfileId: fanout.auditProfileId,
+            error: sanitizeErrorMessage(String(error)),
+          });
+          if (sinkFailureMode === 'retry_until_ttl') {
+            throw error;
+          }
+        }
+        if (!logpushClaimed) {
+          continue;
+        }
+      }
+    }
+
     try {
       await deliverSinkTarget(sink, body, env);
-      await recordDeliveryEvent(deliveryEventStore, logger, {
-        id: await createAuditFanoutStableLoggingId('lde', body, `${stablePurpose}:delivered`),
-        tenantKey,
-        destinationId,
-        logType,
-        plane: 'external_sink',
-        lane,
-        status: 'delivered',
-        attemptCount,
-        metadata: targetMetadata(sink, fanout, body),
-      });
+      if (logpushClaimed && deliveryEventStore) {
+        await deliveryEventStore.completeClaim({
+          id: deliveredEventId,
+          tenantKey,
+          destinationId,
+          logType,
+          plane: 'external_sink',
+          lane,
+          status: 'delivered',
+          attemptCount,
+          metadata: deliveryMetadata,
+        });
+      } else {
+        await recordDeliveryEvent(deliveryEventStore, logger, {
+          id: deliveredEventId,
+          tenantKey,
+          destinationId,
+          logType,
+          plane: 'external_sink',
+          lane,
+          status: 'delivered',
+          attemptCount,
+          metadata: deliveryMetadata,
+        });
+      }
     } catch (error) {
+      if (logpushClaimed && deliveryEventStore) {
+        try {
+          await deliveryEventStore.releaseClaim(deliveredEventId);
+        } catch (releaseError) {
+          logger.warn('audit_logpush_delivery_claim_release_failed', {
+            tenantId: body.tenantId,
+            auditProfileId: fanout.auditProfileId,
+            error: sanitizeErrorMessage(String(releaseError)),
+          });
+        }
+      }
       const status = deliveryStatusForFailure(sinkFailureMode);
       const errorClass = deliveryErrorClass(error, 'sink_delivery_failed');
-      const metadata = targetMetadata(sink, fanout, body);
       await recordDeliveryEvent(deliveryEventStore, logger, {
         id: await createAuditFanoutStableLoggingId('lde', body, `${stablePurpose}:${status}`),
         tenantKey,
@@ -1790,7 +1858,7 @@ async function processFanoutMessage(
         status,
         attemptCount,
         errorClass,
-        metadata,
+        metadata: deliveryMetadata,
       });
       await recordDeliveryNotification(notificationRepository, logger, {
         id: await createAuditFanoutStableLoggingId(
@@ -1807,7 +1875,7 @@ async function processFanoutMessage(
         status,
         attemptCount,
         errorClass,
-        metadata,
+        metadata: deliveryMetadata,
       });
       if (sinkFailureMode === 'retry_until_ttl') {
         throw error;

--- a/packages/ar-lib-core/src/services/audit/queue-consumer.ts
+++ b/packages/ar-lib-core/src/services/audit/queue-consumer.ts
@@ -138,6 +138,22 @@ async function createAuditFanoutStableLoggingId(
   )}`;
 }
 
+async function createPayloadStableLoggingId(
+  prefix: QueueStableIdPrefix,
+  createdAt: number,
+  purpose: string,
+  payloadId: string
+): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(`${purpose}\u0000${payloadId}`)
+  );
+  return `${prefix}_${createUuidV7(
+    stableTimestamp(createdAt),
+    new Uint8Array(digest).slice(0, 10)
+  )}`;
+}
+
 function getDefaultLoggingDeliveryPayloadBucket(env: AuditQueueConsumerEnv): R2Bucket | null {
   return env.AUDIT_ARCHIVE ?? null;
 }
@@ -614,9 +630,25 @@ interface RuntimeCredentialCacheEntry {
 }
 
 const RUNTIME_CREDENTIAL_CACHE_TTL_MS = 60_000;
-const LOGPUSH_DELIVERY_CLAIM_LEASE_MS = 60_000;
+const DELIVERY_CLAIM_LEASE_MS = 60_000;
 const runtimeCredentialCache = new Map<string, RuntimeCredentialCacheEntry>();
 const tenantKeyCache = new Map<string, string>();
+
+function retryQueueMessage(message: Message<unknown>, error: unknown): void {
+  const retryAt =
+    error &&
+    typeof error === 'object' &&
+    (error as { name?: unknown }).name === 'LogChunkWriteClaimActiveError' &&
+    typeof (error as { retryAt?: unknown }).retryAt === 'number'
+      ? (error as { retryAt: number }).retryAt
+      : null;
+  if (retryAt !== null) {
+    const delaySeconds = Math.max(1, Math.ceil((retryAt - Date.now()) / 1000));
+    message.retry({ delaySeconds });
+    return;
+  }
+  message.retry();
+}
 
 type RuntimeLoggingDeliveryQueueBindingName =
   | 'LOGGING_DELIVERY_CRITICAL_QUEUE'
@@ -693,7 +725,7 @@ export async function processAuditQueue(
       });
 
       // Retry the message (goes to DLQ after max_retries)
-      message.retry();
+      retryQueueMessage(message, error);
     }
   }
 }
@@ -1668,33 +1700,78 @@ async function processFanoutMessage(
         }
         continue;
       }
+      const deliveryMetadata = targetMetadata(sink, fanout, body);
+      const deliveredEventId = await createAuditFanoutStableLoggingId(
+        'lde',
+        body,
+        `${stablePurpose}:delivered`
+      );
+      let deliveryClaimed = false;
+      let deliveryEmitted = false;
       let recordedFailure = false;
       try {
+        if (!deliveryEventStore) {
+          throw new Error('logging_delivery_claim_store_unavailable');
+        }
+        const claimNow = Date.now();
+        deliveryClaimed = await deliveryEventStore.claimEvent({
+          id: deliveredEventId,
+          tenantKey,
+          destinationId,
+          logType,
+          plane: 'external_sink',
+          lane,
+          attemptCount,
+          metadata: deliveryMetadata,
+          now: claimNow,
+          leaseUntil: claimNow + DELIVERY_CLAIM_LEASE_MS,
+        });
+        if (!deliveryClaimed) {
+          continue;
+        }
         const result = await deliverHttpSink(sink, body, env);
         const status: LoggingDeliveryStatus =
           result.status === 'delivered' ? 'delivered' : deliveryStatusForFailure(sinkFailureMode);
         const errorClass =
           result.status === 'delivered' ? null : `http_status_${String(result.httpStatus)}`;
         const metadata = {
-          ...targetMetadata(sink, fanout, body),
+          ...deliveryMetadata,
           http_status: result.httpStatus,
         };
-        await recordDeliveryEvent(deliveryEventStore, logger, {
-          id: await createAuditFanoutStableLoggingId('lde', body, `${stablePurpose}:${status}`),
-          tenantKey,
-          destinationId,
-          logType,
-          plane: 'external_sink',
-          lane,
-          status,
-          attemptCount,
-          errorClass,
-          nextRetryAt:
-            result.status === 'retrying' && result.retryDelayMs
-              ? Date.now() + result.retryDelayMs
-              : null,
-          metadata,
-        });
+        if (result.status === 'delivered') {
+          deliveryEmitted = true;
+          await deliveryEventStore.completeClaim({
+            id: deliveredEventId,
+            tenantKey,
+            destinationId,
+            logType,
+            plane: 'external_sink',
+            lane,
+            status: 'delivered',
+            attemptCount,
+            metadata,
+          });
+          deliveryClaimed = false;
+        } else {
+          await deliveryEventStore.releaseClaim(deliveredEventId);
+          deliveryClaimed = false;
+          await recordDeliveryEvent(deliveryEventStore, logger, {
+            id: await createAuditFanoutStableLoggingId('lde', body, `${stablePurpose}:${status}`),
+            tenantKey,
+            destinationId,
+            logType,
+            plane: 'external_sink',
+            lane,
+            status,
+            attemptCount,
+            errorClass,
+            nextRetryAt:
+              result.status === 'retrying' && result.retryDelayMs
+                ? Date.now() + result.retryDelayMs
+                : null,
+            metadata,
+          });
+        }
         if (result.status !== 'delivered') {
           recordedFailure = true;
           await recordDeliveryNotification(notificationRepository, logger, {
@@ -1717,10 +1794,25 @@ async function processFanoutMessage(
           throw new Error(`HTTP sink delivery ${result.status}: ${result.httpStatus}`);
         }
       } catch (error) {
+        if (deliveryClaimed && deliveryEventStore) {
+          try {
+            if (deliveryEmitted) {
+              await deliveryEventStore.preserveEmittedClaim(deliveredEventId);
+            } else {
+              await deliveryEventStore.releaseClaim(deliveredEventId);
+            }
+          } catch (claimError) {
+            logger.warn('audit_http_delivery_claim_cleanup_failed', {
+              tenantId: body.tenantId,
+              auditProfileId: fanout.auditProfileId,
+              error: sanitizeErrorMessage(String(claimError)),
+            });
+          }
+        }
         if (!recordedFailure) {
           const status = deliveryStatusForFailure(sinkFailureMode);
           const errorClass = deliveryErrorClass(error, 'http_sink_delivery_failed');
-          const metadata = targetMetadata(sink, fanout, body);
+          const metadata = deliveryMetadata;
           await recordDeliveryEvent(deliveryEventStore, logger, {
             id: await createAuditFanoutStableLoggingId('lde', body, `${stablePurpose}:${status}`),
             tenantKey,
@@ -1789,7 +1881,7 @@ async function processFanoutMessage(
             attemptCount,
             metadata: deliveryMetadata,
             now: claimNow,
-            leaseUntil: claimNow + LOGPUSH_DELIVERY_CLAIM_LEASE_MS,
+            leaseUntil: claimNow + DELIVERY_CLAIM_LEASE_MS,
           });
         } catch (error) {
           logger.warn('audit_logpush_delivery_claim_failed', {
@@ -2125,7 +2217,7 @@ export async function processDLQQueue(
         messageId: message.id,
         error: sanitizeErrorMessage(String(error)),
       });
-      message.retry();
+      retryQueueMessage(message, error);
     }
   }
 }
@@ -2941,26 +3033,52 @@ async function processHttpSinkBatchDeliveryPayload(input: {
   const deliveryEventStore = createDeliveryEventStore(env);
   const notificationRepository = createInternalNotificationRepository(env);
   const attemptCount = Math.max(1, message.attempts);
-  const body = await readHttpSinkBatchBody(payload, env);
-  const destination = await loadLoggingDestinationForDelivery(env, payload.destination_id).catch(
-    () => null
+  const deliveredEventId = await createPayloadStableLoggingId(
+    'lde',
+    payload.created_at,
+    `http-sink:${payload.destination_id}`,
+    payload.payload_id
   );
-  const providerConfig = parseJsonObject(destination?.provider_config);
-  const credentialPlaintext = await resolveRuntimeCredentialSecret({
-    env,
-    credentialRef: destination?.credential_ref,
-    credentialVersion: destination?.credential_version,
-  });
-  const auth = buildRuntimeHttpSinkAuth({ providerConfig, credentialPlaintext });
   const metadataBase = {
     payload_id: payload.payload_id,
     batch_id: payload.batch_id,
     record_count: payload.record_count,
-    byte_count: body.byteCount,
-    body_object_ref: body.objectRef,
+    body_object_ref: payload.body_object_ref ?? null,
   };
+  let deliveryClaimed = false;
+  let deliveryEmitted = false;
 
   try {
+    if (!deliveryEventStore) {
+      throw new Error('logging_delivery_claim_store_unavailable');
+    }
+    const claimNow = Date.now();
+    deliveryClaimed = await deliveryEventStore.claimEvent({
+      id: deliveredEventId,
+      tenantKey: payload.tenant_key,
+      destinationId: payload.destination_id,
+      logType: payload.log_type,
+      plane: payload.plane,
+      lane: payload.lane,
+      attemptCount,
+      metadata: metadataBase,
+      now: claimNow,
+      leaseUntil: claimNow + DELIVERY_CLAIM_LEASE_MS,
+    });
+    if (!deliveryClaimed) {
+      return 'ack';
+    }
+    const body = await readHttpSinkBatchBody(payload, env);
+    const destination = await loadLoggingDestinationForDelivery(env, payload.destination_id).catch(
+      () => null
+    );
+    const providerConfig = parseJsonObject(destination?.provider_config);
+    const credentialPlaintext = await resolveRuntimeCredentialSecret({
+      env,
+      credentialRef: destination?.credential_ref,
+      credentialVersion: destination?.credential_version,
+    });
+    const auth = buildRuntimeHttpSinkAuth({ providerConfig, credentialPlaintext });
     const result = await deliverHttpSinkBatch({
       endpointUrl: payload.endpoint_url,
       body: body.body,
@@ -2984,22 +3102,42 @@ async function processHttpSinkBatchDeliveryPayload(input: {
     const errorClass = status === 'delivered' ? null : `http_status_${String(result.httpStatus)}`;
     const metadata = {
       ...metadataBase,
+      byte_count: body.byteCount,
+      body_object_ref: body.objectRef,
       http_status: result.httpStatus,
       redacted_headers: result.redactedHeaders,
     };
-    await recordDeliveryEvent(deliveryEventStore, logger, {
-      tenantKey: payload.tenant_key,
-      destinationId: payload.destination_id,
-      logType: payload.log_type,
-      plane: payload.plane,
-      lane: payload.lane,
-      status,
-      attemptCount,
-      errorClass,
-      nextRetryAt:
-        status === 'retrying' && result.retryDelayMs ? Date.now() + result.retryDelayMs : null,
-      metadata,
-    });
+    if (status === 'delivered') {
+      deliveryEmitted = true;
+      await deliveryEventStore.completeClaim({
+        id: deliveredEventId,
+        tenantKey: payload.tenant_key,
+        destinationId: payload.destination_id,
+        logType: payload.log_type,
+        plane: payload.plane,
+        lane: payload.lane,
+        status: 'delivered',
+        attemptCount,
+        metadata,
+      });
+      deliveryClaimed = false;
+    } else {
+      await deliveryEventStore.releaseClaim(deliveredEventId);
+      deliveryClaimed = false;
+      await recordDeliveryEvent(deliveryEventStore, logger, {
+        tenantKey: payload.tenant_key,
+        destinationId: payload.destination_id,
+        logType: payload.log_type,
+        plane: payload.plane,
+        lane: payload.lane,
+        status,
+        attemptCount,
+        errorClass,
+        nextRetryAt:
+          status === 'retrying' && result.retryDelayMs ? Date.now() + result.retryDelayMs : null,
+        metadata,
+      });
+    }
     if (status !== 'delivered') {
       await recordDeliveryNotification(notificationRepository, logger, {
         tenantId: payload.tenant_key,
@@ -3024,6 +3162,20 @@ async function processHttpSinkBatchDeliveryPayload(input: {
     }
     return status === 'retrying' ? 'retry' : 'ack';
   } catch (error) {
+    if (deliveryClaimed && deliveryEventStore) {
+      try {
+        if (deliveryEmitted) {
+          await deliveryEventStore.preserveEmittedClaim(deliveredEventId);
+        } else {
+          await deliveryEventStore.releaseClaim(deliveredEventId);
+        }
+      } catch (claimError) {
+        logger.warn('logging_http_delivery_claim_cleanup_failed', {
+          payloadId: payload.payload_id,
+          error: sanitizeErrorMessage(String(claimError)),
+        });
+      }
+    }
     const errorClass = deliveryErrorClass(error, 'http_sink_delivery_failed');
     const retryDelayMs = computeHttpSinkRetryDelayMs({ attempt: attemptCount });
     const metadata = {
@@ -3092,6 +3244,14 @@ async function processDeliveryFanoutPayload(input: {
     object_key: payload.object_key,
     record_count: payload.record_count,
   };
+  const deliveredEventId = await createPayloadStableLoggingId(
+    'lde',
+    payload.created_at,
+    `delivery-fanout:${payload.destination_id}`,
+    payload.payload_id
+  );
+  let deliveryClaimed = false;
+  let deliveryEmitted = false;
 
   try {
     const isLegacyPlatformDefaultArchive =
@@ -3137,6 +3297,26 @@ async function processDeliveryFanoutPayload(input: {
         record_count: payload.record_count,
         created_at: payload.created_at,
       });
+      if (!deliveryEventStore) {
+        throw new Error('logging_delivery_claim_store_unavailable');
+      }
+      const claimNow = Date.now();
+      deliveryClaimed = await deliveryEventStore.claimEvent({
+        id: deliveredEventId,
+        tenantKey: payload.tenant_key,
+        destinationId: payload.destination_id,
+        logType: payload.log_type,
+        plane: payload.plane,
+        lane: payload.lane,
+        attemptCount,
+        objectCatalogId: payload.catalog_id,
+        metadata: metadataBase,
+        now: claimNow,
+        leaseUntil: claimNow + DELIVERY_CLAIM_LEASE_MS,
+      });
+      if (!deliveryClaimed) {
+        return 'ack';
+      }
       const result = await deliverHttpSinkBatch({
         endpointUrl,
         body,
@@ -3164,20 +3344,39 @@ async function processDeliveryFanoutPayload(input: {
         http_status: result.httpStatus,
         redacted_headers: result.redactedHeaders,
       };
-      await recordDeliveryEvent(deliveryEventStore, logger, {
-        tenantKey: payload.tenant_key,
-        destinationId: payload.destination_id,
-        logType: payload.log_type,
-        plane: payload.plane,
-        lane: payload.lane,
-        status,
-        attemptCount,
-        errorClass,
-        objectCatalogId: payload.catalog_id,
-        nextRetryAt:
-          status === 'retrying' && result.retryDelayMs ? Date.now() + result.retryDelayMs : null,
-        metadata,
-      });
+      if (status === 'delivered') {
+        deliveryEmitted = true;
+        await deliveryEventStore.completeClaim({
+          id: deliveredEventId,
+          tenantKey: payload.tenant_key,
+          destinationId: payload.destination_id,
+          logType: payload.log_type,
+          plane: payload.plane,
+          lane: payload.lane,
+          status: 'delivered',
+          attemptCount,
+          objectCatalogId: payload.catalog_id,
+          metadata,
+        });
+        deliveryClaimed = false;
+      } else {
+        await deliveryEventStore.releaseClaim(deliveredEventId);
+        deliveryClaimed = false;
+        await recordDeliveryEvent(deliveryEventStore, logger, {
+          tenantKey: payload.tenant_key,
+          destinationId: payload.destination_id,
+          logType: payload.log_type,
+          plane: payload.plane,
+          lane: payload.lane,
+          status,
+          attemptCount,
+          errorClass,
+          objectCatalogId: payload.catalog_id,
+          nextRetryAt:
+            status === 'retrying' && result.retryDelayMs ? Date.now() + result.retryDelayMs : null,
+          metadata,
+        });
+      }
       if (status !== 'delivered') {
         await recordDeliveryNotification(notificationRepository, logger, {
           tenantId: payload.tenant_key,
@@ -3216,6 +3415,20 @@ async function processDeliveryFanoutPayload(input: {
 
     throw new Error(`logging_delivery_destination_provider_unsupported:${destination.provider}`);
   } catch (error) {
+    if (deliveryClaimed && deliveryEventStore) {
+      try {
+        if (deliveryEmitted) {
+          await deliveryEventStore.preserveEmittedClaim(deliveredEventId);
+        } else {
+          await deliveryEventStore.releaseClaim(deliveredEventId);
+        }
+      } catch (claimError) {
+        logger.warn('logging_http_delivery_claim_cleanup_failed', {
+          payloadId: payload.payload_id,
+          error: sanitizeErrorMessage(String(claimError)),
+        });
+      }
+    }
     const errorClass = deliveryErrorClass(error, 'delivery_fanout_failed');
     const retryDelayMs = computeHttpSinkRetryDelayMs({ attempt: attemptCount });
     const metadata = {
@@ -3899,7 +4112,7 @@ export async function processLoggingDeliveryQueue(
         attempts: message.attempts,
         error: sanitizeErrorMessage(String(error)),
       });
-      message.retry();
+      retryQueueMessage(message, error);
     }
   }
 }

--- a/packages/ar-lib-core/src/services/audit/queue-consumer.ts
+++ b/packages/ar-lib-core/src/services/audit/queue-consumer.ts
@@ -92,7 +92,11 @@ function fetchInputToUrl(input: Parameters<typeof fetch>[0]): string {
   return input.url;
 }
 
-type QueueStableIdPrefix = 'chk' | 'obj' | 'dlq' | 'lde';
+type QueueStableIdPrefix = 'batch' | 'chk' | 'obj' | 'dlq' | 'lde' | 'qpl';
+
+function stableTimestamp(value: number): number {
+  return Number.isFinite(value) && value >= 0 ? value : 0;
+}
 
 function queueMessageTimestamp(message: { timestamp?: Date }): number {
   const timestamp = message.timestamp instanceof Date ? message.timestamp.getTime() : 0;
@@ -109,6 +113,29 @@ async function createQueueStableLoggingId(
     new TextEncoder().encode(`${purpose}\u0000${message.id}`)
   );
   return `${prefix}_${createUuidV7(queueMessageTimestamp(message), new Uint8Array(digest).slice(0, 10))}`;
+}
+
+async function createAuditFanoutStableLoggingId(
+  prefix: QueueStableIdPrefix,
+  body: AuditQueueMessage,
+  purpose: string
+): Promise<string> {
+  const source = [
+    body.type,
+    body.tenantId,
+    String(stableTimestamp(body.timestamp)),
+    ...body.entries
+      .map((entry) => `${entry.id}:${String(stableTimestamp(entry.createdAt))}`)
+      .sort(),
+  ].join('\u0000');
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(`${purpose}\u0000${source}`)
+  );
+  return `${prefix}_${createUuidV7(
+    stableTimestamp(body.timestamp),
+    new Uint8Array(digest).slice(0, 10)
+  )}`;
 }
 
 function getDefaultLoggingDeliveryPayloadBucket(env: AuditQueueConsumerEnv): R2Bucket | null {
@@ -885,6 +912,7 @@ async function enqueueWrittenChunkForDelivery(input: {
   logType: LogType;
   plane: LogPlane;
   lane: LoggingDeliveryLane;
+  payloadId: string;
   env: AuditQueueConsumerEnv;
 }): Promise<RuntimeLoggingDeliveryEnqueueResult | null> {
   const destinationId = explicitDeliveryDestinationId(input.target);
@@ -896,7 +924,7 @@ async function enqueueWrittenChunkForDelivery(input: {
     {
       payload_type: 'delivery_fanout',
       schema_version: 1,
-      payload_id: `qpl_${crypto.randomUUID()}`,
+      payload_id: input.payloadId,
       tenant_key: input.tenantKey,
       lane: input.lane,
       created_at: input.result.createdAt,
@@ -917,6 +945,7 @@ async function enqueueHttpSinkBatchForDelivery(input: {
   tenantKey: string;
   logType: LogType;
   lane: LoggingDeliveryLane;
+  identity: { payloadId: string; batchId: string; createdAt: number };
   env: AuditQueueConsumerEnv;
 }): Promise<RuntimeLoggingDeliveryEnqueueResult | null> {
   const destinationId = explicitDeliveryDestinationId(input.target);
@@ -932,14 +961,12 @@ async function enqueueHttpSinkBatchForDelivery(input: {
     throw new Error(`HTTP sink URL not resolved: ${input.target.urlRef ?? 'missing_url'}`);
   }
 
-  const now = Date.now();
-  const payloadId = `qpl_${crypto.randomUUID()}`;
-  const batchId = `batch_${crypto.randomUUID()}`;
+  const { payloadId, batchId, createdAt } = input.identity;
   const bucket = getDefaultLoggingDeliveryPayloadBucket(input.env);
   if (!bucket) {
     throw new Error('logging_delivery_payload_bucket_unavailable');
   }
-  const partition = formatUtcPartition(now);
+  const partition = formatUtcPartition(createdAt);
   const objectKey = [
     'logging-delivery-payloads/v1',
     cleanR2ObjectKeySegment(input.tenantKey),
@@ -963,7 +990,7 @@ async function enqueueHttpSinkBatchForDelivery(input: {
       recordCount: String(input.body.entries.length),
       payloadId,
       batchId,
-      createdAt: String(now),
+      createdAt: String(createdAt),
     },
   });
 
@@ -974,7 +1001,7 @@ async function enqueueHttpSinkBatchForDelivery(input: {
       payload_id: payloadId,
       tenant_key: input.tenantKey,
       lane: input.lane,
-      created_at: now,
+      created_at: createdAt,
       destination_id: destinationId,
       endpoint_url: endpointUrl,
       log_type: input.logType,
@@ -1470,10 +1497,10 @@ async function processFanoutMessage(
     const lane = laneForLogPolicy(logType, 'archive');
     const destinationId = deliveryDestinationId(archive);
     const stablePurpose = `audit-fanout:${destinationId}`;
-    const stableCreatedAt = queueMessageTimestamp(message);
-    const chunkId = await createQueueStableLoggingId('chk', message, stablePurpose);
-    const objectCatalogId = await createQueueStableLoggingId('obj', message, stablePurpose);
-    const deliveryEventId = await createQueueStableLoggingId('lde', message, stablePurpose);
+    const stableCreatedAt = stableTimestamp(body.timestamp);
+    const chunkId = await createAuditFanoutStableLoggingId('chk', body, stablePurpose);
+    const objectCatalogId = await createAuditFanoutStableLoggingId('obj', body, stablePurpose);
+    const deliveryEventId = await createAuditFanoutStableLoggingId('lde', body, stablePurpose);
     try {
       const result = await writeArchiveTarget(archive, body, env, tenantKey, {
         chunkId,
@@ -1487,6 +1514,7 @@ async function processFanoutMessage(
         logType,
         plane: 'archive',
         lane,
+        payloadId: await createAuditFanoutStableLoggingId('qpl', body, stablePurpose),
         env,
       });
       await recordDeliveryEvent(deliveryEventStore, logger, {
@@ -1510,7 +1538,7 @@ async function processFanoutMessage(
       });
       if (enqueueResult && !enqueueResult.queued) {
         await recordDeliveryNotification(notificationRepository, logger, {
-          id: await createQueueStableLoggingId('lde', message, `${stablePurpose}:notification`),
+          id: await createAuditFanoutStableLoggingId('lde', body, `${stablePurpose}:notification`),
           tenantId: body.tenantId,
           tenantKey,
           destinationId,
@@ -1535,7 +1563,7 @@ async function processFanoutMessage(
       const errorClass = deliveryErrorClass(error, 'archive_delivery_failed');
       const metadata = targetMetadata(archive, fanout, body);
       await recordDeliveryEvent(deliveryEventStore, logger, {
-        id: await createQueueStableLoggingId('lde', message, `${stablePurpose}:failure`),
+        id: await createAuditFanoutStableLoggingId('lde', body, `${stablePurpose}:failure`),
         tenantKey,
         destinationId,
         logType,
@@ -1547,9 +1575,9 @@ async function processFanoutMessage(
         metadata,
       });
       await recordDeliveryNotification(notificationRepository, logger, {
-        id: await createQueueStableLoggingId(
+        id: await createAuditFanoutStableLoggingId(
           'lde',
-          message,
+          body,
           `${stablePurpose}:failure-notification`
         ),
         tenantId: body.tenantId,
@@ -1578,6 +1606,7 @@ async function processFanoutMessage(
   for (const sink of fanout.sinks) {
     const lane = laneForLogPolicy(logType, 'external_sink');
     const destinationId = deliveryDestinationId(sink);
+    const stablePurpose = `audit-fanout:${destinationId}`;
     if (sink.type === 'http') {
       const queuedSink = await enqueueHttpSinkBatchForDelivery({
         target: sink,
@@ -1585,6 +1614,11 @@ async function processFanoutMessage(
         tenantKey,
         logType,
         lane,
+        identity: {
+          payloadId: await createAuditFanoutStableLoggingId('qpl', body, stablePurpose),
+          batchId: await createAuditFanoutStableLoggingId('batch', body, stablePurpose),
+          createdAt: stableTimestamp(body.timestamp),
+        },
         env,
       });
       if (queuedSink) {
@@ -1598,6 +1632,7 @@ async function processFanoutMessage(
           delivery_queue_attempted_bindings: queuedSink.attemptedBindingNames,
         };
         await recordDeliveryEvent(deliveryEventStore, logger, {
+          id: await createAuditFanoutStableLoggingId('lde', body, `${stablePurpose}:${status}`),
           tenantKey,
           destinationId,
           logType,
@@ -1610,6 +1645,11 @@ async function processFanoutMessage(
         });
         if (status === 'retrying') {
           await recordDeliveryNotification(notificationRepository, logger, {
+            id: await createAuditFanoutStableLoggingId(
+              'lde',
+              body,
+              `${stablePurpose}:${status}:notification`
+            ),
             tenantId: body.tenantId,
             tenantKey,
             destinationId,
@@ -1639,6 +1679,7 @@ async function processFanoutMessage(
           http_status: result.httpStatus,
         };
         await recordDeliveryEvent(deliveryEventStore, logger, {
+          id: await createAuditFanoutStableLoggingId('lde', body, `${stablePurpose}:${status}`),
           tenantKey,
           destinationId,
           logType,
@@ -1656,6 +1697,11 @@ async function processFanoutMessage(
         if (result.status !== 'delivered') {
           recordedFailure = true;
           await recordDeliveryNotification(notificationRepository, logger, {
+            id: await createAuditFanoutStableLoggingId(
+              'lde',
+              body,
+              `${stablePurpose}:${status}:notification`
+            ),
             tenantId: body.tenantId,
             tenantKey,
             destinationId,
@@ -1675,6 +1721,7 @@ async function processFanoutMessage(
           const errorClass = deliveryErrorClass(error, 'http_sink_delivery_failed');
           const metadata = targetMetadata(sink, fanout, body);
           await recordDeliveryEvent(deliveryEventStore, logger, {
+            id: await createAuditFanoutStableLoggingId('lde', body, `${stablePurpose}:${status}`),
             tenantKey,
             destinationId,
             logType,
@@ -1686,6 +1733,11 @@ async function processFanoutMessage(
             metadata,
           });
           await recordDeliveryNotification(notificationRepository, logger, {
+            id: await createAuditFanoutStableLoggingId(
+              'lde',
+              body,
+              `${stablePurpose}:${status}:notification`
+            ),
             tenantId: body.tenantId,
             tenantKey,
             destinationId,
@@ -1714,6 +1766,7 @@ async function processFanoutMessage(
     try {
       await deliverSinkTarget(sink, body, env);
       await recordDeliveryEvent(deliveryEventStore, logger, {
+        id: await createAuditFanoutStableLoggingId('lde', body, `${stablePurpose}:delivered`),
         tenantKey,
         destinationId,
         logType,
@@ -1728,6 +1781,7 @@ async function processFanoutMessage(
       const errorClass = deliveryErrorClass(error, 'sink_delivery_failed');
       const metadata = targetMetadata(sink, fanout, body);
       await recordDeliveryEvent(deliveryEventStore, logger, {
+        id: await createAuditFanoutStableLoggingId('lde', body, `${stablePurpose}:${status}`),
         tenantKey,
         destinationId,
         logType,
@@ -1739,6 +1793,11 @@ async function processFanoutMessage(
         metadata,
       });
       await recordDeliveryNotification(notificationRepository, logger, {
+        id: await createAuditFanoutStableLoggingId(
+          'lde',
+          body,
+          `${stablePurpose}:${status}:notification`
+        ),
         tenantId: body.tenantId,
         tenantKey,
         destinationId,

--- a/packages/ar-lib-core/src/services/audit/storage/__tests__/hyperdrive-adapter.test.ts
+++ b/packages/ar-lib-core/src/services/audit/storage/__tests__/hyperdrive-adapter.test.ts
@@ -43,6 +43,26 @@ describe('HyperdriveAuditAdapter', () => {
     expect(query.mock.calls[0]?.[0]).not.toContain('ON CONFLICT');
   });
 
+  it('reports zero event writes when PostgreSQL skips an existing ID', async () => {
+    const adapter = new HyperdriveAuditAdapter({
+      id: 'audit-pg',
+      hyperdrive: {
+        connectionString: 'postgres://user:pass@example.com:5432/authrim',
+      } as Hyperdrive,
+      schema: 'audit',
+      isPiiDb: false,
+      clientFactory: async () => ({
+        query: async () => ({ rows: [], rowCount: 0 }),
+        end: async () => undefined,
+      }),
+    });
+
+    await expect(adapter.writeEventLog(createEventEntry())).resolves.toMatchObject({
+      success: true,
+      entriesWritten: 0,
+    });
+  });
+
   it('uses PostgreSQL-safe retention cleanup SQL with tenant scoping', async () => {
     const query = vi.fn().mockResolvedValue({ rows: [], rowCount: 7 });
     const adapter = new HyperdriveAuditAdapter({

--- a/packages/ar-lib-core/src/services/audit/storage/__tests__/mysql-audit-adapter.test.ts
+++ b/packages/ar-lib-core/src/services/audit/storage/__tests__/mysql-audit-adapter.test.ts
@@ -48,6 +48,33 @@ describe('MysqlAuditAdapter', () => {
     expect(execute.mock.calls[0]?.[0]).not.toContain('ON DUPLICATE KEY');
   });
 
+  it('reports zero event writes when MySQL skips an existing ID', async () => {
+    const adapter = new MysqlAuditAdapter({
+      id: 'audit-mysql',
+      hyperdrive: {
+        host: 'mysql.example.com',
+        user: 'worker',
+        password: 'secret',
+        database: 'authrim',
+        port: 3306,
+      } as Hyperdrive,
+      isPiiDb: false,
+      clientFactory: async () => ({
+        query: async () => ({ rows: [] }),
+        execute: async () => ({ rows: [], affectedRows: 0 }),
+        beginTransaction: async () => undefined,
+        commit: async () => undefined,
+        rollback: async () => undefined,
+        end: async () => undefined,
+      }),
+    });
+
+    await expect(adapter.writeEventLog(createEventEntry())).resolves.toMatchObject({
+      success: true,
+      entriesWritten: 0,
+    });
+  });
+
   it('uses MySQL retention cleanup with tenant scoping and limit', async () => {
     const execute = vi.fn().mockResolvedValue({ rows: [], affectedRows: 5 });
     const adapter = new MysqlAuditAdapter({

--- a/packages/ar-lib-core/src/services/audit/storage/hyperdrive-adapter.ts
+++ b/packages/ar-lib-core/src/services/audit/storage/hyperdrive-adapter.ts
@@ -242,11 +242,11 @@ export class HyperdriveAuditAdapter implements IAuditStorageAdapter {
         entries.length
       );
 
-      await client.query(sql, values);
+      const result = await client.query(sql, values);
 
       return {
         success: true,
-        entriesWritten: entries.length,
+        entriesWritten: result.rowCount,
         backend: this.id,
         durationMs: Date.now() - startTime,
       };
@@ -330,11 +330,11 @@ export class HyperdriveAuditAdapter implements IAuditStorageAdapter {
         entries.length
       );
 
-      await client.query(sql, values);
+      const result = await client.query(sql, values);
 
       return {
         success: true,
-        entriesWritten: entries.length,
+        entriesWritten: result.rowCount,
         backend: this.id,
         durationMs: Date.now() - startTime,
       };

--- a/packages/ar-lib-core/src/services/audit/storage/mysql-audit-adapter.ts
+++ b/packages/ar-lib-core/src/services/audit/storage/mysql-audit-adapter.ts
@@ -207,7 +207,7 @@ export class MysqlAuditAdapter implements IAuditStorageAdapter {
         );
       });
 
-      await client.execute(
+      const result = await client.execute(
         buildInsertIfNotExistsSql(
           qualifyTable(this.schema, 'event_log'),
           [...columns],
@@ -219,7 +219,7 @@ export class MysqlAuditAdapter implements IAuditStorageAdapter {
 
       return {
         success: true,
-        entriesWritten: entries.length,
+        entriesWritten: result.affectedRows ?? 0,
         backend: this.id,
         durationMs: Date.now() - startTime,
       };
@@ -289,7 +289,7 @@ export class MysqlAuditAdapter implements IAuditStorageAdapter {
         );
       });
 
-      await client.execute(
+      const result = await client.execute(
         buildInsertIfNotExistsSql(
           qualifyTable(this.schema, 'pii_log'),
           [...columns],
@@ -301,7 +301,7 @@ export class MysqlAuditAdapter implements IAuditStorageAdapter {
 
       return {
         success: true,
-        entriesWritten: entries.length,
+        entriesWritten: result.affectedRows ?? 0,
         backend: this.id,
         durationMs: Date.now() - startTime,
       };

--- a/packages/ar-lib-core/src/services/audit/types.ts
+++ b/packages/ar-lib-core/src/services/audit/types.ts
@@ -391,6 +391,9 @@ export interface EventLogParams {
 
   /** Additional details (will be sanitized for PII) */
   details?: EventDetails;
+
+  /** Require a configured gated fanout to be accepted before this write succeeds. */
+  requireDurableFanout?: boolean;
 }
 
 /**

--- a/packages/ar-lib-core/src/services/audit/types.ts
+++ b/packages/ar-lib-core/src/services/audit/types.ts
@@ -353,6 +353,9 @@ export interface EventLogParams {
   /** Stable event ID for idempotent retries. Generated when omitted. */
   id?: string;
 
+  /** Original event timestamp in epoch milliseconds. Generated when omitted. */
+  createdAt?: number;
+
   /** Event type (e.g., 'auth.login', 'token.issued') */
   eventType: string;
 

--- a/packages/ar-lib-core/src/utils/__tests__/audit-log.test.ts
+++ b/packages/ar-lib-core/src/utils/__tests__/audit-log.test.ts
@@ -930,6 +930,7 @@ describe('createAuditLogFromContext', () => {
 
   it('should extract user info from adminAuth context', async () => {
     const mockEnv = createMockEnv();
+    const createdAt = 1_779_321_600_123;
     const context = createMockContext({
       adminAuth: { userId: 'admin-user-456' },
       env: mockEnv,
@@ -941,12 +942,14 @@ describe('createAuditLogFromContext', () => {
       'signing_keys',
       'key-123',
       { reason: 'test rotation' },
-      'warning'
+      'warning',
+      'fixed-audit-id',
+      createdAt
     );
 
     const bindCall = (mockEnv.DB.prepare as ReturnType<typeof vi.fn>).mock.results[0].value.bind;
     expect(bindCall).toHaveBeenCalledWith(
-      expect.any(String), // id
+      'fixed-audit-id', // id
       'default', // tenantId
       'admin-user-456', // userId
       'signing_keys.rotate.normal',
@@ -956,8 +959,12 @@ describe('createAuditLogFromContext', () => {
       'Mozilla/5.0 Test Browser',
       '{"reason":"test rotation"}',
       'warning',
-      expect.any(Number), // createdAt
-      expect.any(String) // idempotency lookup ID
+      Math.floor(createdAt / 1000), // createdAt
+      'fixed-audit-id' // idempotency lookup ID
+    );
+    expect(mockUnifiedAuditService.logEvent).toHaveBeenCalledWith(
+      'default',
+      expect.objectContaining({ id: 'fixed-audit-id', createdAt })
     );
   });
 

--- a/packages/ar-lib-core/src/utils/__tests__/audit-log.test.ts
+++ b/packages/ar-lib-core/src/utils/__tests__/audit-log.test.ts
@@ -427,6 +427,39 @@ describe('createAuditLog', () => {
     );
   });
 
+  it('keeps fail-closed deletion evidence pending when archive-only fanout fails', async () => {
+    mockResolveTenantRuntimeProfilesFromEnv.mockResolvedValue({
+      auditProfile: {
+        id: 'builtin:audit:archive-only-logpush',
+        kind: 'audit',
+        builtin: true,
+        label: 'Archive Only + Logpush',
+        primary: null,
+        archive: { type: 'r2', bucketRef: 'DIAGNOSTIC_LOGS', prefix: 'audit/' },
+        sinks: [{ type: 'logpush', destinationRef: 'workers-logpush' }],
+        archiveFailureMode: 'gate_cleanup',
+      },
+    });
+    mockUnifiedAuditService.logEvent.mockRejectedValueOnce(new Error('audit_fanout_queue_failed'));
+
+    await expect(
+      createAuditLog(mockEnv, {
+        tenantId: 'default',
+        userId: 'admin-user',
+        action: 'user.deleted',
+        resource: 'user',
+        resourceId: 'guest-user',
+        ipAddress: '192.0.2.1',
+        userAgent: 'Test Agent',
+        metadata: '{}',
+        severity: 'info',
+      })
+    ).rejects.toThrow('audit_log_unified_mirror_failed');
+    expect(mockEnv.DB.prepare).not.toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO audit_log')
+    );
+  });
+
   it('uses cached runtime logging policy snapshots for audit fanout routing', async () => {
     const tenantId = 'tenant-snapshot-routing';
     const kvValues = new Map<string, string>();

--- a/packages/ar-lib-core/src/utils/__tests__/audit-log.test.ts
+++ b/packages/ar-lib-core/src/utils/__tests__/audit-log.test.ts
@@ -220,6 +220,54 @@ describe('createAuditLog', () => {
     );
   });
 
+  it('preserves an original event timestamp across legacy and unified audit writes', async () => {
+    const createdAt = 1_779_321_600_123;
+    mockResolveTenantRuntimeProfilesFromEnv.mockResolvedValue({
+      auditProfile: {
+        id: 'legacy-d1-audit',
+        kind: 'audit',
+        builtin: false,
+        label: 'Legacy D1 Audit',
+        primary: { type: 'd1', bindingRef: 'DB', dataset: 'audit_log' },
+        archive: null,
+        sinks: [],
+      },
+    });
+
+    await createAuditLog(mockEnv, {
+      tenantId: 'default',
+      userId: 'admin-user',
+      action: 'user.deleted',
+      resource: 'user',
+      resourceId: 'guest-user',
+      ipAddress: '192.0.2.1',
+      userAgent: 'Test Agent',
+      metadata: '{}',
+      severity: 'info',
+      createdAt,
+    });
+
+    const bindCall = (mockEnv.DB.prepare as ReturnType<typeof vi.fn>).mock.results[0].value.bind;
+    expect(bindCall).toHaveBeenCalledWith(
+      expect.any(String),
+      'default',
+      'admin-user',
+      'user.deleted',
+      'user',
+      'guest-user',
+      '192.0.2.1',
+      'Test Agent',
+      '{}',
+      'info',
+      Math.floor(createdAt / 1000),
+      expect.any(String)
+    );
+    expect(mockUnifiedAuditService.logEvent).toHaveBeenCalledWith(
+      'default',
+      expect.objectContaining({ createdAt })
+    );
+  });
+
   it('should generate unique ID for each log entry', async () => {
     mockResolveTenantRuntimeProfilesFromEnv.mockResolvedValue({
       auditProfile: {

--- a/packages/ar-lib-core/src/utils/__tests__/audit-log.test.ts
+++ b/packages/ar-lib-core/src/utils/__tests__/audit-log.test.ts
@@ -453,8 +453,13 @@ describe('createAuditLog', () => {
         userAgent: 'Test Agent',
         metadata: '{}',
         severity: 'info',
+        requireDurableFanout: true,
       })
     ).rejects.toThrow('audit_log_unified_mirror_failed');
+    expect(mockUnifiedAuditService.logEvent).toHaveBeenCalledWith(
+      'default',
+      expect.objectContaining({ requireDurableFanout: true })
+    );
     expect(mockEnv.DB.prepare).not.toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO audit_log')
     );

--- a/packages/ar-lib-core/src/utils/audit-log.ts
+++ b/packages/ar-lib-core/src/utils/audit-log.ts
@@ -1081,6 +1081,8 @@ export async function createAuditLog(
  * @param resourceId - Resource identifier (e.g., kid)
  * @param metadata - Additional metadata object (will be JSON stringified)
  * @param severity - Severity level (default: 'info')
+ * @param auditId - Stable audit ID for idempotent retries
+ * @param createdAt - Original event timestamp in epoch milliseconds
  */
 export async function createAuditLogFromContext(
   c: Context<{ Bindings: Env }>,
@@ -1089,7 +1091,8 @@ export async function createAuditLogFromContext(
   resourceId: string,
   metadata: Record<string, unknown>,
   severity: 'info' | 'warning' | 'critical' = 'info',
-  auditId?: string
+  auditId?: string,
+  createdAt?: number
 ): Promise<void> {
   // Debug: Log that we're attempting to create audit log
   log.info('Creating audit log from context', { action, resource, resourceId });
@@ -1137,6 +1140,7 @@ export async function createAuditLogFromContext(
 
   await createAuditLog(c.env, {
     id: auditId,
+    createdAt,
     tenantId,
     userId: adminAuth.userId,
     action,

--- a/packages/ar-lib-core/src/utils/audit-log.ts
+++ b/packages/ar-lib-core/src/utils/audit-log.ts
@@ -891,7 +891,11 @@ async function resolveAuditDeliveryPlanFromEnv(
 
 async function mirrorLegacyAuditLogToUnifiedService(
   env: Env,
-  entry: Omit<AuditLogEntry, 'id' | 'createdAt'> & { tenantId: string; id?: string }
+  entry: Omit<AuditLogEntry, 'id' | 'createdAt'> & {
+    tenantId: string;
+    id?: string;
+    createdAt?: number;
+  }
 ): Promise<void> {
   const tenantId = requireAuditTenantId(entry.tenantId, entry.action);
   if (!tenantId) {
@@ -905,6 +909,7 @@ async function mirrorLegacyAuditLogToUnifiedService(
 
   await auditService.logEvent(tenantId, {
     id: entry.id,
+    createdAt: entry.createdAt,
     eventType: entry.action,
     eventCategory: mapLegacyAuditCategory(entry.action, entry.resource),
     result: 'success',
@@ -956,7 +961,11 @@ export async function writeLegacyAuditLog(
  */
 export async function createAuditLog(
   env: Env,
-  entry: Omit<AuditLogEntry, 'id' | 'createdAt'> & { tenantId: string; id?: string }
+  entry: Omit<AuditLogEntry, 'id' | 'createdAt'> & {
+    tenantId: string;
+    id?: string;
+    createdAt?: number;
+  }
 ): Promise<void> {
   const tenantId = requireAuditTenantId(entry.tenantId, entry.action);
   if (!tenantId) {
@@ -967,8 +976,12 @@ export async function createAuditLog(
   if (!/^[A-Za-z0-9._:-]{1,200}$/u.test(id)) {
     throw new AuditLogDeliveryError('audit_log_id_invalid', entry.action, tenantId);
   }
-  // Use seconds (not milliseconds) for consistency with other audit log writers
-  const createdAt = Math.floor(Date.now() / 1000);
+  const createdAtMs = entry.createdAt ?? Date.now();
+  if (!Number.isSafeInteger(createdAtMs) || createdAtMs < 0) {
+    throw new AuditLogDeliveryError('audit_log_created_at_invalid', entry.action, tenantId);
+  }
+  // The legacy audit_log schema stores seconds; the unified service stores milliseconds.
+  const createdAt = Math.floor(createdAtMs / 1000);
   let failureBehavior: ReturnType<typeof resolveAuditEventFailureBehavior>['behavior'] =
     'fail_closed_or_strong_retry';
   let legacyD1WasPrimary = true;
@@ -1025,7 +1038,12 @@ export async function createAuditLog(
   }
 
   try {
-    await mirrorLegacyAuditLogToUnifiedService(env, { ...entry, id, tenantId });
+    await mirrorLegacyAuditLogToUnifiedService(env, {
+      ...entry,
+      id,
+      tenantId,
+      createdAt: createdAtMs,
+    });
   } catch (error) {
     log.warn('Failed to mirror audit log to unified audit service', {
       action: entry.action,

--- a/packages/ar-lib-core/src/utils/audit-log.ts
+++ b/packages/ar-lib-core/src/utils/audit-log.ts
@@ -897,6 +897,7 @@ async function mirrorLegacyAuditLogToUnifiedService(
     tenantId: string;
     id?: string;
     createdAt?: number;
+    requireDurableFanout?: boolean;
   }
 ): Promise<void> {
   const tenantId = requireAuditTenantId(entry.tenantId, entry.action);
@@ -916,6 +917,7 @@ async function mirrorLegacyAuditLogToUnifiedService(
     eventCategory: mapLegacyAuditCategory(entry.action, entry.resource),
     result: 'success',
     severity: mapLegacySeverity(entry.severity),
+    ...(entry.requireDurableFanout ? { requireDurableFanout: true } : {}),
     details: {
       source: 'legacy_audit_log',
       resourceType: entry.resource,
@@ -967,6 +969,7 @@ export async function createAuditLog(
     tenantId: string;
     id?: string;
     createdAt?: number;
+    requireDurableFanout?: boolean;
   }
 ): Promise<void> {
   const tenantId = requireAuditTenantId(entry.tenantId, entry.action);
@@ -1052,7 +1055,10 @@ export async function createAuditLog(
       tenantId,
     });
     log.error('Unified audit mirror failed', {}, error as Error);
-    if (failureBehavior === 'fail_closed_or_strong_retry' && !legacyD1WasPrimary) {
+    if (
+      entry.requireDurableFanout ||
+      (failureBehavior === 'fail_closed_or_strong_retry' && !legacyD1WasPrimary)
+    ) {
       throw new AuditLogDeliveryError('audit_log_unified_mirror_failed', entry.action, tenantId);
     }
   }
@@ -1085,6 +1091,7 @@ export async function createAuditLog(
  * @param severity - Severity level (default: 'info')
  * @param auditId - Stable audit ID for idempotent retries
  * @param createdAt - Original event timestamp in epoch milliseconds
+ * @param requireDurableFanout - Require gated archive/sink queue acceptance
  */
 export async function createAuditLogFromContext(
   c: Context<{ Bindings: Env }>,
@@ -1094,7 +1101,8 @@ export async function createAuditLogFromContext(
   metadata: Record<string, unknown>,
   severity: 'info' | 'warning' | 'critical' = 'info',
   auditId?: string,
-  createdAt?: number
+  createdAt?: number,
+  requireDurableFanout = false
 ): Promise<void> {
   // Debug: Log that we're attempting to create audit log
   log.info('Creating audit log from context', { action, resource, resourceId });
@@ -1152,6 +1160,7 @@ export async function createAuditLogFromContext(
     userAgent,
     metadata: JSON.stringify(auditMetadata),
     severity,
+    ...(requireDurableFanout ? { requireDurableFanout: true } : {}),
   });
 }
 

--- a/packages/ar-lib-core/src/utils/audit-log.ts
+++ b/packages/ar-lib-core/src/utils/audit-log.ts
@@ -278,7 +278,9 @@ function getRequestIdFromContext(c: Context<{ Bindings: Env }>): string | undefi
   return c.req.header('X-Request-Id') || c.req.header('X-Correlation-Id') || undefined;
 }
 
-function getAdminProxyMetadataFromContext(c: Context<{ Bindings: Env }>): Record<string, unknown> {
+export function getAdminProxyMetadataFromContext(
+  c: Context<{ Bindings: Env }>
+): Record<string, unknown> {
   const requestId = getRequestIdFromContext(c);
   const apiMode = c.req.header('X-Authrim-Admin-UI-Api-Mode');
   const forwardedHost =

--- a/packages/ar-lib-logging/src/chunks/__tests__/r2-chunk-writer.test.ts
+++ b/packages/ar-lib-logging/src/chunks/__tests__/r2-chunk-writer.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import { decodeStoredLogChunkRecord } from '../r2-chunk-reader';
-import { writeLogChunkToR2 } from '../r2-chunk-writer';
+import {
+  LOG_CHUNK_WRITE_CLAIM_LEASE_MS,
+  LogChunkWriteClaimActiveError,
+  writeLogChunkToR2,
+} from '../r2-chunk-writer';
 import { normalizeR2Prefix } from '../r2-keys';
 import type { LogChunkCatalogStore } from '../types';
 
@@ -280,6 +284,78 @@ describe('writeLogChunkToR2', () => {
       expect.objectContaining({ status: 'committed', checksumSha256: expect.any(String) })
     );
     expect(indexStatus).toBe('committed');
+  });
+
+  it('reclaims an expired pending claim when archive failure cleanup also failed', async () => {
+    vi.useFakeTimers();
+    const firstAttemptAt = 1_700_000_000_000;
+    vi.setSystemTime(firstAttemptAt);
+    let objectRow: Parameters<LogChunkCatalogStore['createPendingObject']>[0] | null = null;
+    const catalogStore: LogChunkCatalogStore = {
+      createPendingObject: vi.fn(async (row) => {
+        if (objectRow) return false;
+        objectRow = row;
+        return true;
+      }),
+      getObject: vi.fn(async () => objectRow),
+      reclaimExpiredPendingObject: vi.fn(async (_id, now, claimLeaseUntil) => {
+        if (
+          !objectRow ||
+          objectRow.status !== 'pending' ||
+          (objectRow.claimLeaseUntil ?? Number.POSITIVE_INFINITY) > now
+        ) {
+          return false;
+        }
+        objectRow = { ...objectRow, claimLeaseUntil };
+        return true;
+      }),
+      createPendingRecordIndexes: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('catalog_index_write_failed'))
+        .mockResolvedValueOnce(undefined),
+      commitObject: vi.fn(async (_id, update) => {
+        if (objectRow) {
+          objectRow = {
+            ...objectRow,
+            status: 'committed',
+            byteCount: update.byteCount,
+            checksumSha256: update.checksumSha256,
+            committedAt: update.committedAt,
+            claimLeaseUntil: undefined,
+          };
+        }
+      }),
+      commitRecordIndexes: vi.fn(),
+      markObjectOrphanCandidate: vi.fn().mockRejectedValueOnce(new Error('catalog_cleanup_failed')),
+    };
+    const bucket = { put: vi.fn().mockResolvedValue(undefined) } as unknown as R2Bucket;
+    const input = {
+      bucket,
+      tenantKey: 't_safeopaque',
+      logType: 'audit' as const,
+      plane: 'archive' as const,
+      records: [{ id: 'evt-recovery', eventAt: 1, payload: { id: 'evt-recovery' } }],
+      catalogStore,
+      encryption: testEncryption(),
+      now: 1_700_000_000_000,
+      chunkId: 'chk_recovery',
+      objectCatalogId: 'obj_recovery',
+    };
+
+    const firstError = await writeLogChunkToR2(input).catch((error: unknown) => error);
+    expect(firstError).toBeInstanceOf(LogChunkWriteClaimActiveError);
+    expect((firstError as LogChunkWriteClaimActiveError).retryAt).toBe(
+      firstAttemptAt + LOG_CHUNK_WRITE_CLAIM_LEASE_MS
+    );
+    expect(objectRow).toEqual(expect.objectContaining({ status: 'pending' }));
+
+    vi.setSystemTime(firstAttemptAt + LOG_CHUNK_WRITE_CLAIM_LEASE_MS + 1);
+    await expect(writeLogChunkToR2(input)).resolves.toEqual(
+      expect.objectContaining({ objectCatalogId: 'obj_recovery' })
+    );
+    expect(catalogStore.reclaimExpiredPendingObject).toHaveBeenCalledOnce();
+    expect(bucket.put).toHaveBeenCalledOnce();
+    vi.useRealTimers();
   });
 
   it('finishes pending indexes on replay after the object commit succeeded', async () => {

--- a/packages/ar-lib-logging/src/chunks/__tests__/r2-chunk-writer.test.ts
+++ b/packages/ar-lib-logging/src/chunks/__tests__/r2-chunk-writer.test.ts
@@ -141,6 +141,70 @@ describe('writeLogChunkToR2', () => {
     ]);
   });
 
+  it('allows only one R2 writer for the same stable catalog identity', async () => {
+    let objectRow: Parameters<LogChunkCatalogStore['createPendingObject']>[0] | null = null;
+    let releasePut: (() => void) | undefined;
+    let notifyPutStarted: (() => void) | undefined;
+    const putStarted = new Promise<void>((resolve) => {
+      notifyPutStarted = resolve;
+    });
+    const catalogStore: LogChunkCatalogStore = {
+      createPendingObject: vi.fn(async (row) => {
+        if (objectRow) {
+          return false;
+        }
+        objectRow = row;
+        return true;
+      }),
+      getObject: vi.fn(async () => objectRow),
+      createPendingRecordIndexes: vi.fn(),
+      commitObject: vi.fn(async (_id, update) => {
+        if (objectRow) {
+          objectRow = {
+            ...objectRow,
+            status: 'committed',
+            byteCount: update.byteCount,
+            checksumSha256: update.checksumSha256,
+            committedAt: update.committedAt,
+          };
+        }
+      }),
+      commitRecordIndexes: vi.fn(),
+      markObjectOrphanCandidate: vi.fn(),
+    };
+    const bucket = {
+      put: vi.fn(async () => {
+        notifyPutStarted?.();
+        await new Promise<void>((resolve) => {
+          releasePut = resolve;
+        });
+      }),
+    } as unknown as R2Bucket;
+    const input = {
+      bucket,
+      tenantKey: 't_safeopaque',
+      logType: 'audit' as const,
+      plane: 'archive' as const,
+      records: [{ id: 'evt-stable', eventAt: 1, payload: { id: 'evt-stable' } }],
+      catalogStore,
+      encryption: testEncryption(),
+      now: 1_700_000_000_000,
+      chunkId: 'chk_stable',
+      objectCatalogId: 'obj_stable',
+    };
+
+    const first = writeLogChunkToR2(input);
+    await putStarted;
+    await expect(writeLogChunkToR2(input)).rejects.toThrow(
+      'log_chunk_write_in_progress_or_conflicted'
+    );
+    expect(bucket.put).toHaveBeenCalledOnce();
+    releasePut?.();
+    await expect(first).resolves.toEqual(
+      expect.objectContaining({ chunkId: 'chk_stable', objectCatalogId: 'obj_stable' })
+    );
+  });
+
   it('stores block offsets for record-level lookup indexes', async () => {
     let indexRows: Parameters<LogChunkCatalogStore['createPendingRecordIndexes']>[0] = [];
     const catalogStore: LogChunkCatalogStore = {

--- a/packages/ar-lib-logging/src/chunks/__tests__/r2-chunk-writer.test.ts
+++ b/packages/ar-lib-logging/src/chunks/__tests__/r2-chunk-writer.test.ts
@@ -205,6 +205,83 @@ describe('writeLogChunkToR2', () => {
     );
   });
 
+  it('reclaims an orphaned stable archive claim after a transient write failure', async () => {
+    let objectRow: Parameters<LogChunkCatalogStore['createPendingObject']>[0] | null = null;
+    let indexStatus: 'pending' | 'committed' | 'deleted' | undefined;
+    const catalogStore: LogChunkCatalogStore = {
+      createPendingObject: vi.fn(async (row) => {
+        if (objectRow) {
+          return false;
+        }
+        objectRow = row;
+        return true;
+      }),
+      getObject: vi.fn(async () => objectRow),
+      reclaimOrphanObject: vi.fn(async () => {
+        if (!objectRow || objectRow.status !== 'orphan_candidate') {
+          return false;
+        }
+        objectRow = { ...objectRow, status: 'pending', committedAt: undefined };
+        return true;
+      }),
+      createPendingRecordIndexes: vi.fn(async () => {
+        indexStatus = 'pending';
+      }),
+      commitObject: vi.fn(async (_id, update) => {
+        if (objectRow) {
+          objectRow = {
+            ...objectRow,
+            status: 'committed',
+            byteCount: update.byteCount,
+            checksumSha256: update.checksumSha256,
+            committedAt: update.committedAt,
+          };
+        }
+      }),
+      commitRecordIndexes: vi.fn(async () => {
+        indexStatus = 'committed';
+      }),
+      markObjectOrphanCandidate: vi.fn(async () => {
+        if (objectRow?.status === 'pending') {
+          objectRow = { ...objectRow, status: 'orphan_candidate' };
+          indexStatus = 'deleted';
+        }
+      }),
+    };
+    const bucket = {
+      put: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('transient_r2_failure'))
+        .mockResolvedValueOnce(undefined),
+    } as unknown as R2Bucket;
+    const input = {
+      bucket,
+      tenantKey: 't_safeopaque',
+      logType: 'audit' as const,
+      plane: 'archive' as const,
+      records: [{ id: 'evt-retry', eventAt: 1, payload: { id: 'evt-retry' } }],
+      catalogStore,
+      encryption: testEncryption(),
+      now: 1_700_000_000_000,
+      chunkId: 'chk_retry',
+      objectCatalogId: 'obj_retry',
+    };
+
+    await expect(writeLogChunkToR2(input)).rejects.toThrow('transient_r2_failure');
+    expect(objectRow).toEqual(expect.objectContaining({ status: 'orphan_candidate' }));
+    expect(indexStatus).toBe('deleted');
+
+    await expect(writeLogChunkToR2(input)).resolves.toEqual(
+      expect.objectContaining({ chunkId: 'chk_retry', objectCatalogId: 'obj_retry' })
+    );
+    expect(catalogStore.reclaimOrphanObject).toHaveBeenCalledOnce();
+    expect(bucket.put).toHaveBeenCalledTimes(2);
+    expect(objectRow).toEqual(
+      expect.objectContaining({ status: 'committed', checksumSha256: expect.any(String) })
+    );
+    expect(indexStatus).toBe('committed');
+  });
+
   it('stores block offsets for record-level lookup indexes', async () => {
     let indexRows: Parameters<LogChunkCatalogStore['createPendingRecordIndexes']>[0] = [];
     const catalogStore: LogChunkCatalogStore = {

--- a/packages/ar-lib-logging/src/chunks/__tests__/r2-chunk-writer.test.ts
+++ b/packages/ar-lib-logging/src/chunks/__tests__/r2-chunk-writer.test.ts
@@ -282,6 +282,67 @@ describe('writeLogChunkToR2', () => {
     expect(indexStatus).toBe('committed');
   });
 
+  it('finishes pending indexes on replay after the object commit succeeded', async () => {
+    let objectRow: Parameters<LogChunkCatalogStore['createPendingObject']>[0] | null = null;
+    let indexStatus: 'pending' | 'committed' | 'deleted' | undefined;
+    const catalogStore: LogChunkCatalogStore = {
+      createPendingObject: vi.fn(async (row) => {
+        if (objectRow) return false;
+        objectRow = row;
+        return true;
+      }),
+      getObject: vi.fn(async () => objectRow),
+      createPendingRecordIndexes: vi.fn(async () => {
+        indexStatus = 'pending';
+      }),
+      commitObject: vi.fn(async (_id, update) => {
+        if (objectRow) {
+          objectRow = {
+            ...objectRow,
+            status: 'committed',
+            byteCount: update.byteCount,
+            checksumSha256: update.checksumSha256,
+            committedAt: update.committedAt,
+          };
+        }
+      }),
+      commitRecordIndexes: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('transient_index_commit_failure'))
+        .mockImplementationOnce(async () => {
+          indexStatus = 'committed';
+        }),
+      markObjectOrphanCandidate: vi.fn(async () => {
+        indexStatus = 'deleted';
+      }),
+    };
+    const bucket = { put: vi.fn().mockResolvedValue(undefined) } as unknown as R2Bucket;
+    const input = {
+      bucket,
+      tenantKey: 't_safeopaque',
+      logType: 'audit' as const,
+      plane: 'archive' as const,
+      records: [{ id: 'evt-index-retry', eventAt: 1, payload: { id: 'evt-index-retry' } }],
+      catalogStore,
+      encryption: testEncryption(),
+      now: 1_700_000_000_000,
+      chunkId: 'chk_index_retry',
+      objectCatalogId: 'obj_index_retry',
+    };
+
+    await expect(writeLogChunkToR2(input)).rejects.toThrow('transient_index_commit_failure');
+    expect(objectRow).toEqual(expect.objectContaining({ status: 'committed' }));
+    expect(indexStatus).toBe('pending');
+    expect(catalogStore.markObjectOrphanCandidate).not.toHaveBeenCalled();
+
+    await expect(writeLogChunkToR2(input)).resolves.toEqual(
+      expect.objectContaining({ objectCatalogId: 'obj_index_retry' })
+    );
+    expect(bucket.put).toHaveBeenCalledOnce();
+    expect(catalogStore.commitRecordIndexes).toHaveBeenCalledTimes(2);
+    expect(indexStatus).toBe('committed');
+  });
+
   it('stores block offsets for record-level lookup indexes', async () => {
     let indexRows: Parameters<LogChunkCatalogStore['createPendingRecordIndexes']>[0] = [];
     const catalogStore: LogChunkCatalogStore = {

--- a/packages/ar-lib-logging/src/chunks/r2-chunk-writer.ts
+++ b/packages/ar-lib-logging/src/chunks/r2-chunk-writer.ts
@@ -11,6 +11,18 @@ import type {
   WriteLogChunkResult,
 } from './types';
 
+export const LOG_CHUNK_WRITE_CLAIM_LEASE_MS = 60_000;
+
+export class LogChunkWriteClaimActiveError extends Error {
+  readonly retryAt: number;
+
+  constructor(retryAt: number, options?: ErrorOptions) {
+    super('log_chunk_write_in_progress_or_conflicted', options);
+    this.name = 'LogChunkWriteClaimActiveError';
+    this.retryAt = retryAt;
+  }
+}
+
 function toHex(bytes: Uint8Array): string {
   return [...bytes].map((value) => value.toString(16).padStart(2, '0')).join('');
 }
@@ -94,7 +106,9 @@ export async function writeLogChunkToR2(input: WriteLogChunkInput): Promise<Writ
     throw new Error('log_chunk_encryption_required');
   }
 
-  const createdAt = input.now ?? Date.now();
+  const claimStartedAt = Date.now();
+  const claimLeaseUntil = claimStartedAt + LOG_CHUNK_WRITE_CLAIM_LEASE_MS;
+  const createdAt = input.now ?? claimStartedAt;
   const chunkId = input.chunkId ?? createLoggingId('chk', createdAt);
   const objectCatalogId = input.objectCatalogId ?? createLoggingId('obj', createdAt);
   const compression: LogChunkCompression = input.compression ?? 'gzip_block';
@@ -140,6 +154,7 @@ export async function writeLogChunkToR2(input: WriteLogChunkInput): Promise<Writ
     encryptionScope: input.encryption?.encryptionScope,
     keyVersion: input.encryption?.keyVersion,
     createdAt,
+    claimLeaseUntil,
   };
 
   const indexRows: LogChunkRecordIndexRow[] = input.records.map((record, index) => {
@@ -201,11 +216,17 @@ export async function writeLogChunkToR2(input: WriteLogChunkInput): Promise<Writ
         createdAt: existing.createdAt,
       };
     }
-    const orphanReclaimed =
-      existing.status === 'orphan_candidate' &&
-      (await input.catalogStore?.reclaimOrphanObject?.(objectCatalogId));
-    if (!orphanReclaimed) {
-      throw new Error('log_chunk_write_in_progress_or_conflicted');
+    const claimReclaimed =
+      (existing.status === 'orphan_candidate' &&
+        (await input.catalogStore?.reclaimOrphanObject?.(objectCatalogId, claimLeaseUntil))) ||
+      (existing.status === 'pending' &&
+        (await input.catalogStore?.reclaimExpiredPendingObject?.(
+          objectCatalogId,
+          claimStartedAt,
+          claimLeaseUntil
+        )));
+    if (!claimReclaimed) {
+      throw new LogChunkWriteClaimActiveError(existing.claimLeaseUntil ?? claimLeaseUntil);
     }
   }
 
@@ -262,7 +283,11 @@ export async function writeLogChunkToR2(input: WriteLogChunkInput): Promise<Writ
     };
   } catch (error) {
     if (!objectCommitted) {
-      await input.catalogStore?.markObjectOrphanCandidate(objectCatalogId, Date.now());
+      try {
+        await input.catalogStore?.markObjectOrphanCandidate(objectCatalogId, Date.now());
+      } catch (cleanupError) {
+        throw new LogChunkWriteClaimActiveError(claimLeaseUntil, { cause: cleanupError });
+      }
     }
     throw error;
   }

--- a/packages/ar-lib-logging/src/chunks/r2-chunk-writer.ts
+++ b/packages/ar-lib-logging/src/chunks/r2-chunk-writer.ts
@@ -166,7 +166,34 @@ export async function writeLogChunkToR2(input: WriteLogChunkInput): Promise<Writ
     };
   });
 
-  await input.catalogStore?.createPendingObject(objectRow);
+  const pendingObjectCreated = await input.catalogStore?.createPendingObject(objectRow);
+  if (pendingObjectCreated === false) {
+    const existing = await input.catalogStore?.getObject?.(objectCatalogId);
+    if (
+      !existing ||
+      existing.status !== 'committed' ||
+      existing.tenantKey !== input.tenantKey ||
+      existing.logType !== input.logType ||
+      existing.plane !== input.plane ||
+      existing.objectKey !== objectKey ||
+      !existing.checksumSha256
+    ) {
+      throw new Error('log_chunk_write_in_progress_or_conflicted');
+    }
+    return {
+      chunkId,
+      objectCatalogId,
+      objectKey,
+      shard,
+      recordCount: existing.recordCount,
+      byteCount: existing.byteCount,
+      checksumSha256: existing.checksumSha256,
+      compression: existing.compression,
+      encryptionScope: existing.encryptionScope,
+      keyVersion: existing.keyVersion,
+      createdAt: existing.createdAt,
+    };
+  }
   await input.catalogStore?.createPendingRecordIndexes(indexRows);
 
   try {

--- a/packages/ar-lib-logging/src/chunks/r2-chunk-writer.ts
+++ b/packages/ar-lib-logging/src/chunks/r2-chunk-writer.ts
@@ -169,34 +169,48 @@ export async function writeLogChunkToR2(input: WriteLogChunkInput): Promise<Writ
   const pendingObjectCreated = await input.catalogStore?.createPendingObject(objectRow);
   if (pendingObjectCreated === false) {
     const existing = await input.catalogStore?.getObject?.(objectCatalogId);
+    if (!existing) {
+      throw new Error('log_chunk_write_in_progress_or_conflicted');
+    }
     if (
-      !existing ||
-      existing.status !== 'committed' ||
       existing.tenantKey !== input.tenantKey ||
       existing.logType !== input.logType ||
       existing.plane !== input.plane ||
+      existing.surface !== input.surface ||
       existing.objectKey !== objectKey ||
-      !existing.checksumSha256
+      existing.recordCount !== input.records.length ||
+      existing.compression !== compression ||
+      existing.encryptionScope !== input.encryption?.encryptionScope ||
+      existing.keyVersion !== input.encryption?.keyVersion
     ) {
       throw new Error('log_chunk_write_in_progress_or_conflicted');
     }
-    return {
-      chunkId,
-      objectCatalogId,
-      objectKey,
-      shard,
-      recordCount: existing.recordCount,
-      byteCount: existing.byteCount,
-      checksumSha256: existing.checksumSha256,
-      compression: existing.compression,
-      encryptionScope: existing.encryptionScope,
-      keyVersion: existing.keyVersion,
-      createdAt: existing.createdAt,
-    };
+    if (existing.status === 'committed' && existing.checksumSha256) {
+      await input.catalogStore?.commitRecordIndexes(objectCatalogId, Date.now());
+      return {
+        chunkId,
+        objectCatalogId,
+        objectKey,
+        shard,
+        recordCount: existing.recordCount,
+        byteCount: existing.byteCount,
+        checksumSha256: existing.checksumSha256,
+        compression: existing.compression,
+        encryptionScope: existing.encryptionScope,
+        keyVersion: existing.keyVersion,
+        createdAt: existing.createdAt,
+      };
+    }
+    const orphanReclaimed =
+      existing.status === 'orphan_candidate' &&
+      (await input.catalogStore?.reclaimOrphanObject?.(objectCatalogId));
+    if (!orphanReclaimed) {
+      throw new Error('log_chunk_write_in_progress_or_conflicted');
+    }
   }
-  await input.catalogStore?.createPendingRecordIndexes(indexRows);
 
   try {
+    await input.catalogStore?.createPendingRecordIndexes(indexRows);
     await input.bucket.put(objectKey, storedBody, {
       httpMetadata: {
         contentType: input.encryption
@@ -223,30 +237,29 @@ export async function writeLogChunkToR2(input: WriteLogChunkInput): Promise<Writ
         createdAt: String(createdAt),
       },
     });
+    const committedAt = Date.now();
+    await input.catalogStore?.commitObject(objectCatalogId, {
+      byteCount: storedBody.byteLength,
+      checksumSha256,
+      committedAt,
+    });
+    await input.catalogStore?.commitRecordIndexes(objectCatalogId, committedAt);
+
+    return {
+      chunkId,
+      objectCatalogId,
+      objectKey,
+      shard,
+      recordCount: input.records.length,
+      byteCount: storedBody.byteLength,
+      checksumSha256,
+      compression,
+      encryptionScope: input.encryption?.encryptionScope,
+      keyVersion: input.encryption?.keyVersion,
+      createdAt,
+    };
   } catch (error) {
     await input.catalogStore?.markObjectOrphanCandidate(objectCatalogId, Date.now());
     throw error;
   }
-
-  const committedAt = Date.now();
-  await input.catalogStore?.commitObject(objectCatalogId, {
-    byteCount: storedBody.byteLength,
-    checksumSha256,
-    committedAt,
-  });
-  await input.catalogStore?.commitRecordIndexes(objectCatalogId, committedAt);
-
-  return {
-    chunkId,
-    objectCatalogId,
-    objectKey,
-    shard,
-    recordCount: input.records.length,
-    byteCount: storedBody.byteLength,
-    checksumSha256,
-    compression,
-    encryptionScope: input.encryption?.encryptionScope,
-    keyVersion: input.encryption?.keyVersion,
-    createdAt,
-  };
 }

--- a/packages/ar-lib-logging/src/chunks/r2-chunk-writer.ts
+++ b/packages/ar-lib-logging/src/chunks/r2-chunk-writer.ts
@@ -209,6 +209,7 @@ export async function writeLogChunkToR2(input: WriteLogChunkInput): Promise<Writ
     }
   }
 
+  let objectCommitted = false;
   try {
     await input.catalogStore?.createPendingRecordIndexes(indexRows);
     await input.bucket.put(objectKey, storedBody, {
@@ -243,6 +244,7 @@ export async function writeLogChunkToR2(input: WriteLogChunkInput): Promise<Writ
       checksumSha256,
       committedAt,
     });
+    objectCommitted = true;
     await input.catalogStore?.commitRecordIndexes(objectCatalogId, committedAt);
 
     return {
@@ -259,7 +261,9 @@ export async function writeLogChunkToR2(input: WriteLogChunkInput): Promise<Writ
       createdAt,
     };
   } catch (error) {
-    await input.catalogStore?.markObjectOrphanCandidate(objectCatalogId, Date.now());
+    if (!objectCommitted) {
+      await input.catalogStore?.markObjectOrphanCandidate(objectCatalogId, Date.now());
+    }
     throw error;
   }
 }

--- a/packages/ar-lib-logging/src/chunks/types.ts
+++ b/packages/ar-lib-logging/src/chunks/types.ts
@@ -24,6 +24,7 @@ export interface LogObjectCatalogRow {
   keyVersion?: number;
   createdAt: number;
   committedAt?: number;
+  claimLeaseUntil?: number;
 }
 
 export interface LogChunkRecordIndexRow {
@@ -49,7 +50,8 @@ export interface LogChunkRecordIndexRow {
 export interface LogChunkCatalogStore {
   createPendingObject(row: LogObjectCatalogRow): Promise<boolean | void>;
   getObject?(id: string): Promise<LogObjectCatalogRow | null>;
-  reclaimOrphanObject?(id: string): Promise<boolean>;
+  reclaimOrphanObject?(id: string, claimLeaseUntil: number): Promise<boolean>;
+  reclaimExpiredPendingObject?(id: string, now: number, claimLeaseUntil: number): Promise<boolean>;
   createPendingRecordIndexes(rows: LogChunkRecordIndexRow[]): Promise<void>;
   upsertManifest?(row: LogChunkManifestRow): Promise<void>;
   commitObject(

--- a/packages/ar-lib-logging/src/chunks/types.ts
+++ b/packages/ar-lib-logging/src/chunks/types.ts
@@ -47,7 +47,8 @@ export interface LogChunkRecordIndexRow {
 }
 
 export interface LogChunkCatalogStore {
-  createPendingObject(row: LogObjectCatalogRow): Promise<void>;
+  createPendingObject(row: LogObjectCatalogRow): Promise<boolean | void>;
+  getObject?(id: string): Promise<LogObjectCatalogRow | null>;
   createPendingRecordIndexes(rows: LogChunkRecordIndexRow[]): Promise<void>;
   upsertManifest?(row: LogChunkManifestRow): Promise<void>;
   commitObject(

--- a/packages/ar-lib-logging/src/chunks/types.ts
+++ b/packages/ar-lib-logging/src/chunks/types.ts
@@ -49,6 +49,7 @@ export interface LogChunkRecordIndexRow {
 export interface LogChunkCatalogStore {
   createPendingObject(row: LogObjectCatalogRow): Promise<boolean | void>;
   getObject?(id: string): Promise<LogObjectCatalogRow | null>;
+  reclaimOrphanObject?(id: string): Promise<boolean>;
   createPendingRecordIndexes(rows: LogChunkRecordIndexRow[]): Promise<void>;
   upsertManifest?(row: LogChunkManifestRow): Promise<void>;
   commitObject(

--- a/packages/ar-lib-logging/src/delivery/__tests__/delivery-events.test.ts
+++ b/packages/ar-lib-logging/src/delivery/__tests__/delivery-events.test.ts
@@ -7,6 +7,69 @@ import {
 } from '../delivery-events';
 
 describe('SqlLoggingDeliveryEventStore', () => {
+  it('claims one delivery and rejects an active duplicate claim', async () => {
+    const executor = {
+      execute: vi
+        .fn()
+        .mockResolvedValueOnce({ rowsAffected: 1 })
+        .mockResolvedValueOnce({ rowsAffected: 0 })
+        .mockResolvedValueOnce({ rowsAffected: 0 }),
+    };
+    const store = new SqlLoggingDeliveryEventStore(executor);
+    const claim = {
+      id: 'lde_stable_logpush',
+      tenantKey: 'tk_abc',
+      destinationId: 'dest_logpush',
+      logType: 'audit' as const,
+      plane: 'external_sink' as const,
+      lane: 'critical' as const,
+      attemptCount: 1,
+      now: 1_700_000_000_000,
+      leaseUntil: 1_700_000_060_000,
+    };
+
+    await expect(store.claimEvent(claim)).resolves.toBe(true);
+    await expect(store.claimEvent(claim)).resolves.toBe(false);
+    expect(executor.execute).toHaveBeenLastCalledWith(
+      expect.stringContaining("error_class = 'delivery_in_progress'"),
+      expect.arrayContaining(['lde_stable_logpush', 1_700_000_000_000])
+    );
+  });
+
+  it('reclaims an expired delivery lease and completes it', async () => {
+    const executor = {
+      execute: vi
+        .fn()
+        .mockResolvedValueOnce({ rowsAffected: 0 })
+        .mockResolvedValueOnce({ rowsAffected: 1 })
+        .mockResolvedValueOnce({ rowsAffected: 1 })
+        .mockResolvedValueOnce({ rowsAffected: 1 }),
+    };
+    const store = new SqlLoggingDeliveryEventStore(executor);
+    const input = {
+      id: 'lde_stale_logpush',
+      tenantKey: 'tk_abc',
+      destinationId: 'dest_logpush',
+      logType: 'audit' as const,
+      plane: 'external_sink' as const,
+      lane: 'critical' as const,
+      attemptCount: 2,
+      metadata: { record_count: 1 },
+      now: 1_700_000_060_000,
+    };
+
+    await expect(store.claimEvent({ ...input, leaseUntil: 1_700_000_120_000 })).resolves.toBe(true);
+    await expect(store.completeClaim({ ...input, status: 'delivered' })).resolves.toBeUndefined();
+    expect(executor.execute).toHaveBeenCalledWith(
+      expect.stringContaining("SET status = 'delivered'"),
+      expect.arrayContaining(['lde_stale_logpush'])
+    );
+    expect(executor.execute).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE logging_delivery_event_aggregates'),
+      expect.any(Array)
+    );
+  });
+
   it('inserts delivery events with generated ids and JSON metadata', async () => {
     const executor = {
       execute: vi

--- a/packages/ar-lib-logging/src/delivery/__tests__/delivery-events.test.ts
+++ b/packages/ar-lib-logging/src/delivery/__tests__/delivery-events.test.ts
@@ -70,6 +70,22 @@ describe('SqlLoggingDeliveryEventStore', () => {
     );
   });
 
+  it('preserves an emitted claim without leaving a reclaim deadline', async () => {
+    const executor = { execute: vi.fn().mockResolvedValue({ rowsAffected: 1 }) };
+    const store = new SqlLoggingDeliveryEventStore(executor);
+
+    await store.preserveEmittedClaim('lde_uncertain_logpush', 1_700_000_060_000);
+
+    expect(executor.execute).toHaveBeenCalledWith(
+      expect.stringContaining("error_class = 'delivery_emission_uncertain'"),
+      [1_700_000_060_000, 'lde_uncertain_logpush']
+    );
+    expect(executor.execute).toHaveBeenCalledWith(
+      expect.stringContaining('next_retry_at = NULL'),
+      expect.any(Array)
+    );
+  });
+
   it('inserts delivery events with generated ids and JSON metadata', async () => {
     const executor = {
       execute: vi

--- a/packages/ar-lib-logging/src/delivery/__tests__/http-sink-delivery.test.ts
+++ b/packages/ar-lib-logging/src/delivery/__tests__/http-sink-delivery.test.ts
@@ -30,6 +30,7 @@ describe('HTTP sink delivery service', () => {
         method: 'POST',
         headers: expect.objectContaining({
           'Content-Type': 'application/json',
+          'X-Authrim-Delivery': 'delivery-1',
           Authorization: 'Bearer token-123',
         }),
         body: '{"records":[]}',

--- a/packages/ar-lib-logging/src/delivery/delivery-events.ts
+++ b/packages/ar-lib-logging/src/delivery/delivery-events.ts
@@ -42,6 +42,16 @@ export interface LoggingDeliveryEventRecord {
 
 export interface LoggingDeliveryEventStore {
   insertEvent(input: LoggingDeliveryEventInput): Promise<LoggingDeliveryEventRecord>;
+  claimEvent(
+    input: Omit<LoggingDeliveryEventInput, 'status' | 'errorClass' | 'nextRetryAt'> & {
+      id: string;
+      leaseUntil: number;
+    }
+  ): Promise<boolean>;
+  completeClaim(
+    input: LoggingDeliveryEventInput & { id: string; status: 'delivered' }
+  ): Promise<void>;
+  releaseClaim(id: string): Promise<void>;
 }
 
 export interface LoggingDeliveryEventAggregateInput {
@@ -182,6 +192,112 @@ function readRowsAffected(result: unknown): number | null {
 
 export class SqlLoggingDeliveryEventStore implements LoggingDeliveryEventStore {
   constructor(private readonly executor: LoggingSqlExecutor) {}
+
+  async claimEvent(
+    input: Omit<LoggingDeliveryEventInput, 'status' | 'errorClass' | 'nextRetryAt'> & {
+      id: string;
+      leaseUntil: number;
+    }
+  ): Promise<boolean> {
+    const now = input.now ?? Date.now();
+    const metadata = metadataToJson(input.metadata);
+    const insert = await this.executor.execute(
+      `INSERT INTO logging_delivery_events (
+        id, tenant_key, destination_id, log_type, plane, lane, status, attempt_count,
+        error_class, object_catalog_id, created_at, updated_at, next_retry_at, metadata
+      ) VALUES (?, ?, ?, ?, ?, ?, 'retrying', ?, 'delivery_in_progress', ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO NOTHING`,
+      [
+        input.id,
+        input.tenantKey,
+        input.destinationId ?? null,
+        input.logType,
+        input.plane,
+        input.lane,
+        input.attemptCount ?? 0,
+        input.objectCatalogId ?? null,
+        now,
+        now,
+        input.leaseUntil,
+        metadata,
+      ]
+    );
+    const inserted = readRowsAffected(insert);
+    if (inserted === null || inserted > 0) {
+      return true;
+    }
+
+    const reclaimed = await this.executor.execute(
+      `UPDATE logging_delivery_events
+       SET tenant_key = ?, destination_id = ?, log_type = ?, plane = ?, lane = ?,
+           attempt_count = ?, object_catalog_id = ?, updated_at = ?, next_retry_at = ?, metadata = ?
+       WHERE id = ?
+         AND status = 'retrying'
+         AND error_class = 'delivery_in_progress'
+         AND next_retry_at IS NOT NULL
+         AND next_retry_at <= ?`,
+      [
+        input.tenantKey,
+        input.destinationId ?? null,
+        input.logType,
+        input.plane,
+        input.lane,
+        input.attemptCount ?? 0,
+        input.objectCatalogId ?? null,
+        now,
+        input.leaseUntil,
+        metadata,
+        input.id,
+        now,
+      ]
+    );
+    return (readRowsAffected(reclaimed) ?? 0) > 0;
+  }
+
+  async completeClaim(
+    input: LoggingDeliveryEventInput & { id: string; status: 'delivered' }
+  ): Promise<void> {
+    const now = input.now ?? Date.now();
+    const completed = await this.executor.execute(
+      `UPDATE logging_delivery_events
+       SET status = 'delivered', attempt_count = ?, error_class = NULL,
+           object_catalog_id = ?, updated_at = ?, next_retry_at = NULL, metadata = ?
+       WHERE id = ?
+         AND status = 'retrying'
+         AND error_class = 'delivery_in_progress'`,
+      [
+        input.attemptCount ?? 0,
+        input.objectCatalogId ?? null,
+        now,
+        metadataToJson(input.metadata),
+        input.id,
+      ]
+    );
+    if (readRowsAffected(completed) === 0) {
+      throw new Error('logging_delivery_claim_not_owned');
+    }
+    await this.upsertAggregate({
+      tenantKey: input.tenantKey,
+      destinationId: input.destinationId,
+      logType: input.logType,
+      plane: input.plane,
+      lane: input.lane,
+      status: 'delivered',
+      attemptCount: input.attemptCount,
+      recordCount:
+        typeof input.metadata?.record_count === 'number' ? input.metadata.record_count : 0,
+      byteCount: typeof input.metadata?.byte_count === 'number' ? input.metadata.byte_count : 0,
+      eventAt: now,
+    });
+  }
+
+  async releaseClaim(id: string): Promise<void> {
+    await this.executor.execute(
+      `DELETE FROM logging_delivery_events
+       WHERE id = ? AND status = 'retrying' AND error_class = 'delivery_in_progress'`,
+      [id]
+    );
+  }
 
   async insertEvent(input: LoggingDeliveryEventInput): Promise<LoggingDeliveryEventRecord> {
     const now = input.now ?? Date.now();

--- a/packages/ar-lib-logging/src/delivery/delivery-events.ts
+++ b/packages/ar-lib-logging/src/delivery/delivery-events.ts
@@ -51,6 +51,7 @@ export interface LoggingDeliveryEventStore {
   completeClaim(
     input: LoggingDeliveryEventInput & { id: string; status: 'delivered' }
   ): Promise<void>;
+  preserveEmittedClaim(id: string, now?: number): Promise<void>;
   releaseClaim(id: string): Promise<void>;
 }
 
@@ -296,6 +297,15 @@ export class SqlLoggingDeliveryEventStore implements LoggingDeliveryEventStore {
       `DELETE FROM logging_delivery_events
        WHERE id = ? AND status = 'retrying' AND error_class = 'delivery_in_progress'`,
       [id]
+    );
+  }
+
+  async preserveEmittedClaim(id: string, now = Date.now()): Promise<void> {
+    await this.executor.execute(
+      `UPDATE logging_delivery_events
+       SET error_class = 'delivery_emission_uncertain', updated_at = ?, next_retry_at = NULL
+       WHERE id = ? AND status = 'retrying' AND error_class = 'delivery_in_progress'`,
+      [now, id]
     );
   }
 

--- a/packages/ar-lib-logging/src/delivery/http-sink-delivery.ts
+++ b/packages/ar-lib-logging/src/delivery/http-sink-delivery.ts
@@ -132,6 +132,7 @@ export async function deliverHttpSinkBatch(
   const headers = {
     'Content-Type': request.contentType ?? 'application/json',
     ...authHeaders.headers,
+    ...(request.deliveryId ? { 'X-Authrim-Delivery': request.deliveryId } : {}),
   };
   const response = await (request.fetcher ?? fetch)(url.toString(), {
     method,

--- a/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
+++ b/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
@@ -260,6 +260,68 @@ describe('guest deletion audit reconciliation outbox', () => {
     expect(await repository.listDue(1001, 100)).toEqual([]);
   });
 
+  it('shares the default reconciliation deadline across every adapter', async () => {
+    await adapter.execute(
+      `INSERT INTO identity_accounts
+         (tenant_id, legacy_user_id, account_type, registration_state, deleted_at)
+       VALUES (?, ?, 'user', 'guest', NULL)`,
+      ['tenant-b', 'guest-b']
+    );
+    const lifecycle = new GuestLifecycleRepository(adapter, 'tenant-b');
+    await lifecycle.enroll({
+      userId: 'guest-b',
+      clientId: 'client-1',
+      createdAt: 100,
+      deletionAfterDays: null,
+      policyVersion: 'policy-1',
+    });
+    expect(
+      await lifecycle.beginAdministrativeDeletion(
+        'guest-b',
+        'operation-b',
+        999,
+        deletionRouteJson,
+        999000
+      )
+    ).toBe(true);
+    expect(await lifecycle.completeDeletion('guest-b', 'operation-b', 1000)).toBe(true);
+    await new GuestDeletionAuditOutboxRepository(adapter, 'tenant-b').enqueue({
+      auditId: 'account-guest-deleted-operation-b',
+      userId: 'guest-b',
+      operationId: 'operation-b',
+      actorUserId: 'admin-1',
+      ipAddress: 'unknown',
+      userAgent: 'unknown',
+      metadataJson: '{}',
+      createdAt: 900,
+    });
+    const nowMs = vi
+      .fn()
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(1)
+      .mockReturnValueOnce(2)
+      .mockReturnValue(5000);
+    const writeAudit = vi.fn().mockResolvedValue(undefined);
+
+    expect(
+      await processGuestDeletionAuditOutbox(
+        {} as Env,
+        [
+          { tenantId: 'tenant-a', adapters: [{ adapter, bindingRef: 'CORE_A' }] },
+          { tenantId: 'tenant-b', adapters: [{ adapter, bindingRef: 'CORE_B' }] },
+        ],
+        { info: vi.fn(), warn: vi.fn() },
+        { now: () => 1001, nowMs, writeAudit }
+      )
+    ).toEqual({ processed: 0, succeeded: 0, retrying: 0 });
+    expect(writeAudit).not.toHaveBeenCalled();
+    expect(
+      await new GuestDeletionAuditOutboxRepository(adapter, 'tenant-b').get(
+        'account-guest-deleted-operation-b'
+      )
+    ).not.toBeNull();
+  });
+
   it('uses the configured audit store rather than the identity shard during replay', async () => {
     const repository = new GuestDeletionAuditOutboxRepository(adapter, 'tenant-a');
     await repository.enqueue({

--- a/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
+++ b/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
@@ -94,7 +94,7 @@ describe('guest deletion audit reconciliation outbox', () => {
         reason: 'manual_cleanup',
         source: 'guest_cleanup_api',
       }),
-      createdAt: 1000,
+      createdAt: 900,
     });
     const lifecycle = new GuestLifecycleRepository(adapter, 'tenant-a');
     expect(
@@ -121,7 +121,7 @@ describe('guest deletion audit reconciliation outbox', () => {
       { info: vi.fn(), warn: vi.fn() },
       {
         now: () => 1001,
-        writeAudit: async (task) => {
+        writeAudit: async (task, _adapter, completedAt) => {
           await writeLegacyAuditLog(adapter, {
             id: task.audit_id,
             tenantId: task.tenant_id,
@@ -133,7 +133,7 @@ describe('guest deletion audit reconciliation outbox', () => {
             userAgent: task.user_agent,
             metadata: task.metadata_json,
             severity: 'info',
-            createdAt: Number(task.created_at),
+            createdAt: completedAt / 1000,
           });
         },
       }
@@ -141,11 +141,11 @@ describe('guest deletion audit reconciliation outbox', () => {
 
     expect(summary).toEqual({ processed: 1, succeeded: 1, retrying: 0 });
     expect(
-      await adapter.queryOne<{ action: string; user_id: string }>(
-        'SELECT action, user_id FROM audit_log WHERE id = ?',
+      await adapter.queryOne<{ action: string; user_id: string; created_at: number }>(
+        'SELECT action, user_id, created_at FROM audit_log WHERE id = ?',
         ['account-guest-deleted-operation-1']
       )
-    ).toEqual({ action: 'user.deleted', user_id: 'admin-1' });
+    ).toEqual({ action: 'user.deleted', user_id: 'admin-1', created_at: 1000 });
     expect((await restartedRepository.get('account-guest-deleted-operation-1'))?.status).toBe(
       'succeeded'
     );

--- a/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
+++ b/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
@@ -1,5 +1,13 @@
 import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockCreateAuditLog = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock('@authrim/ar-lib-core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@authrim/ar-lib-core')>()),
+  createAuditLog: mockCreateAuditLog,
+}));
+
 import type { DatabaseAdapter, Env } from '@authrim/ar-lib-core';
 import { GuestLifecycleRepository, writeLegacyAuditLog } from '@authrim/ar-lib-core';
 import { DatabaseSync, type SQLiteDatabase, type SQLInputValue } from './test-sqlite';
@@ -15,6 +23,7 @@ describe('guest deletion audit reconciliation outbox', () => {
   let adapter: DatabaseAdapter;
 
   beforeEach(async () => {
+    mockCreateAuditLog.mockReset().mockResolvedValue(undefined);
     db = new DatabaseSync(':memory:');
     db.exec(`
       CREATE TABLE identity_accounts (
@@ -189,6 +198,51 @@ describe('guest deletion audit reconciliation outbox', () => {
     expect((await restartedRepository.get('account-guest-deleted-operation-1'))?.status).toBe(
       'succeeded'
     );
+  });
+
+  it('uses the configured audit store rather than the identity shard during replay', async () => {
+    const repository = new GuestDeletionAuditOutboxRepository(adapter, 'tenant-a');
+    await repository.enqueue({
+      auditId: 'account-guest-deleted-canonical-audit',
+      userId: 'guest-1',
+      operationId: 'canonical-audit',
+      actorUserId: 'admin-1',
+      ipAddress: 'unknown',
+      userAgent: 'unknown',
+      metadataJson: '{}',
+      createdAt: 900,
+    });
+    const lifecycle = new GuestLifecycleRepository(adapter, 'tenant-a');
+    expect(
+      await lifecycle.beginAdministrativeDeletion(
+        'guest-1',
+        'canonical-audit',
+        999,
+        deletionRouteJson,
+        999000
+      )
+    ).toBe(true);
+    expect(await lifecycle.completeDeletion('guest-1', 'canonical-audit', 1000)).toBe(true);
+    const canonicalAuditDb = { prepare: vi.fn() } as unknown as D1Database;
+    const env = { DB: canonicalAuditDb } as Env;
+
+    expect(
+      await processGuestDeletionAuditOutbox(
+        env,
+        [{ tenantId: 'tenant-a', adapters: [{ adapter, bindingRef: 'IDENTITY_SHARD' }] }],
+        { info: vi.fn(), warn: vi.fn() },
+        { now: () => 1001 }
+      )
+    ).toEqual({ processed: 1, succeeded: 1, retrying: 0 });
+    expect(mockCreateAuditLog).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({
+        id: 'account-guest-deleted-canonical-audit',
+        createdAt: 1000 * 1000,
+      })
+    );
+    expect(mockCreateAuditLog.mock.calls[0][0].DB).toBe(canonicalAuditDb);
+    expect(mockCreateAuditLog.mock.calls[0][0].DB).not.toBe(adapter);
   });
 
   it('does not emit completion before the account deletion is committed', async () => {

--- a/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
+++ b/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
@@ -195,9 +195,7 @@ describe('guest deletion audit reconciliation outbox', () => {
         ['account-guest-deleted-operation-1']
       )
     ).toEqual({ action: 'user.deleted', user_id: 'admin-1', created_at: 1000 });
-    expect((await restartedRepository.get('account-guest-deleted-operation-1'))?.status).toBe(
-      'succeeded'
-    );
+    expect(await restartedRepository.get('account-guest-deleted-operation-1')).toBeNull();
   });
 
   it('uses the configured audit store rather than the identity shard during replay', async () => {

--- a/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
+++ b/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
@@ -260,7 +260,28 @@ describe('guest deletion audit reconciliation outbox', () => {
     expect(await repository.listDue(1001, 100)).toEqual([]);
   });
 
-  it('shares the default reconciliation deadline across every adapter', async () => {
+  it('rotates the first adapter after a shared deadline is exhausted', async () => {
+    const lifecycleA = new GuestLifecycleRepository(adapter, 'tenant-a');
+    expect(
+      await lifecycleA.beginAdministrativeDeletion(
+        'guest-1',
+        'operation-a',
+        999,
+        deletionRouteJson,
+        999000
+      )
+    ).toBe(true);
+    expect(await lifecycleA.completeDeletion('guest-1', 'operation-a', 1000)).toBe(true);
+    await new GuestDeletionAuditOutboxRepository(adapter, 'tenant-a').enqueue({
+      auditId: 'account-guest-deleted-operation-a',
+      userId: 'guest-1',
+      operationId: 'operation-a',
+      actorUserId: 'admin-1',
+      ipAddress: 'unknown',
+      userAgent: 'unknown',
+      metadataJson: '{}',
+      createdAt: 900,
+    });
     await adapter.execute(
       `INSERT INTO identity_accounts
          (tenant_id, legacy_user_id, account_type, registration_state, deleted_at)
@@ -302,24 +323,61 @@ describe('guest deletion audit reconciliation outbox', () => {
       .mockReturnValueOnce(2)
       .mockReturnValue(5000);
     const writeAudit = vi.fn().mockResolvedValue(undefined);
+    let cursor: string | null = null;
+    const env = {
+      AUTHRIM_CONFIG: {
+        get: vi.fn(async () => cursor),
+        put: vi.fn(async (_key: string, value: string) => {
+          cursor = value;
+        }),
+      },
+    } as unknown as Env;
+    const targets = [
+      { tenantId: 'tenant-a', adapters: [{ adapter, bindingRef: 'CORE_A' }] },
+      { tenantId: 'tenant-b', adapters: [{ adapter, bindingRef: 'CORE_B' }] },
+    ];
 
     expect(
       await processGuestDeletionAuditOutbox(
-        {} as Env,
-        [
-          { tenantId: 'tenant-a', adapters: [{ adapter, bindingRef: 'CORE_A' }] },
-          { tenantId: 'tenant-b', adapters: [{ adapter, bindingRef: 'CORE_B' }] },
-        ],
+        env,
+        targets,
         { info: vi.fn(), warn: vi.fn() },
-        { now: () => 1001, nowMs, writeAudit }
+        {
+          now: () => 1001,
+          nowMs,
+          writeAudit,
+        }
       )
-    ).toEqual({ processed: 0, succeeded: 0, retrying: 0 });
-    expect(writeAudit).not.toHaveBeenCalled();
+    ).toEqual({ processed: 1, succeeded: 1, retrying: 0 });
+    expect(writeAudit).toHaveBeenCalledTimes(1);
     expect(
       await new GuestDeletionAuditOutboxRepository(adapter, 'tenant-b').get(
         'account-guest-deleted-operation-b'
       )
     ).not.toBeNull();
+
+    expect(
+      await processGuestDeletionAuditOutbox(
+        env,
+        targets,
+        { info: vi.fn(), warn: vi.fn() },
+        {
+          now: () => 1001,
+          nowMs: () => 0,
+          deadlineMs: 1,
+          writeAudit,
+        }
+      )
+    ).toEqual({ processed: 1, succeeded: 1, retrying: 0 });
+    expect(writeAudit).toHaveBeenCalledTimes(2);
+    expect(writeAudit.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({ tenant_id: 'tenant-b' })
+    );
+    expect(
+      await new GuestDeletionAuditOutboxRepository(adapter, 'tenant-b').get(
+        'account-guest-deleted-operation-b'
+      )
+    ).toBeNull();
   });
 
   it('uses the configured audit store rather than the identity shard during replay', async () => {

--- a/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
+++ b/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
@@ -4,6 +4,7 @@ import type { DatabaseAdapter, Env } from '@authrim/ar-lib-core';
 import { GuestLifecycleRepository, writeLegacyAuditLog } from '@authrim/ar-lib-core';
 import { DatabaseSync, type SQLiteDatabase, type SQLInputValue } from './test-sqlite';
 import {
+  createGuestDeletionAuditTaskFromContext,
   GuestDeletionAuditOutboxRepository,
   processGuestDeletionAuditOutbox,
 } from '../guest-deletion-audit-outbox';
@@ -78,6 +79,45 @@ describe('guest deletion audit reconciliation outbox', () => {
   });
 
   afterEach(() => db.close());
+
+  it('persists the request and proxy metadata used by immediate audit delivery', () => {
+    const headers: Record<string, string> = {
+      'CF-Connecting-IP': '192.0.2.1',
+      'User-Agent': 'test-agent',
+      'X-Request-Id': 'proxy-request',
+      'X-Correlation-Id': 'correlation-1',
+      'X-Authrim-Admin-UI-Api-Mode': 'bff',
+      'X-Authrim-Forwarded-Host': 'admin.example.com',
+      'X-Forwarded-Proto': 'https',
+    };
+    const task = createGuestDeletionAuditTaskFromContext(
+      {
+        get: (name: string) =>
+          name === 'adminAuth'
+            ? { userId: 'admin-1' }
+            : name === 'requestId'
+              ? 'context-request'
+              : undefined,
+        req: { header: (name: string) => headers[name] },
+      } as never,
+      {
+        auditId: 'audit-1',
+        userId: 'guest-1',
+        operationId: 'operation-1',
+        metadata: { reason: 'admin_action' },
+      }
+    );
+
+    expect(JSON.parse(task.metadataJson)).toEqual({
+      reason: 'admin_action',
+      request_id: 'context-request',
+      admin_ui_api_mode: 'bff',
+      admin_ui_bff_forwarded_host: 'admin.example.com',
+      admin_ui_bff_forwarded_proto: 'https',
+      admin_ui_bff_request_id: 'proxy-request',
+      admin_ui_bff_correlation_id: 'correlation-1',
+    });
+  });
 
   it('survives a processor restart and persists the missing completion audit', async () => {
     const repository = new GuestDeletionAuditOutboxRepository(adapter, 'tenant-a');
@@ -217,8 +257,8 @@ describe('guest deletion audit reconciliation outbox', () => {
         { info: vi.fn(), warn: vi.fn() },
         { now: () => 1001, writeAudit }
       )
-    ).toEqual({ processed: 1, succeeded: 0, retrying: 1 });
+    ).toEqual({ processed: 1, succeeded: 0, retrying: 0 });
     expect(writeAudit).not.toHaveBeenCalled();
-    expect((await repository.get('account-guest-deleted-operation-stale'))?.status).toBe('retry');
+    expect(await repository.get('account-guest-deleted-operation-stale')).toBeNull();
   });
 });

--- a/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
+++ b/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
@@ -89,6 +89,14 @@ describe('guest deletion audit reconciliation outbox', () => {
 
   afterEach(() => db.close());
 
+  it('runs lifecycle recovery before scheduled completion-audit reconciliation', () => {
+    const source = readFileSync(new URL('../index.ts', import.meta.url), 'utf8');
+    const maintenanceBlock = source.slice(source.indexOf('const maintenancePage'));
+    expect(maintenanceBlock.indexOf('processGuestLifecycleMaintenance(')).toBeLessThan(
+      maintenanceBlock.indexOf('processGuestDeletionAuditOutbox(')
+    );
+  });
+
   it('persists the request and proxy metadata used by immediate audit delivery', () => {
     const headers: Record<string, string> = {
       'CF-Connecting-IP': '192.0.2.1',

--- a/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
+++ b/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
@@ -198,6 +198,60 @@ describe('guest deletion audit reconciliation outbox', () => {
     expect(await restartedRepository.get('account-guest-deleted-operation-1')).toBeNull();
   });
 
+  it('drains more than one due page during the same maintenance visit', async () => {
+    const lifecycle = new GuestLifecycleRepository(adapter, 'tenant-a');
+    const repository = new GuestDeletionAuditOutboxRepository(adapter, 'tenant-a');
+    for (let index = 0; index < 21; index += 1) {
+      const userId = `guest-bulk-${index}`;
+      const operationId = `operation-bulk-${index}`;
+      await adapter.execute(
+        `INSERT INTO identity_accounts
+           (tenant_id, legacy_user_id, account_type, registration_state, deleted_at)
+         VALUES (?, ?, 'user', 'guest', NULL)`,
+        ['tenant-a', userId]
+      );
+      await lifecycle.enroll({
+        userId,
+        clientId: 'client-1',
+        createdAt: 100,
+        deletionAfterDays: null,
+        policyVersion: 'policy-1',
+      });
+      expect(
+        await lifecycle.beginAdministrativeDeletion(
+          userId,
+          operationId,
+          999,
+          deletionRouteJson,
+          999000
+        )
+      ).toBe(true);
+      expect(await lifecycle.completeDeletion(userId, operationId, 1000)).toBe(true);
+      await repository.enqueue({
+        auditId: `account-guest-deleted-${operationId}`,
+        userId,
+        operationId,
+        actorUserId: 'admin-1',
+        ipAddress: 'unknown',
+        userAgent: 'unknown',
+        metadataJson: '{}',
+        createdAt: 900,
+      });
+    }
+    const writeAudit = vi.fn().mockResolvedValue(undefined);
+
+    expect(
+      await processGuestDeletionAuditOutbox(
+        {} as Env,
+        [{ tenantId: 'tenant-a', adapters: [{ adapter, bindingRef: 'CORE' }] }],
+        { info: vi.fn(), warn: vi.fn() },
+        { now: () => 1001, nowMs: () => 0, deadlineMs: 1, writeAudit }
+      )
+    ).toEqual({ processed: 21, succeeded: 21, retrying: 0 });
+    expect(writeAudit).toHaveBeenCalledTimes(21);
+    expect(await repository.listDue(1001, 100)).toEqual([]);
+  });
+
   it('uses the configured audit store rather than the identity shard during replay', async () => {
     const repository = new GuestDeletionAuditOutboxRepository(adapter, 'tenant-a');
     await repository.enqueue({

--- a/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
+++ b/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
@@ -225,6 +225,32 @@ describe('guest deletion audit reconciliation outbox', () => {
     expect((await repository.get('account-guest-deleted-operation-2'))?.status).toBe('retry');
   });
 
+  it('keeps a fresh task while its lifecycle claim may still be in flight', async () => {
+    const repository = new GuestDeletionAuditOutboxRepository(adapter, 'tenant-a');
+    await repository.enqueue({
+      auditId: 'account-guest-deleted-operation-pending',
+      userId: 'guest-1',
+      operationId: 'operation-pending',
+      actorUserId: 'admin-1',
+      ipAddress: 'unknown',
+      userAgent: 'unknown',
+      metadataJson: '{}',
+      createdAt: 1000,
+    });
+    const writeAudit = vi.fn();
+
+    expect(
+      await processGuestDeletionAuditOutbox(
+        {} as Env,
+        [{ tenantId: 'tenant-a', adapters: [{ adapter, bindingRef: 'CORE' }] }],
+        { info: vi.fn(), warn: vi.fn() },
+        { now: () => 1001, writeAudit }
+      )
+    ).toEqual({ processed: 1, succeeded: 0, retrying: 1 });
+    expect(writeAudit).not.toHaveBeenCalled();
+    expect((await repository.get('account-guest-deleted-operation-pending'))?.status).toBe('retry');
+  });
+
   it('does not emit completion for a different deletion operation', async () => {
     const lifecycle = new GuestLifecycleRepository(adapter, 'tenant-a');
     expect(
@@ -255,7 +281,7 @@ describe('guest deletion audit reconciliation outbox', () => {
         {} as Env,
         [{ tenantId: 'tenant-a', adapters: [{ adapter, bindingRef: 'CORE' }] }],
         { info: vi.fn(), warn: vi.fn() },
-        { now: () => 1001, writeAudit }
+        { now: () => 2000, writeAudit }
       )
     ).toEqual({ processed: 1, succeeded: 0, retrying: 0 });
     expect(writeAudit).not.toHaveBeenCalled();

--- a/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
+++ b/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
@@ -1,0 +1,180 @@
+import { readFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DatabaseAdapter, Env } from '@authrim/ar-lib-core';
+import { writeLegacyAuditLog } from '@authrim/ar-lib-core';
+import { DatabaseSync, type SQLiteDatabase, type SQLInputValue } from './test-sqlite';
+import {
+  GuestDeletionAuditOutboxRepository,
+  processGuestDeletionAuditOutbox,
+} from '../guest-deletion-audit-outbox';
+
+describe('guest deletion audit reconciliation outbox', () => {
+  let db: SQLiteDatabase;
+  let adapter: DatabaseAdapter;
+
+  beforeEach(() => {
+    db = new DatabaseSync(':memory:');
+    db.exec(`
+      CREATE TABLE guest_account_lifecycle (
+        tenant_id TEXT NOT NULL,
+        user_id TEXT NOT NULL,
+        phase TEXT NOT NULL,
+        deletion_operation_id TEXT
+      );
+      CREATE TABLE audit_log (
+        id TEXT PRIMARY KEY,
+        tenant_id TEXT NOT NULL,
+        user_id TEXT,
+        action TEXT NOT NULL,
+        resource_type TEXT,
+        resource_id TEXT,
+        ip_address TEXT,
+        user_agent TEXT,
+        metadata_json TEXT,
+        severity TEXT,
+        created_at INTEGER NOT NULL
+      );
+      INSERT INTO guest_account_lifecycle
+        VALUES ('tenant-a', 'guest-1', 'deleted', 'operation-1');
+    `);
+    db.exec(
+      readFileSync(
+        new URL(
+          '../../../../migrations/core/d1/004_guest_deletion_audit_outbox.sql',
+          import.meta.url
+        ),
+        'utf8'
+      )
+    );
+    adapter = {
+      async queryOne<T>(sql: string, params: unknown[] = []) {
+        return (db.prepare(sql).get(...(params as SQLInputValue[])) ?? null) as T | null;
+      },
+      async query<T>(sql: string, params: unknown[] = []) {
+        return db.prepare(sql).all(...(params as SQLInputValue[])) as T[];
+      },
+      async execute(sql: string, params: unknown[] = []) {
+        return {
+          success: true,
+          rowsAffected: Number(db.prepare(sql).run(...(params as SQLInputValue[])).changes),
+        };
+      },
+    } as DatabaseAdapter;
+  });
+
+  afterEach(() => db.close());
+
+  it('survives a processor restart and persists the missing completion audit', async () => {
+    const repository = new GuestDeletionAuditOutboxRepository(adapter, 'tenant-a');
+    await repository.enqueue({
+      auditId: 'account-guest-deleted-operation-1',
+      userId: 'guest-1',
+      operationId: 'operation-1',
+      actorUserId: 'admin-1',
+      ipAddress: '192.0.2.1',
+      userAgent: 'test-agent',
+      metadataJson: JSON.stringify({
+        operationId: 'operation-1',
+        registration_state: 'guest',
+        reason: 'manual_cleanup',
+        source: 'guest_cleanup_api',
+      }),
+      createdAt: 1000,
+    });
+
+    expect(await repository.listDue(1000, 10)).toHaveLength(1);
+
+    const restartedRepository = new GuestDeletionAuditOutboxRepository(adapter, 'tenant-a');
+    const summary = await processGuestDeletionAuditOutbox(
+      {} as Env,
+      [{ tenantId: 'tenant-a', adapters: [{ adapter, bindingRef: 'CORE' }] }],
+      { info: vi.fn(), warn: vi.fn() },
+      {
+        now: () => 1001,
+        writeAudit: async (task) => {
+          await writeLegacyAuditLog(adapter, {
+            id: task.audit_id,
+            tenantId: task.tenant_id,
+            userId: task.actor_user_id,
+            action: 'user.deleted',
+            resource: 'user',
+            resourceId: task.user_id,
+            ipAddress: task.ip_address,
+            userAgent: task.user_agent,
+            metadata: task.metadata_json,
+            severity: 'info',
+            createdAt: Number(task.created_at),
+          });
+        },
+      }
+    );
+
+    expect(summary).toEqual({ processed: 1, succeeded: 1, retrying: 0 });
+    expect(
+      await adapter.queryOne<{ action: string; user_id: string }>(
+        'SELECT action, user_id FROM audit_log WHERE id = ?',
+        ['account-guest-deleted-operation-1']
+      )
+    ).toEqual({ action: 'user.deleted', user_id: 'admin-1' });
+    expect((await restartedRepository.get('account-guest-deleted-operation-1'))?.status).toBe(
+      'succeeded'
+    );
+  });
+
+  it('does not emit completion before the account deletion is committed', async () => {
+    await adapter.execute(
+      `UPDATE guest_account_lifecycle SET phase = 'deleting'
+       WHERE tenant_id = ? AND user_id = ?`,
+      ['tenant-a', 'guest-1']
+    );
+    const repository = new GuestDeletionAuditOutboxRepository(adapter, 'tenant-a');
+    await repository.enqueue({
+      auditId: 'account-guest-deleted-operation-2',
+      userId: 'guest-1',
+      operationId: 'operation-2',
+      actorUserId: 'admin-1',
+      ipAddress: 'unknown',
+      userAgent: 'unknown',
+      metadataJson: '{}',
+      createdAt: 1000,
+    });
+    const writeAudit = vi.fn();
+
+    expect(
+      await processGuestDeletionAuditOutbox(
+        {} as Env,
+        [{ tenantId: 'tenant-a', adapters: [{ adapter, bindingRef: 'CORE' }] }],
+        { info: vi.fn(), warn: vi.fn() },
+        { now: () => 1001, writeAudit }
+      )
+    ).toEqual({ processed: 1, succeeded: 0, retrying: 1 });
+    expect(writeAudit).not.toHaveBeenCalled();
+    expect((await repository.get('account-guest-deleted-operation-2'))?.status).toBe('retry');
+  });
+
+  it('does not emit completion for a different deletion operation', async () => {
+    const repository = new GuestDeletionAuditOutboxRepository(adapter, 'tenant-a');
+    await repository.enqueue({
+      auditId: 'account-guest-deleted-operation-stale',
+      userId: 'guest-1',
+      operationId: 'operation-stale',
+      actorUserId: 'admin-1',
+      ipAddress: 'unknown',
+      userAgent: 'unknown',
+      metadataJson: '{}',
+      createdAt: 1000,
+    });
+    const writeAudit = vi.fn();
+
+    expect(
+      await processGuestDeletionAuditOutbox(
+        {} as Env,
+        [{ tenantId: 'tenant-a', adapters: [{ adapter, bindingRef: 'CORE' }] }],
+        { info: vi.fn(), warn: vi.fn() },
+        { now: () => 1001, writeAudit }
+      )
+    ).toEqual({ processed: 1, succeeded: 0, retrying: 1 });
+    expect(writeAudit).not.toHaveBeenCalled();
+    expect((await repository.get('account-guest-deleted-operation-stale'))?.status).toBe('retry');
+  });
+});

--- a/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
+++ b/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../guest-deletion-audit-outbox';
 
 describe('guest deletion audit reconciliation outbox', () => {
+  const deletionRouteJson = '{"schemaVersion":1}';
   let db: SQLiteDatabase;
   let adapter: DatabaseAdapter;
 
@@ -96,9 +97,15 @@ describe('guest deletion audit reconciliation outbox', () => {
       createdAt: 1000,
     });
     const lifecycle = new GuestLifecycleRepository(adapter, 'tenant-a');
-    expect(await lifecycle.beginAdministrativeDeletion('guest-1', 'operation-1', 999, 999000)).toBe(
-      true
-    );
+    expect(
+      await lifecycle.beginAdministrativeDeletion(
+        'guest-1',
+        'operation-1',
+        999,
+        deletionRouteJson,
+        999000
+      )
+    ).toBe(true);
     await adapter.execute(
       'UPDATE identity_accounts SET deleted_at = ? WHERE tenant_id = ? AND legacy_user_id = ?',
       [999, 'tenant-a', 'guest-1']
@@ -149,7 +156,8 @@ describe('guest deletion audit reconciliation outbox', () => {
       await new GuestLifecycleRepository(adapter, 'tenant-a').beginAdministrativeDeletion(
         'guest-1',
         'operation-2',
-        999
+        999,
+        deletionRouteJson
       )
     ).toBe(true);
     const repository = new GuestDeletionAuditOutboxRepository(adapter, 'tenant-a');
@@ -179,9 +187,15 @@ describe('guest deletion audit reconciliation outbox', () => {
 
   it('does not emit completion for a different deletion operation', async () => {
     const lifecycle = new GuestLifecycleRepository(adapter, 'tenant-a');
-    expect(await lifecycle.beginAdministrativeDeletion('guest-1', 'operation-1', 999, 999000)).toBe(
-      true
-    );
+    expect(
+      await lifecycle.beginAdministrativeDeletion(
+        'guest-1',
+        'operation-1',
+        999,
+        deletionRouteJson,
+        999000
+      )
+    ).toBe(true);
     expect(await lifecycle.completeDeletion('guest-1', 'operation-1', 1000)).toBe(true);
     const repository = new GuestDeletionAuditOutboxRepository(adapter, 'tenant-a');
     await repository.enqueue({

--- a/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
+++ b/packages/ar-management/src/__tests__/guest-deletion-audit-outbox.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DatabaseAdapter, Env } from '@authrim/ar-lib-core';
-import { writeLegacyAuditLog } from '@authrim/ar-lib-core';
+import { GuestLifecycleRepository, writeLegacyAuditLog } from '@authrim/ar-lib-core';
 import { DatabaseSync, type SQLiteDatabase, type SQLInputValue } from './test-sqlite';
 import {
   GuestDeletionAuditOutboxRepository,
@@ -12,14 +12,15 @@ describe('guest deletion audit reconciliation outbox', () => {
   let db: SQLiteDatabase;
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     db = new DatabaseSync(':memory:');
     db.exec(`
-      CREATE TABLE guest_account_lifecycle (
+      CREATE TABLE identity_accounts (
         tenant_id TEXT NOT NULL,
-        user_id TEXT NOT NULL,
-        phase TEXT NOT NULL,
-        deletion_operation_id TEXT
+        legacy_user_id TEXT NOT NULL,
+        account_type TEXT NOT NULL,
+        registration_state TEXT NOT NULL,
+        deleted_at INTEGER
       );
       CREATE TABLE audit_log (
         id TEXT PRIMARY KEY,
@@ -34,9 +35,15 @@ describe('guest deletion audit reconciliation outbox', () => {
         severity TEXT,
         created_at INTEGER NOT NULL
       );
-      INSERT INTO guest_account_lifecycle
-        VALUES ('tenant-a', 'guest-1', 'deleted', 'operation-1');
+      INSERT INTO identity_accounts
+        VALUES ('tenant-a', 'guest-1', 'user', 'guest', NULL);
     `);
+    db.exec(
+      readFileSync(
+        new URL('../../../../migrations/core/d1/002_guest_account_lifecycle.sql', import.meta.url),
+        'utf8'
+      )
+    );
     db.exec(
       readFileSync(
         new URL(
@@ -60,6 +67,13 @@ describe('guest deletion audit reconciliation outbox', () => {
         };
       },
     } as DatabaseAdapter;
+    await new GuestLifecycleRepository(adapter, 'tenant-a').enroll({
+      userId: 'guest-1',
+      clientId: 'client-1',
+      createdAt: 100,
+      deletionAfterDays: null,
+      policyVersion: 'policy-1',
+    });
   });
 
   afterEach(() => db.close());
@@ -81,6 +95,15 @@ describe('guest deletion audit reconciliation outbox', () => {
       }),
       createdAt: 1000,
     });
+    const lifecycle = new GuestLifecycleRepository(adapter, 'tenant-a');
+    expect(await lifecycle.beginAdministrativeDeletion('guest-1', 'operation-1', 999, 999000)).toBe(
+      true
+    );
+    await adapter.execute(
+      'UPDATE identity_accounts SET deleted_at = ? WHERE tenant_id = ? AND legacy_user_id = ?',
+      [999, 'tenant-a', 'guest-1']
+    );
+    expect(await lifecycle.completeDeletion('guest-1', 'operation-1', 1000)).toBe(true);
 
     expect(await repository.listDue(1000, 10)).toHaveLength(1);
 
@@ -122,11 +145,13 @@ describe('guest deletion audit reconciliation outbox', () => {
   });
 
   it('does not emit completion before the account deletion is committed', async () => {
-    await adapter.execute(
-      `UPDATE guest_account_lifecycle SET phase = 'deleting'
-       WHERE tenant_id = ? AND user_id = ?`,
-      ['tenant-a', 'guest-1']
-    );
+    expect(
+      await new GuestLifecycleRepository(adapter, 'tenant-a').beginAdministrativeDeletion(
+        'guest-1',
+        'operation-2',
+        999
+      )
+    ).toBe(true);
     const repository = new GuestDeletionAuditOutboxRepository(adapter, 'tenant-a');
     await repository.enqueue({
       auditId: 'account-guest-deleted-operation-2',
@@ -153,6 +178,11 @@ describe('guest deletion audit reconciliation outbox', () => {
   });
 
   it('does not emit completion for a different deletion operation', async () => {
+    const lifecycle = new GuestLifecycleRepository(adapter, 'tenant-a');
+    expect(await lifecycle.beginAdministrativeDeletion('guest-1', 'operation-1', 999, 999000)).toBe(
+      true
+    );
+    expect(await lifecycle.completeDeletion('guest-1', 'operation-1', 1000)).toBe(true);
     const repository = new GuestDeletionAuditOutboxRepository(adapter, 'tenant-a');
     await repository.enqueue({
       auditId: 'account-guest-deleted-operation-stale',

--- a/packages/ar-management/src/__tests__/guest-lifecycle-scheduled.test.ts
+++ b/packages/ar-management/src/__tests__/guest-lifecycle-scheduled.test.ts
@@ -396,11 +396,28 @@ describe('hourly guest deletion state transitions', () => {
 
     await expect(run()).rejects.toThrow('pii_temporarily_unavailable');
     expect((await lifecycle.get('guest'))?.phase).toBe('deleting');
+    expect(mocks.transition).toHaveBeenLastCalledWith(
+      env,
+      expect.objectContaining({
+        lifecycle: 'deleting',
+        operationId: 'admin-delete',
+        sourceVersionMs: 90000000,
+      })
+    );
 
     mocks.resolve.mockRejectedValue(new Error('account_route_removed'));
     expect(await run(93600)).toBe('deleted');
     expect(mocks.resolve).not.toHaveBeenCalled();
     expect(mocks.audit).not.toHaveBeenCalled();
+    expect(
+      mocks.transition.mock.calls
+        .filter(([, input]) => input.lifecycle === 'deleting')
+        .map(([, input]) => input.operationId)
+    ).toEqual(['admin-delete', 'admin-delete']);
+    expect(mocks.transition).toHaveBeenLastCalledWith(
+      env,
+      expect.objectContaining({ lifecycle: 'deleted', operationId: 'admin-delete' })
+    );
   });
   it('does not regress deleted authentication when retrying the final audit step', async () => {
     mocks.audit.mockRejectedValueOnce(new Error('audit_unavailable'));

--- a/packages/ar-management/src/__tests__/guest-lifecycle-scheduled.test.ts
+++ b/packages/ar-management/src/__tests__/guest-lifecycle-scheduled.test.ts
@@ -367,6 +367,41 @@ describe('hourly guest deletion state transitions', () => {
       expect.objectContaining({ tenantId: 'tenant', bindingRef: 'PII', role: 'tenant_pii' })
     );
   });
+  it('resumes an administrative deletion from its pinned route without duplicating its audit', async () => {
+    const routeJson = JSON.stringify({
+      schemaVersion: 1,
+      tenantId: 'tenant',
+      userId: 'guest',
+      coreBindingRef: 'CORE',
+      piiBindingRef: 'PII',
+      piiResidencyPartition: 'default',
+      routeProjection: { schemaVersion: 1 },
+      completionAuditMode: 'outbox',
+    });
+    expect(
+      await lifecycle.beginAdministrativeDeletion(
+        'guest',
+        'admin-delete',
+        90000,
+        routeJson,
+        90000000
+      )
+    ).toBe(true);
+    expect(await lifecycle.get('guest')).toMatchObject({
+      phase: 'deleting',
+      deletion_route_json: routeJson,
+      deletion_operation_id: 'admin-delete',
+    });
+    mocks.erase.mockRejectedValueOnce(new Error('pii_temporarily_unavailable'));
+
+    await expect(run()).rejects.toThrow('pii_temporarily_unavailable');
+    expect((await lifecycle.get('guest'))?.phase).toBe('deleting');
+
+    mocks.resolve.mockRejectedValue(new Error('account_route_removed'));
+    expect(await run(93600)).toBe('deleted');
+    expect(mocks.resolve).not.toHaveBeenCalled();
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
   it('does not regress deleted authentication when retrying the final audit step', async () => {
     mocks.audit.mockRejectedValueOnce(new Error('audit_unavailable'));
     await expect(run()).rejects.toThrow('audit_unavailable');

--- a/packages/ar-management/src/__tests__/guest-lifecycle-scheduled.test.ts
+++ b/packages/ar-management/src/__tests__/guest-lifecycle-scheduled.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   audit: vi.fn(),
   hold: vi.fn(),
   recover: vi.fn(),
+  releaseReservation: vi.fn(),
   events: [] as string[],
 }));
 vi.mock('../account-guest-upgrade', () => ({ recoverAccountGuestUpgrade: mocks.recover }));
@@ -38,11 +39,16 @@ vi.mock('../account-identifier-addition', () => ({
   buildAccountExternalSubjectAddition: vi.fn(),
 }));
 vi.mock('../account-directory-reservation', () => ({
-  InitialAccountIdentifierReservationService: vi.fn(),
+  InitialAccountIdentifierReservationService: vi.fn(function () {
+    return { release: mocks.releaseReservation };
+  }),
 }));
-vi.mock('../lookup-bucket-write-route', () => ({ createLookupBucketWriteResolver: vi.fn() }));
+vi.mock('../lookup-bucket-write-route', () => ({
+  createLookupBucketWriteResolver: vi.fn(async () => vi.fn()),
+}));
 vi.mock('@authrim/ar-lib-core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@authrim/ar-lib-core')>()),
+  validateAccountDirectoryPublication: vi.fn(async (value) => value),
   resolveAccountDataContext: mocks.resolve,
   resolveTenantDatabaseSourceFromRegistry: mocks.piiSource,
   ensureDatabaseAdapter: () => ({ execute: mocks.piiExecute, query: mocks.piiQuery }),
@@ -316,6 +322,25 @@ describe('hourly guest deletion state transitions', () => {
         resourceId: 'guest',
       })
     );
+  });
+  it('releases verified upgrade reservations and clears proof before completing deletion', async () => {
+    const publication = { operationId: 'verified-upgrade-reservation' };
+    mocks.piiQuery.mockResolvedValueOnce([
+      {
+        operation_id: 'verified-upgrade',
+        user_id: 'guest',
+        state: 'verified',
+        reservation_publication_json: JSON.stringify(publication),
+      },
+    ]);
+
+    expect(await run()).toBe('deleted');
+    expect(mocks.releaseReservation).toHaveBeenCalledWith(publication);
+    expect(mocks.piiExecute).toHaveBeenCalledWith(
+      expect.stringContaining("SET state = 'canceled', proof_payload_json = NULL"),
+      [90000, 'tenant', 'guest']
+    );
+    expect((await lifecycle.get('guest'))?.phase).toBe('deleted');
   });
   it.each(['registered', 'upgrading'])('does not delete a guest that became %s', async (phase) => {
     await core.execute('UPDATE guest_account_lifecycle SET phase = ?', [phase]);

--- a/packages/ar-management/src/__tests__/guest-users.test.ts
+++ b/packages/ar-management/src/__tests__/guest-users.test.ts
@@ -10,6 +10,8 @@ const mocks = vi.hoisted(() => ({
   auditOutboxEnqueue: vi.fn(),
   auditOutboxMarkSucceeded: vi.fn(),
   auditOutboxMarkRetry: vi.fn(),
+  guestLifecycleBeginAdministrativeDeletion: vi.fn(),
+  guestLifecycleCompleteDeletion: vi.fn(),
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 vi.mock('@authrim/ar-lib-core', async (importOriginal) => ({
@@ -22,6 +24,12 @@ vi.mock('@authrim/ar-lib-core', async (importOriginal) => ({
   getLogger: vi.fn(() => ({ module: vi.fn(() => mocks.logger) })),
   CanonicalRuntimeUserStore: vi.fn(function () {
     return { findById: mocks.findUser, deleteUser: mocks.deleteUser };
+  }),
+  GuestLifecycleRepository: vi.fn(function () {
+    return {
+      beginAdministrativeDeletion: mocks.guestLifecycleBeginAdministrativeDeletion,
+      completeDeletion: mocks.guestLifecycleCompleteDeletion,
+    };
   }),
 }));
 vi.mock('../guest-deletion-audit-outbox', () => ({
@@ -127,6 +135,8 @@ describe('guest account administration', () => {
     }));
     mocks.auditOutboxMarkSucceeded.mockResolvedValue(undefined);
     mocks.auditOutboxMarkRetry.mockResolvedValue(undefined);
+    mocks.guestLifecycleBeginAdministrativeDeletion.mockResolvedValue(true);
+    mocks.guestLifecycleCompleteDeletion.mockResolvedValue(true);
   });
   it.each([false, true])('lists guest accounts include_expired=%s', async (includeExpired) => {
     mocks.adapter.queryOne.mockResolvedValueOnce({ count: 2 });
@@ -333,6 +343,18 @@ describe('guest account administration', () => {
           mocks.transitionAccountAuthenticationState.mock.invocationCallOrder[0]
         );
         expect(mocks.auditOutboxMarkSucceeded).toHaveBeenCalledTimes(1);
+        const deletionOperationId = mocks.auditOutboxEnqueue.mock.calls[0][0].operationId;
+        expect(mocks.guestLifecycleBeginAdministrativeDeletion).toHaveBeenCalledWith(
+          'user-1',
+          deletionOperationId,
+          expect.any(Number),
+          expect.any(Number)
+        );
+        expect(mocks.guestLifecycleCompleteDeletion).toHaveBeenCalledWith(
+          'user-1',
+          deletionOperationId,
+          expect.any(Number)
+        );
       }
     }
   );
@@ -354,6 +376,9 @@ describe('guest account administration', () => {
     expect(completionCalls).toHaveLength(2);
     expect(completionCalls[0][6]).toBe(completionCalls[1][6]);
     expect(mocks.auditOutboxMarkSucceeded).toHaveBeenCalledTimes(1);
+    expect(mocks.guestLifecycleCompleteDeletion.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.auditOutboxMarkSucceeded.mock.invocationCallOrder[0]
+    );
   });
   it('does not begin deletion until durable audit intent is recorded', async () => {
     mocks.findUser.mockResolvedValueOnce(user());
@@ -363,6 +388,17 @@ describe('guest account administration', () => {
     expect(mocks.transitionAccountAuthenticationState).not.toHaveBeenCalled();
     expect(mocks.adapter.execute).not.toHaveBeenCalled();
     expect(mocks.deleteUser).not.toHaveBeenCalled();
+  });
+  it('does not perform destructive work when the guest lifecycle claim loses a race', async () => {
+    mocks.findUser.mockResolvedValueOnce(user());
+    mocks.guestLifecycleBeginAdministrativeDeletion.mockResolvedValueOnce(false);
+
+    expect((await deleteGuestUser(context({ id: 'user-1' }))).status).toBe(500);
+    expect(mocks.auditOutboxEnqueue).toHaveBeenCalledTimes(1);
+    expect(mocks.transitionAccountAuthenticationState).not.toHaveBeenCalled();
+    expect(mocks.adapter.execute).not.toHaveBeenCalled();
+    expect(mocks.deleteUser).not.toHaveBeenCalled();
+    expect(mocks.guestLifecycleCompleteDeletion).not.toHaveBeenCalled();
   });
   it('returns the committed deletion when completion audit delivery remains unavailable', async () => {
     mocks.findUser.mockResolvedValueOnce(user());
@@ -465,6 +501,8 @@ describe('guest account administration', () => {
     );
     expect(mocks.auditOutboxEnqueue).toHaveBeenCalledTimes(1);
     expect(mocks.auditOutboxMarkSucceeded).toHaveBeenCalledTimes(1);
+    expect(mocks.guestLifecycleBeginAdministrativeDeletion).toHaveBeenCalledTimes(1);
+    expect(mocks.guestLifecycleCompleteDeletion).toHaveBeenCalledTimes(1);
   });
   it('preserves cleanup deletion outcomes and retries completion audit delivery', async () => {
     mocks.adapter.query.mockResolvedValueOnce([

--- a/packages/ar-management/src/__tests__/guest-users.test.ts
+++ b/packages/ar-management/src/__tests__/guest-users.test.ts
@@ -32,6 +32,23 @@ vi.mock('@authrim/ar-lib-core', async (importOriginal) => ({
     };
   }),
 }));
+vi.mock('../guest-lifecycle-scheduled', () => ({
+  createGuestDeletionRoute: vi.fn(
+    async (
+      _env: unknown,
+      input: { tenantId: string; userId: string; completionAuditMode?: 'outbox' }
+    ) => ({
+      schemaVersion: 1,
+      tenantId: input.tenantId,
+      userId: input.userId,
+      coreBindingRef: 'CORE',
+      piiBindingRef: 'PII',
+      piiResidencyPartition: 'default',
+      routeProjection: {},
+      completionAuditMode: input.completionAuditMode,
+    })
+  ),
+}));
 vi.mock('../guest-deletion-audit-outbox', () => ({
   createGuestDeletionAuditTaskFromContext: vi.fn(
     (
@@ -348,6 +365,7 @@ describe('guest account administration', () => {
           'user-1',
           deletionOperationId,
           expect.any(Number),
+          expect.stringContaining('"completionAuditMode":"outbox"'),
           expect.any(Number)
         );
         expect(mocks.guestLifecycleCompleteDeletion).toHaveBeenCalledWith(

--- a/packages/ar-management/src/__tests__/guest-users.test.ts
+++ b/packages/ar-management/src/__tests__/guest-users.test.ts
@@ -374,10 +374,21 @@ describe('guest account administration', () => {
     expect(mocks.adapter.execute).toHaveBeenCalledTimes(2);
     expect(mocks.audit).toHaveBeenCalledWith(
       expect.anything(),
+      'account.guest.deletion_started',
+      'user',
+      'u1',
+      expect.objectContaining({ registration_state: 'guest', reason: 'manual_cleanup' }),
+      'info',
+      expect.stringMatching(/^account-guest-delete-started-/)
+    );
+    expect(mocks.audit).toHaveBeenCalledWith(
+      expect.anything(),
       'user.deleted',
       'user',
       'u1',
-      expect.objectContaining({ registration_state: 'guest', reason: 'manual_cleanup' })
+      expect.objectContaining({ registration_state: 'guest', reason: 'manual_cleanup' }),
+      'info',
+      expect.stringMatching(/^account-guest-deleted-/)
     );
     expect(mocks.audit).toHaveBeenCalledWith(
       expect.anything(),
@@ -386,6 +397,91 @@ describe('guest account administration', () => {
       'u2',
       expect.objectContaining({ reason: 'manual_cleanup' })
     );
+  });
+  it('preserves cleanup deletion outcomes and retries completion audit delivery', async () => {
+    mocks.adapter.query.mockResolvedValueOnce([
+      { user_id: 'u1', credential_id: 'c1', expires_at: 1 },
+      { user_id: 'u2', credential_id: 'c2', expires_at: 2 },
+    ]);
+    mocks.adapter.queryOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    let completionAttempts = 0;
+    mocks.audit.mockImplementation(async (_c, action: string, _type, userId: string) => {
+      if (action === 'user.deleted' && userId === 'u1' && completionAttempts++ === 0) {
+        throw new Error('transient audit failure');
+      }
+    });
+
+    const response = await cleanupExpiredGuestUsers(
+      context({ body: { dry_run: false, limit: 10 } })
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      deleted_users: 2,
+      deleted_credentials: 2,
+    });
+
+    const firstUserCompletionCalls = mocks.audit.mock.calls.filter(
+      ([, action, , userId]) => action === 'user.deleted' && userId === 'u1'
+    );
+    expect(firstUserCompletionCalls).toHaveLength(2);
+    expect(firstUserCompletionCalls[0][6]).toBe(firstUserCompletionCalls[1][6]);
+    const firstUserTransitions = mocks.transitionAccountAuthenticationState.mock.calls.filter(
+      ([, input]) => input.userId === 'u1'
+    );
+    expect(firstUserTransitions).toHaveLength(2);
+    expect(firstUserTransitions[0][1].operationId).toBe(firstUserTransitions[1][1].operationId);
+    expect(mocks.deleteUser).toHaveBeenCalledTimes(2);
+  });
+  it('continues cleanup after persistent completion audit delivery failure', async () => {
+    mocks.adapter.query.mockResolvedValueOnce([
+      { user_id: 'u1', credential_id: 'c1', expires_at: 1 },
+    ]);
+    mocks.adapter.queryOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    mocks.audit.mockImplementation(async (_c, action: string) => {
+      if (action === 'user.deleted') throw new Error('persistent audit failure');
+    });
+
+    const response = await cleanupExpiredGuestUsers(
+      context({ body: { dry_run: false, limit: 10 } })
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      deleted_users: 1,
+      deleted_credentials: 1,
+    });
+    expect(mocks.audit.mock.calls.filter(([, action]) => action === 'user.deleted')).toHaveLength(
+      2
+    );
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      'Guest cleanup deletion committed but completion audit delivery is pending',
+      expect.objectContaining({
+        action: 'guest_cleanup_user_delete_audit_pending',
+        tenantId: 'tenant-a',
+      }),
+      expect.any(Error)
+    );
+  });
+  it('does not start cleanup deletion until its durable audit intent is recorded', async () => {
+    mocks.adapter.query.mockResolvedValueOnce([
+      { user_id: 'u1', credential_id: 'c1', expires_at: 1 },
+    ]);
+    mocks.adapter.queryOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    mocks.audit.mockImplementation(async (_c, action: string) => {
+      if (action === 'account.guest.deletion_started') {
+        throw new Error('audit unavailable');
+      }
+    });
+
+    expect(
+      (await cleanupExpiredGuestUsers(context({ body: { dry_run: false, limit: 10 } }))).status
+    ).toBe(500);
+    expect(mocks.transitionAccountAuthenticationState).not.toHaveBeenCalled();
+    expect(mocks.adapter.execute).not.toHaveBeenCalled();
+    expect(mocks.deleteUser).not.toHaveBeenCalled();
   });
   it('skips scheduled anonymous cleanup while an account legal hold is active', async () => {
     mocks.adapter.query.mockResolvedValueOnce([

--- a/packages/ar-management/src/__tests__/guest-users.test.ts
+++ b/packages/ar-management/src/__tests__/guest-users.test.ts
@@ -12,7 +12,8 @@ const mocks = vi.hoisted(() => ({
   auditOutboxMarkRetry: vi.fn(),
   auditOutboxRemove: vi.fn(),
   guestLifecycleBeginAdministrativeDeletion: vi.fn(),
-  guestLifecycleCompleteDeletion: vi.fn(),
+  guestLifecycleGet: vi.fn(),
+  deleteOneGuestAccount: vi.fn(),
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 vi.mock('@authrim/ar-lib-core', async (importOriginal) => ({
@@ -29,11 +30,12 @@ vi.mock('@authrim/ar-lib-core', async (importOriginal) => ({
   GuestLifecycleRepository: vi.fn(function () {
     return {
       beginAdministrativeDeletion: mocks.guestLifecycleBeginAdministrativeDeletion,
-      completeDeletion: mocks.guestLifecycleCompleteDeletion,
+      get: mocks.guestLifecycleGet,
     };
   }),
 }));
 vi.mock('../guest-lifecycle-scheduled', () => ({
+  deleteOneGuestAccount: mocks.deleteOneGuestAccount,
   createGuestDeletionRoute: vi.fn(
     async (
       _env: unknown,
@@ -156,7 +158,12 @@ describe('guest account administration', () => {
     mocks.auditOutboxMarkRetry.mockResolvedValue(undefined);
     mocks.auditOutboxRemove.mockResolvedValue(undefined);
     mocks.guestLifecycleBeginAdministrativeDeletion.mockResolvedValue(true);
-    mocks.guestLifecycleCompleteDeletion.mockResolvedValue(true);
+    mocks.guestLifecycleGet.mockImplementation(async (userId: string) => ({
+      tenant_id: 'tenant-a',
+      user_id: userId,
+      phase: 'deleting',
+    }));
+    mocks.deleteOneGuestAccount.mockResolvedValue('deleted');
   });
   it.each([false, true])('lists guest accounts include_expired=%s', async (includeExpired) => {
     mocks.adapter.queryOne.mockResolvedValueOnce({ count: 2 });
@@ -295,8 +302,7 @@ describe('guest account administration', () => {
     });
     const response = await deleteGuestUser(context({ id: 'user-1' }));
     expect(response.status).toBe(409);
-    expect(mocks.deleteUser).not.toHaveBeenCalled();
-    expect(mocks.transitionAccountAuthenticationState).not.toHaveBeenCalled();
+    expect(mocks.deleteOneGuestAccount).not.toHaveBeenCalled();
   });
   it('formats an absent upgrade and expired browser resume credential', async () => {
     mocks.findUser.mockResolvedValueOnce(user());
@@ -334,9 +340,8 @@ describe('guest account administration', () => {
       mocks.findUser.mockResolvedValueOnce(value);
       const response = await deleteGuestUser(context({ id: 'user-1' }));
       expect(response.status).toBe(!value ? 404 : value.registration_state === 'guest' ? 200 : 400);
-      expect(mocks.deleteUser).toHaveBeenCalledTimes(value?.registration_state === 'guest' ? 1 : 0);
-      expect(mocks.transitionAccountAuthenticationState).toHaveBeenCalledTimes(
-        value?.registration_state === 'guest' ? 2 : 0
+      expect(mocks.deleteOneGuestAccount).toHaveBeenCalledTimes(
+        value?.registration_state === 'guest' ? 1 : 0
       );
       expect(mocks.audit).toHaveBeenCalledTimes(value?.registration_state === 'guest' ? 2 : 0);
       if (value?.registration_state === 'guest') {
@@ -361,7 +366,7 @@ describe('guest account administration', () => {
         );
         expect(mocks.auditOutboxEnqueue).toHaveBeenCalledTimes(1);
         expect(mocks.auditOutboxEnqueue.mock.invocationCallOrder[0]).toBeLessThan(
-          mocks.transitionAccountAuthenticationState.mock.invocationCallOrder[0]
+          mocks.deleteOneGuestAccount.mock.invocationCallOrder[0]
         );
         expect(mocks.auditOutboxMarkSucceeded).toHaveBeenCalledTimes(1);
         const deletionOperationId = mocks.auditOutboxEnqueue.mock.calls[0][0].operationId;
@@ -372,10 +377,15 @@ describe('guest account administration', () => {
           expect.stringContaining('"completionAuditMode":"outbox"'),
           expect.any(Number)
         );
-        expect(mocks.guestLifecycleCompleteDeletion).toHaveBeenCalledWith(
-          'user-1',
-          deletionOperationId,
-          expect.any(Number)
+        expect(mocks.deleteOneGuestAccount).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            tenantId: 'tenant-a',
+            core: mocks.adapter,
+            coreBindingRef: 'CORE',
+            candidate: expect.objectContaining({ user_id: 'user-1' }),
+            now: expect.any(Number),
+          })
         );
       }
     }
@@ -390,7 +400,7 @@ describe('guest account administration', () => {
     });
 
     expect((await deleteGuestUser(context({ id: 'user-1' }))).status).toBe(200);
-    expect(mocks.deleteUser).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteOneGuestAccount).toHaveBeenCalledTimes(1);
 
     const completionCalls = mocks.audit.mock.calls.filter(
       ([, action]) => action === 'user.deleted'
@@ -398,11 +408,9 @@ describe('guest account administration', () => {
     expect(completionCalls).toHaveLength(2);
     expect(completionCalls[0][6]).toBe(completionCalls[1][6]);
     expect(completionCalls[0][7]).toBe(completionCalls[1][7]);
-    expect(completionCalls[0][7]).toBe(
-      mocks.guestLifecycleCompleteDeletion.mock.calls[0][2] * 1000
-    );
+    expect(completionCalls[0][7]).toBe(mocks.deleteOneGuestAccount.mock.calls[0][1].now * 1000);
     expect(mocks.auditOutboxMarkSucceeded).toHaveBeenCalledTimes(1);
-    expect(mocks.guestLifecycleCompleteDeletion.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(mocks.deleteOneGuestAccount.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.auditOutboxMarkSucceeded.mock.invocationCallOrder[0]
     );
   });
@@ -411,9 +419,8 @@ describe('guest account administration', () => {
     mocks.audit.mockRejectedValueOnce(new Error('audit unavailable'));
 
     expect((await deleteGuestUser(context({ id: 'user-1' }))).status).toBe(500);
-    expect(mocks.transitionAccountAuthenticationState).not.toHaveBeenCalled();
     expect(mocks.adapter.execute).not.toHaveBeenCalled();
-    expect(mocks.deleteUser).not.toHaveBeenCalled();
+    expect(mocks.deleteOneGuestAccount).not.toHaveBeenCalled();
   });
   it('does not perform destructive work when the guest lifecycle claim loses a race', async () => {
     mocks.findUser.mockResolvedValueOnce(user());
@@ -424,10 +431,17 @@ describe('guest account administration', () => {
     expect(mocks.auditOutboxRemove).toHaveBeenCalledWith(
       mocks.auditOutboxEnqueue.mock.calls[0][0].auditId
     );
-    expect(mocks.transitionAccountAuthenticationState).not.toHaveBeenCalled();
     expect(mocks.adapter.execute).not.toHaveBeenCalled();
-    expect(mocks.deleteUser).not.toHaveBeenCalled();
-    expect(mocks.guestLifecycleCompleteDeletion).not.toHaveBeenCalled();
+    expect(mocks.deleteOneGuestAccount).not.toHaveBeenCalled();
+  });
+  it('does not publish completion when the complete deletion pipeline cannot finish', async () => {
+    mocks.findUser.mockResolvedValueOnce(user());
+    mocks.deleteOneGuestAccount.mockResolvedValueOnce('skipped');
+
+    expect((await deleteGuestUser(context({ id: 'user-1' }))).status).toBe(500);
+    expect(mocks.deleteOneGuestAccount).toHaveBeenCalledTimes(1);
+    expect(mocks.audit.mock.calls.filter(([, action]) => action === 'user.deleted')).toEqual([]);
+    expect(mocks.auditOutboxMarkSucceeded).not.toHaveBeenCalled();
   });
   it('returns the committed deletion when completion audit delivery remains unavailable', async () => {
     mocks.findUser.mockResolvedValueOnce(user());
@@ -436,7 +450,7 @@ describe('guest account administration', () => {
     });
 
     expect((await deleteGuestUser(context({ id: 'user-1' }))).status).toBe(200);
-    expect(mocks.deleteUser).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteOneGuestAccount).toHaveBeenCalledTimes(1);
     expect(mocks.audit.mock.calls.filter(([, action]) => action === 'user.deleted')).toHaveLength(
       2
     );
@@ -501,8 +515,8 @@ describe('guest account administration', () => {
       deleted_credentials: 2,
       deactivated_credentials: 1,
     });
-    expect(mocks.deleteUser).toHaveBeenCalledTimes(1);
-    expect(mocks.adapter.execute).toHaveBeenCalledTimes(2);
+    expect(mocks.deleteOneGuestAccount).toHaveBeenCalledTimes(1);
+    expect(mocks.adapter.execute).toHaveBeenCalledTimes(1);
     expect(mocks.audit).toHaveBeenCalledWith(
       expect.anything(),
       'account.guest.deletion_started',
@@ -532,7 +546,6 @@ describe('guest account administration', () => {
     expect(mocks.auditOutboxEnqueue).toHaveBeenCalledTimes(1);
     expect(mocks.auditOutboxMarkSucceeded).toHaveBeenCalledTimes(1);
     expect(mocks.guestLifecycleBeginAdministrativeDeletion).toHaveBeenCalledTimes(1);
-    expect(mocks.guestLifecycleCompleteDeletion).toHaveBeenCalledTimes(1);
   });
   it('preserves cleanup deletion outcomes and retries completion audit delivery', async () => {
     mocks.adapter.query.mockResolvedValueOnce([
@@ -566,12 +579,7 @@ describe('guest account administration', () => {
     expect(firstUserCompletionCalls).toHaveLength(2);
     expect(firstUserCompletionCalls[0][6]).toBe(firstUserCompletionCalls[1][6]);
     expect(firstUserCompletionCalls[0][7]).toBe(firstUserCompletionCalls[1][7]);
-    const firstUserTransitions = mocks.transitionAccountAuthenticationState.mock.calls.filter(
-      ([, input]) => input.userId === 'u1'
-    );
-    expect(firstUserTransitions).toHaveLength(2);
-    expect(firstUserTransitions[0][1].operationId).toBe(firstUserTransitions[1][1].operationId);
-    expect(mocks.deleteUser).toHaveBeenCalledTimes(2);
+    expect(mocks.deleteOneGuestAccount).toHaveBeenCalledTimes(2);
     expect(mocks.auditOutboxEnqueue).toHaveBeenCalledTimes(2);
     expect(mocks.auditOutboxMarkSucceeded).toHaveBeenCalledTimes(2);
   });
@@ -619,9 +627,8 @@ describe('guest account administration', () => {
     expect(
       (await cleanupExpiredGuestUsers(context({ body: { dry_run: false, limit: 10 } }))).status
     ).toBe(500);
-    expect(mocks.transitionAccountAuthenticationState).not.toHaveBeenCalled();
     expect(mocks.adapter.execute).not.toHaveBeenCalled();
-    expect(mocks.deleteUser).not.toHaveBeenCalled();
+    expect(mocks.deleteOneGuestAccount).not.toHaveBeenCalled();
   });
   it('does not start cleanup deletion until the reconciliation task is durable', async () => {
     mocks.adapter.query.mockResolvedValueOnce([
@@ -633,9 +640,22 @@ describe('guest account administration', () => {
     expect(
       (await cleanupExpiredGuestUsers(context({ body: { dry_run: false, limit: 10 } }))).status
     ).toBe(500);
-    expect(mocks.transitionAccountAuthenticationState).not.toHaveBeenCalled();
     expect(mocks.adapter.execute).not.toHaveBeenCalled();
-    expect(mocks.deleteUser).not.toHaveBeenCalled();
+    expect(mocks.deleteOneGuestAccount).not.toHaveBeenCalled();
+  });
+  it('does not count or publish cleanup completion when the complete deletion pipeline stops', async () => {
+    mocks.adapter.query.mockResolvedValueOnce([
+      { user_id: 'u1', credential_id: 'c1', expires_at: 1 },
+    ]);
+    mocks.adapter.queryOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    mocks.deleteOneGuestAccount.mockResolvedValueOnce('held');
+
+    expect(
+      (await cleanupExpiredGuestUsers(context({ body: { dry_run: false, limit: 10 } }))).status
+    ).toBe(500);
+    expect(mocks.deleteOneGuestAccount).toHaveBeenCalledTimes(1);
+    expect(mocks.audit.mock.calls.filter(([, action]) => action === 'user.deleted')).toEqual([]);
+    expect(mocks.auditOutboxMarkSucceeded).not.toHaveBeenCalled();
   });
   it('skips scheduled anonymous cleanup while an account legal hold is active', async () => {
     mocks.adapter.query.mockResolvedValueOnce([
@@ -649,7 +669,7 @@ describe('guest account administration', () => {
       await cleanupExpiredGuestUsers(context({ body: { dry_run: false, limit: 10 } }))
     ).json();
     expect(body).toMatchObject({ deleted_users: 0 });
-    expect(mocks.deleteUser).not.toHaveBeenCalled();
+    expect(mocks.deleteOneGuestAccount).not.toHaveBeenCalled();
   });
   it('deduplicates cleanup user IDs and handles cleanup errors', async () => {
     mocks.adapter.query.mockRejectedValueOnce(new Error('failure'));

--- a/packages/ar-management/src/__tests__/guest-users.test.ts
+++ b/packages/ar-management/src/__tests__/guest-users.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   auditOutboxEnqueue: vi.fn(),
   auditOutboxMarkSucceeded: vi.fn(),
   auditOutboxMarkRetry: vi.fn(),
+  auditOutboxRemove: vi.fn(),
   guestLifecycleBeginAdministrativeDeletion: vi.fn(),
   guestLifecycleCompleteDeletion: vi.fn(),
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -75,6 +76,7 @@ vi.mock('../guest-deletion-audit-outbox', () => ({
       enqueue: mocks.auditOutboxEnqueue,
       markSucceeded: mocks.auditOutboxMarkSucceeded,
       markRetry: mocks.auditOutboxMarkRetry,
+      remove: mocks.auditOutboxRemove,
     };
   }),
 }));
@@ -152,6 +154,7 @@ describe('guest account administration', () => {
     }));
     mocks.auditOutboxMarkSucceeded.mockResolvedValue(undefined);
     mocks.auditOutboxMarkRetry.mockResolvedValue(undefined);
+    mocks.auditOutboxRemove.mockResolvedValue(undefined);
     mocks.guestLifecycleBeginAdministrativeDeletion.mockResolvedValue(true);
     mocks.guestLifecycleCompleteDeletion.mockResolvedValue(true);
   });
@@ -418,6 +421,9 @@ describe('guest account administration', () => {
 
     expect((await deleteGuestUser(context({ id: 'user-1' }))).status).toBe(500);
     expect(mocks.auditOutboxEnqueue).toHaveBeenCalledTimes(1);
+    expect(mocks.auditOutboxRemove).toHaveBeenCalledWith(
+      mocks.auditOutboxEnqueue.mock.calls[0][0].auditId
+    );
     expect(mocks.transitionAccountAuthenticationState).not.toHaveBeenCalled();
     expect(mocks.adapter.execute).not.toHaveBeenCalled();
     expect(mocks.deleteUser).not.toHaveBeenCalled();

--- a/packages/ar-management/src/__tests__/guest-users.test.ts
+++ b/packages/ar-management/src/__tests__/guest-users.test.ts
@@ -7,6 +7,9 @@ const mocks = vi.hoisted(() => ({
   deleteUser: vi.fn(),
   transitionAccountAuthenticationState: vi.fn(),
   audit: vi.fn(),
+  auditOutboxEnqueue: vi.fn(),
+  auditOutboxMarkSucceeded: vi.fn(),
+  auditOutboxMarkRetry: vi.fn(),
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 vi.mock('@authrim/ar-lib-core', async (importOriginal) => ({
@@ -19,6 +22,35 @@ vi.mock('@authrim/ar-lib-core', async (importOriginal) => ({
   getLogger: vi.fn(() => ({ module: vi.fn(() => mocks.logger) })),
   CanonicalRuntimeUserStore: vi.fn(function () {
     return { findById: mocks.findUser, deleteUser: mocks.deleteUser };
+  }),
+}));
+vi.mock('../guest-deletion-audit-outbox', () => ({
+  createGuestDeletionAuditTaskFromContext: vi.fn(
+    (
+      _c: unknown,
+      input: {
+        auditId: string;
+        userId: string;
+        operationId: string;
+        metadata: Record<string, unknown>;
+      }
+    ) => ({
+      auditId: input.auditId,
+      userId: input.userId,
+      operationId: input.operationId,
+      actorUserId: 'admin-1',
+      ipAddress: 'unknown',
+      userAgent: 'unknown',
+      metadataJson: JSON.stringify(input.metadata),
+      createdAt: 1000,
+    })
+  ),
+  GuestDeletionAuditOutboxRepository: vi.fn(function () {
+    return {
+      enqueue: mocks.auditOutboxEnqueue,
+      markSucceeded: mocks.auditOutboxMarkSucceeded,
+      markRetry: mocks.auditOutboxMarkRetry,
+    };
   }),
 }));
 import {
@@ -41,11 +73,15 @@ function context(
     req: {
       param: vi.fn(() => options.id),
       query: vi.fn((n: string) => options.query?.[n]),
+      header: vi.fn(() => undefined),
       json: options.bodyError
         ? vi.fn().mockRejectedValue(new SyntaxError('bad'))
         : vi.fn().mockResolvedValue(options.body ?? {}),
     },
     env: options.env ?? {},
+    get: vi.fn((name: string) =>
+      name === 'adminAuth' ? { userId: 'admin-1' } : name === 'tenantId' ? 'tenant-a' : undefined
+    ),
     json: vi.fn((v: unknown, s = 200) => Response.json(v, { status: s })),
   } as never;
 }
@@ -72,6 +108,25 @@ describe('guest account administration', () => {
     mocks.deleteUser.mockResolvedValue(true);
     mocks.transitionAccountAuthenticationState.mockResolvedValue({ lifecycle: 'active' });
     mocks.audit.mockResolvedValue(undefined);
+    mocks.auditOutboxEnqueue.mockImplementation(async (input) => ({
+      audit_id: input.auditId,
+      tenant_id: 'tenant-a',
+      user_id: input.userId,
+      operation_id: input.operationId,
+      actor_user_id: input.actorUserId,
+      ip_address: input.ipAddress,
+      user_agent: input.userAgent,
+      metadata_json: input.metadataJson,
+      status: 'pending',
+      attempt_count: 0,
+      next_attempt_at: input.createdAt,
+      last_error_code: null,
+      created_at: input.createdAt,
+      updated_at: input.createdAt,
+      succeeded_at: null,
+    }));
+    mocks.auditOutboxMarkSucceeded.mockResolvedValue(undefined);
+    mocks.auditOutboxMarkRetry.mockResolvedValue(undefined);
   });
   it.each([false, true])('lists guest accounts include_expired=%s', async (includeExpired) => {
     mocks.adapter.queryOne.mockResolvedValueOnce({ count: 2 });
@@ -273,6 +328,11 @@ describe('guest account administration', () => {
           'info',
           expect.stringMatching(/^account-guest-deleted-/)
         );
+        expect(mocks.auditOutboxEnqueue).toHaveBeenCalledTimes(1);
+        expect(mocks.auditOutboxEnqueue.mock.invocationCallOrder[0]).toBeLessThan(
+          mocks.transitionAccountAuthenticationState.mock.invocationCallOrder[0]
+        );
+        expect(mocks.auditOutboxMarkSucceeded).toHaveBeenCalledTimes(1);
       }
     }
   );
@@ -293,6 +353,7 @@ describe('guest account administration', () => {
     );
     expect(completionCalls).toHaveLength(2);
     expect(completionCalls[0][6]).toBe(completionCalls[1][6]);
+    expect(mocks.auditOutboxMarkSucceeded).toHaveBeenCalledTimes(1);
   });
   it('does not begin deletion until durable audit intent is recorded', async () => {
     mocks.findUser.mockResolvedValueOnce(user());
@@ -315,9 +376,14 @@ describe('guest account administration', () => {
       2
     );
     expect(mocks.logger.error).toHaveBeenCalledWith(
-      'Guest account deletion committed but completion audit delivery is pending',
+      'Guest account deletion committed; completion audit is queued for reconciliation',
       expect.objectContaining({ action: 'guest_user_delete_audit_pending', tenantId: 'tenant-a' }),
       expect.any(Error)
+    );
+    expect(mocks.auditOutboxMarkRetry).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: 'user-1', status: 'pending' }),
+      expect.any(Number),
+      'audit_log_write_failed'
     );
   });
   it('handles anonymous user get/delete failures', async () => {
@@ -397,6 +463,8 @@ describe('guest account administration', () => {
       'u2',
       expect.objectContaining({ reason: 'manual_cleanup' })
     );
+    expect(mocks.auditOutboxEnqueue).toHaveBeenCalledTimes(1);
+    expect(mocks.auditOutboxMarkSucceeded).toHaveBeenCalledTimes(1);
   });
   it('preserves cleanup deletion outcomes and retries completion audit delivery', async () => {
     mocks.adapter.query.mockResolvedValueOnce([
@@ -435,6 +503,8 @@ describe('guest account administration', () => {
     expect(firstUserTransitions).toHaveLength(2);
     expect(firstUserTransitions[0][1].operationId).toBe(firstUserTransitions[1][1].operationId);
     expect(mocks.deleteUser).toHaveBeenCalledTimes(2);
+    expect(mocks.auditOutboxEnqueue).toHaveBeenCalledTimes(2);
+    expect(mocks.auditOutboxMarkSucceeded).toHaveBeenCalledTimes(2);
   });
   it('continues cleanup after persistent completion audit delivery failure', async () => {
     mocks.adapter.query.mockResolvedValueOnce([
@@ -457,13 +527,14 @@ describe('guest account administration', () => {
       2
     );
     expect(mocks.logger.error).toHaveBeenCalledWith(
-      'Guest cleanup deletion committed but completion audit delivery is pending',
+      'Guest account deletion committed; completion audit is queued for reconciliation',
       expect.objectContaining({
         action: 'guest_cleanup_user_delete_audit_pending',
         tenantId: 'tenant-a',
       }),
       expect.any(Error)
     );
+    expect(mocks.auditOutboxMarkRetry).toHaveBeenCalledTimes(1);
   });
   it('does not start cleanup deletion until its durable audit intent is recorded', async () => {
     mocks.adapter.query.mockResolvedValueOnce([
@@ -475,6 +546,20 @@ describe('guest account administration', () => {
         throw new Error('audit unavailable');
       }
     });
+
+    expect(
+      (await cleanupExpiredGuestUsers(context({ body: { dry_run: false, limit: 10 } }))).status
+    ).toBe(500);
+    expect(mocks.transitionAccountAuthenticationState).not.toHaveBeenCalled();
+    expect(mocks.adapter.execute).not.toHaveBeenCalled();
+    expect(mocks.deleteUser).not.toHaveBeenCalled();
+  });
+  it('does not start cleanup deletion until the reconciliation task is durable', async () => {
+    mocks.adapter.query.mockResolvedValueOnce([
+      { user_id: 'u1', credential_id: 'c1', expires_at: 1 },
+    ]);
+    mocks.adapter.queryOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    mocks.auditOutboxEnqueue.mockRejectedValueOnce(new Error('outbox unavailable'));
 
     expect(
       (await cleanupExpiredGuestUsers(context({ body: { dry_run: false, limit: 10 } }))).status

--- a/packages/ar-management/src/__tests__/guest-users.test.ts
+++ b/packages/ar-management/src/__tests__/guest-users.test.ts
@@ -362,7 +362,8 @@ describe('guest account administration', () => {
           expect.objectContaining({ registration_state: 'guest', reason: 'admin_action' }),
           'info',
           expect.stringMatching(/^account-guest-deleted-/),
-          expect.any(Number)
+          expect.any(Number),
+          true
         );
         expect(mocks.auditOutboxEnqueue).toHaveBeenCalledTimes(1);
         expect(mocks.auditOutboxEnqueue.mock.invocationCallOrder[0]).toBeLessThan(
@@ -534,7 +535,8 @@ describe('guest account administration', () => {
       expect.objectContaining({ registration_state: 'guest', reason: 'manual_cleanup' }),
       'info',
       expect.stringMatching(/^account-guest-deleted-/),
-      expect.any(Number)
+      expect.any(Number),
+      true
     );
     expect(mocks.audit).toHaveBeenCalledWith(
       expect.anything(),

--- a/packages/ar-management/src/__tests__/guest-users.test.ts
+++ b/packages/ar-management/src/__tests__/guest-users.test.ts
@@ -353,7 +353,8 @@ describe('guest account administration', () => {
           'user-1',
           expect.objectContaining({ registration_state: 'guest', reason: 'admin_action' }),
           'info',
-          expect.stringMatching(/^account-guest-deleted-/)
+          expect.stringMatching(/^account-guest-deleted-/),
+          expect.any(Number)
         );
         expect(mocks.auditOutboxEnqueue).toHaveBeenCalledTimes(1);
         expect(mocks.auditOutboxEnqueue.mock.invocationCallOrder[0]).toBeLessThan(
@@ -393,6 +394,10 @@ describe('guest account administration', () => {
     );
     expect(completionCalls).toHaveLength(2);
     expect(completionCalls[0][6]).toBe(completionCalls[1][6]);
+    expect(completionCalls[0][7]).toBe(completionCalls[1][7]);
+    expect(completionCalls[0][7]).toBe(
+      mocks.guestLifecycleCompleteDeletion.mock.calls[0][2] * 1000
+    );
     expect(mocks.auditOutboxMarkSucceeded).toHaveBeenCalledTimes(1);
     expect(mocks.guestLifecycleCompleteDeletion.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.auditOutboxMarkSucceeded.mock.invocationCallOrder[0]
@@ -508,7 +513,8 @@ describe('guest account administration', () => {
       'u1',
       expect.objectContaining({ registration_state: 'guest', reason: 'manual_cleanup' }),
       'info',
-      expect.stringMatching(/^account-guest-deleted-/)
+      expect.stringMatching(/^account-guest-deleted-/),
+      expect.any(Number)
     );
     expect(mocks.audit).toHaveBeenCalledWith(
       expect.anything(),
@@ -553,6 +559,7 @@ describe('guest account administration', () => {
     );
     expect(firstUserCompletionCalls).toHaveLength(2);
     expect(firstUserCompletionCalls[0][6]).toBe(firstUserCompletionCalls[1][6]);
+    expect(firstUserCompletionCalls[0][7]).toBe(firstUserCompletionCalls[1][7]);
     const firstUserTransitions = mocks.transitionAccountAuthenticationState.mock.calls.filter(
       ([, input]) => input.userId === 'u1'
     );

--- a/packages/ar-management/src/guest-deletion-audit-outbox.ts
+++ b/packages/ar-management/src/guest-deletion-audit-outbox.ts
@@ -163,12 +163,10 @@ export class GuestDeletionAuditOutboxRepository {
     );
   }
 
-  async markSucceeded(auditId: string, now: number): Promise<void> {
+  async markSucceeded(auditId: string): Promise<void> {
     await this.db.execute(
-      `UPDATE guest_deletion_audit_outbox
-       SET status = 'succeeded', succeeded_at = ?, last_error_code = NULL, updated_at = ?
-       WHERE tenant_id = ? AND audit_id = ? AND status <> 'succeeded'`,
-      [now, now, this.tenantId, auditId]
+      'DELETE FROM guest_deletion_audit_outbox WHERE tenant_id = ? AND audit_id = ?',
+      [this.tenantId, auditId]
     );
   }
 
@@ -187,14 +185,6 @@ export class GuestDeletionAuditOutboxRepository {
     await this.db.execute(
       'DELETE FROM guest_deletion_audit_outbox WHERE tenant_id = ? AND audit_id = ?',
       [this.tenantId, auditId]
-    );
-  }
-
-  async pruneSucceeded(before: number): Promise<void> {
-    await this.db.execute(
-      `DELETE FROM guest_deletion_audit_outbox
-       WHERE tenant_id = ? AND status = 'succeeded' AND succeeded_at < ?`,
-      [this.tenantId, before]
     );
   }
 }
@@ -279,7 +269,7 @@ export async function processGuestDeletionAuditOutbox(
             continue;
           }
           await writeAudit(task, adapter, completedAt * 1000);
-          await repository.markSucceeded(task.audit_id, attemptAt);
+          await repository.markSucceeded(task.audit_id);
           succeeded += 1;
         } catch (error) {
           await repository.markRetry(task, attemptAt, errorCode(error));
@@ -292,7 +282,6 @@ export async function processGuestDeletionAuditOutbox(
           });
         }
       }
-      await repository.pruneSucceeded(now() - 30 * 86400);
     }
   }
 

--- a/packages/ar-management/src/guest-deletion-audit-outbox.ts
+++ b/packages/ar-management/src/guest-deletion-audit-outbox.ts
@@ -6,6 +6,8 @@ import {
 } from '@authrim/ar-lib-core';
 import type { Context } from 'hono';
 
+const ORPHAN_TASK_GRACE_SECONDS = 300;
+
 export interface GuestDeletionAuditOutboxRow {
   audit_id: string;
   tenant_id: string;
@@ -257,7 +259,13 @@ export async function processGuestDeletionAuditOutbox(
             { consistencyClass: 'primary_required' }
           );
           if (!lifecycle || lifecycle.deletion_operation_id !== task.operation_id) {
-            await repository.remove(task.audit_id);
+            const taskCreatedAt = asNonNegativeInteger(task.created_at);
+            if (taskCreatedAt > 0 && attemptAt - taskCreatedAt < ORPHAN_TASK_GRACE_SECONDS) {
+              await repository.markRetry(task, attemptAt, 'guest_deletion_claim_pending');
+              retrying += 1;
+            } else {
+              await repository.remove(task.audit_id);
+            }
             continue;
           }
           if (lifecycle.phase !== 'deleted') {

--- a/packages/ar-management/src/guest-deletion-audit-outbox.ts
+++ b/packages/ar-management/src/guest-deletion-audit-outbox.ts
@@ -209,6 +209,7 @@ async function writeGuestDeletionAudit(
     userAgent: task.user_agent,
     metadata: task.metadata_json,
     severity: 'info',
+    requireDurableFanout: true,
   });
 }
 

--- a/packages/ar-management/src/guest-deletion-audit-outbox.ts
+++ b/packages/ar-management/src/guest-deletion-audit-outbox.ts
@@ -10,6 +10,7 @@ const ORPHAN_TASK_GRACE_SECONDS = 300;
 const RECONCILIATION_PAGE_SIZE = 20;
 const MAX_RECONCILIATION_PAGES_PER_ADAPTER = 50;
 const DEFAULT_RECONCILIATION_BUDGET_MS = 5_000;
+const RECONCILIATION_ADAPTER_CURSOR_KEY = 'jobs:guest-deletion-audit:adapter-cursor';
 
 export interface GuestDeletionAuditOutboxRow {
   audit_id: string;
@@ -238,68 +239,94 @@ export async function processGuestDeletionAuditOutbox(
   let succeeded = 0;
   let retrying = 0;
 
-  for (const target of targets) {
-    for (const { adapter, bindingRef } of target.adapters) {
-      const repository = new GuestDeletionAuditOutboxRepository(adapter, target.tenantId);
-      pageLoop: for (
-        let page = 0;
-        page < MAX_RECONCILIATION_PAGES_PER_ADAPTER && nowMs() < deadlineMs;
-        page += 1
-      ) {
-        const tasks = await repository.listDue(now(), RECONCILIATION_PAGE_SIZE);
-        if (tasks.length === 0) break;
-        for (const task of tasks) {
-          if (nowMs() >= deadlineMs) break pageLoop;
-          processed += 1;
-          const attemptAt = now();
-          try {
-            const lifecycle = await adapter.queryOne<{
-              phase: string;
-              deletion_operation_id: string | null;
-              deleted_at: number | string | null;
-            }>(
-              `SELECT phase, deletion_operation_id, deleted_at FROM guest_account_lifecycle
-               WHERE tenant_id = ? AND user_id = ?`,
-              [target.tenantId, task.user_id],
-              { consistencyClass: 'primary_required' }
-            );
-            if (!lifecycle || lifecycle.deletion_operation_id !== task.operation_id) {
-              const taskCreatedAt = asNonNegativeInteger(task.created_at);
-              if (taskCreatedAt > 0 && attemptAt - taskCreatedAt < ORPHAN_TASK_GRACE_SECONDS) {
-                await repository.markRetry(task, attemptAt, 'guest_deletion_claim_pending');
-                retrying += 1;
-              } else {
-                await repository.remove(task.audit_id);
-              }
-              continue;
-            }
-            if (lifecycle.phase !== 'deleted') {
-              await repository.markRetry(task, attemptAt, 'guest_deletion_not_committed');
-              retrying += 1;
-              continue;
-            }
-            const completedAt = asNonNegativeInteger(lifecycle.deleted_at ?? -1);
-            if (completedAt === 0) {
-              await repository.markRetry(task, attemptAt, 'guest_deletion_completion_time_missing');
-              retrying += 1;
-              continue;
-            }
-            await writeAudit(task, adapter, completedAt * 1000);
-            await repository.markSucceeded(task.audit_id);
-            succeeded += 1;
-          } catch (error) {
-            await repository.markRetry(task, attemptAt, errorCode(error));
-            retrying += 1;
-            log.warn('Guest deletion audit reconciliation deferred', {
-              tenantId: target.tenantId,
-              bindingRef,
-              operationId: task.operation_id,
-              errorCode: errorCode(error),
-            });
-          }
-        }
-        if (tasks.length < RECONCILIATION_PAGE_SIZE) break;
+  const adapters = targets.flatMap((target) =>
+    target.adapters.map(({ adapter, bindingRef }) => ({
+      adapter,
+      bindingRef,
+      tenantId: target.tenantId,
+    }))
+  );
+  let startIndex = 0;
+  if (adapters.length > 1 && env.AUTHRIM_CONFIG) {
+    try {
+      const storedCursor = Number.parseInt(
+        (await env.AUTHRIM_CONFIG.get(RECONCILIATION_ADAPTER_CURSOR_KEY)) ?? '',
+        10
+      );
+      if (Number.isSafeInteger(storedCursor) && storedCursor >= 0) {
+        startIndex = storedCursor % adapters.length;
       }
+      await env.AUTHRIM_CONFIG.put(
+        RECONCILIATION_ADAPTER_CURSOR_KEY,
+        String((startIndex + 1) % adapters.length)
+      );
+    } catch {
+      log.warn('Guest deletion audit adapter cursor update failed');
+    }
+  }
+  const orderedAdapters =
+    startIndex === 0 ? adapters : [...adapters.slice(startIndex), ...adapters.slice(0, startIndex)];
+
+  for (const { adapter, bindingRef, tenantId } of orderedAdapters) {
+    const repository = new GuestDeletionAuditOutboxRepository(adapter, tenantId);
+    pageLoop: for (
+      let page = 0;
+      page < MAX_RECONCILIATION_PAGES_PER_ADAPTER && nowMs() < deadlineMs;
+      page += 1
+    ) {
+      const tasks = await repository.listDue(now(), RECONCILIATION_PAGE_SIZE);
+      if (tasks.length === 0) break;
+      for (const task of tasks) {
+        if (nowMs() >= deadlineMs) break pageLoop;
+        processed += 1;
+        const attemptAt = now();
+        try {
+          const lifecycle = await adapter.queryOne<{
+            phase: string;
+            deletion_operation_id: string | null;
+            deleted_at: number | string | null;
+          }>(
+            `SELECT phase, deletion_operation_id, deleted_at FROM guest_account_lifecycle
+               WHERE tenant_id = ? AND user_id = ?`,
+            [tenantId, task.user_id],
+            { consistencyClass: 'primary_required' }
+          );
+          if (!lifecycle || lifecycle.deletion_operation_id !== task.operation_id) {
+            const taskCreatedAt = asNonNegativeInteger(task.created_at);
+            if (taskCreatedAt > 0 && attemptAt - taskCreatedAt < ORPHAN_TASK_GRACE_SECONDS) {
+              await repository.markRetry(task, attemptAt, 'guest_deletion_claim_pending');
+              retrying += 1;
+            } else {
+              await repository.remove(task.audit_id);
+            }
+            continue;
+          }
+          if (lifecycle.phase !== 'deleted') {
+            await repository.markRetry(task, attemptAt, 'guest_deletion_not_committed');
+            retrying += 1;
+            continue;
+          }
+          const completedAt = asNonNegativeInteger(lifecycle.deleted_at ?? -1);
+          if (completedAt === 0) {
+            await repository.markRetry(task, attemptAt, 'guest_deletion_completion_time_missing');
+            retrying += 1;
+            continue;
+          }
+          await writeAudit(task, adapter, completedAt * 1000);
+          await repository.markSucceeded(task.audit_id);
+          succeeded += 1;
+        } catch (error) {
+          await repository.markRetry(task, attemptAt, errorCode(error));
+          retrying += 1;
+          log.warn('Guest deletion audit reconciliation deferred', {
+            tenantId,
+            bindingRef,
+            operationId: task.operation_id,
+            errorCode: errorCode(error),
+          });
+        }
+      }
+      if (tasks.length < RECONCILIATION_PAGE_SIZE) break;
     }
   }
 

--- a/packages/ar-management/src/guest-deletion-audit-outbox.ts
+++ b/packages/ar-management/src/guest-deletion-audit-outbox.ts
@@ -1,0 +1,267 @@
+import { createAuditLog, type DatabaseAdapter, type Env } from '@authrim/ar-lib-core';
+import type { Context } from 'hono';
+
+export interface GuestDeletionAuditOutboxRow {
+  audit_id: string;
+  tenant_id: string;
+  user_id: string;
+  operation_id: string;
+  actor_user_id: string;
+  ip_address: string;
+  user_agent: string;
+  metadata_json: string;
+  status: 'pending' | 'retry' | 'succeeded';
+  attempt_count: number | string;
+  next_attempt_at: number | string;
+  last_error_code: string | null;
+  created_at: number | string;
+  updated_at: number | string;
+  succeeded_at: number | string | null;
+}
+
+export interface GuestDeletionAuditTaskInput {
+  auditId: string;
+  userId: string;
+  operationId: string;
+  actorUserId: string;
+  ipAddress: string;
+  userAgent: string;
+  metadataJson: string;
+  createdAt: number;
+}
+
+export function createGuestDeletionAuditTaskFromContext(
+  c: Context<{ Bindings: Env }>,
+  input: {
+    auditId: string;
+    userId: string;
+    operationId: string;
+    metadata: Record<string, unknown>;
+  }
+): GuestDeletionAuditTaskInput {
+  const adminAuth = (c as unknown as { get(name: string): unknown }).get('adminAuth') as
+    | { userId?: unknown }
+    | undefined;
+  if (typeof adminAuth?.userId !== 'string' || !adminAuth.userId) {
+    throw new Error('guest_deletion_audit_actor_missing');
+  }
+  return {
+    auditId: input.auditId,
+    userId: input.userId,
+    operationId: input.operationId,
+    actorUserId: adminAuth.userId,
+    ipAddress:
+      c.req.header('CF-Connecting-IP') ||
+      c.req.header('X-Forwarded-For')?.split(',')[0]?.trim() ||
+      c.req.header('X-Real-IP') ||
+      'unknown',
+    userAgent: c.req.header('User-Agent') || 'unknown',
+    metadataJson: JSON.stringify(input.metadata),
+    createdAt: Math.floor(Date.now() / 1000),
+  };
+}
+
+export interface GuestDeletionAuditTarget {
+  tenantId: string;
+  adapters: Array<{ adapter: DatabaseAdapter; bindingRef: string }>;
+}
+
+interface GuestDeletionAuditLogger {
+  info(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+}
+
+function asNonNegativeInteger(value: number | string): number {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+function retryDelaySeconds(attemptCount: number): number {
+  return Math.min(3600, 30 * 2 ** Math.min(attemptCount, 7));
+}
+
+function errorCode(error: unknown): string {
+  const value = error instanceof Error ? error.message : '';
+  return /^[a-z0-9][a-z0-9_.:-]{0,127}$/u.test(value)
+    ? value
+    : 'guest_deletion_audit_delivery_failed';
+}
+
+function sameTask(row: GuestDeletionAuditOutboxRow, input: GuestDeletionAuditTaskInput): boolean {
+  return (
+    row.audit_id === input.auditId &&
+    row.user_id === input.userId &&
+    row.operation_id === input.operationId &&
+    row.actor_user_id === input.actorUserId &&
+    row.ip_address === input.ipAddress &&
+    row.user_agent === input.userAgent &&
+    row.metadata_json === input.metadataJson &&
+    asNonNegativeInteger(row.created_at) === input.createdAt
+  );
+}
+
+/** Durable task storage is intentionally independent of the account row it outlives. */
+export class GuestDeletionAuditOutboxRepository {
+  constructor(
+    private readonly db: DatabaseAdapter,
+    private readonly tenantId: string
+  ) {}
+
+  async enqueue(input: GuestDeletionAuditTaskInput): Promise<GuestDeletionAuditOutboxRow> {
+    await this.db.execute(
+      `INSERT INTO guest_deletion_audit_outbox (
+         audit_id, tenant_id, user_id, operation_id, actor_user_id, ip_address, user_agent,
+         metadata_json, status, attempt_count, next_attempt_at, created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?)
+       ON CONFLICT (audit_id) DO NOTHING`,
+      [
+        input.auditId,
+        this.tenantId,
+        input.userId,
+        input.operationId,
+        input.actorUserId,
+        input.ipAddress,
+        input.userAgent,
+        input.metadataJson,
+        input.createdAt,
+        input.createdAt,
+        input.createdAt,
+      ]
+    );
+    const stored = await this.get(input.auditId);
+    if (!stored || !sameTask(stored, input)) {
+      throw new Error('guest_deletion_audit_outbox_conflict');
+    }
+    return stored;
+  }
+
+  get(auditId: string): Promise<GuestDeletionAuditOutboxRow | null> {
+    return this.db.queryOne<GuestDeletionAuditOutboxRow>(
+      'SELECT * FROM guest_deletion_audit_outbox WHERE tenant_id = ? AND audit_id = ?',
+      [this.tenantId, auditId],
+      { consistencyClass: 'primary_required' }
+    );
+  }
+
+  listDue(now: number, limit: number): Promise<GuestDeletionAuditOutboxRow[]> {
+    return this.db.query<GuestDeletionAuditOutboxRow>(
+      `SELECT * FROM guest_deletion_audit_outbox
+       WHERE tenant_id = ? AND status IN ('pending', 'retry') AND next_attempt_at <= ?
+       ORDER BY next_attempt_at, created_at, audit_id LIMIT ?`,
+      [this.tenantId, now, limit],
+      { consistencyClass: 'primary_required' }
+    );
+  }
+
+  async markSucceeded(auditId: string, now: number): Promise<void> {
+    await this.db.execute(
+      `UPDATE guest_deletion_audit_outbox
+       SET status = 'succeeded', succeeded_at = ?, last_error_code = NULL, updated_at = ?
+       WHERE tenant_id = ? AND audit_id = ? AND status <> 'succeeded'`,
+      [now, now, this.tenantId, auditId]
+    );
+  }
+
+  async markRetry(task: GuestDeletionAuditOutboxRow, now: number, code: string): Promise<void> {
+    const attemptCount = asNonNegativeInteger(task.attempt_count) + 1;
+    await this.db.execute(
+      `UPDATE guest_deletion_audit_outbox
+       SET status = 'retry', attempt_count = ?, next_attempt_at = ?, last_error_code = ?,
+           updated_at = ?
+       WHERE tenant_id = ? AND audit_id = ? AND status <> 'succeeded'`,
+      [attemptCount, now + retryDelaySeconds(attemptCount), code, now, this.tenantId, task.audit_id]
+    );
+  }
+
+  async pruneSucceeded(before: number): Promise<void> {
+    await this.db.execute(
+      `DELETE FROM guest_deletion_audit_outbox
+       WHERE tenant_id = ? AND status = 'succeeded' AND succeeded_at < ?`,
+      [this.tenantId, before]
+    );
+  }
+}
+
+async function writeGuestDeletionAudit(
+  env: Env,
+  adapter: DatabaseAdapter,
+  task: GuestDeletionAuditOutboxRow
+): Promise<void> {
+  await createAuditLog({ ...env, DB: adapter } as unknown as Env, {
+    id: task.audit_id,
+    tenantId: task.tenant_id,
+    userId: task.actor_user_id,
+    action: 'user.deleted',
+    resource: 'user',
+    resourceId: task.user_id,
+    ipAddress: task.ip_address,
+    userAgent: task.user_agent,
+    metadata: task.metadata_json,
+    severity: 'info',
+  });
+}
+
+export async function processGuestDeletionAuditOutbox(
+  env: Env,
+  targets: GuestDeletionAuditTarget[],
+  log: GuestDeletionAuditLogger,
+  options: {
+    now?: () => number;
+    writeAudit?: (task: GuestDeletionAuditOutboxRow, adapter: DatabaseAdapter) => Promise<void>;
+  } = {}
+): Promise<{ processed: number; succeeded: number; retrying: number }> {
+  const now = options.now ?? (() => Math.floor(Date.now() / 1000));
+  const writeAudit =
+    options.writeAudit ?? ((task, adapter) => writeGuestDeletionAudit(env, adapter, task));
+  let processed = 0;
+  let succeeded = 0;
+  let retrying = 0;
+
+  for (const target of targets) {
+    for (const { adapter, bindingRef } of target.adapters) {
+      const repository = new GuestDeletionAuditOutboxRepository(adapter, target.tenantId);
+      for (const task of await repository.listDue(now(), 20)) {
+        processed += 1;
+        const attemptAt = now();
+        try {
+          const lifecycle = await adapter.queryOne<{
+            phase: string;
+            deletion_operation_id: string | null;
+          }>(
+            `SELECT phase, deletion_operation_id FROM guest_account_lifecycle
+             WHERE tenant_id = ? AND user_id = ?`,
+            [target.tenantId, task.user_id],
+            { consistencyClass: 'primary_required' }
+          );
+          if (
+            !lifecycle ||
+            lifecycle.phase !== 'deleted' ||
+            lifecycle.deletion_operation_id !== task.operation_id
+          ) {
+            await repository.markRetry(task, attemptAt, 'guest_deletion_not_committed');
+            retrying += 1;
+            continue;
+          }
+          await writeAudit(task, adapter);
+          await repository.markSucceeded(task.audit_id, attemptAt);
+          succeeded += 1;
+        } catch (error) {
+          await repository.markRetry(task, attemptAt, errorCode(error));
+          retrying += 1;
+          log.warn('Guest deletion audit reconciliation deferred', {
+            tenantId: target.tenantId,
+            bindingRef,
+            operationId: task.operation_id,
+            errorCode: errorCode(error),
+          });
+        }
+      }
+      await repository.pruneSucceeded(now() - 30 * 86400);
+    }
+  }
+
+  if (processed > 0) {
+    log.info('Guest deletion audit reconciliation completed', { processed, succeeded, retrying });
+  }
+  return { processed, succeeded, retrying };
+}

--- a/packages/ar-management/src/guest-deletion-audit-outbox.ts
+++ b/packages/ar-management/src/guest-deletion-audit-outbox.ts
@@ -201,11 +201,10 @@ export class GuestDeletionAuditOutboxRepository {
 
 async function writeGuestDeletionAudit(
   env: Env,
-  adapter: DatabaseAdapter,
   task: GuestDeletionAuditOutboxRow,
   completedAt: number
 ): Promise<void> {
-  await createAuditLog({ ...env, DB: adapter } as unknown as Env, {
+  await createAuditLog(env, {
     id: task.audit_id,
     createdAt: completedAt,
     tenantId: task.tenant_id,
@@ -236,7 +235,7 @@ export async function processGuestDeletionAuditOutbox(
   const now = options.now ?? (() => Math.floor(Date.now() / 1000));
   const writeAudit =
     options.writeAudit ??
-    ((task, adapter, completedAt) => writeGuestDeletionAudit(env, adapter, task, completedAt));
+    ((task, _adapter, completedAt) => writeGuestDeletionAudit(env, task, completedAt));
   let processed = 0;
   let succeeded = 0;
   let retrying = 0;

--- a/packages/ar-management/src/guest-deletion-audit-outbox.ts
+++ b/packages/ar-management/src/guest-deletion-audit-outbox.ts
@@ -233,6 +233,7 @@ export async function processGuestDeletionAuditOutbox(
   const writeAudit =
     options.writeAudit ??
     ((task, _adapter, completedAt) => writeGuestDeletionAudit(env, task, completedAt));
+  const deadlineMs = options.deadlineMs ?? nowMs() + DEFAULT_RECONCILIATION_BUDGET_MS;
   let processed = 0;
   let succeeded = 0;
   let retrying = 0;
@@ -240,7 +241,6 @@ export async function processGuestDeletionAuditOutbox(
   for (const target of targets) {
     for (const { adapter, bindingRef } of target.adapters) {
       const repository = new GuestDeletionAuditOutboxRepository(adapter, target.tenantId);
-      const deadlineMs = options.deadlineMs ?? nowMs() + DEFAULT_RECONCILIATION_BUDGET_MS;
       pageLoop: for (
         let page = 0;
         page < MAX_RECONCILIATION_PAGES_PER_ADAPTER && nowMs() < deadlineMs;

--- a/packages/ar-management/src/guest-deletion-audit-outbox.ts
+++ b/packages/ar-management/src/guest-deletion-audit-outbox.ts
@@ -185,11 +185,12 @@ export class GuestDeletionAuditOutboxRepository {
 async function writeGuestDeletionAudit(
   env: Env,
   adapter: DatabaseAdapter,
-  task: GuestDeletionAuditOutboxRow
+  task: GuestDeletionAuditOutboxRow,
+  completedAt: number
 ): Promise<void> {
   await createAuditLog({ ...env, DB: adapter } as unknown as Env, {
     id: task.audit_id,
-    createdAt: asNonNegativeInteger(task.created_at) * 1000,
+    createdAt: completedAt,
     tenantId: task.tenant_id,
     userId: task.actor_user_id,
     action: 'user.deleted',
@@ -208,12 +209,17 @@ export async function processGuestDeletionAuditOutbox(
   log: GuestDeletionAuditLogger,
   options: {
     now?: () => number;
-    writeAudit?: (task: GuestDeletionAuditOutboxRow, adapter: DatabaseAdapter) => Promise<void>;
+    writeAudit?: (
+      task: GuestDeletionAuditOutboxRow,
+      adapter: DatabaseAdapter,
+      completedAt: number
+    ) => Promise<void>;
   } = {}
 ): Promise<{ processed: number; succeeded: number; retrying: number }> {
   const now = options.now ?? (() => Math.floor(Date.now() / 1000));
   const writeAudit =
-    options.writeAudit ?? ((task, adapter) => writeGuestDeletionAudit(env, adapter, task));
+    options.writeAudit ??
+    ((task, adapter, completedAt) => writeGuestDeletionAudit(env, adapter, task, completedAt));
   let processed = 0;
   let succeeded = 0;
   let retrying = 0;
@@ -228,8 +234,9 @@ export async function processGuestDeletionAuditOutbox(
           const lifecycle = await adapter.queryOne<{
             phase: string;
             deletion_operation_id: string | null;
+            deleted_at: number | string | null;
           }>(
-            `SELECT phase, deletion_operation_id FROM guest_account_lifecycle
+            `SELECT phase, deletion_operation_id, deleted_at FROM guest_account_lifecycle
              WHERE tenant_id = ? AND user_id = ?`,
             [target.tenantId, task.user_id],
             { consistencyClass: 'primary_required' }
@@ -243,7 +250,13 @@ export async function processGuestDeletionAuditOutbox(
             retrying += 1;
             continue;
           }
-          await writeAudit(task, adapter);
+          const completedAt = asNonNegativeInteger(lifecycle.deleted_at ?? -1);
+          if (completedAt === 0) {
+            await repository.markRetry(task, attemptAt, 'guest_deletion_completion_time_missing');
+            retrying += 1;
+            continue;
+          }
+          await writeAudit(task, adapter, completedAt * 1000);
           await repository.markSucceeded(task.audit_id, attemptAt);
           succeeded += 1;
         } catch (error) {

--- a/packages/ar-management/src/guest-deletion-audit-outbox.ts
+++ b/packages/ar-management/src/guest-deletion-audit-outbox.ts
@@ -1,4 +1,9 @@
-import { createAuditLog, type DatabaseAdapter, type Env } from '@authrim/ar-lib-core';
+import {
+  createAuditLog,
+  getAdminProxyMetadataFromContext,
+  type DatabaseAdapter,
+  type Env,
+} from '@authrim/ar-lib-core';
 import type { Context } from 'hono';
 
 export interface GuestDeletionAuditOutboxRow {
@@ -56,7 +61,10 @@ export function createGuestDeletionAuditTaskFromContext(
       c.req.header('X-Real-IP') ||
       'unknown',
     userAgent: c.req.header('User-Agent') || 'unknown',
-    metadataJson: JSON.stringify(input.metadata),
+    metadataJson: JSON.stringify({
+      ...input.metadata,
+      ...getAdminProxyMetadataFromContext(c),
+    }),
     createdAt: Math.floor(Date.now() / 1000),
   };
 }
@@ -173,6 +181,13 @@ export class GuestDeletionAuditOutboxRepository {
     );
   }
 
+  async remove(auditId: string): Promise<void> {
+    await this.db.execute(
+      'DELETE FROM guest_deletion_audit_outbox WHERE tenant_id = ? AND audit_id = ?',
+      [this.tenantId, auditId]
+    );
+  }
+
   async pruneSucceeded(before: number): Promise<void> {
     await this.db.execute(
       `DELETE FROM guest_deletion_audit_outbox
@@ -241,11 +256,11 @@ export async function processGuestDeletionAuditOutbox(
             [target.tenantId, task.user_id],
             { consistencyClass: 'primary_required' }
           );
-          if (
-            !lifecycle ||
-            lifecycle.phase !== 'deleted' ||
-            lifecycle.deletion_operation_id !== task.operation_id
-          ) {
+          if (!lifecycle || lifecycle.deletion_operation_id !== task.operation_id) {
+            await repository.remove(task.audit_id);
+            continue;
+          }
+          if (lifecycle.phase !== 'deleted') {
             await repository.markRetry(task, attemptAt, 'guest_deletion_not_committed');
             retrying += 1;
             continue;

--- a/packages/ar-management/src/guest-deletion-audit-outbox.ts
+++ b/packages/ar-management/src/guest-deletion-audit-outbox.ts
@@ -189,6 +189,7 @@ async function writeGuestDeletionAudit(
 ): Promise<void> {
   await createAuditLog({ ...env, DB: adapter } as unknown as Env, {
     id: task.audit_id,
+    createdAt: asNonNegativeInteger(task.created_at) * 1000,
     tenantId: task.tenant_id,
     userId: task.actor_user_id,
     action: 'user.deleted',

--- a/packages/ar-management/src/guest-deletion-audit-outbox.ts
+++ b/packages/ar-management/src/guest-deletion-audit-outbox.ts
@@ -7,6 +7,9 @@ import {
 import type { Context } from 'hono';
 
 const ORPHAN_TASK_GRACE_SECONDS = 300;
+const RECONCILIATION_PAGE_SIZE = 20;
+const MAX_RECONCILIATION_PAGES_PER_ADAPTER = 50;
+const DEFAULT_RECONCILIATION_BUDGET_MS = 5_000;
 
 export interface GuestDeletionAuditOutboxRow {
   audit_id: string;
@@ -215,6 +218,8 @@ export async function processGuestDeletionAuditOutbox(
   log: GuestDeletionAuditLogger,
   options: {
     now?: () => number;
+    nowMs?: () => number;
+    deadlineMs?: number;
     writeAudit?: (
       task: GuestDeletionAuditOutboxRow,
       adapter: DatabaseAdapter,
@@ -223,6 +228,7 @@ export async function processGuestDeletionAuditOutbox(
   } = {}
 ): Promise<{ processed: number; succeeded: number; retrying: number }> {
   const now = options.now ?? (() => Math.floor(Date.now() / 1000));
+  const nowMs = options.nowMs ?? Date.now;
   const writeAudit =
     options.writeAudit ??
     ((task, _adapter, completedAt) => writeGuestDeletionAudit(env, task, completedAt));
@@ -233,54 +239,65 @@ export async function processGuestDeletionAuditOutbox(
   for (const target of targets) {
     for (const { adapter, bindingRef } of target.adapters) {
       const repository = new GuestDeletionAuditOutboxRepository(adapter, target.tenantId);
-      for (const task of await repository.listDue(now(), 20)) {
-        processed += 1;
-        const attemptAt = now();
-        try {
-          const lifecycle = await adapter.queryOne<{
-            phase: string;
-            deletion_operation_id: string | null;
-            deleted_at: number | string | null;
-          }>(
-            `SELECT phase, deletion_operation_id, deleted_at FROM guest_account_lifecycle
-             WHERE tenant_id = ? AND user_id = ?`,
-            [target.tenantId, task.user_id],
-            { consistencyClass: 'primary_required' }
-          );
-          if (!lifecycle || lifecycle.deletion_operation_id !== task.operation_id) {
-            const taskCreatedAt = asNonNegativeInteger(task.created_at);
-            if (taskCreatedAt > 0 && attemptAt - taskCreatedAt < ORPHAN_TASK_GRACE_SECONDS) {
-              await repository.markRetry(task, attemptAt, 'guest_deletion_claim_pending');
-              retrying += 1;
-            } else {
-              await repository.remove(task.audit_id);
+      const deadlineMs = options.deadlineMs ?? nowMs() + DEFAULT_RECONCILIATION_BUDGET_MS;
+      pageLoop: for (
+        let page = 0;
+        page < MAX_RECONCILIATION_PAGES_PER_ADAPTER && nowMs() < deadlineMs;
+        page += 1
+      ) {
+        const tasks = await repository.listDue(now(), RECONCILIATION_PAGE_SIZE);
+        if (tasks.length === 0) break;
+        for (const task of tasks) {
+          if (nowMs() >= deadlineMs) break pageLoop;
+          processed += 1;
+          const attemptAt = now();
+          try {
+            const lifecycle = await adapter.queryOne<{
+              phase: string;
+              deletion_operation_id: string | null;
+              deleted_at: number | string | null;
+            }>(
+              `SELECT phase, deletion_operation_id, deleted_at FROM guest_account_lifecycle
+               WHERE tenant_id = ? AND user_id = ?`,
+              [target.tenantId, task.user_id],
+              { consistencyClass: 'primary_required' }
+            );
+            if (!lifecycle || lifecycle.deletion_operation_id !== task.operation_id) {
+              const taskCreatedAt = asNonNegativeInteger(task.created_at);
+              if (taskCreatedAt > 0 && attemptAt - taskCreatedAt < ORPHAN_TASK_GRACE_SECONDS) {
+                await repository.markRetry(task, attemptAt, 'guest_deletion_claim_pending');
+                retrying += 1;
+              } else {
+                await repository.remove(task.audit_id);
+              }
+              continue;
             }
-            continue;
-          }
-          if (lifecycle.phase !== 'deleted') {
-            await repository.markRetry(task, attemptAt, 'guest_deletion_not_committed');
+            if (lifecycle.phase !== 'deleted') {
+              await repository.markRetry(task, attemptAt, 'guest_deletion_not_committed');
+              retrying += 1;
+              continue;
+            }
+            const completedAt = asNonNegativeInteger(lifecycle.deleted_at ?? -1);
+            if (completedAt === 0) {
+              await repository.markRetry(task, attemptAt, 'guest_deletion_completion_time_missing');
+              retrying += 1;
+              continue;
+            }
+            await writeAudit(task, adapter, completedAt * 1000);
+            await repository.markSucceeded(task.audit_id);
+            succeeded += 1;
+          } catch (error) {
+            await repository.markRetry(task, attemptAt, errorCode(error));
             retrying += 1;
-            continue;
+            log.warn('Guest deletion audit reconciliation deferred', {
+              tenantId: target.tenantId,
+              bindingRef,
+              operationId: task.operation_id,
+              errorCode: errorCode(error),
+            });
           }
-          const completedAt = asNonNegativeInteger(lifecycle.deleted_at ?? -1);
-          if (completedAt === 0) {
-            await repository.markRetry(task, attemptAt, 'guest_deletion_completion_time_missing');
-            retrying += 1;
-            continue;
-          }
-          await writeAudit(task, adapter, completedAt * 1000);
-          await repository.markSucceeded(task.audit_id);
-          succeeded += 1;
-        } catch (error) {
-          await repository.markRetry(task, attemptAt, errorCode(error));
-          retrying += 1;
-          log.warn('Guest deletion audit reconciliation deferred', {
-            tenantId: target.tenantId,
-            bindingRef,
-            operationId: task.operation_id,
-            errorCode: errorCode(error),
-          });
         }
+        if (tasks.length < RECONCILIATION_PAGE_SIZE) break;
       }
     }
   }

--- a/packages/ar-management/src/guest-lifecycle-scheduled.ts
+++ b/packages/ar-management/src/guest-lifecycle-scheduled.ts
@@ -29,7 +29,7 @@ import {
 import { InitialAccountIdentifierReservationService } from './account-directory-reservation';
 import { createLookupBucketWriteResolver } from './lookup-bucket-write-route';
 
-interface DeletionRoute {
+export interface GuestDeletionRoute {
   schemaVersion: 1;
   tenantId: string;
   userId: string;
@@ -37,6 +37,7 @@ interface DeletionRoute {
   piiBindingRef: string;
   piiResidencyPartition: string;
   routeProjection: AccountRouteProjection;
+  completionAuditMode?: 'outbox';
 }
 export interface GuestMaintenanceTarget {
   tenantId: string;
@@ -59,8 +60,8 @@ function readRoute(
   tenantId: string,
   userId: string,
   coreBindingRef: string
-): DeletionRoute {
-  const route = JSON.parse(json ?? 'null') as DeletionRoute | null;
+): GuestDeletionRoute {
+  const route = JSON.parse(json ?? 'null') as GuestDeletionRoute | null;
   if (
     !route ||
     route.schemaVersion !== 1 ||
@@ -70,17 +71,44 @@ function readRoute(
     typeof route.piiBindingRef !== 'string' ||
     !route.piiBindingRef ||
     typeof route.piiResidencyPartition !== 'string' ||
+    (route.completionAuditMode !== undefined && route.completionAuditMode !== 'outbox') ||
     !route.routeProjection
   )
     throw new Error('guest_deletion_route_invalid');
   return route;
 }
 
+export async function createGuestDeletionRoute(
+  env: Env,
+  input: {
+    tenantId: string;
+    userId: string;
+    completionAuditMode?: 'outbox';
+  }
+): Promise<GuestDeletionRoute> {
+  const account = await resolveAccountDataContext(env, {
+    tenantId: input.tenantId,
+    accountId: input.userId,
+  });
+  if (account.tenantId !== input.tenantId || account.legacyUserId !== input.userId)
+    throw new Error('guest_deletion_account_route_changed');
+  return {
+    schemaVersion: 1,
+    tenantId: input.tenantId,
+    userId: input.userId,
+    coreBindingRef: account.coreBindingRef,
+    piiBindingRef: account.piiBindingRef,
+    piiResidencyPartition: account.piiResidencyPartition,
+    routeProjection: account.membership.routeProjection,
+    ...(input.completionAuditMode ? { completionAuditMode: input.completionAuditMode } : {}),
+  };
+}
+
 /** Remove reservations made by verified attempts that lost to deletion; never remove another owner. */
 async function releaseUncommittedReservations(
   env: Env,
   pii: DatabaseAdapter,
-  route: DeletionRoute
+  route: GuestDeletionRoute
 ): Promise<void> {
   const operations = await pii.query<GuestUpgradeOperation>(
     `SELECT * FROM guest_upgrade_operations WHERE tenant_id = ? AND user_id = ? AND state = 'verified'`,
@@ -118,12 +146,8 @@ export async function deleteOneGuestAccount(
   if (!row || !['active', 'deleting'].includes(row.phase)) return 'skipped';
   if (await findActiveAccountLegalHold(core, tenantId, row.user_id)) return 'held';
   if (row.phase === 'active') {
-    const account = await resolveAccountDataContext(env, { tenantId, accountId: row.user_id });
-    if (
-      account.tenantId !== tenantId ||
-      account.legacyUserId !== row.user_id ||
-      account.coreBindingRef !== coreBindingRef
-    )
+    const route = await createGuestDeletionRoute(env, { tenantId, userId: row.user_id });
+    if (route.coreBindingRef !== coreBindingRef)
       throw new Error('guest_deletion_account_route_changed');
     const identity = await core.queryOne<{ account_type: string; registration_state: string }>(
       'SELECT account_type, registration_state FROM identity_accounts WHERE tenant_id = ? AND legacy_user_id = ? AND deleted_at IS NULL',
@@ -132,15 +156,6 @@ export async function deleteOneGuestAccount(
     );
     if (identity?.account_type !== 'user' || identity.registration_state !== 'guest')
       return 'skipped';
-    const route: DeletionRoute = {
-      schemaVersion: 1,
-      tenantId,
-      userId: row.user_id,
-      coreBindingRef,
-      piiBindingRef: account.piiBindingRef,
-      piiResidencyPartition: account.piiResidencyPartition,
-      routeProjection: account.membership.routeProjection,
-    };
     const operationId = `guest-delete:${crypto.randomUUID()}`;
     if (
       !(await lifecycle.beginDeletion(
@@ -216,17 +231,22 @@ export async function deleteOneGuestAccount(
   await markAccountDirectoryRemovalsReady(core, removals);
   await attemptImmediateAccountDirectoryRemovals(env.ACCOUNT_DIRECTORY, removals);
   await invalidateUserCache(env, tenantId, row.user_id);
-  await createAuditLog(env, {
-    tenantId,
-    userId: 'system',
-    action: 'user.deleted',
-    resource: 'user',
-    resourceId: row.user_id,
-    severity: 'info',
-    ipAddress: 'system',
-    userAgent: 'Authrim guest lifecycle',
-    metadata: JSON.stringify({ reason: 'guest_retention', operationId: row.deletion_operation_id }),
-  });
+  if (route.completionAuditMode !== 'outbox') {
+    await createAuditLog(env, {
+      tenantId,
+      userId: 'system',
+      action: 'user.deleted',
+      resource: 'user',
+      resourceId: row.user_id,
+      severity: 'info',
+      ipAddress: 'system',
+      userAgent: 'Authrim guest lifecycle',
+      metadata: JSON.stringify({
+        reason: 'guest_retention',
+        operationId: row.deletion_operation_id,
+      }),
+    });
+  }
   if (!(await lifecycle.completeDeletion(row.user_id, row.deletion_operation_id, now)))
     throw new Error('guest_deletion_completion_conflict');
   return 'deleted';

--- a/packages/ar-management/src/guest-lifecycle-scheduled.ts
+++ b/packages/ar-management/src/guest-lifecycle-scheduled.ts
@@ -186,12 +186,15 @@ export async function deleteOneGuestAccount(
     tenantId,
     row.user_id
   ).getAccountStateRpc(tenantId, row.user_id, `account:${row.user_id}`);
+  const resumesAdministrativeTransition = route.completionAuditMode === 'outbox';
   if (authentication.lifecycle !== 'deleted')
     await transitionAccountAuthenticationState(env, {
       tenantId,
       userId: row.user_id,
       lifecycle: 'deleting',
-      operationId: `${row.deletion_operation_id}:begin`,
+      operationId: resumesAdministrativeTransition
+        ? row.deletion_operation_id
+        : `${row.deletion_operation_id}:begin`,
       sourceVersionMs: row.deletion_started_at_ms,
       revokeSessions: true,
     });
@@ -224,7 +227,9 @@ export async function deleteOneGuestAccount(
       tenantId,
       userId: row.user_id,
       lifecycle: 'deleted',
-      operationId: `${row.deletion_operation_id}:complete`,
+      operationId: resumesAdministrativeTransition
+        ? row.deletion_operation_id
+        : `${row.deletion_operation_id}:complete`,
       sourceVersionMs: row.deletion_started_at_ms + 1,
       revokeSessions: true,
     });

--- a/packages/ar-management/src/index.ts
+++ b/packages/ar-management/src/index.ts
@@ -4258,6 +4258,7 @@ async function handleScheduled(event: ScheduledEvent, env: Env): Promise<void> {
     const maintenanceTargets = maintenancePage.targets;
     const maintenanceTenantIds = maintenanceTargets.map((target) => target.tenantId);
 
+    await processGuestLifecycleMaintenance(env, maintenanceTargets, log.module('GUEST-LIFECYCLE'));
     try {
       await processGuestDeletionAuditOutbox(
         env,
@@ -4270,8 +4271,6 @@ async function handleScheduled(event: ScheduledEvent, env: Env): Promise<void> {
           auditReconciliationError instanceof Error ? auditReconciliationError.name : 'Unknown',
       });
     }
-
-    await processGuestLifecycleMaintenance(env, maintenanceTargets, log.module('GUEST-LIFECYCLE'));
 
     // Session expiration is owned by SessionStore alarms and its authoritative DO state.
 

--- a/packages/ar-management/src/index.ts
+++ b/packages/ar-management/src/index.ts
@@ -79,6 +79,7 @@ import {
   listGuestLifecycleHandler,
 } from './admin-guest-retention';
 import { processGuestLifecycleMaintenance } from './guest-lifecycle-scheduled';
+import { processGuestDeletionAuditOutbox } from './guest-deletion-audit-outbox';
 import { processScheduledIdentifierReplacements } from './identifier-replacement-scheduled';
 import {
   getR2MaintenanceDashboard,
@@ -4256,6 +4257,19 @@ async function handleScheduled(event: ScheduledEvent, env: Env): Promise<void> {
     const maintenancePage = await listMaintenanceTenantIds(env, log);
     const maintenanceTargets = maintenancePage.targets;
     const maintenanceTenantIds = maintenanceTargets.map((target) => target.tenantId);
+
+    try {
+      await processGuestDeletionAuditOutbox(
+        env,
+        maintenanceTargets,
+        log.module('GUEST-DELETION-AUDIT')
+      );
+    } catch (auditReconciliationError) {
+      log.warn('Guest deletion audit reconciliation failed', {
+        errorType:
+          auditReconciliationError instanceof Error ? auditReconciliationError.name : 'Unknown',
+      });
+    }
 
     await processGuestLifecycleMaintenance(env, maintenanceTargets, log.module('GUEST-LIFECYCLE'));
 

--- a/packages/ar-management/src/routes/guest-users.ts
+++ b/packages/ar-management/src/routes/guest-users.ts
@@ -18,6 +18,7 @@ import {
   createAuthContextFromHono,
   createPIIContextFromHono,
   CanonicalRuntimeUserStore,
+  GuestLifecycleRepository,
   getTenantIdFromContext,
   getLogger,
   createAuditLogFromContext,
@@ -514,6 +515,17 @@ export async function deleteGuestUser(c: Context<{ Bindings: Env }>) {
     );
 
     const deletingVersionMs = Date.now();
+    const lifecycle = new GuestLifecycleRepository(authCtx.coreAdapter, tenantId);
+    if (
+      !(await lifecycle.beginAdministrativeDeletion(
+        userId,
+        deletionOperationId,
+        Math.floor(deletingVersionMs / 1000),
+        deletingVersionMs
+      ))
+    ) {
+      throw new Error('guest_administrative_deletion_conflict');
+    }
     await transitionAccountAuthenticationState(c.env, {
       tenantId,
       userId,
@@ -539,6 +551,15 @@ export async function deleteGuestUser(c: Context<{ Bindings: Env }>) {
       operationId: deletionOperationId,
       revokeSessions: true,
     });
+    if (
+      !(await lifecycle.completeDeletion(
+        userId,
+        deletionOperationId,
+        Math.floor(Date.now() / 1000)
+      ))
+    ) {
+      throw new Error('guest_administrative_deletion_completion_conflict');
+    }
 
     await deliverGuestDeletionCompletionAudit(c, {
       repository: auditOutbox,
@@ -684,6 +705,17 @@ export async function cleanupExpiredGuestUsers(c: Context<{ Bindings: Env }>) {
         );
 
         const deletingVersionMs = Date.now();
+        const lifecycle = new GuestLifecycleRepository(authCtx.coreAdapter, tenantId);
+        if (
+          !(await lifecycle.beginAdministrativeDeletion(
+            userId,
+            deletionOperationId,
+            Math.floor(deletingVersionMs / 1000),
+            deletingVersionMs
+          ))
+        ) {
+          throw new Error('guest_administrative_deletion_conflict');
+        }
         await transitionAccountAuthenticationState(c.env, {
           tenantId,
           userId,
@@ -706,6 +738,15 @@ export async function cleanupExpiredGuestUsers(c: Context<{ Bindings: Env }>) {
           operationId: deletionOperationId,
           revokeSessions: true,
         });
+        if (
+          !(await lifecycle.completeDeletion(
+            userId,
+            deletionOperationId,
+            Math.floor(Date.now() / 1000)
+          ))
+        ) {
+          throw new Error('guest_administrative_deletion_completion_conflict');
+        }
         await deliverGuestDeletionCompletionAudit(c, {
           repository: auditOutbox,
           task: auditTask,

--- a/packages/ar-management/src/routes/guest-users.ts
+++ b/packages/ar-management/src/routes/guest-users.ts
@@ -90,7 +90,7 @@ async function deliverGuestDeletionCompletionAudit(
         input.completedAt * 1000
       );
       try {
-        await input.repository.markSucceeded(input.task.audit_id, Math.floor(Date.now() / 1000));
+        await input.repository.markSucceeded(input.task.audit_id);
       } catch (outboxError) {
         // The pending task remains durable and the audit ID is idempotent, so the scheduler can
         // safely replay it and finish the acknowledgement later.

--- a/packages/ar-management/src/routes/guest-users.ts
+++ b/packages/ar-management/src/routes/guest-users.ts
@@ -70,6 +70,7 @@ async function deliverGuestDeletionCompletionAudit(
   input: {
     repository: GuestDeletionAuditOutboxRepository;
     task: GuestDeletionAuditOutboxRow;
+    completedAt: number;
     metadata: Record<string, unknown>;
     log: GuestDeletionAuditLogger;
     logActionPrefix: 'guest_user_delete' | 'guest_cleanup_user_delete';
@@ -85,7 +86,8 @@ async function deliverGuestDeletionCompletionAudit(
         input.task.user_id,
         input.metadata,
         'info',
-        input.task.audit_id
+        input.task.audit_id,
+        input.completedAt * 1000
       );
       try {
         await input.repository.markSucceeded(input.task.audit_id, Math.floor(Date.now() / 1000));
@@ -560,19 +562,15 @@ export async function deleteGuestUser(c: Context<{ Bindings: Env }>) {
       operationId: deletionOperationId,
       revokeSessions: true,
     });
-    if (
-      !(await lifecycle.completeDeletion(
-        userId,
-        deletionOperationId,
-        Math.floor(Date.now() / 1000)
-      ))
-    ) {
+    const completedAt = Math.floor(Date.now() / 1000);
+    if (!(await lifecycle.completeDeletion(userId, deletionOperationId, completedAt))) {
       throw new Error('guest_administrative_deletion_completion_conflict');
     }
 
     await deliverGuestDeletionCompletionAudit(c, {
       repository: auditOutbox,
       task: auditTask,
+      completedAt,
       metadata: auditMetadata,
       log,
       logActionPrefix: 'guest_user_delete',
@@ -755,18 +753,14 @@ export async function cleanupExpiredGuestUsers(c: Context<{ Bindings: Env }>) {
           operationId: deletionOperationId,
           revokeSessions: true,
         });
-        if (
-          !(await lifecycle.completeDeletion(
-            userId,
-            deletionOperationId,
-            Math.floor(Date.now() / 1000)
-          ))
-        ) {
+        const completedAt = Math.floor(Date.now() / 1000);
+        if (!(await lifecycle.completeDeletion(userId, deletionOperationId, completedAt))) {
           throw new Error('guest_administrative_deletion_completion_conflict');
         }
         await deliverGuestDeletionCompletionAudit(c, {
           repository: auditOutbox,
           task: auditTask,
+          completedAt,
           metadata: auditMetadata,
           log,
           logActionPrefix: 'guest_cleanup_user_delete',

--- a/packages/ar-management/src/routes/guest-users.ts
+++ b/packages/ar-management/src/routes/guest-users.ts
@@ -526,15 +526,15 @@ export async function deleteGuestUser(c: Context<{ Bindings: Env }>) {
 
     const deletingVersionMs = Date.now();
     const lifecycle = new GuestLifecycleRepository(authCtx.coreAdapter, tenantId);
-    if (
-      !(await lifecycle.beginAdministrativeDeletion(
-        userId,
-        deletionOperationId,
-        Math.floor(deletingVersionMs / 1000),
-        deletionRouteJson,
-        deletingVersionMs
-      ))
-    ) {
+    const deletionClaimed = await lifecycle.beginAdministrativeDeletion(
+      userId,
+      deletionOperationId,
+      Math.floor(deletingVersionMs / 1000),
+      deletionRouteJson,
+      deletingVersionMs
+    );
+    if (!deletionClaimed) {
+      await auditOutbox.remove(auditTask.audit_id);
       throw new Error('guest_administrative_deletion_conflict');
     }
     await transitionAccountAuthenticationState(c.env, {
@@ -720,15 +720,15 @@ export async function cleanupExpiredGuestUsers(c: Context<{ Bindings: Env }>) {
 
         const deletingVersionMs = Date.now();
         const lifecycle = new GuestLifecycleRepository(authCtx.coreAdapter, tenantId);
-        if (
-          !(await lifecycle.beginAdministrativeDeletion(
-            userId,
-            deletionOperationId,
-            Math.floor(deletingVersionMs / 1000),
-            deletionRouteJson,
-            deletingVersionMs
-          ))
-        ) {
+        const deletionClaimed = await lifecycle.beginAdministrativeDeletion(
+          userId,
+          deletionOperationId,
+          Math.floor(deletingVersionMs / 1000),
+          deletionRouteJson,
+          deletingVersionMs
+        );
+        if (!deletionClaimed) {
+          await auditOutbox.remove(auditTask.audit_id);
           throw new Error('guest_administrative_deletion_conflict');
         }
         await transitionAccountAuthenticationState(c.env, {

--- a/packages/ar-management/src/routes/guest-users.ts
+++ b/packages/ar-management/src/routes/guest-users.ts
@@ -591,13 +591,30 @@ export async function cleanupExpiredGuestUsers(c: Context<{ Bindings: Env }>) {
         if (legalHold) {
           continue;
         }
+        const deletionOperationId = crypto.randomUUID();
+        const auditMetadata = {
+          operationId: deletionOperationId,
+          registration_state: 'guest',
+          reason: 'manual_cleanup',
+          source: 'guest_cleanup_api',
+        };
+        await createAuditLogFromContext(
+          c,
+          'account.guest.deletion_started',
+          'user',
+          userId,
+          auditMetadata,
+          'info',
+          `account-guest-delete-started-${deletionOperationId}`
+        );
+
         const deletingVersionMs = Date.now();
         await transitionAccountAuthenticationState(c.env, {
           tenantId,
           userId,
           lifecycle: 'deleting',
           sourceVersionMs: deletingVersionMs,
-          operationId: crypto.randomUUID(),
+          operationId: deletionOperationId,
           revokeSessions: true,
         });
         // No active credential remains, delete the guest account.
@@ -611,14 +628,50 @@ export async function cleanupExpiredGuestUsers(c: Context<{ Bindings: Env }>) {
           userId,
           lifecycle: 'deleted',
           sourceVersionMs: Math.max(Date.now(), deletingVersionMs + 1),
-          operationId: crypto.randomUUID(),
+          operationId: deletionOperationId,
           revokeSessions: true,
         });
-        await createAuditLogFromContext(c, 'user.deleted', 'user', userId, {
-          registration_state: 'guest',
-          reason: 'manual_cleanup',
-          source: 'guest_cleanup_api',
-        });
+        const completionAuditId = `account-guest-deleted-${deletionOperationId}`;
+        try {
+          await createAuditLogFromContext(
+            c,
+            'user.deleted',
+            'user',
+            userId,
+            auditMetadata,
+            'info',
+            completionAuditId
+          );
+        } catch (_error) {
+          log.warn('Retrying guest cleanup completion audit', {
+            action: 'guest_cleanup_user_delete_audit_retry',
+            tenantId,
+            operationId: deletionOperationId,
+          });
+          try {
+            await createAuditLogFromContext(
+              c,
+              'user.deleted',
+              'user',
+              userId,
+              auditMetadata,
+              'info',
+              completionAuditId
+            );
+          } catch (retryError) {
+            // The durable deletion_started audit identifies a cleanup deletion whose
+            // idempotent completion audit still needs reconciliation.
+            log.error(
+              'Guest cleanup deletion committed but completion audit delivery is pending',
+              {
+                action: 'guest_cleanup_user_delete_audit_pending',
+                tenantId,
+                operationId: deletionOperationId,
+              },
+              retryError as Error
+            );
+          }
+        }
         deletedUsers++;
         deletedCredentials += expiredCredentials.filter(
           (credential) => credential.user_id === userId

--- a/packages/ar-management/src/routes/guest-users.ts
+++ b/packages/ar-management/src/routes/guest-users.ts
@@ -25,6 +25,11 @@ import {
   type Env,
 } from '@authrim/ar-lib-core';
 import { findActiveAccountLegalHold } from '../account-legal-hold-guard';
+import {
+  createGuestDeletionAuditTaskFromContext,
+  GuestDeletionAuditOutboxRepository,
+  type GuestDeletionAuditOutboxRow,
+} from '../guest-deletion-audit-outbox';
 
 function createRuntimeUserStore(c: Context<{ Bindings: Env }>, tenantId: string) {
   const authCtx = createAuthContextFromHono(c, tenantId);
@@ -51,6 +56,90 @@ function parseIntegerQuery(
 
 function invalidRequest(c: Context<{ Bindings: Env }>, description: string): Response {
   return c.json({ error: 'invalid_request', error_description: description }, 400);
+}
+
+interface GuestDeletionAuditLogger {
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, context?: Record<string, unknown>, error?: Error): void;
+}
+
+async function deliverGuestDeletionCompletionAudit(
+  c: Context<{ Bindings: Env }>,
+  input: {
+    repository: GuestDeletionAuditOutboxRepository;
+    task: GuestDeletionAuditOutboxRow;
+    metadata: Record<string, unknown>;
+    log: GuestDeletionAuditLogger;
+    logActionPrefix: 'guest_user_delete' | 'guest_cleanup_user_delete';
+  }
+): Promise<void> {
+  let deliveryError: unknown;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      await createAuditLogFromContext(
+        c,
+        'user.deleted',
+        'user',
+        input.task.user_id,
+        input.metadata,
+        'info',
+        input.task.audit_id
+      );
+      try {
+        await input.repository.markSucceeded(input.task.audit_id, Math.floor(Date.now() / 1000));
+      } catch (outboxError) {
+        // The pending task remains durable and the audit ID is idempotent, so the scheduler can
+        // safely replay it and finish the acknowledgement later.
+        input.log.error(
+          'Guest deletion audit succeeded but outbox acknowledgement is pending',
+          {
+            action: `${input.logActionPrefix}_audit_ack_pending`,
+            tenantId: input.task.tenant_id,
+            operationId: input.task.operation_id,
+          },
+          outboxError as Error
+        );
+      }
+      return;
+    } catch (error) {
+      deliveryError = error;
+      if (attempt === 0) {
+        input.log.warn('Retrying guest deletion completion audit', {
+          action: `${input.logActionPrefix}_audit_retry`,
+          tenantId: input.task.tenant_id,
+          operationId: input.task.operation_id,
+        });
+      }
+    }
+  }
+
+  try {
+    await input.repository.markRetry(
+      input.task,
+      Math.floor(Date.now() / 1000),
+      'audit_log_write_failed'
+    );
+  } catch (outboxError) {
+    // The task was persisted before deletion and remains pending if this update fails.
+    input.log.error(
+      'Guest deletion audit retry scheduling update failed',
+      {
+        action: `${input.logActionPrefix}_audit_retry_schedule_failed`,
+        tenantId: input.task.tenant_id,
+        operationId: input.task.operation_id,
+      },
+      outboxError as Error
+    );
+  }
+  input.log.error(
+    'Guest account deletion committed; completion audit is queued for reconciliation',
+    {
+      action: `${input.logActionPrefix}_audit_pending`,
+      tenantId: input.task.tenant_id,
+      operationId: input.task.operation_id,
+    },
+    deliveryError as Error
+  );
 }
 
 // ============================================================================
@@ -404,6 +493,7 @@ export async function deleteGuestUser(c: Context<{ Bindings: Env }>) {
       reason: 'admin_action',
       source: 'guest_admin_api',
     };
+    const completionAuditId = `account-guest-deleted-${deletionOperationId}`;
     await createAuditLogFromContext(
       c,
       'account.guest.deletion_started',
@@ -412,6 +502,15 @@ export async function deleteGuestUser(c: Context<{ Bindings: Env }>) {
       auditMetadata,
       'info',
       `account-guest-delete-started-${deletionOperationId}`
+    );
+    const auditOutbox = new GuestDeletionAuditOutboxRepository(authCtx.coreAdapter, tenantId);
+    const auditTask = await auditOutbox.enqueue(
+      createGuestDeletionAuditTaskFromContext(c, {
+        auditId: completionAuditId,
+        userId,
+        operationId: deletionOperationId,
+        metadata: auditMetadata,
+      })
     );
 
     const deletingVersionMs = Date.now();
@@ -441,47 +540,13 @@ export async function deleteGuestUser(c: Context<{ Bindings: Env }>) {
       revokeSessions: true,
     });
 
-    const completionAuditId = `account-guest-deleted-${deletionOperationId}`;
-    try {
-      await createAuditLogFromContext(
-        c,
-        'user.deleted',
-        'user',
-        userId,
-        auditMetadata,
-        'info',
-        completionAuditId
-      );
-    } catch (_error) {
-      log.warn('Retrying guest deletion completion audit', {
-        action: 'guest_user_delete_audit_retry',
-        tenantId,
-        operationId: deletionOperationId,
-      });
-      try {
-        await createAuditLogFromContext(
-          c,
-          'user.deleted',
-          'user',
-          userId,
-          auditMetadata,
-          'info',
-          completionAuditId
-        );
-      } catch (retryError) {
-        // The account is already irreversibly deleted. Preserve that successful API outcome;
-        // the durable deletion_started audit identifies the operation for reconciliation.
-        log.error(
-          'Guest account deletion committed but completion audit delivery is pending',
-          {
-            action: 'guest_user_delete_audit_pending',
-            tenantId,
-            operationId: deletionOperationId,
-          },
-          retryError as Error
-        );
-      }
-    }
+    await deliverGuestDeletionCompletionAudit(c, {
+      repository: auditOutbox,
+      task: auditTask,
+      metadata: auditMetadata,
+      log,
+      logActionPrefix: 'guest_user_delete',
+    });
     log.info('Guest account deleted by administrator', {
       action: 'guest_user_delete',
       tenantId,
@@ -598,6 +663,7 @@ export async function cleanupExpiredGuestUsers(c: Context<{ Bindings: Env }>) {
           reason: 'manual_cleanup',
           source: 'guest_cleanup_api',
         };
+        const completionAuditId = `account-guest-deleted-${deletionOperationId}`;
         await createAuditLogFromContext(
           c,
           'account.guest.deletion_started',
@@ -606,6 +672,15 @@ export async function cleanupExpiredGuestUsers(c: Context<{ Bindings: Env }>) {
           auditMetadata,
           'info',
           `account-guest-delete-started-${deletionOperationId}`
+        );
+        const auditOutbox = new GuestDeletionAuditOutboxRepository(authCtx.coreAdapter, tenantId);
+        const auditTask = await auditOutbox.enqueue(
+          createGuestDeletionAuditTaskFromContext(c, {
+            auditId: completionAuditId,
+            userId,
+            operationId: deletionOperationId,
+            metadata: auditMetadata,
+          })
         );
 
         const deletingVersionMs = Date.now();
@@ -631,47 +706,13 @@ export async function cleanupExpiredGuestUsers(c: Context<{ Bindings: Env }>) {
           operationId: deletionOperationId,
           revokeSessions: true,
         });
-        const completionAuditId = `account-guest-deleted-${deletionOperationId}`;
-        try {
-          await createAuditLogFromContext(
-            c,
-            'user.deleted',
-            'user',
-            userId,
-            auditMetadata,
-            'info',
-            completionAuditId
-          );
-        } catch (_error) {
-          log.warn('Retrying guest cleanup completion audit', {
-            action: 'guest_cleanup_user_delete_audit_retry',
-            tenantId,
-            operationId: deletionOperationId,
-          });
-          try {
-            await createAuditLogFromContext(
-              c,
-              'user.deleted',
-              'user',
-              userId,
-              auditMetadata,
-              'info',
-              completionAuditId
-            );
-          } catch (retryError) {
-            // The durable deletion_started audit identifies a cleanup deletion whose
-            // idempotent completion audit still needs reconciliation.
-            log.error(
-              'Guest cleanup deletion committed but completion audit delivery is pending',
-              {
-                action: 'guest_cleanup_user_delete_audit_pending',
-                tenantId,
-                operationId: deletionOperationId,
-              },
-              retryError as Error
-            );
-          }
-        }
+        await deliverGuestDeletionCompletionAudit(c, {
+          repository: auditOutbox,
+          task: auditTask,
+          metadata: auditMetadata,
+          log,
+          logActionPrefix: 'guest_cleanup_user_delete',
+        });
         deletedUsers++;
         deletedCredentials += expiredCredentials.filter(
           (credential) => credential.user_id === userId

--- a/packages/ar-management/src/routes/guest-users.ts
+++ b/packages/ar-management/src/routes/guest-users.ts
@@ -22,11 +22,10 @@ import {
   getTenantIdFromContext,
   getLogger,
   createAuditLogFromContext,
-  transitionAccountAuthenticationState,
   type Env,
 } from '@authrim/ar-lib-core';
 import { findActiveAccountLegalHold } from '../account-legal-hold-guard';
-import { createGuestDeletionRoute } from '../guest-lifecycle-scheduled';
+import { createGuestDeletionRoute, deleteOneGuestAccount } from '../guest-lifecycle-scheduled';
 import {
   createGuestDeletionAuditTaskFromContext,
   GuestDeletionAuditOutboxRepository,
@@ -497,13 +496,11 @@ export async function deleteGuestUser(c: Context<{ Bindings: Env }>) {
       reason: 'admin_action',
       source: 'guest_admin_api',
     };
-    const deletionRouteJson = JSON.stringify(
-      await createGuestDeletionRoute(c.env, {
-        tenantId,
-        userId,
-        completionAuditMode: 'outbox',
-      })
-    );
+    const deletionRoute = await createGuestDeletionRoute(c.env, {
+      tenantId,
+      userId,
+      completionAuditMode: 'outbox',
+    });
     const completionAuditId = `account-guest-deleted-${deletionOperationId}`;
     await createAuditLogFromContext(
       c,
@@ -530,40 +527,25 @@ export async function deleteGuestUser(c: Context<{ Bindings: Env }>) {
       userId,
       deletionOperationId,
       Math.floor(deletingVersionMs / 1000),
-      deletionRouteJson,
+      JSON.stringify(deletionRoute),
       deletingVersionMs
     );
     if (!deletionClaimed) {
       await auditOutbox.remove(auditTask.audit_id);
       throw new Error('guest_administrative_deletion_conflict');
     }
-    await transitionAccountAuthenticationState(c.env, {
-      tenantId,
-      userId,
-      lifecycle: 'deleting',
-      sourceVersionMs: deletingVersionMs,
-      operationId: deletionOperationId,
-      revokeSessions: true,
-    });
-
-    // Delete devices first (foreign key constraint)
-    await authCtx.coreAdapter.execute(
-      'DELETE FROM guest_devices WHERE tenant_id = ? AND user_id = ?',
-      [tenantId, userId]
-    );
-
-    // Delete user (upgrade history preserved for audit)
-    await runtimeUsers.deleteUser(userId);
-    await transitionAccountAuthenticationState(c.env, {
-      tenantId,
-      userId,
-      lifecycle: 'deleted',
-      sourceVersionMs: Math.max(Date.now(), deletingVersionMs + 1),
-      operationId: deletionOperationId,
-      revokeSessions: true,
-    });
     const completedAt = Math.floor(Date.now() / 1000);
-    if (!(await lifecycle.completeDeletion(userId, deletionOperationId, completedAt))) {
+    const claimedLifecycle = await lifecycle.get(userId);
+    if (
+      !claimedLifecycle ||
+      (await deleteOneGuestAccount(c.env, {
+        tenantId,
+        core: authCtx.coreAdapter,
+        coreBindingRef: deletionRoute.coreBindingRef,
+        candidate: claimedLifecycle,
+        now: completedAt,
+      })) !== 'deleted'
+    ) {
       throw new Error('guest_administrative_deletion_completion_conflict');
     }
 
@@ -691,13 +673,11 @@ export async function cleanupExpiredGuestUsers(c: Context<{ Bindings: Env }>) {
           reason: 'manual_cleanup',
           source: 'guest_cleanup_api',
         };
-        const deletionRouteJson = JSON.stringify(
-          await createGuestDeletionRoute(c.env, {
-            tenantId,
-            userId,
-            completionAuditMode: 'outbox',
-          })
-        );
+        const deletionRoute = await createGuestDeletionRoute(c.env, {
+          tenantId,
+          userId,
+          completionAuditMode: 'outbox',
+        });
         const completionAuditId = `account-guest-deleted-${deletionOperationId}`;
         await createAuditLogFromContext(
           c,
@@ -724,37 +704,25 @@ export async function cleanupExpiredGuestUsers(c: Context<{ Bindings: Env }>) {
           userId,
           deletionOperationId,
           Math.floor(deletingVersionMs / 1000),
-          deletionRouteJson,
+          JSON.stringify(deletionRoute),
           deletingVersionMs
         );
         if (!deletionClaimed) {
           await auditOutbox.remove(auditTask.audit_id);
           throw new Error('guest_administrative_deletion_conflict');
         }
-        await transitionAccountAuthenticationState(c.env, {
-          tenantId,
-          userId,
-          lifecycle: 'deleting',
-          sourceVersionMs: deletingVersionMs,
-          operationId: deletionOperationId,
-          revokeSessions: true,
-        });
-        // No active credential remains, delete the guest account.
-        await authCtx.coreAdapter.execute(
-          'DELETE FROM guest_devices WHERE tenant_id = ? AND user_id = ?',
-          [tenantId, userId]
-        );
-        await createRuntimeUserStore(c, tenantId).deleteUser(userId);
-        await transitionAccountAuthenticationState(c.env, {
-          tenantId,
-          userId,
-          lifecycle: 'deleted',
-          sourceVersionMs: Math.max(Date.now(), deletingVersionMs + 1),
-          operationId: deletionOperationId,
-          revokeSessions: true,
-        });
         const completedAt = Math.floor(Date.now() / 1000);
-        if (!(await lifecycle.completeDeletion(userId, deletionOperationId, completedAt))) {
+        const claimedLifecycle = await lifecycle.get(userId);
+        if (
+          !claimedLifecycle ||
+          (await deleteOneGuestAccount(c.env, {
+            tenantId,
+            core: authCtx.coreAdapter,
+            coreBindingRef: deletionRoute.coreBindingRef,
+            candidate: claimedLifecycle,
+            now: completedAt,
+          })) !== 'deleted'
+        ) {
           throw new Error('guest_administrative_deletion_completion_conflict');
         }
         await deliverGuestDeletionCompletionAudit(c, {

--- a/packages/ar-management/src/routes/guest-users.ts
+++ b/packages/ar-management/src/routes/guest-users.ts
@@ -26,6 +26,7 @@ import {
   type Env,
 } from '@authrim/ar-lib-core';
 import { findActiveAccountLegalHold } from '../account-legal-hold-guard';
+import { createGuestDeletionRoute } from '../guest-lifecycle-scheduled';
 import {
   createGuestDeletionAuditTaskFromContext,
   GuestDeletionAuditOutboxRepository,
@@ -494,6 +495,13 @@ export async function deleteGuestUser(c: Context<{ Bindings: Env }>) {
       reason: 'admin_action',
       source: 'guest_admin_api',
     };
+    const deletionRouteJson = JSON.stringify(
+      await createGuestDeletionRoute(c.env, {
+        tenantId,
+        userId,
+        completionAuditMode: 'outbox',
+      })
+    );
     const completionAuditId = `account-guest-deleted-${deletionOperationId}`;
     await createAuditLogFromContext(
       c,
@@ -521,6 +529,7 @@ export async function deleteGuestUser(c: Context<{ Bindings: Env }>) {
         userId,
         deletionOperationId,
         Math.floor(deletingVersionMs / 1000),
+        deletionRouteJson,
         deletingVersionMs
       ))
     ) {
@@ -684,6 +693,13 @@ export async function cleanupExpiredGuestUsers(c: Context<{ Bindings: Env }>) {
           reason: 'manual_cleanup',
           source: 'guest_cleanup_api',
         };
+        const deletionRouteJson = JSON.stringify(
+          await createGuestDeletionRoute(c.env, {
+            tenantId,
+            userId,
+            completionAuditMode: 'outbox',
+          })
+        );
         const completionAuditId = `account-guest-deleted-${deletionOperationId}`;
         await createAuditLogFromContext(
           c,
@@ -711,6 +727,7 @@ export async function cleanupExpiredGuestUsers(c: Context<{ Bindings: Env }>) {
             userId,
             deletionOperationId,
             Math.floor(deletingVersionMs / 1000),
+            deletionRouteJson,
             deletingVersionMs
           ))
         ) {

--- a/packages/ar-management/src/routes/guest-users.ts
+++ b/packages/ar-management/src/routes/guest-users.ts
@@ -86,7 +86,8 @@ async function deliverGuestDeletionCompletionAudit(
         input.metadata,
         'info',
         input.task.audit_id,
-        input.completedAt * 1000
+        input.completedAt * 1000,
+        true
       );
       try {
         await input.repository.markSucceeded(input.task.audit_id);

--- a/test/security-matrices/state-transition-matrix/cases.ts
+++ b/test/security-matrices/state-transition-matrix/cases.ts
@@ -1581,8 +1581,9 @@ export function decideQueueAudit(row: Row): QueueDecision {
     const healthy = acked.length === 1;
     if (healthy && fanout) {
       // fanout success: catalog + index + delivery aggregate + 1 R2 object. Queue-stable
-      // chunk/catalog ids and object keys make redelivery converge on the same effects.
-      writeCalls = 6 * perMessage;
+      // chunk/catalog ids and object keys make redelivery reuse the committed object. The
+      // replay only finalizes indexes and delivery state, so it performs three more writes.
+      writeCalls = delivery === 'duplicate' ? 9 : 6;
       uniqueEffects = 4;
       tenantKey = tenant === 'foreign' ? 'foreign' : 'default';
     } else if (healthy && !fanout) {
@@ -1596,7 +1597,8 @@ export function decideQueueAudit(row: Row): QueueDecision {
       uniqueEffects = 2;
     } else if (fanout && bindingState === 'present' && dlqArchive === 'throws') {
       // fanout archive-throws: catalog + delivery event/aggregate + notification
-      writeCalls = 6 * perMessage;
+      // A duplicate first reclaims the stable orphaned catalog claim before retrying.
+      writeCalls = delivery === 'duplicate' ? 13 : 6;
       uniqueEffects = 4;
     } else {
       writeCalls = 0;
@@ -1606,7 +1608,7 @@ export function decideQueueAudit(row: Row): QueueDecision {
     // mixed/all-fail batches: only the healthy message writes anything. A redelivery
     // re-runs the healthy message, so the per-delivery effects double.
     if (acked.length > 0 && fanout) {
-      writeCalls = 6 * perMessage;
+      writeCalls = delivery === 'duplicate' ? 9 : 6;
       uniqueEffects = 4;
       tenantKey = tenant === 'foreign' ? 'foreign' : 'default';
     } else if (acked.length > 0) {
@@ -1618,7 +1620,7 @@ export function decideQueueAudit(row: Row): QueueDecision {
       uniqueEffects = 2;
       tenantKey = tenant === 'foreign' ? 'foreign' : 'default';
     } else if (fanout && bindingState === 'present' && dlqArchive === 'throws') {
-      writeCalls = 6 * perMessage;
+      writeCalls = delivery === 'duplicate' ? 13 : 6;
       uniqueEffects = 4;
       tenantKey = tenant === 'foreign' ? 'foreign' : 'default';
     }
@@ -1758,11 +1760,11 @@ export function decideQueueLog(row: Row): QueueDecision {
       dlqSaved = true;
       tenantKey = tenant === 'foreign' ? 'foreign' : 'default';
     } else {
-      // chunk-write: catalog + index + aggregates + 1 R2 object. A redelivery writes a
-      // NEW chunk id and a NEW R2 object; the decision keeps the IDEMPOTENT expectation
-      // so the duplication fails the row as a strict finding.
-      writeCalls = 7 * perMessage;
-      uniqueEffects = delivery === 'duplicate' ? 4 : 4 * perMessage;
+      // chunk-write: catalog + index + aggregates + 1 R2 object. Stable catalog and chunk
+      // identifiers make redelivery reuse the committed object and only finalize indexes
+      // and delivery state.
+      writeCalls = delivery === 'duplicate' ? 11 : 7;
+      uniqueEffects = 4;
       tenantKey = tenant === 'foreign' ? 'foreign' : 'default';
     }
   } else if (

--- a/test/security-matrices/state-transition-matrix/harness.ts
+++ b/test/security-matrices/state-transition-matrix/harness.ts
@@ -325,11 +325,20 @@ function createStateProxiedStub<TInstance extends object>(
 
 import type { MemoryDatabaseAdapter, ExecuteResult } from '../fixtures/d1-adapter';
 
+interface D1RunResultLike {
+  success: boolean;
+  meta: {
+    changes: number;
+    last_row_id?: number | bigint;
+    duration?: number;
+  };
+}
+
 export interface D1StatementLike {
   bind(...params: unknown[]): D1StatementLike;
   first<T = unknown>(options?: unknown): Promise<T | null>;
   all<T = unknown>(options?: unknown): Promise<{ results: T[]; success: boolean; meta?: unknown }>;
-  run(options?: unknown): Promise<ExecuteResult>;
+  run(options?: unknown): Promise<D1RunResultLike | ExecuteResult>;
   raw<T = unknown>(options?: unknown): Promise<T[]>;
 }
 
@@ -345,6 +354,12 @@ interface D1PreparedLike {
  * adapter + ledger.
  */
 export class D1DatabaseLike {
+  private readonly logObjectCatalog = new Map<string, Record<string, unknown>>();
+  private readonly loggingDeliveryClaims = new Map<
+    string,
+    { status: string; errorClass: string | null; leaseUntil: number | null }
+  >();
+
   constructor(
     private readonly adapter: MemoryDatabaseAdapter,
     private readonly recordParams = false,
@@ -368,6 +383,9 @@ export class D1DatabaseLike {
             params: safeSerializableParams(params),
           });
         }
+        if (query.includes('FROM log_object_catalog') && query.includes('WHERE id = ?')) {
+          return (self.logObjectCatalog.get(String(params[0])) ?? null) as T | null;
+        }
         return self.adapter.queryOne<T>(query, params);
       },
       all: async <T = unknown>() => {
@@ -385,7 +403,145 @@ export class D1DatabaseLike {
             params: safeSerializableParams(params),
           });
         }
-        return self.adapter.execute(query, params);
+        const result = await self.adapter.execute(query, params);
+        if (
+          query.includes('INSERT INTO logging_delivery_events') &&
+          query.includes("'delivery_in_progress'")
+        ) {
+          const id = String(params[0]);
+          const claimed = !self.loggingDeliveryClaims.has(id);
+          if (claimed) {
+            self.loggingDeliveryClaims.set(id, {
+              status: 'retrying',
+              errorClass: 'delivery_in_progress',
+              leaseUntil: Number(params[10]),
+            });
+          }
+          return { success: result.success, meta: { changes: claimed ? 1 : 0 } };
+        }
+        if (query.includes('UPDATE logging_delivery_events')) {
+          if (query.includes("SET status = 'delivered'")) {
+            const id = String(params[4]);
+            const claim = self.loggingDeliveryClaims.get(id);
+            const changed =
+              claim?.status === 'retrying' && claim.errorClass === 'delivery_in_progress';
+            if (changed && claim) {
+              Object.assign(claim, { status: 'delivered', errorClass: null, leaseUntil: null });
+            }
+            return { success: result.success, meta: { changes: changed ? 1 : 0 } };
+          }
+          if (query.includes("error_class = 'delivery_emission_uncertain'")) {
+            const id = String(params[1]);
+            const claim = self.loggingDeliveryClaims.get(id);
+            const changed =
+              claim?.status === 'retrying' && claim.errorClass === 'delivery_in_progress';
+            if (changed && claim) {
+              Object.assign(claim, {
+                errorClass: 'delivery_emission_uncertain',
+                leaseUntil: null,
+              });
+            }
+            return { success: result.success, meta: { changes: changed ? 1 : 0 } };
+          }
+          if (query.includes("error_class = 'delivery_in_progress'")) {
+            const id = String(params[10]);
+            const now = Number(params[11]);
+            const claim = self.loggingDeliveryClaims.get(id);
+            const changed =
+              claim?.status === 'retrying' &&
+              claim.errorClass === 'delivery_in_progress' &&
+              claim.leaseUntil !== null &&
+              claim.leaseUntil <= now;
+            if (changed && claim) {
+              claim.leaseUntil = Number(params[8]);
+            }
+            return { success: result.success, meta: { changes: changed ? 1 : 0 } };
+          }
+        }
+        if (
+          query.includes('DELETE FROM logging_delivery_events') &&
+          query.includes("error_class = 'delivery_in_progress'")
+        ) {
+          const id = String(params[0]);
+          const claim = self.loggingDeliveryClaims.get(id);
+          const changed =
+            claim?.status === 'retrying' && claim.errorClass === 'delivery_in_progress';
+          if (changed) self.loggingDeliveryClaims.delete(id);
+          return { success: result.success, meta: { changes: changed ? 1 : 0 } };
+        }
+        if (query.includes('INSERT INTO log_object_catalog')) {
+          const id = String(params[0]);
+          const claimed = !self.logObjectCatalog.has(id);
+          if (claimed) {
+            self.logObjectCatalog.set(id, {
+              id,
+              tenant_key: params[1],
+              log_type: params[2],
+              plane: params[3],
+              surface: params[4],
+              object_key: params[5],
+              object_kind: params[6],
+              status: params[7],
+              record_count: params[8],
+              byte_count: params[9],
+              checksum_sha256: params[10],
+              compression: params[11],
+              encryption_scope: params[12],
+              key_version: params[13],
+              created_at: params[14],
+              committed_at: params[15],
+            });
+          }
+          return { success: result.success, meta: { changes: claimed ? 1 : 0 } };
+        }
+        if (query.includes('UPDATE log_object_catalog')) {
+          let id: string;
+          let changed = false;
+          if (query.includes("SET status = 'committed'")) {
+            id = String(params[3]);
+            const row = self.logObjectCatalog.get(id);
+            if (row?.status === 'pending') {
+              Object.assign(row, {
+                status: 'committed',
+                byte_count: params[0],
+                checksum_sha256: params[1],
+                committed_at: params[2],
+              });
+              changed = true;
+            }
+          } else if (query.includes("SET status = 'orphan_candidate'")) {
+            id = String(params[1] ?? params[0]);
+            const row = self.logObjectCatalog.get(id);
+            if (row?.status === 'pending') {
+              Object.assign(row, { status: 'orphan_candidate' });
+              changed = true;
+            }
+          } else if (query.includes("SET status = 'pending'")) {
+            id = String(params[1]);
+            const row = self.logObjectCatalog.get(id);
+            if (row?.status === 'orphan_candidate') {
+              Object.assign(row, {
+                status: 'pending',
+                checksum_sha256: null,
+                committed_at: params[0],
+              });
+              changed = true;
+            }
+          } else if (query.includes('(committed_at IS NULL OR committed_at <= ?)')) {
+            id = String(params[1]);
+            const row = self.logObjectCatalog.get(id);
+            const currentLease = row?.committed_at;
+            if (
+              row?.status === 'pending' &&
+              (currentLease === null || Number(currentLease) <= Number(params[2]))
+            ) {
+              Object.assign(row, { committed_at: params[0] });
+              changed = true;
+            }
+          }
+          return { success: result.success, meta: { changes: changed ? 1 : 0 } };
+        }
+        return result;
       },
       raw: async <T = unknown>() => self.adapter.query<T>(query, params),
     };


### PR DESCRIPTION
Guest deletion could commit while its fail-closed `user.deleted` completion audit failed, leaving no durable way to recover the missing evidence.

This change persists a guest deletion audit outbox task before any destructive transition. Admin deletion and manual cleanup make two immediate idempotent delivery attempts, preserve the committed deletion result if audit storage remains unavailable, and leave the task for scheduled reconciliation. Reconciliation emits the completion audit only after `guest_account_lifecycle` reaches `deleted` for the same operation ID, so partial or stale deletion operations cannot create a false completion record. A request that loses the lifecycle claim removes its task, and reconciliation also removes orphaned operation IDs so actor and request metadata are not retained indefinitely.

Both administrative deletion paths now claim and complete that authoritative guest lifecycle with the same operation ID. The claim is independent of automatic-retention deadlines, still verifies an active browser guest, and prevents an upgrade or another deletion from winning the same transition. It also pins the core and PII deletion route before the claim, allowing scheduled maintenance to resume an interrupted administrative deletion after the account directory entry is unavailable. Recovery reuses the original administrative authentication-transition identity and source version, avoiding a conflict with the already committed `deleting` transition. A persisted completion mode leaves the administrator-attributed completion audit exclusively to the outbox during recovery.

Audit retries read the committed lifecycle deletion timestamp and preserve it in both the legacy audit table and unified event log, including queued fanout records. Retention expiry is calculated from that event timestamp, so delayed replay does not extend the configured retention interval. Immediate delivery uses the same completion timestamp, so delayed recovery records when deletion actually committed. Replay keeps the configured audit environment and canonical audit store authoritative while using the tenant identity shard only for outbox reads and acknowledgements. Successfully delivered outbox rows are removed immediately so their actor, IP, user-agent, and request metadata do not outlive the canonical audit event retention policy.

Stable audit event IDs now suppress duplicate fanout enqueue for D1, PostgreSQL, and MySQL primaries. External audit adapters report the database's actual inserted-row count instead of the attempted batch size. Duplicate queue messages also derive archive chunks, delivery payloads, HTTP batch IDs, and delivery evidence from the audit event identity rather than the queue message ID or random UUIDs. Archive-only audit profiles now fail closed when fanout cannot be queued, so the deletion outbox remains available for retry until the evidence is durable. This preserves one idempotency identity across outbox acknowledgement failures and queue replay. The durable task stores the same request, correlation, and Admin UI proxy metadata added to immediate audit events until delivery succeeds.

The outbox is added to both D1 and PostgreSQL core migration streams and the draft migration manifest is refreshed. Integration coverage applies the real D1 migration, recreates the repository to simulate a process restart, writes an actual audit row, and verifies incomplete or mismatched lifecycle operations remain queued.

Validation:

- `pnpm --filter @authrim/ar-lib-core test` (all 357 test files passed)
- `pnpm --filter @authrim/ar-management test` (all 263 test files passed)
- focused lifecycle, guest deletion, outbox, and audit timestamp tests (115 tests)
- `pnpm --filter @authrim/ar-management typecheck`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm migrate:manifest:check`
- `git diff --check`
- `pnpm test` (45/46 workspace tasks passed; the only failure was the Docker Desktop socket returning HTTP 500 before the PostgreSQL semantic migration test could start)
