### PR TITLE
docs: center the README logo and website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <a href="https://authrim.com/">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="docs/images/authrim-logo-dark.svg">
-      <img src="docs/images/authrim-logo-light.svg" alt="Authrim" width="240" height="48">
+      <img src="docs/images/authrim-logo-light.svg" alt="Authrim" width="200" height="48">
     </picture>
   </a>
   <br>

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Authrim
-
-<a href="https://authrim.com/">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/images/authrim-logo-dark.svg">
-    <img src="docs/images/authrim-logo-light.svg" alt="Authrim — official website" width="240" height="48">
-  </picture>
-</a>
-
-**[authrim.com — Official website](https://authrim.com/)**
+<p align="center">
+  <a href="https://authrim.com/">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="docs/images/authrim-logo-dark.svg">
+      <img src="docs/images/authrim-logo-light.svg" alt="Authrim" width="240" height="48">
+    </picture>
+  </a>
+  <br>
+  <strong><a href="https://authrim.com/">authrim.com</a></strong>
+</p>
 
 > **Open Source Identity & Access Platform for the modern web**
 

--- a/docs/images/authrim-logo-dark.svg
+++ b/docs/images/authrim-logo-dark.svg
@@ -1,4 +1,4 @@
-<svg viewBox="0 0 200 40" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="-1.616 0 167.984 40" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <linearGradient id="logoGradient" x1="0%" y1="0%" x2="100%" y2="0%">
       <stop offset="0%" style="stop-color:#f2efe6"/>

--- a/docs/images/authrim-logo-light.svg
+++ b/docs/images/authrim-logo-light.svg
@@ -1,4 +1,4 @@
-<svg viewBox="0 0 200 40" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="-1.616 0 167.984 40" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <linearGradient id="logoGradientLight" x1="0%" y1="0%" x2="100%" y2="0%">
       <stop offset="0%" style="stop-color:#15120c"/>


### PR DESCRIPTION
Remove the redundant Authrim text heading, center the linked theme-aware SVG logo and website link, and shorten the link label to authrim.com.

Validation: git diff --check passes. Documentation only.